### PR TITLE
fix: display entity relationships in diagram Relationships tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Iris are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Entity-to-entity relationships not displayed in diagram Relationships tab — field name mismatch `elementId` → `entityId` in relationship query (ADR-097, Issue #4)
+- Diagram relationships endpoint crash on SQLite — replaced unsupported `async for` cursor iteration with `fetchall()`
+
 ## [2.6.0] - 2026-03-21
 
 ### Added

--- a/backend/app/diagrams/router.py
+++ b/backend/app/diagrams/router.py
@@ -392,9 +392,9 @@ async def get_diagram_relationships(
         """,
         (diagram_id, diagram_id),
     )
-    diagram_links = []
-    async for row in cursor:
-        diagram_links.append({
+    rows = await cursor.fetchall()
+    diagram_links = [
+        {
             "id": row[0],
             "source_package_id": row[1],  # Frontend expects this field name
             "target_package_id": row[2],
@@ -405,7 +405,9 @@ async def get_diagram_relationships(
             "created_at": row[6],
             "source_name": row[7] or row[1],
             "target_name": row[8] or row[2],
-        })
+        }
+        for row in rows
+    ]
 
     return {
         "diagram_relationships": diagram_links,

--- a/backend/app/package_relationships/service.py
+++ b/backend/app/package_relationships/service.py
@@ -110,7 +110,7 @@ async def list_element_relationships_for_diagram(
     for node in nodes:
         node_data = node.get("data", {})
         if isinstance(node_data, dict):
-            eid = node_data.get("elementId")
+            eid = node_data.get("entityId")
             if eid:
                 element_ids.add(eid)
 

--- a/backend/tests/test_diagram_relationships.py
+++ b/backend/tests/test_diagram_relationships.py
@@ -1,0 +1,280 @@
+"""Tests for diagram relationships endpoint — entity-to-entity relationships displayed
+in the Relationships tab (Issue #4, ADR-097, SPEC-097-A).
+
+TDD: written before the fix.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    """Setup admin user and return auth headers."""
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    tokens = resp.json()
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+async def _create_element(
+    client: httpx.AsyncClient, headers: dict, name: str, element_type: str = "component"
+) -> str:
+    """Create an element and return its id."""
+    resp = await client.post(
+        "/api/elements",
+        json={"element_type": element_type, "name": name},
+        headers=headers,
+    )
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+class TestDiagramElementRelationships:
+    """Verify that element-to-element relationships appear in the diagram relationships endpoint."""
+
+    async def test_element_relationships_returned_for_diagram(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """Elements on a diagram's canvas with relationships should appear in
+        GET /api/diagrams/{id}/relationships under element_relationships."""
+        headers = await _auth_headers(client)
+
+        # 1. Create two elements
+        elem_a = await _create_element(client, headers, "Service A")
+        elem_b = await _create_element(client, headers, "Service B")
+
+        # 2. Create a relationship between them
+        rel_resp = await client.post(
+            "/api/relationships",
+            json={
+                "source_element_id": elem_a,
+                "target_element_id": elem_b,
+                "relationship_type": "uses",
+                "label": "calls",
+            },
+            headers=headers,
+        )
+        assert rel_resp.status_code == 201
+        rel_id = rel_resp.json()["id"]
+
+        # 3. Create a diagram with canvas nodes referencing those elements via entityId
+        diag_resp = await client.post(
+            "/api/diagrams",
+            json={"diagram_type": "component", "name": "Test Diagram"},
+            headers=headers,
+        )
+        assert diag_resp.status_code == 201
+        diagram_id = diag_resp.json()["id"]
+
+        canvas_data = {
+            "nodes": [
+                {
+                    "id": "n1",
+                    "type": "default",
+                    "position": {"x": 0, "y": 0},
+                    "data": {
+                        "label": "Service A",
+                        "entityType": "component",
+                        "entityId": elem_a,
+                    },
+                },
+                {
+                    "id": "n2",
+                    "type": "default",
+                    "position": {"x": 200, "y": 0},
+                    "data": {
+                        "label": "Service B",
+                        "entityType": "component",
+                        "entityId": elem_b,
+                    },
+                },
+            ],
+            "edges": [],
+        }
+
+        put_resp = await client.put(
+            f"/api/diagrams/{diagram_id}",
+            json={
+                "name": "Test Diagram",
+                "description": "",
+                "data": canvas_data,
+                "change_summary": "Added entity nodes",
+            },
+            headers={**headers, "If-Match": "1"},
+        )
+        assert put_resp.status_code == 200
+
+        # 4. Fetch diagram relationships
+        rels_resp = await client.get(
+            f"/api/diagrams/{diagram_id}/relationships",
+            headers=headers,
+        )
+        assert rels_resp.status_code == 200
+        data = rels_resp.json()
+
+        # 5. Assert element_relationships contains the relationship
+        element_rels = data["element_relationships"]
+        assert len(element_rels) >= 1, (
+            f"Expected at least 1 element relationship, got {len(element_rels)}"
+        )
+        matching = [r for r in element_rels if r["id"] == rel_id]
+        assert len(matching) == 1
+        assert matching[0]["source_element_id"] == elem_a
+        assert matching[0]["target_element_id"] == elem_b
+        assert matching[0]["relationship_type"] == "uses"
+        assert matching[0]["source_name"] == "Service A"
+        assert matching[0]["target_name"] == "Service B"
+
+    async def test_no_element_relationships_when_no_entities(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """A diagram with no entity nodes should return empty element_relationships."""
+        headers = await _auth_headers(client)
+
+        diag_resp = await client.post(
+            "/api/diagrams",
+            json={"diagram_type": "component", "name": "Empty Diagram"},
+            headers=headers,
+        )
+        assert diag_resp.status_code == 201
+        diagram_id = diag_resp.json()["id"]
+
+        rels_resp = await client.get(
+            f"/api/diagrams/{diagram_id}/relationships",
+            headers=headers,
+        )
+        assert rels_resp.status_code == 200
+        data = rels_resp.json()
+        assert data["element_relationships"] == []
+
+    async def test_element_relationships_only_for_canvas_entities(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """Only relationships involving entities on the canvas should be returned,
+        not all relationships in the system."""
+        headers = await _auth_headers(client)
+
+        # Create three elements: A, B, C
+        elem_a = await _create_element(client, headers, "Entity A")
+        elem_b = await _create_element(client, headers, "Entity B")
+        elem_c = await _create_element(client, headers, "Entity C")
+
+        # Create relationships: A→B and B→C
+        await client.post(
+            "/api/relationships",
+            json={
+                "source_element_id": elem_a,
+                "target_element_id": elem_b,
+                "relationship_type": "uses",
+            },
+            headers=headers,
+        )
+        rel_bc = await client.post(
+            "/api/relationships",
+            json={
+                "source_element_id": elem_b,
+                "target_element_id": elem_c,
+                "relationship_type": "depends_on",
+            },
+            headers=headers,
+        )
+        assert rel_bc.status_code == 201
+
+        # Create diagram with only A and B on canvas (not C)
+        diag_resp = await client.post(
+            "/api/diagrams",
+            json={"diagram_type": "component", "name": "Partial Diagram"},
+            headers=headers,
+        )
+        diagram_id = diag_resp.json()["id"]
+
+        canvas_data = {
+            "nodes": [
+                {
+                    "id": "n1",
+                    "type": "default",
+                    "position": {"x": 0, "y": 0},
+                    "data": {"label": "A", "entityType": "component", "entityId": elem_a},
+                },
+                {
+                    "id": "n2",
+                    "type": "default",
+                    "position": {"x": 200, "y": 0},
+                    "data": {"label": "B", "entityType": "component", "entityId": elem_b},
+                },
+            ],
+            "edges": [],
+        }
+
+        await client.put(
+            f"/api/diagrams/{diagram_id}",
+            json={
+                "name": "Partial Diagram",
+                "description": "",
+                "data": canvas_data,
+                "change_summary": "A and B only",
+            },
+            headers={**headers, "If-Match": "1"},
+        )
+
+        rels_resp = await client.get(
+            f"/api/diagrams/{diagram_id}/relationships",
+            headers=headers,
+        )
+        data = rels_resp.json()
+        element_rels = data["element_relationships"]
+
+        # A→B should be found (both on canvas), B→C should also be found
+        # because B is on the canvas (the query uses OR, not AND)
+        assert len(element_rels) >= 1
+        rel_types = {r["relationship_type"] for r in element_rels}
+        assert "uses" in rel_types

--- a/docs/adrs/ADR-097-Entity-Relationship-Display-Fix.md
+++ b/docs/adrs/ADR-097-Entity-Relationship-Display-Fix.md
@@ -1,0 +1,62 @@
+# ADR-097: Entity Relationship Display Fix
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-097 |
+| **Initiative** | Entity Relationship Display Fix |
+| **Proposed By** | Engineering |
+| **Date** | 2026-03-22 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the Relationships tab on the diagram detail page, which should display entity-to-entity relationships for elements present on the diagram's canvas,
+
+**facing** a bug where the backend function `list_element_relationships_for_diagram` extracts element IDs from canvas nodes using the field name `elementId`, while the frontend and all other backend code stores the entity reference as `entityId` in `CanvasNodeData`, resulting in zero element IDs being found and no relationships ever being returned,
+
+**we decided for** correcting the field name from `elementId` to `entityId` in `backend/app/package_relationships/service.py:113` to match the canonical field name used throughout the codebase,
+
+**and neglected** renaming the frontend field to `elementId` (which would require changes across 20+ files in the frontend and backend, versus a single-line fix),
+
+**to achieve** correct display of entity-to-entity relationships in the Relationships tab when viewing any diagram that contains entity nodes with existing relationships,
+
+**accepting that** this is a straightforward field name correction with no architectural trade-offs.
+
+---
+
+## Summary
+
+| Capability | Description | Specification |
+|------------|-------------|---------------|
+| Field name fix | Correct `elementId` → `entityId` in relationship query | [SPEC-097-A](./specs/SPEC-097-A-Relationship-Field-Fix.md) |
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Relates To | ADR-067 | Unified Relationship Management | Relationship display is part of unified management |
+
+---
+
+## References
+
+| Reference ID | Title | Type | Location |
+|--------------|-------|------|----------|
+| SPEC-097-A | Relationship Field Fix | Technical Specification | [specs/SPEC-097-A-Relationship-Field-Fix.md](./specs/SPEC-097-A-Relationship-Field-Fix.md) |
+| GitHub | Issue #4 | Bug Report | Entity relationships not displayed in diagram view |
+
+---
+
+## Status History
+
+| Status | Approver | Date |
+|--------|----------|------|
+| Approved | Engineering | 2026-03-22 |
+
+---
+
+*This ADR was created following the WH(Y) format as specified in [SPEC-001-A](./specs/SPEC-001-A-WHY-Format.md).*

--- a/docs/adrs/specs/SPEC-097-A-Relationship-Field-Fix.md
+++ b/docs/adrs/specs/SPEC-097-A-Relationship-Field-Fix.md
@@ -1,0 +1,57 @@
+# SPEC-097-A: Relationship Field Fix
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | SPEC-097-A |
+| **ADR** | [ADR-097](../ADR-097-Entity-Relationship-Display-Fix.md) |
+| **Status** | Draft |
+| **Date** | 2026-03-22 |
+
+---
+
+## Overview
+
+Fix the field name mismatch in `list_element_relationships_for_diagram()` that prevents entity-to-entity relationships from being displayed in the diagram Relationships tab.
+
+## Root Cause
+
+In `backend/app/package_relationships/service.py`, line 113:
+
+```python
+eid = node_data.get("elementId")  # ← incorrect field name
+```
+
+The canonical field name used everywhere else in the codebase is `entityId`:
+
+| File | Usage |
+|------|-------|
+| `frontend/src/lib/types/canvas.ts:85` | `entityId?: string` in `CanvasNodeData` |
+| `backend/app/diagrams/service.py:347` | `node["data"].get("entityId")` |
+| `backend/app/diagrams/service.py:366` | `node["data"].get("entityId")` |
+| `backend/app/import_sparx/service.py:587` | `"entityId": element_id` |
+| `backend/app/elements/service.py:531` | `n["data"].get("entityId")` |
+| `backend/app/seed/example_models.py` | `"entityId": eids.get(...)` (multiple) |
+
+## Fix
+
+Change line 113 of `backend/app/package_relationships/service.py`:
+
+```python
+# Before
+eid = node_data.get("elementId")
+
+# After
+eid = node_data.get("entityId")
+```
+
+## Acceptance Criteria
+
+1. `GET /api/diagrams/{id}/relationships` returns non-empty `element_relationships` when the diagram canvas contains entity nodes linked to elements that have relationships in the `relationships` table
+2. The Relationships tab on the diagram page displays element relationships
+3. Existing tests continue to pass
+4. New test covers the fix: create elements with a relationship, create a diagram referencing those elements, verify the relationships endpoint returns them
+
+## Test Plan
+
+- New test file: `backend/tests/test_diagram_relationships.py`
+- Test: create two elements, create a relationship between them, create a diagram with canvas nodes referencing those elements via `entityId`, call `GET /api/diagrams/{id}/relationships`, assert `element_relationships` contains the relationship


### PR DESCRIPTION
## Summary
- Fixed field name mismatch (`elementId` → `entityId`) in `list_element_relationships_for_diagram()` that caused entity relationships to never appear in the Relationships tab
- Fixed `async for` cursor iteration crash in the diagram relationships router (SQLite adapter doesn't support `__aiter__`)

Closes #4 | ADR-097, SPEC-097-A

## Test plan
- [x] New tests in `backend/tests/test_diagram_relationships.py` (3 tests, all passing)
- [ ] Manual: Open a diagram with entity nodes that have relationships → Relationships tab should show them
- [x] Full test suite: 743 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)