### PR TITLE
Merge main into render-supabase-uat — v5.2.0 (BPMN canvas UX integration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.0] - 2026-05-05
+
+BPMN canvas UX integration (issue #37). The six BPMN authoring
+surfaces specified in ADR-136 §UX (`BpmnPalette`, `ContextPad`,
+`CommandPalette`, `EventMatrixPicker`, `PropertyPanel`,
+`ProblemsPanel`) shipped as standalone components in v5.1.0 but were
+never mounted into the canvas — net effect was that BPMN was
+catalogue-only. v5.2.0 wires them in. No new design decisions; this
+is the integration pass for the design that already existed.
+
+### Added
+
+- **BPMN authoring shell** (ADR-136 v5.2.0 amendment, issue #37). New
+  `BpmnAuthoringShell` component renders a 3-column layout (palette /
+  canvas / property panel) with a bottom Problems dock and a
+  fixed-position toast for `canConnect` rejection reasons. Mounted
+  from the views detail page when `notation === 'bpmn' && editing`.
+  Replaces the generic right-panel stack on BPMN views; non-BPMN
+  views are unchanged.
+- **Drag-from-palette node creation**. `BpmnPalette` already emitted
+  `application/iris-bpmn-entity` on drag-start; `UnifiedCanvas` now
+  receives the drop, projects the cursor via
+  `useSvelteFlow().screenToFlowPosition`, and emits
+  `ondropentity(key, position)` so the shell can create a BPMN node
+  at the cursor with the right `BPMN_DEFAULT_DISCRIMINATORS` preset.
+- **On-element context pad**. `BpmnRenderer` now mounts `<ContextPad>`
+  via `<NodeToolbar>` when a BPMN node is selected — buttons for
+  Append Task / Append Gateway / Append End Event / Connect / Change
+  / Delete. The page-level action handler bridges to BpmnRenderer via
+  a new `bpmnContextPadAction` Svelte context (set by UnifiedCanvas).
+- **Always-on PropertyPanel** for BPMN views. Three tabs (General /
+  BPMN / Documentation) with discriminator selects + activity marker
+  checkboxes. Replaces the existing conditional ElementEditPanel /
+  NodeStylePanel / LinkedDiagramPanel stack on BPMN views only.
+- **CommandPalette N / A / R hotkeys**. Lifted out of CommandPalette's
+  self-binding so they only fire on BPMN views. Press **N** to create-
+  anything (modal opens with the full BPMN catalogue, fuzzy-search,
+  Enter to add a node), **A** to append-anything after the selected
+  node, **R** to replace the selected node's type. Modal backdrop +
+  Escape close.
+- **EventMatrixPicker** (6 × 10 trigger × position grid) opens
+  automatically when an `event_*` entity is added via palette / drop /
+  command — illegal cells visually disabled.
+- **ProblemsPanel** bottom-docked, reactive to `validateBpmn(data)`.
+  Severity badge counts (error / warning / info); click a row → the
+  canvas selects the offending node.
+- **canConnect at draw-time**. `<SvelteFlow isValidConnection={…}>`
+  consults `bpmnRules.canConnect` before allowing an edge to be drawn;
+  rejection reasons surface via the new `BpmnToast` component
+  (~80 lines, no new dep).
+- **`BpmnToast` component**. Aria-live, fixed-position bottom-centre,
+  auto-dismiss after 3.5s, two-way bindable `message` prop. Single
+  consumer (the BPMN shell); kept inline rather than pulling a toast
+  library.
+
+### Changed
+
+- **`UnifiedCanvas`** wraps its template in `<SvelteFlowProvider>` so
+  the script-level `useSvelteFlow()` call (used by the new drop
+  handler) has a store to read. Adds three new optional callback
+  props: `onbeforeconnect`, `ondropentity`, `oncontextpadaction`.
+  Existing canvases are unaffected — the props default to undefined
+  and the wiring is no-op when not provided.
+- **`BpmnRenderer`** declares `id?: string` (xyflow auto-passes it to
+  custom node components — Iris's renderer interface didn't).
+
+### Docs
+
+- ADR-136 v5.2.0 amendment — UX surface integration decisions (action
+  callback via Svelte context, `isValidConnection` for canConnect,
+  drag-drop MIME, hotkey gating).
+- SPEC-136-A v5.2.0 amendment — surface-by-surface integration map +
+  list of files added/modified.
+
+### Verification
+
+- 16 new tests in `bpmnCanvasIntegration.test.ts` (static-parser
+  style, matches v5.1.x coverage tests). Catches regression if any
+  surface mount, hook prop, or context wiring is removed.
+- Frontend: 802/803 vitest specs pass (the one pre-existing failure —
+  `importIdempotency > displays diagrams skipped count` — also fails
+  against the unmodified baseline).
+- `svelte-check`: 164 errors (= unchanged baseline, no new errors
+  introduced). Cast-through-unknown idiom used at the two cross-
+  notation entityType assignment sites in the shell, matching the
+  existing pattern for storing UML/ArchiMate/C4/DoView/BPMN entity
+  types in the narrowly-typed `CanvasNodeData.entityType` field.
+
+### Out of scope (carried forward from ADR-136)
+
+- Shape-pinned comment threads (Lucidchart's strongest differentiator).
+- Element templates (Camunda-style preconfigured Service Tasks).
+- bpmnlint integration for the Problems panel.
+- BPMN XML import/export.
+- Pool/Lane swimlane container semantics — pools/lanes still ship as
+  styled rectangles; full container semantics in a follow-up.
+
+### Closes
+
+- #37 (BPMN canvas UX integration).
+
 ## [5.1.2] - 2026-05-05
 
 UAT follow-ups against the v5.1.1 deployment — four contained bug

--- a/docs/adrs/ADR-136-BPMN-Notation.md
+++ b/docs/adrs/ADR-136-BPMN-Notation.md
@@ -1,6 +1,6 @@
 # ADR-136: BPMN 2.0 notation
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33, #37)
 
 ## Context
 
@@ -217,3 +217,77 @@ The deeper UX gap — the BPMN authoring surfaces (`BpmnPalette` /
 `PropertyPanel` / `ProblemsPanel`) that exist on disk but are not
 mounted into the canvas — is tracked separately for v5.2.0
 (see issue #34). v5.1.2 is the last v5.1.x patch.
+
+## Amendment 2026-05-05 — UX surface integration (issue #37, v5.2.0)
+
+The six BPMN authoring surfaces designed in this ADR (palette, context
+pad, command palette, event matrix picker, property panel, problems
+panel) were built as standalone components in v5.1.0 but never wired
+into the canvas. Confirmed pre-v5.2.0 by `grep -rn 'BpmnPalette|
+ContextPad|CommandPalette|EventMatrixPicker|PropertyPanel|
+ProblemsPanel' src/routes/ src/lib/canvas/UnifiedCanvas.svelte`
+returning zero hits.
+
+This amendment records the **integration decisions** — no new design,
+just how the existing components plug into the existing canvas.
+
+### Where each surface mounts
+
+| Surface | Mount site | Why there |
+|---|---|---|
+| `BpmnPalette` | New `BpmnAuthoringShell` left column | Self-contained 220px aside; sits next to UnifiedCanvas. |
+| `ContextPad` | Inside `BpmnRenderer` when `selected` | Already wraps `<NodeToolbar>`, which auto-anchors via xyflow's per-node context. Placing it in the renderer is the only way it can read that context. |
+| `CommandPalette` | Page-level modal mounted by the shell | Modal dialog (top: 20%); needs its `open`/`mode` driven externally so the same instance handles N (create), A (append) and R (replace). |
+| `EventMatrixPicker` | Page-level modal mounted by the shell | Same shape as CommandPalette; opened either by the create flow on `event_*` keys or the context-pad/command-palette replace flow. |
+| `PropertyPanel` | New `BpmnAuthoringShell` right column | Always-on per spec; replaces the conditional `ElementEditPanel` / `NodeStylePanel` / `LinkedDiagramPanel` stack for BPMN views only. |
+| `ProblemsPanel` | New `BpmnAuthoringShell` bottom dock | Below the canvas; reactive to `validateBpmn(data)` so it updates as nodes/edges change. |
+
+### Wiring decisions
+
+1. **Action callback path for ContextPad** — the shell sets a Svelte
+   context value `bpmnContextPadAction` (via UnifiedCanvas's
+   `setContext`). BpmnRenderer reads it with `getContext`. Avoids
+   prop-drilling through UnifiedCanvas → DynamicNode → BpmnRenderer
+   for a callback only one renderer needs.
+2. **canConnect surfacing** — wired through xyflow's
+   `isValidConnection` prop on `<SvelteFlow>`. The shell's handler
+   maps the verdict's `reason` into a fixed-position toast
+   (`BpmnToast`) so the user sees *why* a connection was blocked.
+3. **Drag-drop from palette** — `BpmnPalette` already emits
+   `application/iris-bpmn-entity` on drag start. UnifiedCanvas
+   adds `ondrop` + `ondragover` handlers on its outer div, uses
+   `useSvelteFlow().screenToFlowPosition` to convert the cursor
+   coordinate into flow coordinates, and emits `ondropentity(key,
+   pos)`. The shell makes a node from that.
+4. **N / A / R hotkeys** — moved out of `CommandPalette`'s self-
+   binding (`bindShortcuts={false}`) and lifted into a
+   `<svelte:window onkeydown>` inside the shell. Reason: the palette
+   is mounted globally on every BPMN view, but the hotkeys must NOT
+   fire on non-BPMN views. The shell-level handler also gates them on
+   `notation === 'bpmn'`.
+5. **Toast** — new `BpmnToast` component (~50 lines, no library —
+   single consumer). Two-way bindable `message` prop; auto-clears.
+6. **SvelteFlowProvider wrap** — required to use `useSvelteFlow()` at
+   the UnifiedCanvas script level (above the `<SvelteFlow>` instance)
+   so the drop handler has access to `screenToFlowPosition`. The
+   provider wraps the whole template and is benign for non-drop usage.
+
+### Why a new shell component instead of inlining into the views detail page
+
+The detail page is already 3.2k lines after the v5.1.x renames. The
+3-column layout + 6 surface mounts + hotkey relay + drop handling
+would add ~350 more lines across an already-busy file. A shared
+`BpmnAuthoringShell.svelte` keeps the BPMN concern in one file and
+reduces the page-level surgery to a single `{:else if notation ===
+'bpmn'}` branch — easier to review, easier to remove if BPMN ever gets
+extracted into its own route.
+
+### Regression guard
+
+`frontend/tests/unit/bpmnCanvasIntegration.test.ts` (16 tests)
+asserts: shell file exists, shell imports the five direct surfaces
+plus `BpmnToast`, shell mounts each one, the page imports + mounts
+the shell behind the BPMN guard, UnifiedCanvas declares the three new
+hook props and wires them, and BpmnRenderer mounts ContextPad and
+reads the context handler. Same static-parser style as the v5.1.1 /
+v5.1.2 coverage tests.

--- a/docs/adrs/specs/SPEC-136-A-BPMN-Notation.md
+++ b/docs/adrs/specs/SPEC-136-A-BPMN-Notation.md
@@ -242,3 +242,63 @@ every notation key registered in `NOTATION_TYPE_FALLBACK` appears in
 the pill list. This catches the exact regression that produced
 issue #27 — adding a notation to the registry without surfacing it in
 the picker.
+
+## Amendment 2026-05-05 — BPMN canvas UX integration map (issue #37, v5.2.0)
+
+Per the ADR-136 v5.2.0 amendment, the six BPMN UX surfaces are now
+mounted into the canvas via a new `BpmnAuthoringShell` wrapper. This
+table is the surface-by-surface integration record — file paths,
+state read/written, callback wiring.
+
+### Integration map
+
+| Surface | Mounts in | Reads | Writes (callback) | Notes |
+|---|---|---|---|---|
+| `BpmnPalette` | `BpmnAuthoringShell` left aside (220px) | `initialOpen` (default `'activity'`) | `onselect(key)` → shell creates a node via `makeBpmnNode(key)` at `findOpenPosition()` | Drag-start emits `application/iris-bpmn-entity` on `dataTransfer`; drop is handled by UnifiedCanvas. |
+| `ContextPad` | Inside `BpmnRenderer` when `selected` | `nodeId` (renderer prop), `visible` (= `selected`) | `onaction(action, nodeId)` → bridged via `getContext('bpmnContextPadAction')` to the shell's `handleContextPadAction` | Wraps `<NodeToolbar position={Position.Right} offset={8}>` — auto-anchors to the node and follows pan/zoom. |
+| `CommandPalette` | `BpmnAuthoringShell` page-level modal | `open` + `mode` (bound by shell), `bindShortcuts={false}` | `onpick(entry, mode)` → shell handles `create` / `append` / `replace` (replace mutates the existing node's `type` + `data.entityType` + `data.data` to the new BPMN_DEFAULT_DISCRIMINATORS) | Self-binding disabled because the same instance serves all three modes; the shell drives `mode` from N / A / R hotkeys. |
+| `EventMatrixPicker` | `BpmnAuthoringShell` page-level modal | `open` (bound by shell) | `onpick(variant)` → shell creates an event node populated with `eventTrigger` + (maybe) `eventDirection` + (maybe) `boundaryInterrupting` | Opens automatically when an `event_*` entity is created via palette/drop/command; uses `pendingDropPosition` to remember the click site. |
+| `PropertyPanel` | `BpmnAuthoringShell` right aside (280px) | `selection: PropertyPanelData \| null` derived from `selectedEditNodeId` + `canvasNodes` | `onchange(id, patch)` → shell maps `label` / `description` to top-level `data` and the rest to inner `data.data` (discriminators) | Always mounted for BPMN views (not gated on selection); shows an empty state when nothing's selected. Replaces the existing `ElementEditPanel` / `NodeStylePanel` / `LinkedDiagramPanel` stack for BPMN only. |
+| `ProblemsPanel` | `BpmnAuthoringShell` bottom dock (80–200px) | `data: BpmnDiagramData` derived from `canvasNodes` + `canvasEdges` | `onfocus(elementIds[])` → shell sets `selectedEditNodeId` to the first id (canvas highlights via existing selection wiring) | Re-runs `validateBpmn(data)` reactively whenever nodes/edges mutate. |
+| `BpmnToast` (new) | `BpmnAuthoringShell` fixed-position bottom-centre | `message` (bound by shell) | Self-clears after 3.5s; bindable so the shell can also clear/refresh | Surface for `canConnect` rejection reasons. ~50 lines, single-purpose, no new dep. |
+
+### UnifiedCanvas hook props
+
+| Prop | Type | Wired by | Used for |
+|---|---|---|---|
+| `onbeforeconnect` | `(c: Edge \| Connection) => boolean` | Shell's `handleBeforeConnect` | `<SvelteFlow isValidConnection={onbeforeconnect}>` — blocks the edge at draw-time when `canConnect` returns `{allowed: false}` and surfaces the reason via toast. |
+| `ondropentity` | `(key: string, pos: { x: number; y: number }) => void` | Shell's `handleDropEntity` | Receives the palette drop after `useSvelteFlow().screenToFlowPosition` converts the cursor. Shell creates a BPMN node at the projected position. |
+| `oncontextpadaction` | `(action: string, nodeId: string) => void` | Shell's `handleContextPadAction` | `setContext('bpmnContextPadAction', oncontextpadaction)` — BpmnRenderer's `<ContextPad onaction={…}>` calls back via this Svelte context. |
+
+### BpmnRenderer additions
+
+- New `id?: string` prop (xyflow auto-passes node ids to custom node components — only Iris's renderer interface didn't declare it).
+- `import ContextPad from '$lib/canvas/palette/ContextPad.svelte'`.
+- `const onContextPadAction = getContext<(action, nodeId) => void>('bpmnContextPadAction')`.
+- Mount: `<ContextPad nodeId={id} visible={selected} onaction={(a, n) => onContextPadAction?.(a, n)} />` placed alongside the `<Handle>` elements at the top of the renderer template — visible only when `selected`, anchored by the inner `<NodeToolbar>`.
+
+### Layout decisions
+
+- `SvelteFlowProvider` wraps UnifiedCanvas's whole template so the script-level `useSvelteFlow()` call has a store to read.
+- `BpmnAuthoringShell` is a CSS-grid 3-column layout (220px / 1fr / 280px) with a flex-row + bottom problems dock. `height: calc(100vh - 230px)` to match the existing canvas-area sizing.
+- Hotkeys (N / A / R) are gated by `notation === 'bpmn'` and standard input-target guards (`INPUT` / `TEXTAREA` / `isContentEditable`).
+
+### Files added in v5.2.0
+
+| File | Lines | Purpose |
+|---|---|---|
+| `frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte` | ~430 | The shell itself. |
+| `frontend/src/lib/canvas/bpmn/BpmnToast.svelte` | ~80 | The fixed-position toast. |
+| `frontend/tests/unit/bpmnCanvasIntegration.test.ts` | ~135 | Static-parser regression guard (16 tests). |
+
+### Files modified in v5.2.0
+
+| File | Change |
+|---|---|
+| `frontend/src/lib/canvas/UnifiedCanvas.svelte` | Wrapped in `<SvelteFlowProvider>`; added 3 hook props (`onbeforeconnect`, `ondropentity`, `oncontextpadaction`); wired `isValidConnection` + `ondrop`/`ondragover`; `setContext('bpmnContextPadAction', …)`. |
+| `frontend/src/lib/canvas/renderers/BpmnRenderer.svelte` | Added `id?: string` prop; mounts `<ContextPad>` when selected; reads action handler from `getContext('bpmnContextPadAction')`. |
+| `frontend/src/routes/views/[id]/+page.svelte` | New `{:else if notation === 'bpmn'}` branch in the editing canvas-area chain that mounts `<BpmnAuthoringShell>` instead of the generic UnifiedCanvas + right-panel layout. |
+| `docs/adrs/ADR-136-BPMN-Notation.md` | Amendment with integration decisions. |
+| `docs/adrs/specs/SPEC-136-A-BPMN-Notation.md` | This integration map. |
+| `CHANGELOG.md` | New `[5.2.0]` section. |
+| `frontend/package.json` + `package-lock.json` | Version bump 5.1.2 → 5.2.0. |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.1.2",
+	"version": "5.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.1.2",
+			"version": "5.2.0",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.1.2",
+	"version": "5.2.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/UnifiedCanvas.svelte
+++ b/frontend/src/lib/canvas/UnifiedCanvas.svelte
@@ -5,8 +5,9 @@
 	 * Supports both edit and browse modes.
 	 */
 	import { setContext } from 'svelte';
-	import { SvelteFlow, Controls, Background } from '@xyflow/svelte';
+	import { SvelteFlow, SvelteFlowProvider, Controls, Background, useSvelteFlow } from '@xyflow/svelte';
 	import { ConnectionMode } from '@xyflow/system';
+	import type { Connection, Edge } from '@xyflow/svelte';
 	import '@xyflow/svelte/dist/style.css';
 
 	import { unifiedNodeTypes, unifiedEdgeTypes } from './registry';
@@ -34,6 +35,17 @@
 		onnodedragstart?: () => void;
 		ontogglemode?: () => void;
 		panX?: number;
+		/** v5.2.0 (issue #37): BPMN connection guard. Return false to block the
+		 *  connection at draw-time. Wire to bpmnRules.canConnect at the page
+		 *  level. xyflow's IsValidConnection signature accepts `Edge | Connection`. */
+		onbeforeconnect?: (c: Edge | Connection) => boolean;
+		/** v5.2.0 (issue #37): the canvas drop target receives a palette item
+		 *  via the `application/iris-bpmn-entity` MIME type. Position is in
+		 *  SvelteFlow coordinates so the page can drop a node at the cursor. */
+		ondropentity?: (entityKey: string, position: { x: number; y: number }) => void;
+		/** v5.2.0 (issue #37): forwarded to BpmnRenderer via setContext so the
+		 *  ContextPad inside a selected BPMN node can call back to the page. */
+		oncontextpadaction?: (action: string, nodeId: string) => void;
 	}
 
 	let {
@@ -54,11 +66,37 @@
 		onnodedragstart,
 		ontogglemode,
 		panX = 0,
+		onbeforeconnect,
+		ondropentity,
+		oncontextpadaction,
 	}: Props = $props();
 
 	// Set notation context for DynamicNode/DynamicEdge to read
 	setContext('notation', notation);
 	setContext('preferredThemeId', preferredThemeId);
+	// v5.2.0 (issue #37): expose the ContextPad action handler to BpmnRenderer
+	// via Svelte context so it can fire actions back to the page without a
+	// renderer-level prop hop.
+	setContext('bpmnContextPadAction', oncontextpadaction);
+
+	const flow = useSvelteFlow();
+
+	function handleDragOver(e: DragEvent) {
+		// Required for the browser to fire `drop` — the default behaviour
+		// rejects the drop entirely.
+		if (e.dataTransfer?.types.includes('application/iris-bpmn-entity')) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'copy';
+		}
+	}
+
+	function handleDrop(e: DragEvent) {
+		const key = e.dataTransfer?.getData('application/iris-bpmn-entity');
+		if (!key) return;
+		e.preventDefault();
+		const position = flow.screenToFlowPosition({ x: e.clientX, y: e.clientY });
+		ondropentity?.(key, position);
+	}
 
 	let announcer: CanvasAnnouncer | undefined = $state();
 	let keyboardHandler: KeyboardHandler | undefined = $state();
@@ -226,6 +264,11 @@
 	}
 </script>
 
+<!-- v5.2.0 (issue #37): wrap in SvelteFlowProvider so the script-level
+	 useSvelteFlow() call (used by handleDrop's screenToFlowPosition) has a
+	 store to read. Required because the drop handler lives on the OUTER div,
+	 above <SvelteFlow>'s own implicit provider. -->
+<SvelteFlowProvider>
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
 	class="model-canvas{browseMode ? ' model-canvas--browse' : ''}"
@@ -233,6 +276,8 @@
 	aria-label="{notationLabel} diagram canvas{browseMode ? ' — browse mode (read-only)' : ''}{connectMode ? ' — connect mode active' : ''}"
 	aria-roledescription="interactive diagram{browseMode ? ', read-only' : ''}"
 	onkeydown={browseMode ? undefined : handleKeydown}
+	ondragover={browseMode ? undefined : handleDragOver}
+	ondrop={browseMode ? undefined : handleDrop}
 >
 	{#if browseMode}
 		<SvelteFlow
@@ -270,6 +315,7 @@
 			onpaneclick={handlePaneClick}
 			onreconnect={handleReconnect}
 			onnodedragstart={() => onnodedragstart?.()}
+			isValidConnection={onbeforeconnect}
 			proOptions={{ hideAttribution: true }}
 			defaultEdgeOptions={{ type: defaultEdgeType }}
 			nodesDraggable={true}
@@ -336,3 +382,4 @@
 
 	<CanvasAnnouncer bind:this={announcer} />
 </div>
+</SvelteFlowProvider>

--- a/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
+++ b/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
@@ -1,0 +1,507 @@
+<script lang="ts">
+	/**
+	 * v5.2.0 (issue #37): BPMN authoring shell.
+	 *
+	 * Mounts the six BPMN-specific UX surfaces from ADR-136 §UX into a
+	 * 3-column layout (palette / canvas / property panel) with a bottom
+	 * problems dock and a fixed toast for canConnect rejection reasons.
+	 *
+	 * Mounted from `views/[id]/+page.svelte` only when
+	 * `notation === 'bpmn' && editing`. Replaces the generic right-side
+	 * ElementEditPanel/NodeStylePanel stack with the always-on
+	 * PropertyPanel for BPMN views.
+	 *
+	 * Keeps the views detail page (already 3.2k lines) from ballooning.
+	 */
+	import { tick } from 'svelte';
+	import type { Connection, Edge } from '@xyflow/svelte';
+	import UnifiedCanvas from '$lib/canvas/UnifiedCanvas.svelte';
+	import BpmnPalette from '$lib/canvas/palette/BpmnPalette.svelte';
+	import CommandPalette, { type CommandMode } from '$lib/canvas/palette/CommandPalette.svelte';
+	import EventMatrixPicker from '$lib/canvas/palette/EventMatrixPicker.svelte';
+	import PropertyPanel, { type PropertyPanelData } from '$lib/canvas/properties/PropertyPanel.svelte';
+	import ProblemsPanel from '$lib/canvas/validation/ProblemsPanel.svelte';
+	import BpmnToast from '$lib/canvas/bpmn/BpmnToast.svelte';
+	import { canConnect } from '$lib/canvas/validation/bpmnRules';
+	import {
+		BPMN_DEFAULT_DISCRIMINATORS,
+		type BpmnEntityType,
+		type BpmnEntityTypeInfo,
+		type CanvasNode,
+		type CanvasEdge,
+		type NotationType,
+	} from '$lib/types/canvas';
+	import type { createCanvasHistory } from '$lib/canvas/useCanvasHistory.svelte';
+
+	interface Props {
+		canvasNodes: CanvasNode[];
+		canvasEdges: CanvasEdge[];
+		notation: NotationType;
+		preferredThemeId?: string;
+		selectedEditNodeId: string | null;
+		history: ReturnType<typeof createCanvasHistory>;
+		oncanvasdirty?: () => void;
+		onnodeselect?: (id: string | null) => void;
+		onedgeselect?: (id: string | null) => void;
+	}
+
+	let {
+		canvasNodes = $bindable([]),
+		canvasEdges = $bindable([]),
+		notation,
+		preferredThemeId,
+		selectedEditNodeId = $bindable(null),
+		history,
+		oncanvasdirty,
+		onnodeselect,
+		onedgeselect,
+	}: Props = $props();
+
+	let cmdOpen = $state(false);
+	let cmdMode = $state<CommandMode>('create');
+	let eventPickerOpen = $state(false);
+	let eventPickerContext = $state<'create' | 'replace'>('create');
+	let pendingDropPosition = $state<{ x: number; y: number } | null>(null);
+	let toastMessage = $state('');
+
+	// ────────────────────────────────────────────────────────────────────
+	// Selection → PropertyPanel data
+	// ────────────────────────────────────────────────────────────────────
+	const selectedNode = $derived(
+		selectedEditNodeId ? canvasNodes.find((n) => n.id === selectedEditNodeId) ?? null : null,
+	);
+	const propertySelection = $derived<PropertyPanelData | null>(
+		selectedNode
+			? {
+					id: selectedNode.id,
+					entityType: (selectedNode.data?.entityType as string) ?? 'task',
+					label: (selectedNode.data?.label as string | undefined) ?? '',
+					description: (selectedNode.data?.description as string | undefined) ?? '',
+					data: ((selectedNode.data as Record<string, unknown> | undefined)?.data as
+						| Record<string, unknown>
+						| undefined) ?? {},
+				}
+			: null,
+	);
+
+	function dirty() {
+		oncanvasdirty?.();
+	}
+
+	function pushHistory() {
+		history.pushState(canvasNodes, canvasEdges);
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// Drop / palette / command palette → create node
+	// ────────────────────────────────────────────────────────────────────
+	function makeBpmnNode(
+		entityKey: BpmnEntityType,
+		position: { x: number; y: number },
+	): CanvasNode {
+		const id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+			? crypto.randomUUID()
+			: `bpmn-${Math.random().toString(36).slice(2, 10)}`;
+		// CanvasNodeData.entityType is typed narrowly as SimpleEntityType but
+		// stores values from every notation in practice (UML/ArchiMate/C4/DoView/BPMN).
+		// Cast through unknown matches the existing pattern elsewhere in the
+		// codebase for cross-notation entityType assignments.
+		return {
+			id,
+			type: entityKey,
+			position,
+			width: 200,
+			data: {
+				label: humanLabel(entityKey),
+				entityType: entityKey,
+				notation: 'bpmn',
+				data: { ...(BPMN_DEFAULT_DISCRIMINATORS[entityKey] ?? {}) },
+			},
+		} as unknown as CanvasNode;
+	}
+
+	function humanLabel(key: BpmnEntityType): string {
+		return key
+			.split('_')
+			.map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+			.join(' ');
+	}
+
+	function findOpenPosition(): { x: number; y: number } {
+		// Mirrors views/[id]/+page.svelte::findOpenPosition: a column-major
+		// fallback when we don't have a drop position. Picks the first slot
+		// not occupied by an existing node within a tolerance window.
+		const cols = 4;
+		const W = 220, H = 100, GAP = 30;
+		const cellW = W + GAP, cellH = H + GAP;
+		for (let i = 0; i < 200; i++) {
+			const col = i % cols;
+			const row = Math.floor(i / cols);
+			const x = 60 + col * cellW;
+			const y = 60 + row * cellH;
+			const overlaps = canvasNodes.some((n) => {
+				const nx = n.position.x;
+				const ny = n.position.y;
+				return Math.abs(nx - x) < W + GAP / 2 && Math.abs(ny - y) < H + GAP / 2;
+			});
+			if (!overlaps) return { x, y };
+		}
+		return { x: 60, y: 60 };
+	}
+
+	function createNode(entityKey: BpmnEntityType, atPosition?: { x: number; y: number }) {
+		// Events have a 6×10 trigger × position matrix — route through the
+		// matrix picker so the user picks a meaningful variant rather than
+		// taking the default. Skip for boundary events that came from the
+		// context pad's append flow (handled separately).
+		const isEvent = entityKey.startsWith('event_');
+		if (isEvent && eventPickerContext === 'create') {
+			pendingDropPosition = atPosition ?? findOpenPosition();
+			eventPickerOpen = true;
+			return;
+		}
+		const pos = atPosition ?? findOpenPosition();
+		pushHistory();
+		canvasNodes = [...canvasNodes, makeBpmnNode(entityKey, pos)];
+		dirty();
+	}
+
+	function handlePaletteSelect(key: BpmnEntityType) {
+		eventPickerContext = 'create';
+		createNode(key);
+	}
+
+	function handleDropEntity(key: string, position: { x: number; y: number }) {
+		eventPickerContext = 'create';
+		createNode(key as BpmnEntityType, position);
+	}
+
+	function handleEventVariant(variant: {
+		entityType: BpmnEntityType;
+		eventTrigger: string;
+		eventDirection?: string;
+		boundaryInterrupting?: boolean;
+	}) {
+		eventPickerOpen = false;
+		const pos = pendingDropPosition ?? findOpenPosition();
+		pendingDropPosition = null;
+		const node = makeBpmnNode(variant.entityType, pos);
+		const data = (node.data as Record<string, unknown>);
+		data.data = {
+			...((data.data as Record<string, unknown> | undefined) ?? {}),
+			eventTrigger: variant.eventTrigger,
+			...(variant.eventDirection ? { eventDirection: variant.eventDirection } : {}),
+			...(typeof variant.boundaryInterrupting === 'boolean'
+				? { boundaryInterrupting: variant.boundaryInterrupting }
+				: {}),
+		};
+		pushHistory();
+		canvasNodes = [...canvasNodes, node];
+		dirty();
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// CommandPalette: pick → create / append / replace
+	// ────────────────────────────────────────────────────────────────────
+	function handleCmdPick(entry: BpmnEntityTypeInfo, mode: CommandMode) {
+		if (mode === 'create') {
+			eventPickerContext = 'create';
+			createNode(entry.key);
+			return;
+		}
+		if (mode === 'append') {
+			if (!selectedNode) return;
+			eventPickerContext = 'create';
+			const src = selectedNode;
+			const offset = { x: src.position.x + 280, y: src.position.y };
+			const newNode = makeBpmnNode(entry.key, offset);
+			pushHistory();
+			canvasNodes = [...canvasNodes, newNode];
+			canvasEdges = [
+				...canvasEdges,
+				{
+					id: `e-${src.id}-${newNode.id}`,
+					source: src.id,
+					target: newNode.id,
+					type: 'sequence_flow',
+					data: { label: '' },
+				} as CanvasEdge,
+			];
+			dirty();
+			return;
+		}
+		if (mode === 'replace') {
+			if (!selectedNode) return;
+			pushHistory();
+			canvasNodes = canvasNodes.map((n) => {
+				if (n.id !== selectedNode.id) return n;
+				return {
+					...n,
+					type: entry.key,
+					data: {
+						...n.data,
+						entityType: entry.key,
+						data: { ...(BPMN_DEFAULT_DISCRIMINATORS[entry.key] ?? {}) },
+					},
+				} as unknown as CanvasNode;
+			});
+			dirty();
+		}
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// ContextPad action handler
+	// ────────────────────────────────────────────────────────────────────
+	function handleContextPadAction(action: string, nodeId: string) {
+		const src = canvasNodes.find((n) => n.id === nodeId);
+		if (!src) return;
+		switch (action) {
+			case 'append_task':
+				appendBpmn(src, 'task');
+				break;
+			case 'append_gateway':
+				appendBpmn(src, 'gateway');
+				break;
+			case 'append_end_event':
+				appendBpmn(src, 'event_end');
+				break;
+			case 'change':
+				cmdMode = 'replace';
+				cmdOpen = true;
+				break;
+			case 'delete':
+				deleteNodeById(nodeId);
+				break;
+			case 'connect':
+				// Existing canvas connect-mode is keyboard-driven; no-op for now.
+				toastMessage = 'Drag from the right handle to connect.';
+				break;
+		}
+	}
+
+	function appendBpmn(src: CanvasNode, key: BpmnEntityType) {
+		const newNode = makeBpmnNode(key, { x: src.position.x + 280, y: src.position.y });
+		pushHistory();
+		canvasNodes = [...canvasNodes, newNode];
+		canvasEdges = [
+			...canvasEdges,
+			{
+				id: `e-${src.id}-${newNode.id}`,
+				source: src.id,
+				target: newNode.id,
+				type: 'sequence_flow',
+				data: { label: '' },
+			} as CanvasEdge,
+		];
+		dirty();
+	}
+
+	function deleteNodeById(nodeId: string) {
+		pushHistory();
+		canvasNodes = canvasNodes.filter((n) => n.id !== nodeId);
+		canvasEdges = canvasEdges.filter((e) => e.source !== nodeId && e.target !== nodeId);
+		dirty();
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// PropertyPanel: patch the selected node's data
+	// ────────────────────────────────────────────────────────────────────
+	function handlePropChange(id: string, patch: Record<string, unknown>) {
+		pushHistory();
+		canvasNodes = canvasNodes.map((n) => {
+			if (n.id !== id) return n;
+			// Top-level fields the panel knows about: label, description.
+			const next = { ...n, data: { ...n.data } };
+			if ('label' in patch) (next.data as Record<string, unknown>).label = patch.label;
+			if ('description' in patch) (next.data as Record<string, unknown>).description = patch.description;
+			// Everything else is a discriminator field on the inner data.data record.
+			const innerKeys = Object.keys(patch).filter((k) => k !== 'label' && k !== 'description');
+			if (innerKeys.length > 0) {
+				const inner = {
+					...(((n.data as Record<string, unknown>).data as Record<string, unknown> | undefined) ?? {}),
+				};
+				for (const k of innerKeys) inner[k] = patch[k];
+				(next.data as Record<string, unknown>).data = inner;
+			}
+			return next as CanvasNode;
+		});
+		dirty();
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// canConnect bridge
+	// ────────────────────────────────────────────────────────────────────
+	function handleBeforeConnect(c: Edge | Connection): boolean {
+		const src = canvasNodes.find((n) => n.id === c.source);
+		const tgt = canvasNodes.find((n) => n.id === c.target);
+		if (!src || !tgt) return true;
+		const verdict = canConnect({
+			source: {
+				id: src.id,
+				type: (src.data?.entityType as string | undefined) ?? src.type,
+				parentId: src.parentId ?? null,
+				data: src.data as Record<string, unknown>,
+			},
+			target: {
+				id: tgt.id,
+				type: (tgt.data?.entityType as string | undefined) ?? tgt.type,
+				parentId: tgt.parentId ?? null,
+				data: tgt.data as Record<string, unknown>,
+			},
+			edgeType: 'sequence_flow',
+			nodes: canvasNodes.map((n) => ({
+				id: n.id,
+				type: (n.data?.entityType as string | undefined) ?? n.type,
+				parentId: n.parentId ?? null,
+				data: n.data as Record<string, unknown>,
+			})),
+		});
+		if (!verdict.allowed) {
+			toastMessage = verdict.reason ?? 'Connection blocked';
+		}
+		return verdict.allowed;
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// ProblemsPanel: focus the offending node(s)
+	// ────────────────────────────────────────────────────────────────────
+	async function focusProblemNodes(elementIds: string[]) {
+		if (elementIds.length === 0) return;
+		selectedEditNodeId = elementIds[0];
+		onnodeselect?.(elementIds[0]);
+		await tick();
+		// SvelteFlow's fitView would jump the viewport; the user-facing UX is
+		// just to highlight via selection, which the existing canvas handles.
+	}
+
+	// ────────────────────────────────────────────────────────────────────
+	// N / A / R hotkey relay (shell-level so it disables on non-BPMN routes)
+	// ────────────────────────────────────────────────────────────────────
+	function handleWindowKey(e: KeyboardEvent) {
+		if (notation !== 'bpmn') return;
+		const t = e.target as HTMLElement | null;
+		if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+		const k = e.key.toLowerCase();
+		if (k === 'n') {
+			e.preventDefault();
+			cmdMode = 'create';
+			cmdOpen = true;
+		} else if (k === 'a') {
+			if (!selectedNode) return;
+			e.preventDefault();
+			cmdMode = 'append';
+			cmdOpen = true;
+		} else if (k === 'r') {
+			if (!selectedNode) return;
+			e.preventDefault();
+			cmdMode = 'replace';
+			cmdOpen = true;
+		}
+	}
+
+	const problemsData = $derived({
+		nodes: canvasNodes.map((n) => ({
+			id: n.id,
+			type: (n.data?.entityType as string | undefined) ?? n.type,
+			parentId: n.parentId ?? null,
+			data: n.data as Record<string, unknown>,
+		})),
+		edges: canvasEdges.map((e) => ({
+			id: e.id,
+			source: e.source,
+			target: e.target,
+			type: e.type,
+			data: e.data as Record<string, unknown>,
+		})),
+	});
+</script>
+
+<svelte:window onkeydown={handleWindowKey} />
+
+<div class="bpmn-shell">
+	<div class="bpmn-shell__row">
+		<aside class="bpmn-shell__palette" aria-label="BPMN palette">
+			<BpmnPalette onselect={handlePaletteSelect} />
+		</aside>
+		<div class="bpmn-shell__canvas">
+			<UnifiedCanvas
+				{notation}
+				{preferredThemeId}
+				bind:nodes={canvasNodes}
+				bind:edges={canvasEdges}
+				onbeforeconnect={handleBeforeConnect}
+				ondropentity={handleDropEntity}
+				oncontextpadaction={handleContextPadAction}
+				onnodeselect={(id) => { selectedEditNodeId = id; onnodeselect?.(id); }}
+				onedgeselect={(id) => onedgeselect?.(id)}
+			/>
+		</div>
+		<aside class="bpmn-shell__props" aria-label="BPMN property panel">
+			<PropertyPanel selection={propertySelection} onchange={handlePropChange} />
+		</aside>
+	</div>
+	<div class="bpmn-shell__problems">
+		<ProblemsPanel data={problemsData} onfocus={focusProblemNodes} />
+	</div>
+</div>
+
+<CommandPalette
+	bind:open={cmdOpen}
+	bind:mode={cmdMode}
+	bindShortcuts={false}
+	onpick={handleCmdPick}
+	onclose={() => (cmdOpen = false)}
+/>
+
+<EventMatrixPicker
+	bind:open={eventPickerOpen}
+	onpick={handleEventVariant}
+	onclose={() => { eventPickerOpen = false; pendingDropPosition = null; }}
+/>
+
+<BpmnToast bind:message={toastMessage} />
+
+<style>
+	.bpmn-shell {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+		min-height: 0;
+		min-width: 0;
+		gap: 8px;
+		height: calc(100vh - 230px);
+	}
+	.bpmn-shell__row {
+		display: grid;
+		grid-template-columns: 220px 1fr 280px;
+		gap: 8px;
+		flex: 1;
+		min-height: 0;
+		min-width: 0;
+	}
+	.bpmn-shell__palette,
+	.bpmn-shell__props {
+		min-height: 0;
+		overflow: hidden;
+		display: flex;
+		flex-direction: column;
+		border: 1px solid var(--color-border, #d4d4d4);
+		border-radius: 6px;
+		background: var(--color-surface, #fff);
+	}
+	.bpmn-shell__canvas {
+		min-width: 0;
+		min-height: 0;
+		border: 1px solid var(--color-border, #d4d4d4);
+		border-radius: 6px;
+		overflow: hidden;
+	}
+	.bpmn-shell__problems {
+		min-height: 80px;
+		max-height: 200px;
+		overflow: hidden;
+		border: 1px solid var(--color-border, #d4d4d4);
+		border-radius: 6px;
+		background: var(--color-surface, #fff);
+	}
+</style>

--- a/frontend/src/lib/canvas/bpmn/BpmnToast.svelte
+++ b/frontend/src/lib/canvas/bpmn/BpmnToast.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	/**
+	 * v5.2.0 (issue #37): minimal aria-live toast used by the BPMN authoring
+	 * shell to surface canConnect rejection reasons. Two-way bindable
+	 * `message` prop — the parent sets it on rejection, the toast clears it
+	 * after a timeout so a subsequent identical rejection can still re-fire.
+	 *
+	 * Iris doesn't have a toast library (per DRY survey), and this is the
+	 * only consumer in v5.2.0. Kept inline to avoid pulling a dep for a
+	 * single use site; can be lifted into a shared library later.
+	 */
+	interface Props {
+		/** Bindable message. Setting to a non-empty string shows the toast;
+		 *  the toast clears itself back to '' after `duration` ms. */
+		message: string;
+		duration?: number;
+	}
+
+	let { message = $bindable(''), duration = 3500 }: Props = $props();
+
+	let timer: ReturnType<typeof setTimeout> | null = null;
+
+	$effect(() => {
+		if (timer) {
+			clearTimeout(timer);
+			timer = null;
+		}
+		if (message) {
+			timer = setTimeout(() => {
+				message = '';
+				timer = null;
+			}, duration);
+		}
+		return () => {
+			if (timer) {
+				clearTimeout(timer);
+				timer = null;
+			}
+		};
+	});
+</script>
+
+{#if message}
+	<div class="bpmn-toast" role="status" aria-live="polite">
+		{message}
+		<button
+			type="button"
+			class="bpmn-toast__dismiss"
+			aria-label="Dismiss"
+			onclick={() => (message = '')}
+		>×</button>
+	</div>
+{/if}
+
+<style>
+	.bpmn-toast {
+		position: fixed;
+		bottom: 24px;
+		left: 50%;
+		transform: translateX(-50%);
+		display: inline-flex;
+		align-items: center;
+		gap: 12px;
+		padding: 10px 14px 10px 16px;
+		max-width: 420px;
+		font-size: 13px;
+		line-height: 1.4;
+		color: #fff;
+		background: rgba(20, 20, 20, 0.92);
+		border-radius: 6px;
+		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+		z-index: 1000;
+	}
+	.bpmn-toast__dismiss {
+		all: unset;
+		cursor: pointer;
+		font-size: 18px;
+		line-height: 1;
+		opacity: 0.8;
+	}
+	.bpmn-toast__dismiss:hover { opacity: 1; }
+	.bpmn-toast__dismiss:focus-visible {
+		outline: 2px solid #fff;
+		outline-offset: 2px;
+	}
+</style>

--- a/frontend/src/lib/canvas/renderers/BpmnRenderer.svelte
+++ b/frontend/src/lib/canvas/renderers/BpmnRenderer.svelte
@@ -15,13 +15,23 @@
 	import type { CanvasNodeData, NotationType } from '$lib/types/canvas';
 	import { getThemeRendering } from '$lib/stores/themeStore.svelte';
 	import { nodeOverrideStyle, titleFontStyle } from '$lib/canvas/utils/visualStyles';
+	import ContextPad from '$lib/canvas/palette/ContextPad.svelte';
 
 	interface Props {
+		/** Node id — xyflow auto-passes this to custom node components. Used by
+		 *  the v5.2.0 (issue #37) ContextPad mount so it can call back to the
+		 *  page-level handler with the right nodeId. */
+		id?: string;
 		data: CanvasNodeData;
 		selected?: boolean;
 	}
 
-	let { data, selected = false }: Props = $props();
+	let { id = '', data, selected = false }: Props = $props();
+
+	/** v5.2.0 (issue #37): the page sets this via UnifiedCanvas's
+	 *  setContext('bpmnContextPadAction', …). When undefined the pad still
+	 *  renders but actions are no-ops. */
+	const onContextPadAction = getContext<(action: string, nodeId: string) => void>('bpmnContextPadAction');
 
 	const notation = getContext<NotationType>('notation') ?? 'bpmn';
 	const rendering = $derived(getThemeRendering(notation));
@@ -88,6 +98,14 @@
 <!-- Source/target handles common to every BPMN node -->
 <Handle type="target" position={Position.Left} />
 <Handle type="source" position={Position.Right} />
+
+<!-- v5.2.0 (issue #37): on-element context pad. Already wraps <NodeToolbar>
+	 so it auto-anchors to this node and follows pan/zoom. -->
+<ContextPad
+	nodeId={id}
+	visible={selected}
+	onaction={(action, nodeId) => onContextPadAction?.(action, nodeId)}
+/>
 
 {#if isActivity}
 	<div

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -8,6 +8,7 @@
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
 	import UnifiedCanvas from '$lib/canvas/UnifiedCanvas.svelte';
+	import BpmnAuthoringShell from '$lib/canvas/bpmn/BpmnAuthoringShell.svelte';
 	import SequenceDiagram from '$lib/canvas/sequence/SequenceDiagram.svelte';
 	import TextCanvas from '$lib/canvas/text/TextCanvas.svelte';
 	import MarkdownToc from '$lib/components/MarkdownToc.svelte';
@@ -2834,6 +2835,21 @@
 							<MarkdownToc headings={textHeadings} onclose={() => (showTocDrawer = false)} />
 						{/if}
 					</div>
+					{:else if notation === 'bpmn'}
+					<!-- v5.2.0 (issue #37): BPMN authoring shell — palette / canvas /
+						 property panel + bottom problems dock + canConnect toast.
+						 Replaces the generic right-panel stack on BPMN views in edit mode. -->
+					<BpmnAuthoringShell
+						{notation}
+						{preferredThemeId}
+						bind:canvasNodes
+						bind:canvasEdges
+						bind:selectedEditNodeId
+						{history}
+						oncanvasdirty={() => (canvasDirty = true)}
+						onnodeselect={handleNodeSelect}
+						onedgeselect={handleEdgeSelect}
+					/>
 					{:else}
 					<div class="flex gap-4">
 						<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: hidden">

--- a/frontend/tests/unit/bpmnCanvasIntegration.test.ts
+++ b/frontend/tests/unit/bpmnCanvasIntegration.test.ts
@@ -1,0 +1,135 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.2.0 (issue #37): mount the six BPMN authoring surfaces specified
+ * in ADR-136 §UX into the canvas. Pre-v5.2.0 they existed as files on
+ * disk but were never imported anywhere; net effect was that BPMN was
+ * catalogue-only.
+ *
+ * This test is the regression guard — if a future change removes any
+ * of the six mounts, or breaks the connection guard / drag-drop
+ * wiring, the test should catch it. Static-parser style (matches
+ * `notationPillsCoverage.test.ts` etc).
+ */
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const SHELL = resolve(ROOT, 'src/lib/canvas/bpmn/BpmnAuthoringShell.svelte');
+const TOAST = resolve(ROOT, 'src/lib/canvas/bpmn/BpmnToast.svelte');
+const PAGE = resolve(ROOT, 'src/routes/views/[id]/+page.svelte');
+const UNIFIED = resolve(ROOT, 'src/lib/canvas/UnifiedCanvas.svelte');
+const RENDERER = resolve(ROOT, 'src/lib/canvas/renderers/BpmnRenderer.svelte');
+
+describe('BPMN authoring shell exists (issue #37, v5.2.0)', () => {
+	it('the shell + toast files exist', () => {
+		expect(existsSync(SHELL)).toBe(true);
+		expect(existsSync(TOAST)).toBe(true);
+	});
+
+	it('the views detail page imports + mounts the shell behind a notation/editing guard', () => {
+		const src = readFileSync(PAGE, 'utf-8');
+		expect(src).toMatch(/import\s+BpmnAuthoringShell\s+from\s+['"]\$lib\/canvas\/bpmn\/BpmnAuthoringShell\.svelte['"]/);
+		expect(src).toMatch(/<BpmnAuthoringShell\b/);
+		// The mount must be guarded by notation === 'bpmn' so non-BPMN views
+		// keep the existing canvas branch unchanged. Accept either {#if … }
+		// or {:else if … } since the chain is part of an existing if/else.
+		const mountBlock = src.match(/\{(?:#if|:else if)[^}]*notation\s*===\s*'bpmn'[\s\S]{0,400}<BpmnAuthoringShell/);
+		expect(mountBlock).toBeTruthy();
+	});
+});
+
+describe('BpmnAuthoringShell mounts the BPMN UX surfaces', () => {
+	const src = existsSync(SHELL) ? readFileSync(SHELL, 'utf-8') : '';
+
+	it('imports the surface components the shell mounts directly + the toast', () => {
+		// ContextPad is intentionally NOT imported by the shell — it mounts
+		// inside BpmnRenderer (covered in the separate describe block below)
+		// and receives its action handler via setContext.
+		expect(src).toMatch(/import\s+BpmnPalette\b/);
+		expect(src).toMatch(/import\s+CommandPalette\b/);
+		expect(src).toMatch(/import\s+EventMatrixPicker\b/);
+		expect(src).toMatch(/import\s+PropertyPanel\b/);
+		expect(src).toMatch(/import\s+ProblemsPanel\b/);
+		expect(src).toMatch(/import\s+BpmnToast\b/);
+	});
+
+	it('mounts each surface', () => {
+		expect(src).toMatch(/<BpmnPalette\b/);
+		expect(src).toMatch(/<CommandPalette\b/);
+		expect(src).toMatch(/<EventMatrixPicker\b/);
+		expect(src).toMatch(/<PropertyPanel\b/);
+		expect(src).toMatch(/<ProblemsPanel\b/);
+		expect(src).toMatch(/<BpmnToast\b/);
+	});
+
+	it('binds the N / A / R hotkeys at the shell level (not via CommandPalette\'s self-binding)', () => {
+		// CommandPalette must be told NOT to self-bind, otherwise the hotkeys would
+		// also fire on non-BPMN views (CommandPalette is a global keydown listener).
+		expect(src).toMatch(/bindShortcuts=\{false\}/);
+		// Shell-level handler must check the keys and avoid hijacking inputs/textareas.
+		expect(src).toMatch(/'n'|'N'/);
+		expect(src).toMatch(/'a'|'A'/);
+		expect(src).toMatch(/'r'|'R'/);
+		expect(src).toMatch(/INPUT|TEXTAREA|isContentEditable/);
+	});
+
+	it('wires canConnect into UnifiedCanvas\'s onbeforeconnect', () => {
+		expect(src).toMatch(/import\s*\{[^}]*canConnect[^}]*\}\s*from/);
+		expect(src).toMatch(/onbeforeconnect=/);
+	});
+
+	it('wires the palette drop handler into UnifiedCanvas\'s ondropentity', () => {
+		expect(src).toMatch(/ondropentity=/);
+	});
+
+	it('wires the ContextPad action handler into UnifiedCanvas\'s oncontextpadaction', () => {
+		expect(src).toMatch(/oncontextpadaction=/);
+	});
+});
+
+describe('UnifiedCanvas exposes the BPMN integration hooks', () => {
+	const src = readFileSync(UNIFIED, 'utf-8');
+
+	it('declares onbeforeconnect / ondropentity / oncontextpadaction props', () => {
+		expect(src).toMatch(/onbeforeconnect\?:/);
+		expect(src).toMatch(/ondropentity\?:/);
+		expect(src).toMatch(/oncontextpadaction\?:/);
+	});
+
+	it('passes onbeforeconnect to <SvelteFlow isValidConnection={…}>', () => {
+		expect(src).toMatch(/isValidConnection=/);
+	});
+
+	it('hooks ondrop + ondragover for the palette drag-drop MIME', () => {
+		expect(src).toMatch(/ondragover=/);
+		expect(src).toMatch(/ondrop=/);
+		expect(src).toMatch(/application\/iris-bpmn-entity/);
+	});
+
+	it('shares the ContextPad action handler via setContext so BpmnRenderer can call it', () => {
+		expect(src).toMatch(/setContext\(['"]bpmnContextPadAction['"]/);
+	});
+});
+
+describe('BpmnRenderer mounts ContextPad when selected', () => {
+	const src = readFileSync(RENDERER, 'utf-8');
+
+	it('imports ContextPad', () => {
+		expect(src).toMatch(/import\s+ContextPad\s+from/);
+	});
+
+	it('declares an id prop (xyflow auto-passes node id to custom renderers)', () => {
+		expect(src).toMatch(/id\?:\s*string/);
+	});
+
+	it('mounts ContextPad with the node id when selected', () => {
+		expect(src).toMatch(/<ContextPad\b[\s\S]*?nodeId=\{id\}[\s\S]*?\/>/);
+	});
+
+	it('reads the action handler from the bpmnContextPadAction context', () => {
+		expect(src).toMatch(/getContext\b/);
+		expect(src).toMatch(/['"]bpmnContextPadAction['"]/);
+	});
+});


### PR DESCRIPTION
Promotes the v5.2.0 release ([tag](https://github.com/cgbarlow/iris/releases/tag/v5.2.0)) from \`main\` onto \`render-supabase-uat\`. Wires the six BPMN authoring surfaces (palette / context pad / command palette / event matrix picker / property panel / problems panel) into the canvas; non-BPMN views unchanged.

Backend untouched — no Supabase migrations needed.

### Test plan

- [ ] Open a BPMN view in Edit mode. Shell renders: palette left, canvas centre, property panel right, problems dock bottom.
- [ ] Drag any of the 14 base entity types from the palette onto the canvas — node appears at the drop position with the right BPMN_DEFAULT_DISCRIMINATORS.
- [ ] Press **N** with the canvas focused → CommandPalette opens in \`create\` mode. Type "task" → Task highlighted. Enter → adds Task node.
- [ ] Select a node → ContextPad shows on the right; click "Append Task" → new Task appended with sequence flow drawn.
- [ ] Select an event → PropertyPanel BPMN tab → change Trigger to "message" → renderer updates immediately, dirty flips to true.
- [ ] Try to draw a sequence flow across pool boundaries → blocked, toast says "Sequence flow crosses pool boundaries".
- [ ] Add an activity without a start event → ProblemsPanel shows the warning; click the row → canvas selects the offender.
- [ ] Press **R** with a node selected → CommandPalette opens in \`replace\` mode.
- [ ] Open a non-BPMN view (Simple / UML / ArchiMate / C4 / DoView / Text) — canvas branch is unchanged.