### PR TITLE
Merge main into render-supabase-uat — v5.1.2 (UAT bug fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ CLAUDE.md
 
 #temp
 temp/
-ea-visual-audit/iris.code-workspace
+ea-visual-audit/
+iris.code-workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,75 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.2] - 2026-05-05
+
+UAT follow-ups against the v5.1.1 deployment — four contained bug
+fixes against the Text class, Hierarchy controls, and BPMN dialog.
+The deeper BPMN UX integration gap (BpmnPalette / ContextPad /
+CommandPalette / EventMatrixPicker / PropertyPanel / ProblemsPanel
+exist on disk but are not mounted into the canvas) is tracked
+separately for v5.2.0; v5.1.2 is the last v5.1.x patch.
+
+### Fixed
+
+- **Hierarchy panel dropdowns clipped under the AppShell**
+  (ADR-137 amendment, issue #30). `HierarchyControls` previously
+  anchored both menus with `absolute right-0`. On the Dashboard
+  hierarchy panel — which sits flush-left against the AppShell —
+  the right-anchored menu extended *leftwards* off the panel and
+  ended up under the AppShell nav. Switched to `absolute left-0`
+  on both menus so they extend rightwards from the button. Coverage
+  test prevents regression.
+- **Tab in markdown editor moved focus instead of indenting**
+  (ADR-137 amendment, issue #31). `TextCanvas`'s `<textarea>` had
+  no `keydown` handler. Tab now intercepts and inserts a literal `\t`
+  at the selection; `Shift+Tab` outdents (strips a leading `\t` or up
+  to four spaces). Esc-then-Tab still moves focus normally so
+  WCAG 2.1.2 (No Keyboard Trap) is preserved; the affordance is
+  documented in the placeholder text.
+- **Text view browse mode showed "Start Building" instead of
+  rendered markdown** (ADR-137 amendment, issue #32). The v5.1.1
+  `{:else if canvasType === 'text'}` branch existed only inside the
+  `{#if editing}` block. Browse mode for Text views fell through to
+  the empty-canvas branch (Text views legitimately have zero canvas
+  nodes) and rendered the canvas "Start Building" prompt. Added a
+  parallel browse-mode Text branch *before* the empty-canvas check,
+  mounting `<TextCanvas editing={false}>` so MarkdownView fires.
+  Empty Text views show a text-specific "This text view is empty —
+  Start Writing" prompt that mirrors the canvas equivalent.
+- **EntityDialog showed Simple-notation entity types on BPMN views**
+  (ADR-136 amendment, issue #33). The dialog's notation switch had
+  cases for UML / ArchiMate / C4 / DoView and a Simple `default:` —
+  no `case 'bpmn':`. Clicking *Add Element* on a BPMN view silently
+  presented Actor / Boundary / Component / Note / Service. Added the
+  missing case using `BPMN_ENTITY_TYPES` + `BPMN_DIAGRAM_TYPE_FILTER`
+  (mirrors the UML / DoView branches in the same file). New coverage
+  test asserts every notation key in `NotationPills.ALL_NOTATIONS`
+  has a matching switch case in `EntityDialog`, so this regression
+  class can't recur.
+
+### Docs
+
+- ADR-136 amendment — EntityDialog BPMN case (issue #33). Notes the
+  v5.1.0 oversight pattern (registry shipped, picker dialog lagged)
+  and how the new coverage test closes the loop alongside the
+  v5.1.1 NotationPills coverage test.
+- ADR-137 amendment — three v5.1.2 follow-ups (issues #30, #31, #32).
+  Includes the design-intent quote from #32 ("a single Canvas tab
+  whose behaviour switches by notation; the type-of-diagram label
+  remains authoritative").
+
+### Verification
+
+- Frontend: 786/787 vitest specs pass (the one pre-existing failure —
+  `importIdempotency > displays diagrams skipped count` — also fails
+  against the unmodified baseline).
+- 4 new vitest specs added (15 tests total) — `hierarchyControlsAlignment`,
+  `textCanvasTabKey`, `textViewBrowseRender`, `entityDialogBpmn`.
+- Backend: 48/48 in scope-affected tests pass (docref + text + bpmn).
+- `svelte-check`: 164 errors (= unchanged baseline, no new errors
+  introduced).
+
 ## [5.1.1] - 2026-05-05
 
 UAT follow-ups (issue #27) for the v5.1.0 release. The user-facing

--- a/docs/adrs/ADR-136-BPMN-Notation.md
+++ b/docs/adrs/ADR-136-BPMN-Notation.md
@@ -1,6 +1,6 @@
 # ADR-136: BPMN 2.0 notation
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issue #27)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33)
 
 ## Context
 
@@ -186,3 +186,34 @@ This is a one-line root cause that would have been caught earlier by
 a test asserting "every registered notation is rendered in
 NotationPills". A unit test against the registry vs. the pill list now
 exists to prevent regression.
+
+## Amendment 2026-05-05 — EntityDialog BPMN case (issue #33, v5.1.2)
+
+UAT against v5.1.1 surfaced the *next* link in the same chain: the
+NotationPills picker now offers BPMN (per the previous amendment), but
+clicking **Add Element** on a BPMN view opened `EntityDialog` and
+showed Simple-notation entity types (Actor, Boundary, Component, Note,
+Service, …) — because `EntityDialog.svelte`'s entity-type switch had
+no `case 'bpmn':` and silently fell through to the `default:` Simple
+branch.
+
+Fix in v5.1.2: add a `case 'bpmn':` branch that uses
+`BPMN_ENTITY_TYPES` and applies `BPMN_DIAGRAM_TYPE_FILTER`, mirroring
+the UML / DoView pattern in the same file. A new coverage test
+`entityDialogBpmn.test.ts` asserts that **every notation key in
+`NotationPills.ALL_NOTATIONS`** has a corresponding switch case in
+`EntityDialog` (markdown excepted — text views have no entities;
+simple is the `default:` fallback by convention). This catches the
+exact regression class — adding a notation to the pills without
+wiring its entity types in the dialog.
+
+This is the same v5.1.0 oversight pattern as the v5.1.1 NotationPills
+fix: the registry, renderer, themes, palette and validation rules
+shipped, but the picker dialog was not updated. The two coverage
+tests (notation-pills + entity-dialog) together close that loop.
+
+The deeper UX gap — the BPMN authoring surfaces (`BpmnPalette` /
+`ContextPad` / `CommandPalette` / `EventMatrixPicker` /
+`PropertyPanel` / `ProblemsPanel`) that exist on disk but are not
+mounted into the canvas — is tracked separately for v5.2.0
+(see issue #34). v5.1.2 is the last v5.1.x patch.

--- a/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
+++ b/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
@@ -1,6 +1,6 @@
 # ADR-137: Text diagram subclass and shared Markdown renderer
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issue #27)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #30, #31, #32)
 
 ## Context
 
@@ -284,3 +284,56 @@ in this context is misleading.
   current labels even in Text mode. A future pass could rename them in
   Text context ("Insert Element Link" etc.) but the existing labels
   read sensibly enough now that they actually insert what they say.
+
+## Amendment 2026-05-05 — v5.1.2 follow-ups (issues #30 / #31 / #32)
+
+UAT against the v5.1.1 deployment surfaced three more issues against
+the same Text-class + HierarchyControls + Views surfaces. All three
+land as a single v5.1.2 patch.
+
+### #30 — Hierarchy panel dropdowns clipped under AppShell
+
+`HierarchyControls.svelte` previously anchored both menus with
+`absolute right-0`. On the Dashboard hierarchy panel — which sits
+flush-left against the AppShell — the right-anchored dropdown extended
+*leftwards* off the panel and ended up under the AppShell nav.
+
+Fix: switch both menus to `absolute left-0`. The menus extend
+*rightwards* from the button, which works on both the Dashboard
+(plenty of room to the right of the narrow hierarchy panel) and the
+Views toolbar (the buttons sit alongside other toolbar items with
+empty space to their right). Single-line change in two places.
+
+### #31 — Tab in markdown editor moved focus instead of indenting
+
+The TextCanvas `<textarea>` had no `keydown` handler so Tab fell
+through to the browser default (move focus to the next tab-stop). The
+editor now intercepts Tab, splices a literal `\t` at the selection,
+forwards the change through the existing `oncontentchange` callback
+(so `canvasDirty` flips), and restores the cursor.
+
+`Shift+Tab` outdents — strips a leading `\t` or up to four spaces
+from the line containing the caret.
+
+WCAG 2.1.2 (No Keyboard Trap) is preserved via an Esc-then-Tab
+escape hatch: pressing Esc once disables the trap; the next Tab moves
+focus normally; any subsequent keystroke re-enables the trap. The
+placeholder text now mentions this so the affordance is discoverable.
+
+### #32 — Text view browse mode showed "Start Building"
+
+The v5.1.1 amendment introduced the `{:else if canvasType === 'text'}`
+branch only inside the `{#if editing}` block. Browse mode for a Text
+view fell through to `{:else if canvasNodes.length === 0}` (Text views
+legitimately have zero canvas nodes) and rendered the canvas
+"Start Building" empty-state.
+
+Fix: add a parallel `{:else if canvasType === 'text'}` branch in the
+browse-mode chain *before* the empty-canvas check, mounting
+`<TextCanvas content={markdownContent} editing={false} />` so
+MarkdownView fires. When `markdownContent` is blank we render a
+text-specific empty-state ("This text view is empty — Start Writing")
+rather than reusing the canvas wording, mirroring the design intent
+the user spelled out in the issue: a single Canvas tab whose
+behaviour switches by notation; the "type of diagram" label remains
+authoritative.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.1.1",
+			"version": "5.1.2",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/controls/EntityDialog.svelte
+++ b/frontend/src/lib/canvas/controls/EntityDialog.svelte
@@ -7,11 +7,13 @@
 		ARCHIMATE_ENTITY_TYPES,
 		C4_ENTITY_TYPES,
 		DOVIEW_ENTITY_TYPES,
+		BPMN_ENTITY_TYPES,
 		SIMPLE_DIAGRAM_TYPE_FILTER,
 		UML_DIAGRAM_TYPE_FILTER,
 		ARCHIMATE_DIAGRAM_TYPE_LAYERS,
 		C4_DIAGRAM_TYPE_LEVELS,
 		DOVIEW_DIAGRAM_TYPE_FILTER,
+		BPMN_DIAGRAM_TYPE_FILTER,
 		type SimpleEntityType,
 		type NotationType,
 	} from '$lib/types/canvas';
@@ -143,6 +145,17 @@
 					filteredDoview = filteredDoview.filter((t) => allowed.includes(t.key));
 				}
 				types = filteredDoview.map((t) => ({ key: t.key as string, label: t.label, icon: t.icon }));
+				break;
+			}
+			case 'bpmn': {
+				/* Issue #33: previously fell through to `default:` and rendered Simple
+				   types (Actor / Boundary / Component / …) on a BPMN view. */
+				let filteredBpmn = BPMN_ENTITY_TYPES;
+				if (!showAllTypes && diagramType && BPMN_DIAGRAM_TYPE_FILTER[diagramType] !== undefined && BPMN_DIAGRAM_TYPE_FILTER[diagramType] !== null) {
+					const allowed = BPMN_DIAGRAM_TYPE_FILTER[diagramType]!;
+					filteredBpmn = filteredBpmn.filter((t) => allowed.includes(t.key));
+				}
+				types = filteredBpmn.map((t) => ({ key: t.key as string, label: t.label, icon: t.icon }));
 				break;
 			}
 			default: {

--- a/frontend/src/lib/canvas/text/TextCanvas.svelte
+++ b/frontend/src/lib/canvas/text/TextCanvas.svelte
@@ -42,6 +42,60 @@
 		content = value;
 		oncontentchange?.(value);
 	}
+
+	/**
+	 * Issue #31: trap Tab inside the textarea so it indents instead of
+	 * moving focus. Esc temporarily releases the trap so the next Tab
+	 * moves focus normally — preserves WCAG 2.1.2 (No Keyboard Trap).
+	 */
+	let tabTrapEnabled = $state(true);
+
+	function commitChange(ta: HTMLTextAreaElement) {
+		content = ta.value;
+		oncontentchange?.(ta.value);
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		const ta = e.currentTarget as HTMLTextAreaElement;
+
+		if (e.key === 'Escape') {
+			tabTrapEnabled = false;
+			return;
+		}
+
+		if (e.key !== 'Tab') {
+			tabTrapEnabled = true;
+			return;
+		}
+
+		if (!tabTrapEnabled) {
+			tabTrapEnabled = true;
+			return;
+		}
+
+		e.preventDefault();
+		const start = ta.selectionStart;
+		const end = ta.selectionEnd;
+		const value = ta.value;
+
+		if (e.shiftKey) {
+			const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+			if (value[lineStart] === '\t') {
+				ta.value = value.slice(0, lineStart) + value.slice(lineStart + 1);
+				const offset = start === lineStart ? 0 : 1;
+				ta.setSelectionRange(start - offset, end - 1);
+			} else {
+				const spaces = value.slice(lineStart).match(/^ {1,4}/)?.[0].length ?? 0;
+				if (spaces === 0) return;
+				ta.value = value.slice(0, lineStart) + value.slice(lineStart + spaces);
+				ta.setSelectionRange(Math.max(start - spaces, lineStart), end - spaces);
+			}
+		} else {
+			ta.value = value.slice(0, start) + '\t' + value.slice(end);
+			ta.setSelectionRange(start + 1, start + 1);
+		}
+		commitChange(ta);
+	}
 </script>
 
 <div class="text-canvas" data-mode={editing ? 'edit' : 'view'}>
@@ -51,7 +105,8 @@
 			class="text-canvas__editor"
 			value={content ?? ''}
 			oninput={onInput}
-			placeholder="Write markdown… use [label](iris://diagram/<id>) or iris://element/<id> to link to other Iris models."
+			onkeydown={handleKeydown}
+			placeholder="Write markdown… use [label](iris://diagram/<id>) or iris://element/<id> to link to other Iris models. Tab indents; Esc then Tab moves focus."
 			spellcheck="true"
 		></textarea>
 	{:else}

--- a/frontend/src/lib/components/HierarchyControls.svelte
+++ b/frontend/src/lib/components/HierarchyControls.svelte
@@ -6,6 +6,11 @@
 	 *
 	 *  - "+ New"  → create View | create Package
 	 *  - "Show"   → toggle Diagrams / Text visibility (Packages always shown)
+	 *
+	 * Issue #30: dropdowns anchor `left-0` so the menu extends rightwards
+	 * from the button. `right-0` clipped under the AppShell on the
+	 * Dashboard hierarchy panel because that panel sits flush-left and
+	 * a leftward menu had nowhere to go.
 	 */
 	interface Props {
 		showDiagrams: boolean;
@@ -49,7 +54,7 @@
 		{#if newOpen}
 			<div
 				role="menu"
-				class="absolute right-0 z-50 mt-1 min-w-[160px] rounded border py-1 shadow-lg"
+				class="absolute left-0 z-50 mt-1 min-w-[160px] rounded border py-1 shadow-lg"
 				style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
 			>
 				<button
@@ -86,7 +91,7 @@
 		{#if showOpen}
 			<div
 				role="menu"
-				class="absolute right-0 z-50 mt-1 min-w-[180px] rounded border py-1 shadow-lg"
+				class="absolute left-0 z-50 mt-1 min-w-[180px] rounded border py-1 shadow-lg"
 				style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
 			>
 				<label

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2870,6 +2870,36 @@
 						</div>
 					{/if}
 					{/if}
+				{:else if canvasType === 'text'}
+					<!-- Issue #32: browse-mode Text branch — without this Text views fall
+						 through to `canvasNodes.length === 0` and show "Start Building"
+						 because Text views legitimately have zero canvas nodes. -->
+					{#if markdownContent}
+						<div class="flex gap-4">
+							<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: hidden">
+								<TextCanvas
+									content={markdownContent}
+									editing={false}
+									oncontentchange={() => {}}
+									onheadings={(h) => (textHeadings = h)}
+								/>
+							</div>
+							{#if showTocDrawer}
+								<MarkdownToc headings={textHeadings} onclose={() => (showTocDrawer = false)} />
+							{/if}
+						</div>
+					{:else}
+						<div class="flex flex-col items-center justify-center gap-3 rounded border p-8" style="border-color: var(--color-border); min-height: 300px">
+							<p style="color: var(--color-muted)">This text view is empty.</p>
+							<button
+								onclick={handleStartEditing}
+								class="rounded px-4 py-2 text-sm text-white"
+								style="background-color: var(--color-primary)"
+							>
+								Start Writing
+							</button>
+						</div>
+					{/if}
 				{:else if canvasNodes.length === 0}
 					<div class="flex flex-col items-center justify-center gap-3 rounded border p-8" style="border-color: var(--color-border); min-height: 300px">
 						<p style="color: var(--color-muted)">This diagram has no canvas content yet.</p>

--- a/frontend/tests/unit/entityDialogBpmn.test.ts
+++ b/frontend/tests/unit/entityDialogBpmn.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #33: EntityDialog had no `case 'bpmn':` in its entity-type switch
+ * so BPMN views silently fell through to `default:` (Simple). Users on a
+ * BPMN canvas saw Actor / Boundary / Component / Note / Service / etc.
+ * instead of the BPMN catalogue.
+ *
+ * Coverage rule: every notation key visible in the picker
+ * (NotationPills.ALL_NOTATIONS) must have a matching `case '<key>':`
+ * branch in EntityDialog (markdown excepted — text views have no
+ * entities to add).
+ */
+const PILLS = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/components/NotationPills.svelte'),
+	'utf-8',
+);
+const DIALOG = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/controls/EntityDialog.svelte'),
+	'utf-8',
+);
+
+function pillKeys(): string[] {
+	const m = PILLS.match(/ALL_NOTATIONS\s*=\s*\[([\s\S]*?)\]/);
+	if (!m) throw new Error('ALL_NOTATIONS array not found in NotationPills.svelte');
+	const keys: string[] = [];
+	const re = /key:\s*'([^']+)'/g;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(m[1])) !== null) keys.push(match[1]);
+	return keys;
+}
+
+function dialogCaseKeys(): string[] {
+	const keys: string[] = [];
+	const re = /case\s+'([a-z][a-z0-9_]*)':/g;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(DIALOG)) !== null) keys.push(match[1]);
+	return keys;
+}
+
+describe('EntityDialog notation coverage (issue #33)', () => {
+	it('has a case for BPMN', () => {
+		expect(dialogCaseKeys()).toContain('bpmn');
+	});
+
+	it('imports BPMN_ENTITY_TYPES + BPMN_DIAGRAM_TYPE_FILTER', () => {
+		expect(DIALOG).toMatch(/BPMN_ENTITY_TYPES/);
+		expect(DIALOG).toMatch(/BPMN_DIAGRAM_TYPE_FILTER/);
+	});
+
+	it('the BPMN branch reads the BPMN catalogue, not the Simple fallback', () => {
+		const block = DIALOG.match(/case 'bpmn':[\s\S]*?break;/)?.[0];
+		expect(block).toBeTruthy();
+		expect(block).toMatch(/BPMN_ENTITY_TYPES/);
+		expect(block).not.toMatch(/SIMPLE_ENTITY_TYPES/);
+	});
+
+	it('every user-pickable notation has a corresponding switch case (markdown excluded — text views have no entities)', () => {
+		const cases = dialogCaseKeys();
+		const expected = pillKeys().filter((k) => k !== 'markdown' && k !== 'simple');
+		// `simple` is the `default:` fallback by design; it's not listed as an explicit case.
+		const missing = expected.filter((k) => !cases.includes(k));
+		expect(missing).toEqual([]);
+	});
+});

--- a/frontend/tests/unit/hierarchyControlsAlignment.test.ts
+++ b/frontend/tests/unit/hierarchyControlsAlignment.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #30: dropdowns previously used `absolute right-0`, which on the
+ * Dashboard's left-aligned hierarchy panel pushed the menu under the
+ * AppShell nav. They now use `left-0` so the menu extends rightwards
+ * from the button — visible in both the Dashboard panel (panel sits on
+ * the page-content left edge) and the Views toolbar (button sits among
+ * other toolbar items with room to the right).
+ */
+const SRC = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/components/HierarchyControls.svelte'),
+	'utf-8',
+);
+
+describe('HierarchyControls dropdown alignment (issue #30)', () => {
+	it('the + New menu opens to the right (left-anchored)', () => {
+		expect(SRC).toMatch(/min-w-\[160px\]/);
+		const newMenu = SRC.match(/class="([^"]*min-w-\[160px\][^"]*)"/)?.[1] ?? '';
+		expect(newMenu).toContain('left-0');
+		expect(newMenu).not.toContain('right-0');
+	});
+
+	it('the Show menu opens to the right (left-anchored)', () => {
+		expect(SRC).toMatch(/min-w-\[180px\]/);
+		const showMenu = SRC.match(/class="([^"]*min-w-\[180px\][^"]*)"/)?.[1] ?? '';
+		expect(showMenu).toContain('left-0');
+		expect(showMenu).not.toContain('right-0');
+	});
+
+	it('regression guard — neither menu uses right-0', () => {
+		const occurrences = SRC.match(/absolute right-0/g) ?? [];
+		expect(occurrences).toHaveLength(0);
+	});
+});

--- a/frontend/tests/unit/textCanvasTabKey.test.ts
+++ b/frontend/tests/unit/textCanvasTabKey.test.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #31: Tab in the markdown editor used to move focus (browser
+ * default for textareas). It now indents at the cursor instead, with
+ * Esc-then-Tab as the keyboard escape hatch (preserves WCAG 2.1.2 No
+ * Keyboard Trap).
+ */
+const SRC = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/text/TextCanvas.svelte'),
+	'utf-8',
+);
+
+describe('TextCanvas Tab key handling (issue #31)', () => {
+	it('declares a keydown handler', () => {
+		expect(SRC).toMatch(/function handleKeydown\(/);
+		expect(SRC).toMatch(/onkeydown=\{handleKeydown\}/);
+	});
+
+	it('intercepts Tab to insert a literal \\t at the selection', () => {
+		// Either an explicit `=== 'Tab'` check or a guard `!== 'Tab'` returning early.
+		expect(SRC).toMatch(/e\.key (?:===|!==) 'Tab'/);
+		expect(SRC).toMatch(/preventDefault\(\)/);
+		// Tab insert: the insertion expression splices '\t' into the value at selection
+		expect(SRC).toMatch(/\+ '\\t' \+/);
+		expect(SRC).toMatch(/setSelectionRange/);
+	});
+
+	it('handles Shift+Tab as outdent', () => {
+		expect(SRC).toMatch(/e\.shiftKey/);
+	});
+
+	it('keeps an Esc-then-Tab escape hatch (WCAG 2.1.2 No Keyboard Trap)', () => {
+		expect(SRC).toMatch(/e\.key === 'Escape'/);
+		expect(SRC).toMatch(/tabTrapEnabled/);
+	});
+
+	it('forwards the change so the parent dirty flag flips', () => {
+		// commitChange must call oncontentchange so the page-level canvasDirty wiring fires.
+		expect(SRC).toMatch(/function commitChange\(/);
+		expect(SRC).toMatch(/commitChange\(ta\)/);
+		const commitBlock = SRC.match(/function commitChange[\s\S]*?oncontentchange\?\.\([^)]*\);/);
+		expect(commitBlock).toBeTruthy();
+	});
+});

--- a/frontend/tests/unit/textViewBrowseRender.test.ts
+++ b/frontend/tests/unit/textViewBrowseRender.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #32: in v5.1.1 the `{:else if canvasType === 'text'}` branch
+ * existed only inside the `{#if editing}` block, so browse mode for a
+ * Text view fell through to `{:else if canvasNodes.length === 0}` and
+ * showed "Start Building". The browse-mode branch is now in place
+ * before the empty-canvas check.
+ */
+const SRC = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/views/[id]/+page.svelte'),
+	'utf-8',
+);
+
+describe('Text view browse-mode rendering (issue #32)', () => {
+	it('the browse-mode `canvas-area` chain has a Text branch', () => {
+		// Find the chain: {#if editing} … {/if} {:else if canvasType === 'text'} … {:else if canvasNodes.length === 0}
+		// The order matters — the Text check must come before the empty-canvas check.
+		const idxText = SRC.indexOf("{:else if canvasType === 'text'}");
+		const idxEmpty = SRC.indexOf('{:else if canvasNodes.length === 0}');
+		expect(idxText).toBeGreaterThan(-1);
+		expect(idxEmpty).toBeGreaterThan(-1);
+
+		// At least one Text branch must occur before the empty-canvas check
+		// (the editor-only branch is also covered by the existing v5.1.1 chain).
+		const textBranchesBefore = (SRC.slice(0, idxEmpty).match(/\{:else if canvasType === 'text'\}/g) ?? []).length;
+		expect(textBranchesBefore).toBeGreaterThanOrEqual(2);
+	});
+
+	it('renders TextCanvas with editing=false in browse mode', () => {
+		// The browse-mode branch must mount TextCanvas with editing={false}.
+		expect(SRC).toMatch(/<TextCanvas\b[\s\S]*editing=\{false\}/);
+	});
+
+	it('shows a "This text view is empty" prompt when content is blank (mirrors canvas Start Building)', () => {
+		expect(SRC).toMatch(/This text view is empty/);
+		expect(SRC).toMatch(/Start Writing/);
+	});
+});


### PR DESCRIPTION
Promotes the v5.1.2 release ([tag](https://github.com/cgbarlow/iris/releases/tag/v5.1.2)) from `main` onto `render-supabase-uat`. Four UAT bug fixes against v5.1.1:

- **#30** — `HierarchyControls` dropdowns: `right-0` → `left-0` so menus extend rightwards from the button instead of clipping under the AppShell.
- **#31** — Tab in the markdown editor inserts `\t`; Shift+Tab outdents; Esc-then-Tab still moves focus (WCAG 2.1.2).
- **#32** — Browse mode for Text views now renders `MarkdownView` instead of falling through to the canvas "Start Building" prompt. Empty Text views show "Start Writing".
- **#33** — `EntityDialog` adds `case 'bpmn':` so the Add Element picker on BPMN views shows BPMN entity types instead of Simple ones.

Backend untouched — no Supabase migrations needed.

### Test plan

- [ ] Dashboard hierarchy panel + Views toolbar: open the **+ New** and **Show** dropdowns. Menus must extend rightwards from the button and not be clipped under the AppShell nav.
- [ ] In a Text view edit mode: press Tab → inserts a tab in the textarea (does not move focus). Press Esc, then Tab → focus moves out (escape hatch).
- [ ] Save a Text view with content; return to browse mode → renders the markdown (TOC drawer wired). Save an empty Text view → shows "This text view is empty — Start Writing", not "Start Building".
- [ ] On a BPMN view, click **Add Element** → picker shows BPMN entity types (Task / Subprocess / Start Event / etc.), not Simple (Actor / Boundary / Component / Note / Service).