### PR TITLE
feat: DoView element-backed nodes + visual toggles (v2.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Linked Diagram property editor** — set, change, or clear a node's linked diagram directly from the edit sidebar (ADR-099)
 
+## [2.7.2] - 2026-03-23
+
+### Added
+- **Visual Toggles** settings section — user-controlled display preferences for diagram nodes (ADR-101)
+- **Element count badge** — optional top-right badge on nodes showing how many diagrams each element is used in, toggled via Settings → Visual Toggles
+- **Hide description toggle** — `hideDescription` theme rendering option; DoView defaults to hidden, per-node override in edit sidebar
+
+### Changed
+- **DoView element-backed nodes** — all DoView diagram nodes are now created as proper elements with `entityId` linkage, and all causal links as relationships with `relationshipId`, enabling cross-diagram element reuse and diagram-entity relationship tracking (ADR-100)
+- AI diagram creation (`create_diagrams_from_ai`) now materialises element and relationship records for every node and edge
+
+### Fixed
+- Double borders on DoView nodes — removed duplicate `visualStyle` application from DoviewRenderer wrapper
+- Stale seed test assertions for diagram count (35 → 39) after DoView diagrams were added in v2.6.0
+- Seed test setup missing migrations m028 (AI creation prompts) and m029 (sequence order)
+
 ## [2.7.1] - 2026-03-22
 
 ### Added

--- a/backend/app/ai/creation.py
+++ b/backend/app/ai/creation.py
@@ -12,6 +12,8 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from app.elements.materialise import materialise_element, materialise_relationship
+
 if TYPE_CHECKING:
     import aiosqlite
 
@@ -147,6 +149,62 @@ async def create_diagrams_from_ai(
 
     await db.commit()
 
+    # Phase 1.5: materialise elements and relationships for each diagram
+    for i, (diagram_id, canvas_data, diag_def) in enumerate(
+        zip(diagram_ids, canvas_data_list, diagrams_def)
+    ):
+        notation = diag_def.get("notation", "doview")
+        node_element_map: dict[str, str] = {}  # node_id → element_id
+
+        # Create element for each node
+        for node in canvas_data.get("nodes", []):
+            node_data = node.get("data", {})
+            element_id = str(uuid.uuid4())
+            node_id = node.get("id", "")
+            node_element_map[node_id] = element_id
+
+            await materialise_element(
+                db,
+                element_id=element_id,
+                element_type=node_data.get("entityType", "outcome_box"),
+                name=node_data.get("label", ""),
+                description=node_data.get("description"),
+                set_id=set_id,
+                notation=notation,
+                created_by=user_id,
+                now=now,
+            )
+            node_data["entityId"] = element_id
+
+        # Create relationship for each edge
+        for edge in canvas_data.get("edges", []):
+            source_eid = node_element_map.get(edge.get("source", ""))
+            target_eid = node_element_map.get(edge.get("target", ""))
+            if source_eid and target_eid:
+                rel_id = str(uuid.uuid4())
+                edge_data = edge.get("data", {})
+
+                await materialise_relationship(
+                    db,
+                    rel_id=rel_id,
+                    source_element_id=source_eid,
+                    target_element_id=target_eid,
+                    relationship_type=edge_data.get("relationshipType", "causal_link"),
+                    label="",
+                    description="",
+                    created_by=user_id,
+                    now=now,
+                )
+                edge_data["relationshipId"] = rel_id
+
+        # Update diagram_versions with enriched canvas data
+        await db.execute(
+            "UPDATE diagram_versions SET data = ? WHERE diagram_id = ? AND version = 1",
+            (json.dumps(canvas_data), diagram_id),
+        )
+
+    await db.commit()
+
     # Phase 2: resolve linkedDiagramIndex → linkedModelId in overview_tile nodes
     for i, (diagram_id, canvas_data) in enumerate(zip(diagram_ids, canvas_data_list)):
         updated = False
@@ -183,6 +241,9 @@ def _build_canvas_nodes(ai_nodes: list[dict]) -> list[dict]:
             "label": label,
             "entityType": entity_type,
         }
+        description = ai_node.get("description", "")
+        if description:
+            node_data["description"] = description
         if visual:
             node_data["visual"] = visual
 

--- a/backend/app/elements/materialise.py
+++ b/backend/app/elements/materialise.py
@@ -1,0 +1,68 @@
+"""Shared element/relationship materialisation (ADR-100).
+
+Provides low-level INSERT helpers that create element + version and
+relationship + version records without committing.  Callers control
+transaction boundaries.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+async def materialise_element(
+    db: DatabasePort,
+    *,
+    element_id: str,
+    element_type: str,
+    name: str,
+    description: str | None,
+    set_id: str,
+    notation: str,
+    created_by: str,
+    now: str,
+) -> None:
+    """Insert element + initial version records (caller commits)."""
+    await db.execute(
+        "INSERT INTO elements (id, element_type, set_id, current_version, "
+        "created_at, created_by, updated_at, notation) VALUES (?, ?, ?, 1, ?, ?, ?, ?)",
+        (element_id, element_type, set_id, now, created_by, now, notation),
+    )
+    await db.execute(
+        "INSERT INTO element_versions (element_id, version, name, description, "
+        "data, change_type, created_at, created_by) "
+        "VALUES (?, 1, ?, ?, ?, 'create', ?, ?)",
+        (element_id, name, description, json.dumps({}), now, created_by),
+    )
+
+
+async def materialise_relationship(
+    db: DatabasePort,
+    *,
+    rel_id: str,
+    source_element_id: str,
+    target_element_id: str,
+    relationship_type: str,
+    label: str,
+    description: str,
+    created_by: str,
+    now: str,
+) -> None:
+    """Insert relationship + initial version records (caller commits)."""
+    await db.execute(
+        "INSERT INTO relationships (id, source_element_id, target_element_id, "
+        "relationship_type, current_version, created_at, created_by, updated_at) "
+        "VALUES (?, ?, ?, ?, 1, ?, ?, ?)",
+        (rel_id, source_element_id, target_element_id, relationship_type,
+         now, created_by, now),
+    )
+    await db.execute(
+        "INSERT INTO relationship_versions (relationship_id, version, label, "
+        "description, data, change_type, created_at, created_by) "
+        "VALUES (?, 1, ?, ?, ?, 'create', ?, ?)",
+        (rel_id, label, description, json.dumps({}), now, created_by),
+    )

--- a/backend/app/elements/service.py
+++ b/backend/app/elements/service.py
@@ -119,6 +119,25 @@ async def get_element(
     tag_rows = await tag_cursor.fetchall()
     element["tags"] = [r[0] for r in tag_rows]
 
+    # Relationship count
+    rel_cursor = await db.execute(
+        "SELECT COUNT(*) FROM relationships "
+        "WHERE (source_element_id = ? OR target_element_id = ?) AND is_deleted = 0",
+        (element_id, element_id),
+    )
+    rel_row = await rel_cursor.fetchone()
+    element["relationship_count"] = rel_row[0] if rel_row else 0
+
+    # Diagram usage count
+    diagram_cursor = await db.execute(
+        "SELECT COUNT(DISTINCT d.id) FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.is_deleted = 0 AND dv.data LIKE ?",
+        (f'%{element_id}%',),
+    )
+    diagram_row = await diagram_cursor.fetchone()
+    element["diagram_usage_count"] = diagram_row[0] if diagram_row else 0
+
     return element
 
 

--- a/backend/app/migrations/m027_doview_notation.py
+++ b/backend/app/migrations/m027_doview_notation.py
@@ -56,6 +56,7 @@ _DOVIEW_THEME_CONFIG = {
     },
     "rendering": {
         "hideIcons": False,
+        "hideDescription": True,
         "borderRadius": 4,
         "wrapLabels": True,
         "textAlign": "center",

--- a/backend/app/seed/example_models.py
+++ b/backend/app/seed/example_models.py
@@ -1,21 +1,23 @@
 """Idempotent seed: example diagrams covering all diagram-type/notation permutations.
 
-Creates elements representing the Iris system and 34 diagrams organised
-into a 5-package hierarchy by notation:
+Creates 87 elements representing the Iris system and 34 diagrams organised
+into a 6-package hierarchy by notation:
 
   Iris (root package)
   ├── Iris Navigation (root — navigation_cell tiles → each notation)
   ├── Simple Notation   — 11 diagrams (incl. AI Module Architecture)
   ├── UML Notation      — 8 diagrams
   ├── ArchiMate Notation — 7 diagrams
-  └── C4 Notation       — 6 diagrams
+  ├── C4 Notation       — 6 diagrams
+  └── DoView Notation   — 6 diagrams (28 elements, element-backed nodes)
 
-v5 revision: adds AI module elements (AI Service, AI Client, Provider Registry,
-Context Builder), relationships, and AI Module Architecture diagram.
+v8 revision: replaces 7 generic Youth Employment DoView elements with 28
+element-backed nodes covering overview tiles, final outcomes, strategic
+vision, platform delivery, user enablement, and source references.
 
 Idempotency:
-  - If _gen_id("diagram", 33) has v5 marker in metadata → already v5, skip
-  - Otherwise → clear + reseed v5
+  - If _gen_id("diagram", 33) has seed_v8 marker in metadata → already v8, skip
+  - Otherwise → clear + reseed v8
 """
 
 from __future__ import annotations
@@ -250,21 +252,69 @@ _ENTITIES: list[tuple[str, str, str, str, str]] = [
     ("ai4", "component", "Context Builder",
      "Builds structured LLM prompts from Set elements, relationships, and diagrams with token-budget truncation", "simple"),
 
-    # ── DoView notation (7 elements, indices 59–65) ────────────────────────────
-    ("dv1", "outcome_box", "Employers engaged and on-board",
-     "Local employers understand and support the Youth Employment Program", "doview"),
-    ("dv2", "outcome_box", "Youth develop job-ready skills",
-     "Youth complete skills training in CV writing, interview preparation, and workplace readiness", "doview"),
-    ("dv3", "outcome_box", "Youth access employment opportunities",
-     "Youth are matched with suitable job vacancies and employer networks", "doview"),
-    ("dv4", "outcome_box", "Youth gain sustained work experience",
-     "Youth complete work placements, traineeships, or internships over 3+ months", "doview"),
-    ("dv5", "outcome_box", "Youth secure meaningful employment",
-     "Youth obtain paid employment aligned with their skills and career goals", "doview"),
-    ("dv6", "final_outcome", "Youth are economically independent",
-     "Young people have stable income, financial literacy, and long-term career prospects", "doview"),
-    ("dv7", "source_reference", "Youth Employment Research",
-     "Smith J. (2023). Youth Unemployment Interventions: A Systematic Review. Journal of Policy Studies.", "doview"),
+    # ── DoView notation (28 elements, indices 59–86) ───────────────────────────
+    # Overview tiles
+    ("dv_ov1", "overview_tile", "Final Outcomes",
+     "Navigation tile to the Final Outcomes page", "doview"),
+    ("dv_ov2", "overview_tile", "Strategic Vision & Goals",
+     "Navigation tile to the Strategic Vision & Goals outcomes map", "doview"),
+    ("dv_ov3", "overview_tile", "Platform Delivery & Operations",
+     "Navigation tile to the Platform Delivery & Operations outcomes map", "doview"),
+    ("dv_ov4", "overview_tile", "User Enablement & Adoption",
+     "Navigation tile to the User Enablement & Adoption outcomes map", "doview"),
+    ("dv_ov5", "overview_tile", "Sources",
+     "Navigation tile to the Sources page", "doview"),
+    # Final outcomes (shared with Strategic Vision diagram)
+    ("dv_fo1", "final_outcome", "Decision-making improves through reliable architectural insight",
+     "Stakeholders make better choices using trustworthy architecture models", "doview"),
+    ("dv_fo2", "final_outcome", "Digital transformation initiatives succeed with clear technical direction",
+     "Transformation programmes achieve goals with architecture-informed planning", "doview"),
+    ("dv_fo3", "final_outcome", "Organisational knowledge remains stable despite staff turnover",
+     "Architecture knowledge persists in the tool regardless of personnel changes", "doview"),
+    # Strategic Vision — unique outcome boxes
+    ("dv_sv1", "outcome_box", "High-quality architecture models are created and maintained",
+     "Architects produce and curate accurate, up-to-date models", "doview"),
+    ("dv_sv2", "outcome_box", "Enterprise architects are empowered to govern systems effectively",
+     "Governance decisions are informed by live architecture data", "doview"),
+    # Platform Delivery outcome boxes
+    ("dv_pd1", "outcome_box", "User accounts and permissions are managed securely",
+     "Authentication and authorisation protect sensitive architecture data", "doview"),
+    ("dv_pd2", "outcome_box", "Diagrams are versioned with full history & rollback",
+     "Every change is tracked and reversible", "doview"),
+    ("dv_pd3", "outcome_box", "Interactive canvas editing supports multiple notations",
+     "Users create diagrams in Simple, UML, ArchiMate, C4, or DoView notation", "doview"),
+    ("dv_pd4", "outcome_box", "Full-text search across diagrams and elements works instantly",
+     "Users find any element or diagram by keyword in milliseconds", "doview"),
+    ("dv_pd5", "outcome_box", "Diagrams export reliably to SVG, PNG, and PDF",
+     "Architecture artefacts are shareable in standard formats", "doview"),
+    ("dv_pd6", "outcome_box", "Context-aware LLM responses guide users with accurate, bounded answers",
+     "AI assistants answer architecture questions using model context", "doview"),
+    ("dv_pd7", "outcome_box", "Diagram thumbnails auto-generate for quick preview",
+     "Dashboard and navigation show visual previews of each diagram", "doview"),
+    ("dv_pd8", "outcome_box", "Audit logs capture all state-changing actions",
+     "Every create, update, and delete is recorded for compliance", "doview"),
+    ("dv_pd9", "outcome_box", "Diagrams load smoothly across devices and browsers",
+     "Performance is consistent regardless of client device", "doview"),
+    ("dv_pd10", "outcome_box", "Data integrity is preserved with optimistic concurrency (ETag)",
+     "Concurrent edits are detected and handled gracefully", "doview"),
+    # User Enablement outcome boxes
+    ("dv_ue1", "outcome_box", "New users understand Iris\u2019s purpose and value quickly",
+     "Onboarding communicates the product value proposition clearly", "doview"),
+    ("dv_ue2", "outcome_box", "Initial setup (account, team, models) completes in <10 minutes",
+     "First-run experience is streamlined and guided", "doview"),
+    ("dv_ue3", "outcome_box", "Users confidently create and edit diagrams without training",
+     "The UI is intuitive enough for self-service diagram creation", "doview"),
+    ("dv_ue4", "outcome_box", "Users apply appropriate notation for their domain",
+     "Notation selection guidance helps users choose the right notation", "doview"),
+    ("dv_ue5", "outcome_box", "Users contribute feedback that improves the product",
+     "Feedback channels are accessible and acted upon", "doview"),
+    ("dv_ue6", "outcome_box", "Teams sustain shared models over time with clear ownership",
+     "Model governance and ownership patterns support long-term maintenance", "doview"),
+    ("dv_ue7", "outcome_box", "User community grows through peer learning and sharing",
+     "Users learn from each other and share architecture knowledge", "doview"),
+    # Source reference
+    ("dv_src1", "source_reference", "Smith J. (2023). Youth Unemployment Interventions: A Systematic Review. Journal of Policy Studies",
+     "Academic reference for outcomes methodology", "doview"),
 ]
 
 _ELEMENT_DESCRIPTIONS = {nid: desc for nid, _, _, desc, _ in _ENTITIES}
@@ -399,17 +449,48 @@ _RELATIONSHIPS: list[tuple[int, str, str, str, str, str]] = [
     (57, "n1", "ai1", "uses", "Ask AI",
      "Frontend sends user questions to AI Service via REST API"),
 
-    # ── DoView causal links (5, indices 58–62) ────────────────────────────────
-    (58, "dv1", "dv3", "causal_link", "",
-     "Employer engagement enables youth to access job opportunities"),
-    (59, "dv2", "dv3", "causal_link", "",
-     "Job-ready skills enable access to employment opportunities"),
-    (60, "dv3", "dv4", "causal_link", "",
-     "Accessing opportunities leads to gaining work experience"),
-    (61, "dv4", "dv5", "causal_link", "",
-     "Work experience leads to securing meaningful employment"),
-    (62, "dv5", "dv6", "causal_link", "",
-     "Meaningful employment contributes to economic independence"),
+    # ── DoView causal links (19, indices 58–76) ───────────────────────────────
+    # Strategic Vision (4 links)
+    (58, "dv_sv1", "dv_fo1", "causal_link", "",
+     "High-quality models lead to improved decision-making"),
+    (59, "dv_sv2", "dv_fo1", "causal_link", "",
+     "Empowered architects lead to improved decision-making"),
+    (60, "dv_fo1", "dv_fo2", "causal_link", "",
+     "Reliable insight enables digital transformation success"),
+    (61, "dv_fo1", "dv_fo3", "causal_link", "",
+     "Reliable insight supports knowledge stability"),
+    # Platform Delivery (9 links)
+    (62, "dv_pd1", "dv_pd3", "causal_link", "",
+     "Secure accounts enable multi-notation editing"),
+    (63, "dv_pd2", "dv_pd5", "causal_link", "",
+     "Versioning supports reliable export"),
+    (64, "dv_pd3", "dv_pd4", "causal_link", "",
+     "Canvas editing enables search"),
+    (65, "dv_pd4", "dv_pd6", "causal_link", "",
+     "Search enables LLM context"),
+    (66, "dv_pd5", "dv_pd7", "causal_link", "",
+     "Export supports thumbnail generation"),
+    (67, "dv_pd6", "dv_pd8", "causal_link", "",
+     "LLM responses logged via audit"),
+    (68, "dv_pd7", "dv_pd9", "causal_link", "",
+     "Thumbnails support cross-device performance"),
+    (69, "dv_pd8", "dv_pd10", "causal_link", "",
+     "Audit supports data integrity"),
+    (70, "dv_pd9", "dv_pd10", "causal_link", "",
+     "Cross-device performance supports data integrity"),
+    # User Enablement (6 links)
+    (71, "dv_ue1", "dv_ue3", "causal_link", "",
+     "Understanding purpose enables confident editing"),
+    (72, "dv_ue2", "dv_ue3", "causal_link", "",
+     "Quick setup enables confident editing"),
+    (73, "dv_ue3", "dv_ue4", "causal_link", "",
+     "Confident editing leads to notation application"),
+    (74, "dv_ue4", "dv_ue5", "causal_link", "",
+     "Notation application drives feedback"),
+    (75, "dv_ue5", "dv_ue6", "causal_link", "",
+     "Feedback enables team sustainability"),
+    (76, "dv_ue6", "dv_ue7", "causal_link", "",
+     "Team sustainability grows community"),
 ]
 
 # ── Package definitions ─────────────────────────────────────────────────────
@@ -441,6 +522,11 @@ def _r(rids: dict, idx: int) -> str:
 def _ae(eids: dict, nid: str, layer: str, archimate_type: str) -> dict:
     """Build ArchiMate entity data with layer info."""
     return {**_e(eids, nid), "layer": layer, "archimateType": archimate_type}
+
+
+def _de(eids: dict, nid: str, bg: str, border: str, **extra: object) -> dict:
+    """Build DoView entity data with visual colours and optional extras."""
+    return {**_e(eids, nid), "visual": {"bgColor": bg, "borderColor": border}, **extra}
 
 
 # ── Simple Notation Diagrams (10, indices 0–9) ───────────────────────────────
@@ -1373,149 +1459,123 @@ def _build_navigation_overview(
 
 
 def _build_doview_overview(
-    _eids: dict | None = None, _rids: dict | None = None,
+    eids: dict, _rids: dict | None = None,
     *, mids: dict[int, str] | None = None, **_kw: object,
 ) -> dict:
     """DoView overview: Iris System DoView with navigation tiles to subpages."""
     mids = mids or {}
     return {"nodes": [
-        {"id": "tile_final_outcomes", "type": "overview_tile", "position": {"x": 60, "y": 30},
-         "data": {"label": "Final Outcomes", "entityType": "overview_tile",
-                  "visual": {"bgColor": "#FFFFFF", "borderColor": "#CCCCCC"},
-                  "linkedModelId": mids.get(35, "")}, "width": 200, "height": 86},
-        {"id": "tile_strategy", "type": "overview_tile", "position": {"x": 60, "y": 160},
-         "data": {"label": "Strategic Vision & Goals", "entityType": "overview_tile",
-                  "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"},
-                  "linkedModelId": mids.get(36, "")}, "width": 200, "height": 86},
-        {"id": "tile_delivery", "type": "overview_tile", "position": {"x": 300, "y": 160},
-         "data": {"label": "Platform Delivery & Operations", "entityType": "overview_tile",
-                  "visual": {"bgColor": "#F8CECC", "borderColor": "#B85450"},
-                  "linkedModelId": mids.get(37, "")}, "width": 200, "height": 86},
-        {"id": "tile_enablement", "type": "overview_tile", "position": {"x": 540, "y": 160},
-         "data": {"label": "User Enablement & Adoption", "entityType": "overview_tile",
-                  "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"},
-                  "linkedModelId": mids.get(38, "")}, "width": 200, "height": 86},
-        {"id": "tile_sources", "type": "overview_tile", "position": {"x": 780, "y": 160},
-         "data": {"label": "Sources", "entityType": "overview_tile",
-                  "visual": {"bgColor": "#F5F5F5", "borderColor": "#666666"},
-                  "linkedModelId": mids.get(39, "")}, "width": 200, "height": 86},
+        _node("tile_final_outcomes", "overview_tile",
+              _de(eids, "dv_ov1", "#FFFFFF", "#CCCCCC", linkedModelId=mids.get(35, "")),
+              60, 30, 200, 86),
+        _node("tile_strategy", "overview_tile",
+              _de(eids, "dv_ov2", "#FFF2CC", "#D6B656", linkedModelId=mids.get(36, "")),
+              60, 160, 200, 86),
+        _node("tile_delivery", "overview_tile",
+              _de(eids, "dv_ov3", "#F8CECC", "#B85450", linkedModelId=mids.get(37, "")),
+              300, 160, 200, 86),
+        _node("tile_enablement", "overview_tile",
+              _de(eids, "dv_ov4", "#DAE8FC", "#6C8EBF", linkedModelId=mids.get(38, "")),
+              540, 160, 200, 86),
+        _node("tile_sources", "overview_tile",
+              _de(eids, "dv_ov5", "#F5F5F5", "#666666", linkedModelId=mids.get(39, "")),
+              780, 160, 200, 86),
     ], "edges": []}
 
 
-def _build_doview_final_outcomes(_eids: dict | None = None, _rids: dict | None = None, **_kw: object) -> dict:
+def _build_doview_final_outcomes(eids: dict, _rids: dict | None = None, **_kw: object) -> dict:
     """DoView final outcomes page: stacked list of ultimate goals."""
     return {"nodes": [
-        {"id": "fo1", "type": "final_outcome", "position": {"x": 400, "y": 60},
-         "data": {"label": "Decision-making improves through reliable architectural insight",
-                  "entityType": "final_outcome", "visual": {"bgColor": "#FFFFFF", "borderColor": "#CCCCCC"}},
-         "width": 200, "height": 86},
-        {"id": "fo2", "type": "final_outcome", "position": {"x": 400, "y": 166},
-         "data": {"label": "Digital transformation initiatives succeed with clear technical direction",
-                  "entityType": "final_outcome", "visual": {"bgColor": "#FFFFFF", "borderColor": "#CCCCCC"}},
-         "width": 200, "height": 86},
-        {"id": "fo3", "type": "final_outcome", "position": {"x": 400, "y": 272},
-         "data": {"label": "Organisational knowledge remains stable despite staff turnover",
-                  "entityType": "final_outcome", "visual": {"bgColor": "#FFFFFF", "borderColor": "#CCCCCC"}},
-         "width": 200, "height": 86},
+        _node("fo1", "final_outcome",
+              _de(eids, "dv_fo1", "#FFFFFF", "#CCCCCC"),
+              400, 60, 200, 86),
+        _node("fo2", "final_outcome",
+              _de(eids, "dv_fo2", "#FFFFFF", "#CCCCCC"),
+              400, 166, 200, 86),
+        _node("fo3", "final_outcome",
+              _de(eids, "dv_fo3", "#FFFFFF", "#CCCCCC"),
+              400, 272, 200, 86),
     ], "edges": []}
 
 
-def _build_doview_strategic_vision(_eids: dict | None = None, _rids: dict | None = None, **_kw: object) -> dict:
+def _build_doview_strategic_vision(eids: dict, rids: dict, **_kw: object) -> dict:
     """DoView outcomes map: Strategic Vision & Goals."""
     return {"nodes": [
-        {"id": "s1_1", "type": "outcome_box", "position": {"x": 60, "y": 60},
-         "data": {"label": "High-quality architecture models are created and maintained",
-                  "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "s1_2", "type": "outcome_box", "position": {"x": 60, "y": 166},
-         "data": {"label": "Enterprise architects are empowered to govern systems effectively",
-                  "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "s2_1", "type": "outcome_box", "position": {"x": 340, "y": 60},
-         "data": {"label": "Decision-making improves through reliable architectural insight",
-                  "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "s2_2", "type": "outcome_box", "position": {"x": 340, "y": 166},
-         "data": {"label": "Digital transformation initiatives succeed with clear technical direction",
-                  "entityType": "outcome_box", "visual": {"bgColor": "#F8CECC", "borderColor": "#B85450"}}, "width": 200, "height": 86},
-        {"id": "s2_3", "type": "outcome_box", "position": {"x": 340, "y": 272},
-         "data": {"label": "Organisational knowledge remains stable despite staff turnover",
-                  "entityType": "outcome_box", "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"}}, "width": 200, "height": 86},
+        _node("s1_1", "outcome_box",
+              _de(eids, "dv_sv1", "#FFF2CC", "#D6B656"),
+              60, 60, 200, 86),
+        _node("s1_2", "outcome_box",
+              _de(eids, "dv_sv2", "#FFF2CC", "#D6B656"),
+              60, 166, 200, 86),
+        _node("s2_1", "outcome_box",
+              _de(eids, "dv_fo1", "#FFF2CC", "#D6B656"),
+              340, 60, 200, 86),
+        _node("s2_2", "outcome_box",
+              _de(eids, "dv_fo2", "#F8CECC", "#B85450"),
+              340, 166, 200, 86),
+        _node("s2_3", "outcome_box",
+              _de(eids, "dv_fo3", "#DAE8FC", "#6C8EBF"),
+              340, 272, 200, 86),
     ], "edges": [
-        {"id": "e_s1_1_s2_1", "type": "causal_link", "source": "s1_1", "target": "s2_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_s1_2_s2_1", "type": "causal_link", "source": "s1_2", "target": "s2_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_s2_1_s2_2", "type": "causal_link", "source": "s2_1", "target": "s2_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_s2_1_s2_3", "type": "causal_link", "source": "s2_1", "target": "s2_3", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
+        _edge("e_s1_1_s2_1", "s1_1", "s2_1", "causal_link", "", rel_id=_r(rids, 58), source_handle="center", target_handle="center"),
+        _edge("e_s1_2_s2_1", "s1_2", "s2_1", "causal_link", "", rel_id=_r(rids, 59), source_handle="center", target_handle="center"),
+        _edge("e_s2_1_s2_2", "s2_1", "s2_2", "causal_link", "", rel_id=_r(rids, 60), source_handle="center", target_handle="center"),
+        _edge("e_s2_1_s2_3", "s2_1", "s2_3", "causal_link", "", rel_id=_r(rids, 61), source_handle="center", target_handle="center"),
     ]}
 
 
-def _build_doview_platform_delivery(_eids: dict | None = None, _rids: dict | None = None, **_kw: object) -> dict:
+def _build_doview_platform_delivery(eids: dict, rids: dict, **_kw: object) -> dict:
     """DoView outcomes map: Platform Delivery & Operations."""
     return {"nodes": [
-        {"id": "d1_1", "type": "outcome_box", "position": {"x": 60, "y": 60},
-         "data": {"label": "User accounts and permissions are managed securely", "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "d1_2", "type": "outcome_box", "position": {"x": 60, "y": 166},
-         "data": {"label": "Diagrams are versioned with full history & rollback", "entityType": "outcome_box", "visual": {"bgColor": "#F8CECC", "borderColor": "#B85450"}}, "width": 200, "height": 86},
-        {"id": "d2_1", "type": "outcome_box", "position": {"x": 340, "y": 60},
-         "data": {"label": "Interactive canvas editing supports multiple notations", "entityType": "outcome_box", "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"}}, "width": 200, "height": 86},
-        {"id": "d2_2", "type": "outcome_box", "position": {"x": 340, "y": 166},
-         "data": {"label": "Full-text search across diagrams and elements works instantly", "entityType": "outcome_box", "visual": {"bgColor": "#D5E8D4", "borderColor": "#82B366"}}, "width": 200, "height": 86},
-        {"id": "d2_3", "type": "outcome_box", "position": {"x": 340, "y": 272},
-         "data": {"label": "Diagrams export reliably to SVG, PNG, and PDF", "entityType": "outcome_box", "visual": {"bgColor": "#FFF4E6", "borderColor": "#D4A574"}}, "width": 200, "height": 86},
-        {"id": "d3_1", "type": "outcome_box", "position": {"x": 620, "y": 60},
-         "data": {"label": "Context-aware LLM responses guide users with accurate, bounded answers", "entityType": "outcome_box", "visual": {"bgColor": "#E1D5E7", "borderColor": "#9673A6"}}, "width": 200, "height": 86},
-        {"id": "d3_2", "type": "outcome_box", "position": {"x": 620, "y": 166},
-         "data": {"label": "Diagram thumbnails auto-generate for quick preview", "entityType": "outcome_box", "visual": {"bgColor": "#D4E1F5", "borderColor": "#7EA6E0"}}, "width": 200, "height": 86},
-        {"id": "d3_3", "type": "outcome_box", "position": {"x": 620, "y": 272},
-         "data": {"label": "Audit logs capture all state-changing actions", "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "d4_1", "type": "outcome_box", "position": {"x": 900, "y": 60},
-         "data": {"label": "Diagrams load smoothly across devices and browsers", "entityType": "outcome_box", "visual": {"bgColor": "#F8CECC", "borderColor": "#B85450"}}, "width": 200, "height": 86},
-        {"id": "d4_2", "type": "outcome_box", "position": {"x": 900, "y": 166},
-         "data": {"label": "Data integrity is preserved with optimistic concurrency (ETag)", "entityType": "outcome_box", "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"}}, "width": 200, "height": 86},
+        _node("d1_1", "outcome_box", _de(eids, "dv_pd1", "#FFF2CC", "#D6B656"), 60, 60, 200, 86),
+        _node("d1_2", "outcome_box", _de(eids, "dv_pd2", "#F8CECC", "#B85450"), 60, 166, 200, 86),
+        _node("d2_1", "outcome_box", _de(eids, "dv_pd3", "#DAE8FC", "#6C8EBF"), 340, 60, 200, 86),
+        _node("d2_2", "outcome_box", _de(eids, "dv_pd4", "#D5E8D4", "#82B366"), 340, 166, 200, 86),
+        _node("d2_3", "outcome_box", _de(eids, "dv_pd5", "#FFF4E6", "#D4A574"), 340, 272, 200, 86),
+        _node("d3_1", "outcome_box", _de(eids, "dv_pd6", "#E1D5E7", "#9673A6"), 620, 60, 200, 86),
+        _node("d3_2", "outcome_box", _de(eids, "dv_pd7", "#D4E1F5", "#7EA6E0"), 620, 166, 200, 86),
+        _node("d3_3", "outcome_box", _de(eids, "dv_pd8", "#FFF2CC", "#D6B656"), 620, 272, 200, 86),
+        _node("d4_1", "outcome_box", _de(eids, "dv_pd9", "#F8CECC", "#B85450"), 900, 60, 200, 86),
+        _node("d4_2", "outcome_box", _de(eids, "dv_pd10", "#DAE8FC", "#6C8EBF"), 900, 166, 200, 86),
     ], "edges": [
-        {"id": "e_d1_1_d2_1", "type": "causal_link", "source": "d1_1", "target": "d2_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d1_2_d2_3", "type": "causal_link", "source": "d1_2", "target": "d2_3", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d2_1_d2_2", "type": "causal_link", "source": "d2_1", "target": "d2_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d2_2_d3_1", "type": "causal_link", "source": "d2_2", "target": "d3_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d2_3_d3_2", "type": "causal_link", "source": "d2_3", "target": "d3_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d3_1_d3_3", "type": "causal_link", "source": "d3_1", "target": "d3_3", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d3_2_d4_1", "type": "causal_link", "source": "d3_2", "target": "d4_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d3_3_d4_2", "type": "causal_link", "source": "d3_3", "target": "d4_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_d4_1_d4_2", "type": "causal_link", "source": "d4_1", "target": "d4_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
+        _edge("e_d1_1_d2_1", "d1_1", "d2_1", "causal_link", "", rel_id=_r(rids, 62), source_handle="center", target_handle="center"),
+        _edge("e_d1_2_d2_3", "d1_2", "d2_3", "causal_link", "", rel_id=_r(rids, 63), source_handle="center", target_handle="center"),
+        _edge("e_d2_1_d2_2", "d2_1", "d2_2", "causal_link", "", rel_id=_r(rids, 64), source_handle="center", target_handle="center"),
+        _edge("e_d2_2_d3_1", "d2_2", "d3_1", "causal_link", "", rel_id=_r(rids, 65), source_handle="center", target_handle="center"),
+        _edge("e_d2_3_d3_2", "d2_3", "d3_2", "causal_link", "", rel_id=_r(rids, 66), source_handle="center", target_handle="center"),
+        _edge("e_d3_1_d3_3", "d3_1", "d3_3", "causal_link", "", rel_id=_r(rids, 67), source_handle="center", target_handle="center"),
+        _edge("e_d3_2_d4_1", "d3_2", "d4_1", "causal_link", "", rel_id=_r(rids, 68), source_handle="center", target_handle="center"),
+        _edge("e_d3_3_d4_2", "d3_3", "d4_2", "causal_link", "", rel_id=_r(rids, 69), source_handle="center", target_handle="center"),
+        _edge("e_d4_1_d4_2", "d4_1", "d4_2", "causal_link", "", rel_id=_r(rids, 70), source_handle="center", target_handle="center"),
     ]}
 
 
-def _build_doview_user_enablement(_eids: dict | None = None, _rids: dict | None = None, **_kw: object) -> dict:
+def _build_doview_user_enablement(eids: dict, rids: dict, **_kw: object) -> dict:
     """DoView outcomes map: User Enablement & Adoption."""
     return {"nodes": [
-        {"id": "u1_1", "type": "outcome_box", "position": {"x": 60, "y": 60},
-         "data": {"label": "New users understand Iris\u2019s purpose and value quickly", "entityType": "outcome_box", "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}}, "width": 200, "height": 86},
-        {"id": "u1_2", "type": "outcome_box", "position": {"x": 60, "y": 166},
-         "data": {"label": "Initial setup (account, team, models) completes in <10 minutes", "entityType": "outcome_box", "visual": {"bgColor": "#F8CECC", "borderColor": "#B85450"}}, "width": 200, "height": 86},
-        {"id": "u2_1", "type": "outcome_box", "position": {"x": 340, "y": 60},
-         "data": {"label": "Users confidently create and edit diagrams without training", "entityType": "outcome_box", "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"}}, "width": 200, "height": 86},
-        {"id": "u2_2", "type": "outcome_box", "position": {"x": 340, "y": 166},
-         "data": {"label": "Users apply appropriate notation for their domain", "entityType": "outcome_box", "visual": {"bgColor": "#D5E8D4", "borderColor": "#82B366"}}, "width": 200, "height": 86},
-        {"id": "u2_3", "type": "outcome_box", "position": {"x": 340, "y": 272},
-         "data": {"label": "Users contribute feedback that improves the product", "entityType": "outcome_box", "visual": {"bgColor": "#FFF4E6", "borderColor": "#D4A574"}}, "width": 200, "height": 86},
-        {"id": "u3_1", "type": "outcome_box", "position": {"x": 620, "y": 60},
-         "data": {"label": "Teams sustain shared models over time with clear ownership", "entityType": "outcome_box", "visual": {"bgColor": "#E1D5E7", "borderColor": "#9673A6"}}, "width": 200, "height": 86},
-        {"id": "u3_2", "type": "outcome_box", "position": {"x": 620, "y": 166},
-         "data": {"label": "User community grows through peer learning and sharing", "entityType": "outcome_box", "visual": {"bgColor": "#D4E1F5", "borderColor": "#7EA6E0"}}, "width": 200, "height": 86},
+        _node("u1_1", "outcome_box", _de(eids, "dv_ue1", "#FFF2CC", "#D6B656"), 60, 60, 200, 86),
+        _node("u1_2", "outcome_box", _de(eids, "dv_ue2", "#F8CECC", "#B85450"), 60, 166, 200, 86),
+        _node("u2_1", "outcome_box", _de(eids, "dv_ue3", "#DAE8FC", "#6C8EBF"), 340, 60, 200, 86),
+        _node("u2_2", "outcome_box", _de(eids, "dv_ue4", "#D5E8D4", "#82B366"), 340, 166, 200, 86),
+        _node("u2_3", "outcome_box", _de(eids, "dv_ue5", "#FFF4E6", "#D4A574"), 340, 272, 200, 86),
+        _node("u3_1", "outcome_box", _de(eids, "dv_ue6", "#E1D5E7", "#9673A6"), 620, 60, 200, 86),
+        _node("u3_2", "outcome_box", _de(eids, "dv_ue7", "#D4E1F5", "#7EA6E0"), 620, 166, 200, 86),
     ], "edges": [
-        {"id": "e_u1_1_u2_1", "type": "causal_link", "source": "u1_1", "target": "u2_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_u1_2_u2_1", "type": "causal_link", "source": "u1_2", "target": "u2_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_u2_1_u2_2", "type": "causal_link", "source": "u2_1", "target": "u2_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_u2_2_u2_3", "type": "causal_link", "source": "u2_2", "target": "u2_3", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_u2_3_u3_1", "type": "causal_link", "source": "u2_3", "target": "u3_1", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
-        {"id": "e_u3_1_u3_2", "type": "causal_link", "source": "u3_1", "target": "u3_2", "sourceHandle": "center", "targetHandle": "center", "data": {"relationshipType": "causal_link"}},
+        _edge("e_u1_1_u2_1", "u1_1", "u2_1", "causal_link", "", rel_id=_r(rids, 71), source_handle="center", target_handle="center"),
+        _edge("e_u1_2_u2_1", "u1_2", "u2_1", "causal_link", "", rel_id=_r(rids, 72), source_handle="center", target_handle="center"),
+        _edge("e_u2_1_u2_2", "u2_1", "u2_2", "causal_link", "", rel_id=_r(rids, 73), source_handle="center", target_handle="center"),
+        _edge("e_u2_2_u2_3", "u2_2", "u2_3", "causal_link", "", rel_id=_r(rids, 74), source_handle="center", target_handle="center"),
+        _edge("e_u2_3_u3_1", "u2_3", "u3_1", "causal_link", "", rel_id=_r(rids, 75), source_handle="center", target_handle="center"),
+        _edge("e_u3_1_u3_2", "u3_1", "u3_2", "causal_link", "", rel_id=_r(rids, 76), source_handle="center", target_handle="center"),
     ]}
 
 
-def _build_doview_sources(_eids: dict | None = None, _rids: dict | None = None, **_kw: object) -> dict:
+def _build_doview_sources(eids: dict, _rids: dict | None = None, **_kw: object) -> dict:
     """DoView sources page."""
     return {"nodes": [
-        {"id": "src1", "type": "source_reference", "position": {"x": 100, "y": 100},
-         "data": {"label": "Smith J. (2023). Youth Unemployment Interventions: A Systematic Review. Journal of Policy Studies",
-                  "entityType": "source_reference", "visual": {"bgColor": "#F5F5F5", "borderColor": "#666666"}},
-         "width": 600, "height": 50},
+        _node("src1", "source_reference",
+              _de(eids, "dv_src1", "#F5F5F5", "#666666"),
+              100, 100, 600, 50),
     ], "edges": []}
 
 
@@ -1707,8 +1767,8 @@ async def _ensure_system_user(db: DatabasePort) -> None:
 
 async def _clear_old_seed_data(db: DatabasePort) -> None:
     """Delete old seed data by deterministic IDs in dependency order."""
-    max_elements = max(len(_ENTITIES), 66)
-    max_rels = max(len(_RELATIONSHIPS), 63)
+    max_elements = max(len(_ENTITIES), 87)
+    max_rels = max(len(_RELATIONSHIPS), 77)
     max_diagrams = max(len(_DIAGRAMS), 40)
     max_packages = max(len(_PACKAGES), 5)
 
@@ -1761,14 +1821,15 @@ async def _clear_old_seed_data(db: DatabasePort) -> None:
 _V5_MARKER = "seed_v5"
 _V6_MARKER = "seed_v6"
 _V7_MARKER = "seed_v7"
+_V8_MARKER = "seed_v8"
 
 
 async def seed_example_models(db: DatabasePort) -> None:
     """Seed example elements, packages, and diagrams demonstrating Iris architecture.
 
     Idempotency:
-      - If diagram-33 metadata contains 'seed_v7' → already v7, skip
-      - Otherwise → clear + reseed v6
+      - If diagram-33 metadata contains 'seed_v8' → already v8, skip
+      - Otherwise → clear + reseed v8
     """
     # --- Skip if initial setup not yet completed ------------------------------
     # Check users table (SQLite) or profiles table (Supabase)
@@ -1795,7 +1856,7 @@ async def seed_example_models(db: DatabasePort) -> None:
     if row and row[0]:
         try:
             meta = json.loads(row[0])
-            if meta.get("seed_version") == _V7_MARKER:
+            if meta.get("seed_version") == _V8_MARKER:
                 return
         except (json.JSONDecodeError, TypeError):
             pass
@@ -1912,7 +1973,7 @@ async def seed_example_models(db: DatabasePort) -> None:
         # v6 marker in metadata for overview diagram
         metadata: dict[str, object] = {}
         if model_def["index"] == 33:
-            metadata["seed_version"] = _V7_MARKER
+            metadata["seed_version"] = _V8_MARKER
 
         await db.execute(
             "INSERT INTO diagrams (id, diagram_type, set_id, current_version, "

--- a/backend/app/themes/models.py
+++ b/backend/app/themes/models.py
@@ -9,6 +9,7 @@ class ThemeRenderingConfig(BaseModel):
     """Presentation hints for theme rendering (e.g. hide icons, border radius)."""
 
     hideIcons: bool | None = None
+    hideDescription: bool | None = None
     borderRadius: int | None = None
     attrFontColor: str | None = None
     hideTypeStereotypes: bool | None = None

--- a/backend/app/themes/service.py
+++ b/backend/app/themes/service.py
@@ -376,6 +376,7 @@ async def seed_default_themes(db: DatabasePort) -> None:
         },
         "rendering": {
             "hideIcons": False,
+            "hideDescription": True,
             "borderRadius": 4,
             "wrapLabels": True,
             "textAlign": "center",

--- a/backend/tests/test_ai/test_creation.py
+++ b/backend/tests/test_ai/test_creation.py
@@ -1,0 +1,331 @@
+"""Tests for AI creation with element/relationship materialisation (ADR-100).
+
+Verifies that create_diagrams_from_ai() materialises element and relationship
+records alongside diagram nodes and edges, so DoView diagrams have entityId
+and relationshipId references to real database records.
+"""
+
+from __future__ import annotations
+
+import json
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.ai.creation import create_diagrams_from_ai
+
+
+_TEST_USER_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_TEST_SET_ID = "test-set-0001"
+
+
+async def _setup_schema(conn: aiosqlite.Connection) -> None:
+    """Create minimal schema for AI creation + element/relationship tables.
+
+    Mirrors the real schema after all migrations: diagrams, diagram_versions,
+    elements, element_versions, relationships, relationship_versions.
+    """
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS sets (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS diagrams (
+            id TEXT PRIMARY KEY,
+            set_id TEXT NOT NULL,
+            diagram_type TEXT NOT NULL DEFAULT 'free_form',
+            notation TEXT,
+            parent_package_id TEXT,
+            current_version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS diagram_versions (
+            diagram_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            data TEXT NOT NULL DEFAULT '{}',
+            change_type TEXT NOT NULL DEFAULT 'create',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            PRIMARY KEY (diagram_id, version)
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS elements (
+            id TEXT PRIMARY KEY,
+            element_type TEXT NOT NULL,
+            set_id TEXT NOT NULL,
+            current_version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            notation TEXT DEFAULT 'simple'
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS element_versions (
+            element_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            data TEXT NOT NULL DEFAULT '{}',
+            change_type TEXT NOT NULL DEFAULT 'create',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            PRIMARY KEY (element_id, version)
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationships (
+            id TEXT PRIMARY KEY,
+            source_element_id TEXT NOT NULL,
+            target_element_id TEXT NOT NULL,
+            relationship_type TEXT NOT NULL,
+            current_version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationship_versions (
+            relationship_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            label TEXT,
+            description TEXT,
+            data TEXT,
+            change_type TEXT NOT NULL DEFAULT 'create',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            PRIMARY KEY (relationship_id, version)
+        )
+    """)
+    await conn.execute(
+        "INSERT OR IGNORE INTO sets VALUES (?, 'Test Set', NULL, datetime('now'), 'system', datetime('now'), 0)",
+        (_TEST_SET_ID,),
+    )
+    await conn.commit()
+
+
+def _sample_ai_json() -> dict:
+    """Return a minimal DoView AI JSON with 1 diagram, 2 nodes, and 1 edge."""
+    return {
+        "diagrams": [
+            {
+                "name": "Climate Outcomes",
+                "diagram_type": "outcomes_map",
+                "notation": "doview",
+                "nodes": [
+                    {
+                        "id": "n1",
+                        "type": "outcome_box",
+                        "label": "Funding secured",
+                        "position": {"x": 100, "y": 100},
+                        "size": {"width": 200, "height": 86},
+                        "visual": {"bgColor": "#FFF2CC", "borderColor": "#D6B656"},
+                    },
+                    {
+                        "id": "n2",
+                        "type": "outcome_box",
+                        "label": "Programs delivered",
+                        "position": {"x": 400, "y": 100},
+                        "size": {"width": 200, "height": 86},
+                        "visual": {"bgColor": "#D5E8D4", "borderColor": "#82B366"},
+                    },
+                ],
+                "edges": [
+                    {
+                        "id": "e1",
+                        "type": "causal_link",
+                        "source": "n1",
+                        "target": "n2",
+                        "visual": {},
+                    },
+                ],
+            }
+        ]
+    }
+
+
+@pytest_asyncio.fixture
+async def db() -> aiosqlite.Connection:
+    async with aiosqlite.connect(":memory:") as conn:
+        await _setup_schema(conn)
+        yield conn
+
+
+class TestAICreationMaterialisation:
+    """Tests verifying that AI-created diagrams materialise element and relationship records."""
+
+    @pytest.mark.asyncio
+    async def test_nodes_have_entity_id(self, db: aiosqlite.Connection) -> None:
+        """Each node in the saved diagram data has an entityId field."""
+        ids = await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+        assert len(ids) == 1
+
+        cursor = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (ids[0],),
+        )
+        row = await cursor.fetchone()
+        data = json.loads(row[0])
+
+        for node in data["nodes"]:
+            entity_id = node["data"].get("entityId")
+            assert entity_id, (
+                f"Node {node['id']} missing entityId in diagram data"
+            )
+
+    @pytest.mark.asyncio
+    async def test_element_records_exist_for_each_node(self, db: aiosqlite.Connection) -> None:
+        """An element record exists in the database for every node entityId."""
+        ids = await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        cursor = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (ids[0],),
+        )
+        row = await cursor.fetchone()
+        data = json.loads(row[0])
+
+        for node in data["nodes"]:
+            entity_id = node["data"]["entityId"]
+            cursor = await db.execute(
+                "SELECT id FROM elements WHERE id = ?", (entity_id,),
+            )
+            elem_row = await cursor.fetchone()
+            assert elem_row is not None, (
+                f"Element {entity_id} for node {node['id']} not found in elements table"
+            )
+
+            # Verify element_versions row exists too
+            cursor = await db.execute(
+                "SELECT name FROM element_versions WHERE element_id = ? AND version = 1",
+                (entity_id,),
+            )
+            ver_row = await cursor.fetchone()
+            assert ver_row is not None, (
+                f"element_versions missing for element {entity_id}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_edge_has_relationship_id(self, db: aiosqlite.Connection) -> None:
+        """The causal_link edge in the saved diagram data has a relationshipId field."""
+        ids = await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        cursor = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (ids[0],),
+        )
+        row = await cursor.fetchone()
+        data = json.loads(row[0])
+
+        causal_edges = [
+            e for e in data["edges"]
+            if e["data"].get("relationshipType") == "causal_link"
+        ]
+        assert len(causal_edges) == 1
+        rel_id = causal_edges[0]["data"].get("relationshipId")
+        assert rel_id, "Edge missing relationshipId"
+
+    @pytest.mark.asyncio
+    async def test_relationship_record_exists(self, db: aiosqlite.Connection) -> None:
+        """A relationship record exists for the edge's relationshipId."""
+        ids = await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        cursor = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (ids[0],),
+        )
+        row = await cursor.fetchone()
+        data = json.loads(row[0])
+
+        for edge in data["edges"]:
+            rel_id = edge["data"].get("relationshipId")
+            if not rel_id:
+                continue
+            cursor = await db.execute(
+                "SELECT id FROM relationships WHERE id = ?", (rel_id,),
+            )
+            rel_row = await cursor.fetchone()
+            assert rel_row is not None, (
+                f"Relationship {rel_id} for edge {edge['id']} not found in relationships table"
+            )
+
+            # Verify relationship_versions row exists too
+            cursor = await db.execute(
+                "SELECT label FROM relationship_versions WHERE relationship_id = ? AND version = 1",
+                (rel_id,),
+            )
+            ver_row = await cursor.fetchone()
+            assert ver_row is not None, (
+                f"relationship_versions missing for relationship {rel_id}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_element_notation_matches_diagram(self, db: aiosqlite.Connection) -> None:
+        """Elements created from a DoView diagram have notation='doview'."""
+        ids = await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        # Get diagram notation
+        cursor = await db.execute(
+            "SELECT notation FROM diagrams WHERE id = ?", (ids[0],),
+        )
+        diagram_notation = (await cursor.fetchone())[0]
+        assert diagram_notation == "doview"
+
+        # Get all element notations created for this diagram
+        cursor = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (ids[0],),
+        )
+        row = await cursor.fetchone()
+        data = json.loads(row[0])
+
+        for node in data["nodes"]:
+            entity_id = node["data"].get("entityId")
+            if not entity_id:
+                continue
+            cursor = await db.execute(
+                "SELECT notation FROM elements WHERE id = ?", (entity_id,),
+            )
+            elem_row = await cursor.fetchone()
+            assert elem_row is not None, f"Element {entity_id} not found"
+            assert elem_row[0] == diagram_notation, (
+                f"Element {entity_id} notation={elem_row[0]}, expected {diagram_notation}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_element_count_matches_node_count(self, db: aiosqlite.Connection) -> None:
+        """Two nodes produce exactly two element records."""
+        await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM elements WHERE set_id = ?", (_TEST_SET_ID,),
+        )
+        count = (await cursor.fetchone())[0]
+        assert count == 2
+
+    @pytest.mark.asyncio
+    async def test_relationship_count_matches_edge_count(self, db: aiosqlite.Connection) -> None:
+        """One causal_link edge produces exactly one relationship record."""
+        await create_diagrams_from_ai(db, _TEST_SET_ID, _sample_ai_json(), _TEST_USER_ID)
+
+        cursor = await db.execute("SELECT COUNT(*) FROM relationships")
+        count = (await cursor.fetchone())[0]
+        assert count == 1

--- a/backend/tests/test_ai/test_creation_service.py
+++ b/backend/tests/test_ai/test_creation_service.py
@@ -56,6 +56,60 @@ async def _minimal_schema(conn: aiosqlite.Connection) -> None:
             PRIMARY KEY (diagram_id, version)
         )
     """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS elements (
+            id TEXT PRIMARY KEY,
+            element_type TEXT NOT NULL,
+            set_id TEXT,
+            current_version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            notation TEXT
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS element_versions (
+            element_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            name TEXT NOT NULL DEFAULT '',
+            description TEXT,
+            data TEXT NOT NULL DEFAULT '{}',
+            change_type TEXT NOT NULL DEFAULT 'create',
+            change_summary TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            metadata TEXT,
+            PRIMARY KEY (element_id, version)
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationships (
+            id TEXT PRIMARY KEY,
+            source_element_id TEXT NOT NULL,
+            target_element_id TEXT NOT NULL,
+            relationship_type TEXT NOT NULL,
+            current_version INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS relationship_versions (
+            relationship_id TEXT NOT NULL,
+            version INTEGER NOT NULL,
+            label TEXT NOT NULL DEFAULT '',
+            description TEXT,
+            data TEXT NOT NULL DEFAULT '{}',
+            change_type TEXT NOT NULL DEFAULT 'create',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            created_by TEXT NOT NULL DEFAULT 'system',
+            PRIMARY KEY (relationship_id, version)
+        )
+    """)
     await conn.execute("INSERT OR IGNORE INTO sets VALUES ('test-set', 'Test Set', NULL, datetime('now'), 'system', datetime('now'), 0)")
     await conn.commit()
 

--- a/backend/tests/test_seed/test_example_models.py
+++ b/backend/tests/test_seed/test_example_models.py
@@ -58,6 +58,8 @@ async def _run_migrations(db: aiosqlite.Connection) -> None:
     from app.migrations.m025_diagram_links import up as m025
     from app.migrations.m026_ai_providers import up as m026
     from app.migrations.m027_doview_notation import up as m027
+    from app.migrations.m028_ai_creation_prompts import up as m028
+    from app.migrations.m029_sequence_order import up as m029
     from app.migrations.seed import seed_roles_and_permissions
 
     await m001(db)
@@ -86,6 +88,8 @@ async def _run_migrations(db: aiosqlite.Connection) -> None:
     await m025(db)
     await m026(db)
     await m027(db)
+    await m028(db)
+    await m029(db)
     await seed_roles_and_permissions(db)
 
 
@@ -226,14 +230,14 @@ async def test_notation_package_names(seeded_db: aiosqlite.Connection) -> None:
 
 
 @pytest.mark.asyncio
-async def test_thirty_five_diagrams_total(seeded_db: aiosqlite.Connection) -> None:
-    """Seed creates exactly 35 diagrams (33 notation permutations + 1 AI module + 1 overview)."""
+async def test_thirty_nine_diagrams_total(seeded_db: aiosqlite.Connection) -> None:
+    """Seed creates exactly 39 diagrams (33 notation permutations + 1 AI module + 1 navigation + 4 DoView subpages)."""
     cursor = await seeded_db.execute(
         "SELECT COUNT(*) FROM diagrams WHERE set_id = ? AND is_deleted = 0",
         (_DEFAULT_SET_ID,),
     )
     row = await cursor.fetchone()
-    assert row[0] == 35
+    assert row[0] == 39
 
 
 @pytest.mark.asyncio
@@ -245,7 +249,7 @@ async def test_all_diagrams_have_parent_package(seeded_db: aiosqlite.Connection)
         (_DEFAULT_SET_ID,),
     )
     row = await cursor.fetchone()
-    assert row[0] == 35
+    assert row[0] == 39
 
 
 @pytest.mark.asyncio
@@ -301,22 +305,22 @@ async def test_navigation_diagram_has_navigation_cells(seeded_db: aiosqlite.Conn
 
 
 @pytest.mark.asyncio
-async def test_sixty_six_elements(seeded_db: aiosqlite.Connection) -> None:
-    """Seed creates exactly 66 elements (59 system + 7 DoView)."""
+async def test_eighty_seven_elements(seeded_db: aiosqlite.Connection) -> None:
+    """Seed creates exactly 87 elements (59 system + 28 DoView)."""
     cursor = await seeded_db.execute(
         "SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0",
         (_DEFAULT_SET_ID,),
     )
-    assert (await cursor.fetchone())[0] == 66
+    assert (await cursor.fetchone())[0] == 87
 
 
 @pytest.mark.asyncio
-async def test_sixty_three_relationships(seeded_db: aiosqlite.Connection) -> None:
-    """Seed creates exactly 63 relationships (58 system + 5 DoView causal links)."""
+async def test_seventy_seven_relationships(seeded_db: aiosqlite.Connection) -> None:
+    """Seed creates exactly 77 relationships (58 system + 19 DoView causal links)."""
     cursor = await seeded_db.execute(
         "SELECT COUNT(*) FROM relationships WHERE is_deleted = 0",
     )
-    assert (await cursor.fetchone())[0] == 63
+    assert (await cursor.fetchone())[0] == 77
 
 
 @pytest.mark.asyncio
@@ -351,7 +355,96 @@ async def test_elements_have_correct_notations(seeded_db: aiosqlite.Connection) 
     assert notation_counts.get("uml", 0) == 12
     assert notation_counts.get("archimate", 0) == 18
     assert notation_counts.get("c4", 0) == 10
-    assert notation_counts.get("doview", 0) == 7
+    assert notation_counts.get("doview", 0) == 28
+
+
+@pytest.mark.asyncio
+async def test_doview_nodes_have_entity_ids(seeded_db: aiosqlite.Connection) -> None:
+    """All DoView diagram nodes have entityId pointing to real element records."""
+    # Get all DoView diagrams
+    cursor = await seeded_db.execute(
+        "SELECT d.id, dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.notation = 'doview' AND d.is_deleted = 0",
+    )
+    rows = await cursor.fetchall()
+    assert len(rows) >= 6, "Expected at least 6 DoView diagrams"
+
+    for diagram_id, data_json in rows:
+        data = json.loads(data_json)
+        for node in data.get("nodes", []):
+            node_data = node.get("data", {})
+            entity_id = node_data.get("entityId")
+            assert entity_id, (
+                f"Node {node.get('id')} in diagram {diagram_id} missing entityId"
+            )
+            # Verify element exists
+            cursor = await seeded_db.execute(
+                "SELECT id FROM elements WHERE id = ? AND is_deleted = 0",
+                (entity_id,),
+            )
+            row = await cursor.fetchone()
+            assert row is not None, (
+                f"Node {node.get('id')} entityId {entity_id} not found in elements"
+            )
+
+
+@pytest.mark.asyncio
+async def test_doview_cross_diagram_reuse(seeded_db: aiosqlite.Connection) -> None:
+    """Three final outcome elements appear on both Final Outcomes and Strategic Vision diagrams."""
+    # Collect all entityIds from DoView diagrams
+    cursor = await seeded_db.execute(
+        "SELECT dv.name, dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.notation = 'doview' AND d.is_deleted = 0",
+    )
+    rows = await cursor.fetchall()
+    diagram_entities: dict[str, set[str]] = {}
+    for name, data_json in rows:
+        data = json.loads(data_json)
+        eids = set()
+        for node in data.get("nodes", []):
+            eid = node.get("data", {}).get("entityId")
+            if eid:
+                eids.add(eid)
+        diagram_entities[name] = eids
+
+    # Find elements shared between Final Outcomes and Strategic Vision
+    fo_eids = diagram_entities.get("Final Outcomes", set())
+    sv_eids = diagram_entities.get("Strategic Vision & Goals", set())
+    shared = fo_eids & sv_eids
+    assert len(shared) == 3, f"Expected 3 shared elements, got {len(shared)}: {shared}"
+
+
+@pytest.mark.asyncio
+async def test_doview_edges_have_relationship_ids(seeded_db: aiosqlite.Connection) -> None:
+    """DoView causal_link edges have relationshipId matching real relationship records."""
+    cursor = await seeded_db.execute(
+        "SELECT d.id, dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.notation = 'doview' AND d.is_deleted = 0",
+    )
+    rows = await cursor.fetchall()
+    edge_count = 0
+    for diagram_id, data_json in rows:
+        data = json.loads(data_json)
+        for edge in data.get("edges", []):
+            edge_data = edge.get("data", {})
+            if edge_data.get("relationshipType") == "causal_link":
+                rel_id = edge_data.get("relationshipId")
+                assert rel_id, (
+                    f"Edge {edge.get('id')} in diagram {diagram_id} missing relationshipId"
+                )
+                cursor = await seeded_db.execute(
+                    "SELECT id FROM relationships WHERE id = ? AND is_deleted = 0",
+                    (rel_id,),
+                )
+                row = await cursor.fetchone()
+                assert row is not None, (
+                    f"Edge {edge.get('id')} relationshipId {rel_id} not found in relationships"
+                )
+                edge_count += 1
+    assert edge_count == 19, f"Expected 19 causal_link edges with relationshipId, got {edge_count}"
 
 
 # ── Idempotency and migration tests ─────────────────────────────────────────
@@ -375,7 +468,7 @@ async def test_idempotent_no_duplicates(main_db: aiosqlite.Connection) -> None:
         "SELECT COUNT(*) FROM diagrams WHERE set_id = ? AND is_deleted = 0",
         (_DEFAULT_SET_ID,),
     )
-    assert (await cursor.fetchone())[0] == 35
+    assert (await cursor.fetchone())[0] == 39
 
 
 @pytest.mark.asyncio
@@ -420,12 +513,12 @@ async def test_v1_seed_cleared_on_reseed(main_db: aiosqlite.Connection) -> None:
     )
     assert (await cursor.fetchone())[0] == 6
 
-    # Should have 66 elements (not 67 — the old one was cleared)
+    # Should have 87 elements (not 88 — the old one was cleared)
     cursor = await main_db.execute(
         "SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0",
         (_DEFAULT_SET_ID,),
     )
-    assert (await cursor.fetchone())[0] == 66
+    assert (await cursor.fetchone())[0] == 87
 
 
 @pytest.mark.asyncio
@@ -467,9 +560,9 @@ async def test_v2_seed_upgraded_to_v3(main_db: aiosqlite.Connection) -> None:
     )
     assert (await cursor.fetchone())[0] == 6
 
-    # Should have 35 diagrams
+    # Should have 39 diagrams
     cursor = await main_db.execute(
         "SELECT COUNT(*) FROM diagrams WHERE set_id = ? AND is_deleted = 0",
         (_DEFAULT_SET_ID,),
     )
-    assert (await cursor.fetchone())[0] == 35
+    assert (await cursor.fetchone())[0] == 39

--- a/docs/adrs/ADR-100-DoView-Element-Backed-Nodes.md
+++ b/docs/adrs/ADR-100-DoView-Element-Backed-Nodes.md
@@ -1,0 +1,57 @@
+# ADR-100: DoView Element-Backed Nodes
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-100 |
+| **Initiative** | DoView Element-Backed Nodes |
+| **Proposed By** | Engineering |
+| **Date** | 2026-03-23 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** DoView notation diagrams, where diagram nodes represent outcomes, final outcomes, overview tiles, and source references,
+
+**facing** the problem that DoView diagram nodes lack `entityId` linkage to element records — preventing cross-diagram element reuse, breaking diagram-entity relationship tracking, and leaving EntityDetailPanel unable to display element details or "Used in Diagrams" for DoView nodes,
+
+**we decided for** creating backing element and relationship records for every DoView diagram node in both seed data and AI diagram creation, using the same `_e(eids, nid)` pattern established by Simple, UML, ArchiMate, and C4 notations,
+
+**and neglected** leaving nodes as standalone canvas annotations (status quo — perpetuates the broken integration), and lazy-materialising elements on first user click (adds UI complexity and deferred state management),
+
+**to achieve** full diagram-entity integration for DoView, cross-diagram element reuse (same outcome appearing on multiple diagrams), accurate `diagram_usage_count`, working EntityDetailPanel for DoView nodes, and relationship tracking for causal links,
+
+**accepting that** the element count in seed data increases from 66 to 87, and AI diagram creation becomes slightly more complex with an additional materialisation phase.
+
+---
+
+## Summary
+
+| Capability | Description | Specification |
+|------------|-------------|---------------|
+| Seed Element Linkage | All DoView seed nodes backed by elements with entityId | [SPEC-100-A](./specs/SPEC-100-A-DoView-Element-Backed-Nodes.md) |
+| AI Creation Materialisation | AI-created DoView diagrams auto-create elements and relationships | [SPEC-100-A](./specs/SPEC-100-A-DoView-Element-Backed-Nodes.md) |
+| Cross-Diagram Reuse | Same element referenced by multiple diagrams via shared entityId | [SPEC-100-A](./specs/SPEC-100-A-DoView-Element-Backed-Nodes.md) |
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Depends On | ADR-094 | DoView Notation & AI Creation | DoView notation foundation |
+| Relates To | ADR-079 | Notation Registry | Element-notation linkage |
+| Relates To | ADR-081 | Notation-First UX | EntityDetailPanel integration |
+
+---
+
+## Status History
+
+| Status | Approver | Date |
+|--------|----------|------|
+| Approved | Engineering | 2026-03-23 |
+
+---
+
+*This ADR was created following the WH(Y) format as specified in [SPEC-001-A](./specs/SPEC-001-A-WHY-Format.md).*

--- a/docs/adrs/ADR-101-Visual-Toggles.md
+++ b/docs/adrs/ADR-101-Visual-Toggles.md
@@ -1,0 +1,57 @@
+# ADR-101: Visual Toggles — Description Display & Element Count Badge
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-101 |
+| **Initiative** | Visual Toggles |
+| **Proposed By** | Engineering |
+| **Date** | 2026-03-23 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the Iris canvas rendering system, where nodes display labels, descriptions, and visual metadata,
+
+**facing** the need for DoView nodes to hide descriptions by default (since DoView outcome labels are self-descriptive), and the desire to show element reuse counts on nodes to help users understand cross-diagram relationships,
+
+**we decided for** extending the theme rendering config with a `hideDescription` toggle (defaulting to true for DoView), adding a per-node override toggle in the edit sidebar, and adding a user-level "Display element count" setting that shows a diagram usage count badge on each node,
+
+**and neglected** making description visibility a global-only setting (too coarse — different notations need different defaults), and computing element count client-side by scanning all diagrams (expensive and inaccurate),
+
+**to achieve** notation-appropriate default description display, per-node override control in edit mode, and at-a-glance element reuse visibility controlled by user preference,
+
+**accepting that** the element count badge requires an additional data field populated during diagram load, and the user setting is stored in localStorage (client-side only, no cross-device sync).
+
+---
+
+## Summary
+
+| Capability | Description | Specification |
+|------------|-------------|---------------|
+| Hide Description Toggle | Theme-level default + per-node override in edit sidebar | [SPEC-101-A](./specs/SPEC-101-A-Visual-Toggles.md) |
+| Element Count Badge | Diagram usage count in node top-right, controlled by user setting | [SPEC-101-A](./specs/SPEC-101-A-Visual-Toggles.md) |
+| Visual Toggles Settings | New settings section between Default Notation and Change Password | [SPEC-101-A](./specs/SPEC-101-A-Visual-Toggles.md) |
+
+---
+
+## Dependencies
+
+| Relationship | ADR ID | Title | Notes |
+|--------------|--------|-------|-------|
+| Depends On | ADR-094 | DoView Notation & AI Creation | DoView theme config |
+| Depends On | ADR-100 | DoView Element-Backed Nodes | entityId + diagram_usage_count |
+| Relates To | ADR-085 | Theme System | ThemeRenderingConfig extension |
+
+---
+
+## Status History
+
+| Status | Approver | Date |
+|--------|----------|------|
+| Approved | Engineering | 2026-03-23 |
+
+---
+
+*This ADR was created following the WH(Y) format as specified in [SPEC-001-A](./specs/SPEC-001-A-WHY-Format.md).*

--- a/docs/adrs/specs/SPEC-100-A-DoView-Element-Backed-Nodes.md
+++ b/docs/adrs/specs/SPEC-100-A-DoView-Element-Backed-Nodes.md
@@ -1,0 +1,77 @@
+# SPEC-100-A: DoView Element-Backed Nodes
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | SPEC-100-A |
+| **ADR** | [ADR-100](../ADR-100-DoView-Element-Backed-Nodes.md) |
+| **Status** | Draft |
+| **Date** | 2026-03-23 |
+
+---
+
+## Overview
+
+Ensure every DoView diagram node is backed by an element record (with `entityId` in node data) and every causal link edge is backed by a relationship record (with `relationshipId` in edge data). Applies to both seed data and AI-created diagrams.
+
+---
+
+## Part A: Seed Data
+
+### File: `backend/app/seed/example_models.py`
+
+**Helper:** Add `_de(eids, nid, bg, border, **extra)` — DoView entity helper wrapping `_e()` with visual colours, following the `_ae()` pattern for ArchiMate.
+
+**Elements:** Replace 7 orphaned DoView entities (indices 59–65) with 28 Iris-themed entries (indices 59–86) covering all DoView diagram nodes:
+- 5 `overview_tile` (Overview diagram)
+- 3 `final_outcome` (Final Outcomes + Strategic Vision — cross-diagram reuse)
+- 2 `outcome_box` (Strategic Vision only)
+- 10 `outcome_box` (Platform Delivery)
+- 7 `outcome_box` (User Enablement)
+- 1 `source_reference` (Sources)
+
+**Relationships:** Replace 5 orphaned causal_link entries (indices 58–62) with 19 entries (indices 58–76) matching actual diagram edges.
+
+**Diagram builders:** Update all 6 DoView builders to use `_node()` + `_de()` + `_edge()` with `entityId` and `relationshipId`.
+
+**Cross-diagram reuse:** Elements `dv_fo1`, `dv_fo2`, `dv_fo3` appear on both Final Outcomes and Strategic Vision diagrams.
+
+**Version:** Bump to `_V8_MARKER = "seed_v8"`.
+
+---
+
+## Part B: AI Diagram Creation
+
+### File: `backend/app/ai/creation.py`
+
+Add **Phase 1.5** to `create_diagrams_from_ai()` between Phase 1 (create diagrams) and Phase 2 (resolve linkedDiagramIndex):
+
+For each diagram in the AI JSON:
+1. For each node: create element record → inject `entityId` into `node.data`
+2. Build `node_id → element_id` mapping
+3. For each edge: resolve source/target element IDs → create relationship record → inject `relationshipId` into `edge.data`
+4. Update `diagram_versions` with enriched canvas data
+
+### File: `backend/app/elements/materialise.py` (new)
+
+Shared helper functions used by both seed and AI creation:
+- `materialise_element(db, *, element_id, element_type, name, description, set_id, notation, created_by, now)`
+- `materialise_relationship(db, *, rel_id, source_element_id, target_element_id, relationship_type, label, description, created_by, now)`
+
+Both insert records without committing — caller controls transaction boundaries.
+
+---
+
+## Tests
+
+### Seed: `backend/tests/test_seed/test_example_models.py`
+- Element count: 66 → 87
+- Relationship count: 63 → 77
+- DoView notation count: 7 → 28
+- New: `test_doview_nodes_have_entity_ids`
+- New: `test_doview_cross_diagram_reuse`
+- New: `test_doview_edges_have_relationship_ids`
+
+### AI Creation: `backend/tests/test_ai/test_creation.py`
+- New: `test_create_diagrams_creates_elements`
+- New: `test_create_diagrams_creates_relationships`
+- New: `test_element_notation_matches_diagram`

--- a/docs/adrs/specs/SPEC-101-A-Visual-Toggles.md
+++ b/docs/adrs/specs/SPEC-101-A-Visual-Toggles.md
@@ -1,0 +1,44 @@
+# SPEC-101-A: Visual Toggles
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | SPEC-101-A |
+| **ADR** | [ADR-101](../ADR-101-Visual-Toggles.md) |
+| **Status** | Draft |
+| **Date** | 2026-03-23 |
+
+---
+
+## Overview
+
+Three visual improvements: fix DoView double borders, add theme-controlled description visibility with per-node override, and add element usage count badge controlled by user setting.
+
+---
+
+## Fix: DoView Double Borders
+
+**File:** `frontend/src/lib/canvas/renderers/DoviewRenderer.svelte`
+
+Remove `visualStyle` from the wrapper `<div>` — only BaseNode's `.canvas-node` should apply border styles.
+
+---
+
+## Feature: Hide Description Toggle
+
+**ThemeRenderingConfig extension:**
+- Add `hideDescription?: boolean` to the interface
+- DoView default theme sets `hideDescription: true`
+
+**BaseNode change:** Check rendering config before showing description.
+
+**Edit sidebar toggle:** "Show description" checkbox in ElementEditPanel dispatches `nodedatachange` with `field: 'hideDescription'`.
+
+---
+
+## Feature: Element Count Badge
+
+**User setting:** `iris-show-element-count` in localStorage, toggled via Settings → Visual Toggles.
+
+**Badge:** Small count in top-right of `.canvas-node` showing `diagram_usage_count` from the Element API response.
+
+**Data flow:** Diagram page fetches Element per node (existing), passes `diagram_usage_count` to node data.

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -165,6 +165,17 @@ a {
 	white-space: nowrap;
 }
 
+.canvas-node__count-badge {
+	position: absolute;
+	top: 2px;
+	right: 4px;
+	font-size: 9px;
+	line-height: 1;
+	opacity: 0.5;
+	pointer-events: none;
+	color: var(--color-muted, #888);
+}
+
 .canvas-node__description {
 	margin-top: 4px;
 	font-size: 0.75rem;

--- a/frontend/src/lib/canvas/BaseNode.svelte
+++ b/frontend/src/lib/canvas/BaseNode.svelte
@@ -7,10 +7,13 @@
 	 * Used as fallback by DynamicNode and as a wrapper by notation renderers.
 	 */
 	import { Handle, Position } from '@xyflow/svelte';
+	import { getContext } from 'svelte';
 	import type { Snippet } from 'svelte';
-	import type { CanvasNodeData } from '$lib/types/canvas';
+	import type { CanvasNodeData, NotationType } from '$lib/types/canvas';
 	import { nodeOverrideStyle, titleFontStyle, descFontStyle } from '$lib/canvas/utils/visualStyles';
+	import { getThemeRendering } from '$lib/stores/themeStore.svelte';
 	import IconDisplay from '$lib/icons/IconDisplay.svelte';
+	import { getShowElementCount } from '$lib/stores/showElementCount.svelte';
 
 	interface Props {
 		data: CanvasNodeData;
@@ -32,11 +35,17 @@
 		children,
 	}: Props = $props();
 
+	const notation = getContext<NotationType>('notation') ?? 'simple';
+	const rendering = $derived(getThemeRendering(notation));
+	const hideDesc = $derived(rendering?.hideDescription ?? false);
+
 	const visualStyle = $derived(nodeOverrideStyle(data.visual));
 	const titleStyle = $derived(titleFontStyle(data.visual));
 	const descStyle = $derived(descFontStyle(data.visual));
 	const hasCustomIcon = $derived(!!data.visual?.icon);
 	const iconColor = $derived(data.visual?.iconColor);
+	const showCount = $derived(getShowElementCount());
+	const usageCount = $derived((data as Record<string, unknown>).diagramUsageCount as number | undefined);
 </script>
 
 <div
@@ -45,6 +54,11 @@
 	style={visualStyle}
 	aria-label="{data.label}, {typeLabel}"
 >
+	{#if showCount && usageCount && usageCount > 0}
+		<span class="canvas-node__count-badge" aria-label="Used in {usageCount} diagram{usageCount === 1 ? '' : 's'}">
+			{usageCount}
+		</span>
+	{/if}
 	<div class="canvas-node__header" style={titleStyle}>
 		{#if hasCustomIcon && data.visual?.icon}
 			<span class="canvas-node__icon" aria-hidden="true">
@@ -60,7 +74,7 @@
 	{#if children}
 		{@render children()}
 	{/if}
-	{#if data.description && !children}
+	{#if data.description && !children && !hideDesc && !data.hideDescription}
 		<div class="canvas-node__description" style={descStyle}>{data.description}</div>
 	{/if}
 	{#if data.browseMode && data.entityId}

--- a/frontend/src/lib/canvas/controls/ElementEditPanel.svelte
+++ b/frontend/src/lib/canvas/controls/ElementEditPanel.svelte
@@ -18,6 +18,7 @@
 	} from '$lib/types/canvas';
 	import C4TypePicker from '$lib/c4/C4TypePicker.svelte';
 	import DOMPurify from 'dompurify';
+	import { getThemeRendering, getActiveTheme } from '$lib/stores/themeStore.svelte';
 
 	interface Props {
 		entityId?: string | null;
@@ -29,9 +30,11 @@
 		nodeDescription?: string;
 		/** Fallback entity type for unlinked nodes. */
 		nodeEntityType?: string;
+		/** Whether description is hidden on the node. */
+		nodeHideDescription?: boolean;
 	}
 
-	let { entityId, nodeId, notation, nodeLabel = '', nodeDescription = '', nodeEntityType = 'component' }: Props = $props();
+	let { entityId, nodeId, notation, nodeLabel = '', nodeDescription = '', nodeEntityType = 'component', nodeHideDescription = false }: Props = $props();
 
 	const isLinked = $derived(!!entityId);
 
@@ -79,6 +82,9 @@
 	});
 
 	const effectiveNotation = $derived(element?.notation ?? notation ?? 'simple');
+	const themeRendering = $derived(getThemeRendering(effectiveNotation));
+	const themeHidesDescription = $derived(themeRendering?.hideDescription ?? false);
+	const activeThemeName = $derived(getActiveTheme(effectiveNotation)?.name);
 
 	$effect(() => {
 		if (entityId) {
@@ -267,6 +273,30 @@
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 				></textarea>
 			</label>
+
+			<div class="mt-2">
+				<label class="flex items-center gap-2" class:opacity-50={themeHidesDescription}>
+					<input
+						type="checkbox"
+						checked={themeHidesDescription ? false : !nodeHideDescription}
+						disabled={themeHidesDescription}
+						onchange={(e) => {
+							const show = (e.target as HTMLInputElement).checked;
+							document.dispatchEvent(
+								new CustomEvent('nodedatachange', {
+									detail: { nodeId, field: 'hideDescription', value: !show }
+								})
+							);
+						}}
+					/>
+					<span class="text-xs" style="color: var(--color-muted)">Show description on node</span>
+				</label>
+				{#if themeHidesDescription}
+					<p class="mt-0.5 text-xs" style="color: var(--color-muted); font-style: italic">
+						Overridden by theme {activeThemeName ?? effectiveNotation}
+					</p>
+				{/if}
+			</div>
 
 			<div class="text-xs" style="color: var(--color-fg)">
 				<span>Type</span>

--- a/frontend/src/lib/canvas/renderers/DoviewRenderer.svelte
+++ b/frontend/src/lib/canvas/renderers/DoviewRenderer.svelte
@@ -8,7 +8,6 @@
 	import { getContext } from 'svelte';
 	import BaseNode from '../BaseNode.svelte';
 	import type { CanvasNodeData, NotationType } from '$lib/types/canvas';
-	import { nodeOverrideStyle } from '$lib/canvas/utils/visualStyles';
 	import { getThemeRendering } from '$lib/stores/themeStore.svelte';
 
 	interface Props {
@@ -31,7 +30,6 @@
 	};
 
 	const icon = $derived(DOVIEW_ICONS[data.entityType] ?? '▭');
-	const visualStyle = $derived(nodeOverrideStyle(data.visual));
 	const isFinalOutcome = $derived(data.entityType === 'final_outcome');
 </script>
 
@@ -39,7 +37,7 @@
 	class="doview-node doview-node--{data.entityType}"
 	class:doview-node--final={isFinalOutcome}
 	class:doview-node--wrap={wrapLabels}
-	style="{visualStyle} --doview-text-align: {textAlign};"
+	style="--doview-text-align: {textAlign};"
 >
 	<BaseNode
 		{data}

--- a/frontend/src/lib/stores/showElementCount.svelte.ts
+++ b/frontend/src/lib/stores/showElementCount.svelte.ts
@@ -1,0 +1,20 @@
+/**
+ * Reactive localStorage-backed store for the "show element count" user preference.
+ */
+
+let _showElementCount = $state(
+	typeof localStorage !== 'undefined'
+		? localStorage.getItem('iris-show-element-count') !== 'false'
+		: true,
+);
+
+export function getShowElementCount(): boolean {
+	return _showElementCount;
+}
+
+export function setShowElementCount(value: boolean): void {
+	_showElementCount = value;
+	if (typeof localStorage !== 'undefined') {
+		localStorage.setItem('iris-show-element-count', String(value));
+	}
+}

--- a/frontend/src/lib/stores/themeStore.svelte.ts
+++ b/frontend/src/lib/stores/themeStore.svelte.ts
@@ -9,6 +9,7 @@ import type { NodeVisualOverrides, EdgeVisualOverrides } from '$lib/types/canvas
 
 export interface ThemeRenderingConfig {
 	hideIcons?: boolean;
+	hideDescription?: boolean;
 	borderRadius?: number;
 	attrFontColor?: string;
 	hideTypeStereotypes?: boolean;

--- a/frontend/src/lib/types/canvas.ts
+++ b/frontend/src/lib/types/canvas.ts
@@ -84,6 +84,7 @@ export interface CanvasNodeData {
 	entityType: SimpleEntityType;
 	entityId?: string;
 	description?: string;
+	hideDescription?: boolean;
 	linkedModelId?: string;
 	browseMode?: boolean;
 	notation?: string;

--- a/frontend/src/routes/diagrams/[id]/+page.svelte
+++ b/frontend/src/routes/diagrams/[id]/+page.svelte
@@ -527,7 +527,7 @@
 					const element = await apiFetch<Element>(`/api/elements/${entityId}`);
 					const rawDesc = element.description ?? '';
 					const desc = rawDesc.startsWith(node.data.label) ? rawDesc.slice(rawDesc.indexOf('\n') + 1).replace(/^\r?\n/, '') : rawDesc;
-					if (desc !== node.data.description || element.name !== node.data.label) {
+					if (desc !== node.data.description || element.name !== node.data.label || (node.data as Record<string, unknown>).diagramUsageCount !== (element.diagram_usage_count ?? 0)) {
 						updated = true;
 						return {
 							...node,
@@ -535,6 +535,7 @@
 								...node.data,
 								label: element.name,
 								description: desc,
+								diagramUsageCount: element.diagram_usage_count ?? 0,
 							},
 						};
 					}
@@ -1154,6 +1155,13 @@
 		if (!selectedEditNodeId) return '';
 		const node = canvasNodes.find((n) => n.id === selectedEditNodeId);
 		return node?.data?.description ?? '';
+	});
+
+	/** Whether the selected node has hideDescription set. */
+	const selectedNodeHideDescription = $derived.by(() => {
+		if (!selectedEditNodeId) return false;
+		const node = canvasNodes.find((n) => n.id === selectedEditNodeId);
+		return !!(node?.data?.hideDescription);
 	});
 
 	const selectedNodeLinkedModelId = $derived.by(() => {
@@ -2706,7 +2714,7 @@
 									</div>
 									{#if selectedEditNodeId && selectedNodeVisual}
 										<div style="width: 300px; flex-shrink: 0; margin: 8px 8px 8px 0; overflow-y: auto; max-height: calc(100% - 16px); align-self: flex-start; display: flex; flex-direction: column; gap: 8px;">
-											<ElementEditPanel entityId={selectedNodeEntityId} nodeId={selectedEditNodeId} {notation} nodeLabel={selectedNodeLabel} nodeDescription={selectedNodeDescription} nodeEntityType={selectedNodeEntityType} />
+											<ElementEditPanel entityId={selectedNodeEntityId} nodeId={selectedEditNodeId} {notation} nodeLabel={selectedNodeLabel} nodeDescription={selectedNodeDescription} nodeEntityType={selectedNodeEntityType} nodeHideDescription={selectedNodeHideDescription} />
 											<NodeStylePanel nodeId={selectedEditNodeId} visual={selectedNodeVisual} themeVisual={selectedNodeThemeVisual} {notation} entityType={selectedNodeEntityType} />
 											<LinkedDiagramPanel nodeId={selectedEditNodeId} linkedModelId={selectedNodeLinkedModelId} excludeDiagramId={diagram?.id} />
 										</div>
@@ -2738,7 +2746,7 @@
 						</div>
 						{#if selectedEditNodeId && selectedNodeVisual}
 							<div style="width: 300px; display: flex; flex-direction: column; gap: 8px;">
-								<ElementEditPanel entityId={selectedNodeEntityId} nodeId={selectedEditNodeId} {notation} nodeLabel={selectedNodeLabel} nodeDescription={selectedNodeDescription} nodeEntityType={selectedNodeEntityType} />
+								<ElementEditPanel entityId={selectedNodeEntityId} nodeId={selectedEditNodeId} {notation} nodeLabel={selectedNodeLabel} nodeDescription={selectedNodeDescription} nodeEntityType={selectedNodeEntityType} nodeHideDescription={selectedNodeHideDescription} />
 								<NodeStylePanel nodeId={selectedEditNodeId} visual={selectedNodeVisual} themeVisual={selectedNodeThemeVisual} {notation} entityType={selectedNodeEntityType} />
 								<LinkedDiagramPanel nodeId={selectedEditNodeId} linkedModelId={selectedNodeLinkedModelId} excludeDiagramId={diagram?.id} />
 							</div>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -3,10 +3,12 @@
 	import { onMount } from 'svelte';
 	import { apiFetch, ApiError } from '$lib/utils/api';
 	import { getDefaultNotation, setDefaultNotation } from '$lib/stores/defaultNotation.svelte';
+	import { getShowElementCount, setShowElementCount } from '$lib/stores/showElementCount.svelte';
 
 	let highContrast = $state(false);
 	let isSystem = $state(false);
 	let defaultNotation = $state('simple');
+	let showElementCount = $state(false);
 
 	let currentPassword = $state('');
 	let newPassword = $state('');
@@ -19,6 +21,7 @@
 		highContrast = localStorage.getItem('iris-high-contrast') === 'true';
 		isSystem = localStorage.getItem('iris-theme') === 'system';
 		defaultNotation = getDefaultNotation();
+		showElementCount = getShowElementCount();
 		if (highContrast) {
 			document.documentElement.classList.add('high-contrast');
 		}
@@ -139,6 +142,20 @@
 			<option value="c4">C4 — person, software system, container, component</option>
 		</select>
 	</div>
+</section>
+
+<section class="mt-6">
+	<h2 class="text-lg font-semibold" style="color: var(--color-fg)">Visual Toggles</h2>
+	<p class="mt-1 text-sm" style="color: var(--color-muted)">Control what information is displayed on diagram nodes.</p>
+	<label class="mt-3 flex items-center gap-2 cursor-pointer">
+		<input
+			type="checkbox"
+			bind:checked={showElementCount}
+			onchange={() => setShowElementCount(showElementCount)}
+			class="rounded"
+		/>
+		<span class="text-sm" style="color: var(--color-fg)">Display element count — show how many diagrams each element is used in</span>
+	</label>
 </section>
 
 <section class="mt-6">


### PR DESCRIPTION
## Summary
- All DoView diagram nodes now created as proper elements with `entityId` linkage and causal links as relationships with `relationshipId` (ADR-100)
- AI diagram creation materialises element and relationship records for every node/edge
- Fix double borders on DoView nodes
- Add `hideDescription` theme toggle — DoView defaults to hidden, with theme override lock in edit sidebar
- Add element count badge showing diagram usage count on nodes (ADR-101)
- Add Visual Toggles section in Settings page

## Test plan
- [x] Backend: 776 passed, 0 failed
- [x] Seed tests: 20 passed including new entityId linkage, cross-diagram reuse, and relationship ID tests
- [x] AI creation tests: 7 new materialisation tests + 83 existing all pass
- [x] Manual: DoView diagrams show element-backed nodes with working EntityDetailPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)