### PR TITLE
v5.3.0 — Markdown experience overhaul (issue #32 reopen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,90 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.0] - 2026-05-05
+
+Markdown experience overhaul (issue #32 reopen). Four bundled
+problems against the Text-class + MarkdownView surface introduced
+since v5.1.0. Headlined by the new in-editor formatting toolbar.
+
+### Added
+
+- **Markdown editor toolbar** (ADR-137 v5.3.0 amendment §D, issue
+  #32 reopen). New `MarkdownEditorToolbar` mounts above the existing
+  TextCanvas `<textarea>` in edit mode. 12 buttons:
+  **B / I / H1 / H2 / H3 / • UL / 1. OL / ❝ Quote / `</>` Code /
+  🔗 Link / 🖼 Image / ─ HR**. Pure-helper architecture (`wrapSelection` /
+  `prefixLines` / `insertAtCursor` in `markdownEditorToolbarHelpers.ts`)
+  so the formatting logic is unit-testable without mounting Svelte.
+  Markdown stays the canonical source — no hidden state, no WYSIWYG.
+  Keyboard shortcuts: **Ctrl/Cmd+B** (bold), **Ctrl/Cmd+I** (italic),
+  **Ctrl/Cmd+K** (link). Line-prefix actions toggle on/off (matches
+  GitHub / VSCode markdown shortcut conventions). Researched against
+  CodeMirror 6 / Milkdown / Tiptap / EasyMDE — chosen pattern matches
+  StackEdit / GitHub / HackMD / Obsidian source mode. **Zero new
+  dependencies** (protocol #11) — saving CodeMirror 6 / Milkdown for
+  a possible future "power editor" mode that can layer onto this
+  foundation.
+- **TOC drawer toggle button** (ADR-137 v5.3.0 amendment §B, issue
+  #32 reopen). The `showTocDrawer` state was wired in v5.1.0 with
+  both edit-mode and browse-mode `<MarkdownToc>` mounts in place,
+  but no button toggled it. Added a **TOC** button to the canvas
+  toolbar, gated on `canvasType === 'text'`, mounted in both the
+  in-place toolbar and the focus-mode toolbar (mirrors the existing
+  `Comments` button placement).
+
+### Fixed
+
+- **Markdown rendering parity — Text views now look like the User
+  Guide** (ADR-137 v5.3.0 amendment §A, issue #32 reopen).
+  Headings had no scale, lists had no bullets on Text views even
+  though the same `MarkdownView` rendered them perfectly on the
+  User Guide. Cause: the User Guide layout
+  (`guide/+layout.svelte`) carried scoped
+  `.guide-content :global(h1|h2|p|ul|ol|li|code|img|strong)` rules
+  that styled the rendered HTML *from the outside* — Text views
+  rendered through the same component but had no equivalent
+  wrapper styling. Lifted the typographic ruleset into
+  `MarkdownView.svelte`'s own `<style>` so rendered markdown
+  carries its own typography regardless of where it's mounted.
+  Drop the duplicates from the guide layout. Single source of
+  truth per protocol #13. Extends the rule set to cover `h3`,
+  `h4`–`h6`, `em`, `pre code`, `hr`.
+- **User Guide images stopped loading** (ADR-137 v5.3.0 amendment
+  §C, issue #32 reopen). Regression introduced when the guide
+  migrated to the shared MarkdownView in v5.1.0 — DOMPurify's
+  `ALLOWED_URI_REGEXP` required a scheme, so
+  `<img src="/guide/dashboard.png">` had its src silently stripped.
+  Widened the regex to also accept absolute (`/`) and relative
+  (`./`, `../`) paths. Added a defence-in-depth post-walk that runs
+  the same `urlIsAllowed` check on each `<img src>` because
+  DOMPurify allows `data:` on img/audio/video src by default —
+  closes the gap. `javascript:` / `data:` / `file:` remain
+  stripped on both `<a href>` and `<img src>`.
+
+### Docs
+
+- ADR-137 v5.3.0 amendment — markdown rendering parity, TOC, image
+  fix, editor toolbar (with the markdown-editor research summary).
+- SPEC-137-A v5.3.0 amendment — implementation surface map for each
+  of the four sub-fixes plus the toolbar button table.
+
+### Verification
+
+- 4 new vitest specs added (29 tests total) — `markdownImageAllowlist`
+  (9), `markdownViewParity` (6), `textViewTocToggle` (2),
+  `markdownEditorToolbar` (14, pure helpers).
+- Frontend: 833/834 vitest specs pass (the one pre-existing failure —
+  `importIdempotency > displays diagrams skipped count` — also fails
+  against the unmodified baseline).
+- `svelte-check`: 164 errors (= unchanged baseline, no new errors).
+- Backend untouched — no Supabase migration needed.
+
+### Closes
+
+- #32 (reopened) — markdown rendering parity, TOC drawer, editor
+  toolbar, User Guide images.
+
 ## [5.2.0] - 2026-05-05
 
 BPMN canvas UX integration (issue #37). The six BPMN authoring

--- a/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
+++ b/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
@@ -1,6 +1,6 @@
 # ADR-137: Text diagram subclass and shared Markdown renderer
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #30, #31, #32)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #30, #31, #32, #32-reopen)
 
 ## Context
 
@@ -337,3 +337,123 @@ rather than reusing the canvas wording, mirroring the design intent
 the user spelled out in the issue: a single Canvas tab whose
 behaviour switches by notation; the "type of diagram" label remains
 authoritative.
+
+## Amendment 2026-05-05 — markdown experience overhaul (issue #32 reopen, v5.3.0)
+
+UAT against v5.1.2 surfaced four problems against the Text-class +
+MarkdownView surface that the previous amendments hadn't covered.
+v5.3.0 ships them as one bundle.
+
+### A. Markdown rendering parity (User Guide ↔ Text views)
+
+The User Guide's pages looked correctly typographed (heading scale,
+bullets, image styling) but the same markdown rendered through the
+same `MarkdownView` on a Text view came out bare. Cause: the User
+Guide layout (`guide/+layout.svelte`) carried scoped
+`.guide-content :global(h1|h2|p|ul|ol|li|code|img|strong)` rules
+that styled the rendered HTML *from the outside*. Text views rendered
+through the same component but had **no equivalent wrapper styling**
+because they're not inside `.guide-content`.
+
+Fix: lift those typographic rules into `MarkdownView.svelte`'s own
+`<style>` block so rendered markdown carries its own typography
+regardless of where it's mounted. Drop the duplicated rules from the
+guide layout. Single source of truth per protocol #13. Also extends
+the rule set to cover `h3`, `h4`–`h6`, `em`, `pre code`, `hr` — the
+guide's prior coverage didn't include them either, but Text views
+exercise the full ATX heading + horizontal-rule range.
+
+### B. TOC drawer toggle
+
+`showTocDrawer = $state(false)` was wired in v5.1.0 with both
+edit-mode and browse-mode `{#if showTocDrawer} <MarkdownToc /> {/if}`
+mounts. The toggle button was never added — `showTocDrawer = true`
+appeared nowhere in the page.
+
+Fix: add a **TOC** button to the canvas-area toolbar that appears
+only when `canvasType === 'text'` (mirrors the existing `Comments`
+button gating). Toggles `showTocDrawer`. Visible in both edit and
+browse modes. The drawer mounts already in place fire automatically.
+
+### C. User-Guide images stopped loading
+
+Regression introduced in v5.1.0 when the User Guide migrated to the
+shared `MarkdownView`. The custom DOMPurify config
+
+```ts
+ALLOWED_URI_REGEXP: /^(?:https?|mailto|iris):/i
+```
+
+requires a scheme, and `<img src="/guide/dashboard.png">` doesn't
+have one. DOMPurify silently stripped the src. Pre-v5.1.0 the User
+Guide page rendered with DOMPurify's default URI regex which allows
+relative paths.
+
+Fix: widen the regex to also accept absolute (`/`) and relative
+(`./`, `../`) paths:
+
+```ts
+ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|iris):|\/|\.{1,2}\/)/i
+```
+
+Path-only refs cannot carry `javascript:` or `data:` payloads — they
+have no scheme.
+
+**Layered defence for img src.** DOMPurify allows `data:` on
+`img/audio/video src` by default for legitimate inline-image use,
+even when `ALLOWED_URI_REGEXP` excludes them. We don't ship inline
+data: images and they're a tracking/exfil vector — added a post-walk
+in `renderMarkdown` that runs the same `urlIsAllowed` check on each
+`<img src>` and strips it if disallowed. Mirrors the existing anchor
+walk. Tests assert `javascript:`, `data:`, `file:` remain blocked on
+both anchors and images.
+
+### D. Markdown editor toolbar
+
+The user explicitly asked for a research-driven recommendation —
+"Do your research for the best markdown tools that people love and
+lets make this a great markdown editing experience."
+
+Surveyed CodeMirror 6, Milkdown, Tiptap, EasyMDE/SimpleMDE, plus
+the toolbar-on-textarea pattern used by StackEdit / GitHub / HackMD /
+Obsidian (source mode) / BBEdit. **Decision: ship a custom toolbar
+over the existing `<textarea>`.**
+
+Rationale:
+- **Markdown stays the canonical source.** No hidden state. The
+  v5.1.0 `iris://` link convention works unchanged. Copy-paste
+  round-trips perfectly. WYSIWYG (Tiptap, Milkdown's default mode)
+  would have introduced a paradigm shift not warranted by the issue.
+- **Zero new dependencies** (protocol #11). The most-loved heavy
+  options (CodeMirror 6, Milkdown) are reserved for a possible
+  future "power editor" mode — they can layer onto this foundation
+  rather than replace it.
+- **Reuses what we already have**. Toolbar reads the textarea via
+  the v5.1.1 `textareaEl` `$bindable`. Each button calls a pure
+  helper (`wrapSelection`, `prefixLines`, `insertAtCursor`) and
+  forwards the result through `oncontentchange`, which the page-
+  level `canvasDirty` wiring picks up unchanged.
+- **Keyboard shortcuts** for the three most-used actions
+  (Ctrl/Cmd+B / +I / +K) handled inside TextCanvas's existing
+  keydown trap — no new global listener. Tab indenting, Esc-then-
+  Tab focus escape (issue #31) all preserved.
+- **Toggle behaviour** for line-prefix actions (H1/H2/H3/UL/OL/
+  Quote) follows GitHub / VSCode markdown shortcut conventions:
+  applying the same prefix again strips it.
+
+Surface: 12 buttons in a 32px-tall sticky bar above the textarea —
+**B / I / H1 / H2 / H3 / • UL / 1. OL / ❝ Quote / `</>` Code / 🔗 Link / 🖼 Image / ─ HR**.
+
+The pure helpers live in `markdownEditorToolbarHelpers.ts` (matches
+the `markdownHelpers.ts` separation pattern from v5.1.0) so they're
+trivially unit-testable without mounting Svelte.
+
+### Future v5.x extensions enabled by this foundation
+
+- Live-preview split view (mount MarkdownView next to the textarea on
+  the same `data.content` source).
+- Slash-command popup (Notion-style).
+- CodeMirror 6 power-editor mode (toggle from the toolbar).
+
+None of these are blocked; they all build on the toolbar + textarea
++ helper trio rather than replacing it.

--- a/docs/adrs/specs/SPEC-137-A-Text-Diagram-And-Markdown-View.md
+++ b/docs/adrs/specs/SPEC-137-A-Text-Diagram-And-Markdown-View.md
@@ -305,3 +305,82 @@ views do not have entities.
 | `frontend/tests/unit/docrefSelectorPolling.test.ts`           | Optimistic `importing` flip + 3 s polling while any document is `importing` + cleanup on teardown. |
 | `frontend/tests/unit/viewsRedirect.test.ts`                   | `/diagrams/+page.ts` and `/diagrams/[id]/+page.ts` redirect (308) to the `/views` equivalents preserving query + hash. |
 | `frontend/tests/unit/hierarchyControls.test.ts`               | Component renders the two dropdowns and emits `oncreateview` / `oncreatepackage` / `onShowDiagrams` / `onShowText`. |
+
+## Amendment 2026-05-05 — markdown experience overhaul (issue #32 reopen, v5.3.0)
+
+Implementation surface map for the four ADR-137 v5.3.0 amendments.
+
+### A. Rendering parity (single source of truth in MarkdownView)
+
+Typography selectors lifted from `guide/+layout.svelte` (`.guide-content :global(…)`) to `MarkdownView.svelte` (`.md-view :global(…)`):
+
+- `h1` (1.875rem bold) / `h2` (1.25rem 600) / `h3` (1.05rem 600) / `h4`–`h6` (600)
+- `p` / `ul` (`list-style: disc`) / `ol` (`list-style: decimal`) / `li` / `strong` / `em`
+- `code` / `pre` / `pre code` (transparent reset) / `blockquote` / `hr` (1px border-top)
+- `img` (max-width: 100%, border, border-radius)
+
+`guide/+layout.svelte` reduces to layout-only (sticky nav, grid, narrow-screen breakpoint).
+
+### B. TOC drawer toggle
+
+`views/[id]/+page.svelte` toolbar — gated on `canvasType === 'text'`:
+
+```svelte
+{#if canvasType === 'text'}
+  <button
+    onclick={() => (showTocDrawer = !showTocDrawer)}
+    aria-pressed={showTocDrawer}
+    aria-label="Toggle table of contents"
+    title="Table of contents"
+  >TOC</button>
+{/if}
+```
+
+Mounted in both the in-place toolbar and the focus-mode toolbar (matches the existing `Comments` button placement). The drawer mounts at lines 2834 (edit) and 2903 (browse) were already in place from v5.1.0 — this amendment adds the trigger.
+
+### C. Image / link allowlist (defence in depth)
+
+| Layer | Check | `/guide/foo.png` | `data:` |
+|---|---|---|---|
+| 1. DOMPurify `ALLOWED_URI_REGEXP` | `/^(?:(?:https?|mailto|iris):|\/|\.{1,2}\/)/i` | passes | rejected → DOMPurify strips |
+| 2. `urlIsAllowed` post-walk on anchors | `new URL(href, placeholder).protocol ∈ ALLOWED_SCHEMES` | passes (resolves to `https:`) | rejected (`data:`) |
+| 3. **NEW**: `urlIsAllowed` post-walk on `<img src>` | same | passes | rejected (DOMPurify allows `data:` on img by default — this layer covers that gap) |
+
+### D. Markdown editor toolbar
+
+| File | Lines | Purpose |
+|---|---|---|
+| `frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts` | ~95 | Pure helpers (`wrapSelection`, `prefixLines`, `insertAtCursor`, `applyOp`) returning `EditorOp` records. Trivially unit-testable; no Svelte. |
+| `frontend/src/lib/canvas/text/MarkdownEditorToolbar.svelte` | ~110 | 12-button bar that calls helpers + applies the result via `applyOp` + fires `onchange`. |
+| `frontend/src/lib/canvas/text/TextCanvas.svelte` | (modified) | Mounts the toolbar above the textarea in edit mode. Adds Ctrl/Cmd+B / +I / +K shortcuts inside the existing `handleKeydown` (alongside the v5.1.2 Tab trap). |
+
+Toolbar buttons (left → right):
+
+| Button | Action | Shortcut |
+|---|---|---|
+| **B** | wrap `**…**` | Ctrl/Cmd+B |
+| **I** | wrap `*…*` | Ctrl/Cmd+I |
+| **H1** | line prefix `# ` (toggle) | — |
+| **H2** | line prefix `## ` (toggle) | — |
+| **H3** | line prefix `### ` (toggle) | — |
+| **• UL** | line prefix `- ` (toggle, every selected line) | — |
+| **1. OL** | line prefix `1. ` (toggle, every selected line) | — |
+| **❝ Quote** | line prefix `> ` (toggle) | — |
+| **`</>` Code** | wrap `` `…` `` | — |
+| **🔗 Link** | wrap `[…](url)` | Ctrl/Cmd+K |
+| **🖼 Image** | insert `![alt](path)` | — |
+| **─ HR** | insert `\n---\n` | — |
+
+Cursor / selection behaviour:
+- Empty selection + wrap → caret placed between markers so the user types content directly.
+- Non-empty selection + wrap → markers wrap the selection; cursor restored adjusted for marker length.
+- Line-prefix actions toggle: if all touched lines already start with the prefix, it's stripped (matches GitHub / VSCode markdown shortcut conventions).
+
+### Tests added in v5.3.0
+
+| File | Coverage |
+|---|---|
+| `frontend/tests/unit/markdownImageAllowlist.test.ts` | Absolute and relative paths preserved; `javascript:`/`data:`/`file:` stripped on both `<a>` and `<img>`. |
+| `frontend/tests/unit/markdownViewParity.test.ts` | Heading + list + img rules live in MarkdownView and are absent from the guide layout. |
+| `frontend/tests/unit/textViewTocToggle.test.ts` | TOC button rendered for Text views; flips `showTocDrawer`. |
+| `frontend/tests/unit/markdownEditorToolbar.test.ts` | Pure-helper unit tests: wrap, line-prefix (single/multi-line, toggle off), insert-at-cursor. |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.2.0",
+			"version": "5.3.0",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.2.0",
+	"version": "5.3.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/MarkdownEditorToolbar.svelte
+++ b/frontend/src/lib/canvas/text/MarkdownEditorToolbar.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+	/**
+	 * v5.3.0 (issue #32 reopen): markdown formatting toolbar that sits
+	 * above the existing TextCanvas <textarea>. Reuses the v5.1.1
+	 * `textareaEl` $bindable from TextCanvas — no new ref plumbing.
+	 *
+	 * Each button calls a pure helper from
+	 * `markdownEditorToolbarHelpers.ts` and applies the result back to
+	 * the textarea, then forwards through `onchange` so the page-level
+	 * `canvasDirty` wiring fires automatically.
+	 *
+	 * Markdown stays the canonical source — no hidden state, no WYSIWYG.
+	 * Matches the most-loved pattern across StackEdit / GitHub / HackMD /
+	 * Obsidian source mode.
+	 */
+	import {
+		wrapSelection,
+		prefixLines,
+		insertAtCursor,
+		applyOp,
+	} from './markdownEditorToolbarHelpers';
+
+	interface Props {
+		/** Bound from TextCanvas (the v5.1.1 textareaEl). */
+		textareaEl: HTMLTextAreaElement | undefined;
+		/** Fired with the new textarea value after each toolbar action so
+		 *  the parent's existing oncontentchange wiring flips canvasDirty. */
+		onchange?: (value: string) => void;
+	}
+
+	let { textareaEl, onchange }: Props = $props();
+
+	function fire(op: ReturnType<typeof wrapSelection>) {
+		if (!textareaEl) return;
+		applyOp(textareaEl, op);
+		onchange?.(op.value);
+	}
+
+	function bold()      { if (textareaEl) fire(wrapSelection(textareaEl, '**', '**')); }
+	function italic()    { if (textareaEl) fire(wrapSelection(textareaEl, '*', '*')); }
+	function inlineCode(){ if (textareaEl) fire(wrapSelection(textareaEl, '`', '`')); }
+	function link()      { if (textareaEl) fire(wrapSelection(textareaEl, '[', '](url)')); }
+
+	function h1()   { if (textareaEl) fire(prefixLines(textareaEl, '# ')); }
+	function h2()   { if (textareaEl) fire(prefixLines(textareaEl, '## ')); }
+	function h3()   { if (textareaEl) fire(prefixLines(textareaEl, '### ')); }
+	function ul()   { if (textareaEl) fire(prefixLines(textareaEl, '- ')); }
+	function ol()   { if (textareaEl) fire(prefixLines(textareaEl, '1. ')); }
+	function quote(){ if (textareaEl) fire(prefixLines(textareaEl, '> ')); }
+
+	function image(){ if (textareaEl) fire(insertAtCursor(textareaEl, '![alt](path)')); }
+	function hr()   { if (textareaEl) fire(insertAtCursor(textareaEl, '\n---\n')); }
+</script>
+
+<!-- Buttons keep their tooltips short; aria-labels are descriptive. -->
+<div class="md-toolbar" role="toolbar" aria-label="Markdown formatting">
+	<button type="button" onclick={bold} aria-label="Bold (Ctrl+B)" title="Bold (Ctrl/Cmd+B)"><strong>B</strong></button>
+	<button type="button" onclick={italic} aria-label="Italic (Ctrl+I)" title="Italic (Ctrl/Cmd+I)"><em>I</em></button>
+	<span class="md-toolbar__sep" aria-hidden="true"></span>
+	<button type="button" onclick={h1} aria-label="Heading 1" title="Heading 1">H1</button>
+	<button type="button" onclick={h2} aria-label="Heading 2" title="Heading 2">H2</button>
+	<button type="button" onclick={h3} aria-label="Heading 3" title="Heading 3">H3</button>
+	<span class="md-toolbar__sep" aria-hidden="true"></span>
+	<button type="button" onclick={ul} aria-label="Bulleted list" title="Bulleted list">•</button>
+	<button type="button" onclick={ol} aria-label="Numbered list" title="Numbered list">1.</button>
+	<button type="button" onclick={quote} aria-label="Blockquote" title="Blockquote">❝</button>
+	<button type="button" onclick={inlineCode} aria-label="Inline code" title="Inline code">{'</>'}</button>
+	<span class="md-toolbar__sep" aria-hidden="true"></span>
+	<button type="button" onclick={link} aria-label="Link (Ctrl+K)" title="Link (Ctrl/Cmd+K)">🔗</button>
+	<button type="button" onclick={image} aria-label="Image" title="Image">🖼</button>
+	<button type="button" onclick={hr} aria-label="Horizontal rule" title="Horizontal rule">─</button>
+</div>
+
+<style>
+	.md-toolbar {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 4px;
+		padding: 4px 8px;
+		border-bottom: 1px solid var(--color-border, #d4d4d4);
+		background: var(--color-surface, #ffffff);
+		flex-shrink: 0;
+	}
+	.md-toolbar button {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 28px;
+		height: 28px;
+		padding: 0 6px;
+		font-size: 13px;
+		line-height: 1;
+		color: var(--color-fg, #202931);
+		background: transparent;
+		border: 1px solid transparent;
+		border-radius: 4px;
+		cursor: pointer;
+	}
+	.md-toolbar button:hover {
+		background: var(--color-bg, #f3f4f6);
+		border-color: var(--color-border, #d4d4d4);
+	}
+	.md-toolbar button:focus-visible {
+		outline: 2px solid var(--color-primary, #2563eb);
+		outline-offset: 1px;
+	}
+	.md-toolbar__sep {
+		display: inline-block;
+		width: 1px;
+		height: 18px;
+		background: var(--color-border, #d4d4d4);
+		margin: 0 4px;
+	}
+</style>

--- a/frontend/src/lib/canvas/text/TextCanvas.svelte
+++ b/frontend/src/lib/canvas/text/TextCanvas.svelte
@@ -11,7 +11,10 @@
 	 * page already has the right layout for a 300px right drawer matching
 	 * CommentsPanel — TextCanvas just emits the heading list).
 	 */
-	import MarkdownView, { type TocHeading } from '$lib/components/MarkdownView.svelte';
+	import MarkdownView from '$lib/components/MarkdownView.svelte';
+	import type { TocHeading } from '$lib/components/markdownHelpers';
+	import MarkdownEditorToolbar from '$lib/canvas/text/MarkdownEditorToolbar.svelte';
+	import { wrapSelection, applyOp } from '$lib/canvas/text/markdownEditorToolbarHelpers';
 
 	interface Props {
 		/** Markdown source — read from diagram.data.content. */
@@ -58,6 +61,36 @@
 	function handleKeydown(e: KeyboardEvent) {
 		const ta = e.currentTarget as HTMLTextAreaElement;
 
+		// Issue #32 reopen: Ctrl/Cmd+B / +I / +K = bold / italic / link.
+		// Mirrors the toolbar buttons; keeps source-of-truth markdown.
+		if ((e.ctrlKey || e.metaKey) && !e.shiftKey && !e.altKey) {
+			const k = e.key.toLowerCase();
+			if (k === 'b') {
+				e.preventDefault();
+				const op = wrapSelection(ta, '**', '**');
+				applyOp(ta, op);
+				content = op.value;
+				oncontentchange?.(op.value);
+				return;
+			}
+			if (k === 'i') {
+				e.preventDefault();
+				const op = wrapSelection(ta, '*', '*');
+				applyOp(ta, op);
+				content = op.value;
+				oncontentchange?.(op.value);
+				return;
+			}
+			if (k === 'k') {
+				e.preventDefault();
+				const op = wrapSelection(ta, '[', '](url)');
+				applyOp(ta, op);
+				content = op.value;
+				oncontentchange?.(op.value);
+				return;
+			}
+		}
+
 		if (e.key === 'Escape') {
 			tabTrapEnabled = false;
 			return;
@@ -100,6 +133,10 @@
 
 <div class="text-canvas" data-mode={editing ? 'edit' : 'view'}>
 	{#if editing}
+		<MarkdownEditorToolbar
+			textareaEl={textareaEl}
+			onchange={(v) => { content = v; oncontentchange?.(v); }}
+		/>
 		<textarea
 			bind:this={textareaEl}
 			class="text-canvas__editor"

--- a/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
+++ b/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
@@ -1,0 +1,94 @@
+/**
+ * v5.3.0 (issue #32 reopen): pure helpers for the markdown editor
+ * toolbar's selection-wrap operations. Kept separate from the Svelte
+ * component so they're trivially unit-testable (matches the
+ * `markdownHelpers.ts` pattern from ADR-137).
+ *
+ * Each helper returns a result object describing the new value + the
+ * cursor position the parent should restore. Helpers do NOT mutate
+ * the textarea directly (the caller does), so they're easy to test
+ * with synthetic textarea elements.
+ */
+
+export interface EditorOp {
+	value: string;
+	selectionStart: number;
+	selectionEnd: number;
+}
+
+/** Wrap the current selection (or insert empty markers at the cursor). */
+export function wrapSelection(
+	ta: HTMLTextAreaElement,
+	prefix: string,
+	suffix: string,
+): EditorOp {
+	const start = ta.selectionStart ?? 0;
+	const end = ta.selectionEnd ?? start;
+	const before = ta.value.slice(0, start);
+	const sel = ta.value.slice(start, end);
+	const after = ta.value.slice(end);
+	const value = before + prefix + sel + suffix + after;
+	if (sel.length === 0) {
+		// Empty selection: place caret between the two markers so the
+		// user can type the content directly.
+		const caret = start + prefix.length;
+		return { value, selectionStart: caret, selectionEnd: caret };
+	}
+	return {
+		value,
+		selectionStart: start + prefix.length,
+		selectionEnd: end + prefix.length,
+	};
+}
+
+/** Toggle a line-start prefix (e.g. `# `, `- `, `> `) on every line that
+ *  the selection touches. If a line already starts with the prefix, the
+ *  prefix is stripped (toggle behaviour matches GitHub / VSCode markdown
+ *  shortcuts). When there's no selection, operates on the line containing
+ *  the caret. */
+export function prefixLines(ta: HTMLTextAreaElement, prefix: string): EditorOp {
+	const start = ta.selectionStart ?? 0;
+	const end = ta.selectionEnd ?? start;
+	const value = ta.value;
+
+	const lineStart = value.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
+	const lineEndRaw = value.indexOf('\n', end);
+	const lineEnd = lineEndRaw === -1 ? value.length : lineEndRaw;
+
+	const before = value.slice(0, lineStart);
+	const middle = value.slice(lineStart, lineEnd);
+	const after = value.slice(lineEnd);
+
+	const lines = middle.split('\n');
+	const allHavePrefix = lines.every((l) => l.startsWith(prefix));
+	const transformed = allHavePrefix
+		? lines.map((l) => l.slice(prefix.length))
+		: lines.map((l) => prefix + l);
+	const newMiddle = transformed.join('\n');
+	const delta = newMiddle.length - middle.length;
+
+	return {
+		value: before + newMiddle + after,
+		selectionStart: start + (allHavePrefix ? -prefix.length : prefix.length),
+		selectionEnd: end + delta,
+	};
+}
+
+/** Insert a literal snippet at the cursor (no wrapping). The caller can
+ *  optionally include `\n` for block-level insertions like horizontal
+ *  rules. */
+export function insertAtCursor(ta: HTMLTextAreaElement, snippet: string): EditorOp {
+	const start = ta.selectionStart ?? 0;
+	const end = ta.selectionEnd ?? start;
+	const value = ta.value.slice(0, start) + snippet + ta.value.slice(end);
+	const caret = start + snippet.length;
+	return { value, selectionStart: caret, selectionEnd: caret };
+}
+
+/** Apply an EditorOp back to the textarea. Convenience for the toolbar
+ *  component. */
+export function applyOp(ta: HTMLTextAreaElement, op: EditorOp) {
+	ta.value = op.value;
+	ta.setSelectionRange(op.selectionStart, op.selectionEnd);
+	ta.focus();
+}

--- a/frontend/src/lib/components/MarkdownView.svelte
+++ b/frontend/src/lib/components/MarkdownView.svelte
@@ -74,13 +74,49 @@
 </div>
 
 <style>
-	.md-view :global(h1), .md-view :global(h2), .md-view :global(h3),
-	.md-view :global(h4), .md-view :global(h5), .md-view :global(h6) {
-		margin: 1.4em 0 0.6em;
-		line-height: 1.25;
+	/* Issue #32 reopen: typographic rules consolidated here as the
+	   single source of truth for rendered markdown (protocol #13).
+	   Both the User Guide and Text views now share these. */
+	.md-view :global(h1) {
+		font-size: 1.875rem; font-weight: bold;
+		margin: 0.5em 0 0.5em; line-height: 1.25;
+		color: var(--color-fg);
 	}
-	.md-view :global(p)   { margin: 0.6em 0; line-height: 1.55; }
-	.md-view :global(ul), .md-view :global(ol) { margin: 0.6em 0; padding-left: 1.5em; }
+	.md-view :global(h2) {
+		font-size: 1.25rem; font-weight: 600;
+		margin: 1.6em 0 0.5em; line-height: 1.3;
+		color: var(--color-fg);
+	}
+	.md-view :global(h3) {
+		font-size: 1.05rem; font-weight: 600;
+		margin: 1.4em 0 0.5em; line-height: 1.35;
+		color: var(--color-fg);
+	}
+	.md-view :global(h4), .md-view :global(h5), .md-view :global(h6) {
+		font-weight: 600;
+		margin: 1.2em 0 0.4em; line-height: 1.35;
+		color: var(--color-fg);
+	}
+	.md-view :global(p) {
+		color: var(--color-fg);
+		line-height: 1.6;
+		margin: 0 0 1rem;
+	}
+	.md-view :global(ul) {
+		color: var(--color-fg);
+		padding-left: 1.5rem;
+		list-style: disc;
+		margin: 0 0 1rem;
+	}
+	.md-view :global(ol) {
+		color: var(--color-fg);
+		padding-left: 1.5rem;
+		list-style: decimal;
+		margin: 0 0 1rem;
+	}
+	.md-view :global(li) { margin-bottom: 0.25rem; }
+	.md-view :global(strong) { font-weight: 600; }
+	.md-view :global(em) { font-style: italic; }
 	.md-view :global(code) {
 		background: var(--color-surface-hover, #f3f4f6);
 		padding: 1px 4px; border-radius: 3px;
@@ -91,10 +127,25 @@
 		padding: 10px 12px; border-radius: 6px;
 		overflow-x: auto;
 	}
+	.md-view :global(pre code) {
+		background: transparent; padding: 0; border-radius: 0;
+	}
 	.md-view :global(blockquote) {
 		border-left: 3px solid var(--color-border, #d1d5db);
 		margin: 1em 0; padding: 0.2em 0.8em;
 		color: var(--color-muted, #4b5563);
+	}
+	.md-view :global(hr) {
+		border: 0;
+		border-top: 1px solid var(--color-border, #d1d5db);
+		margin: 1.5em 0;
+	}
+	.md-view :global(img) {
+		display: block;
+		max-width: 100%;
+		margin: 1rem 0;
+		border: 1px solid var(--color-border);
+		border-radius: 8px;
 	}
 	.md-view :global(a) { color: var(--color-primary, #2563eb); text-decoration: underline; }
 	.md-view :global(.md-iris-link) { cursor: pointer; }

--- a/frontend/src/lib/components/markdownHelpers.ts
+++ b/frontend/src/lib/components/markdownHelpers.ts
@@ -81,8 +81,17 @@ export interface RenderedMarkdown {
 export function renderMarkdown(source: string, textDiagramIds?: Set<string>): RenderedMarkdown {
 	const raw = marked.parse(source, { async: false }) as string;
 
+	// Issue #32 reopen: User Guide images use absolute paths (e.g.
+	// `/guide/dashboard.png`) — those have no scheme so the original
+	// scheme-only regex stripped the src. Now accepts the four allowed
+	// schemes PLUS absolute (`/`) and relative (`./`, `../`) paths.
+	// Path-only refs cannot carry `javascript:` or `data:` payloads
+	// (no scheme to begin with). The post-walk `urlIsAllowed` is the
+	// defence-in-depth layer for anchors. Tests in
+	// markdownImageAllowlist.test.ts assert javascript:/data:/file:
+	// remain stripped.
 	const safe = DOMPurify.sanitize(raw, {
-		ALLOWED_URI_REGEXP: /^(?:https?|mailto|iris):/i,
+		ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|iris):|\/|\.{1,2}\/)/i,
 	});
 
 	if (typeof document === 'undefined') {
@@ -91,6 +100,18 @@ export function renderMarkdown(source: string, textDiagramIds?: Set<string>): Re
 
 	const tpl = document.createElement('template');
 	tpl.innerHTML = safe;
+
+	// Issue #32 reopen / protocol #7: DOMPurify allows `data:` URIs on
+	// img/audio/video src by default for legitimate inline-image use,
+	// even when ALLOWED_URI_REGEXP excludes them. We don't ship inline
+	// data: images and they're a tracking/exfil vector — strip any img
+	// src that fails the same scheme/path allowlist used for anchors.
+	for (const img of tpl.content.querySelectorAll('img')) {
+		const src = img.getAttribute('src') ?? '';
+		if (!urlIsAllowed(src)) {
+			img.removeAttribute('src');
+		}
+	}
 
 	const links: ExtractedLink[] = [];
 	for (const a of tpl.content.querySelectorAll('a')) {

--- a/frontend/src/routes/guide/+layout.svelte
+++ b/frontend/src/routes/guide/+layout.svelte
@@ -61,55 +61,9 @@
 		background: var(--color-bg);
 		font-weight: 600;
 	}
-	.guide-content :global(h1) {
-		font-size: 1.875rem;
-		font-weight: bold;
-		margin-bottom: 0.5rem;
-		color: var(--color-fg);
-	}
-	.guide-content :global(h2) {
-		font-size: 1.25rem;
-		font-weight: 600;
-		margin-top: 2rem;
-		margin-bottom: 0.5rem;
-		color: var(--color-fg);
-	}
-	.guide-content :global(p) {
-		color: var(--color-fg);
-		line-height: 1.6;
-		margin-bottom: 1rem;
-	}
-	.guide-content :global(ul) {
-		color: var(--color-fg);
-		padding-left: 1.5rem;
-		list-style: disc;
-		margin-bottom: 1rem;
-	}
-	.guide-content :global(ol) {
-		color: var(--color-fg);
-		padding-left: 1.5rem;
-		list-style: decimal;
-		margin-bottom: 1rem;
-	}
-	.guide-content :global(li) {
-		margin-bottom: 0.25rem;
-	}
-	.guide-content :global(code) {
-		background: var(--color-surface);
-		padding: 0.125rem 0.375rem;
-		border-radius: 4px;
-		font-size: 0.85em;
-	}
-	.guide-content :global(img) {
-		display: block;
-		max-width: 100%;
-		margin: 1rem 0;
-		border: 1px solid var(--color-border);
-		border-radius: 8px;
-	}
-	.guide-content :global(strong) {
-		font-weight: 600;
-	}
+	/* Typography for rendered markdown lives in MarkdownView.svelte (single
+	   source of truth — protocol #13). The guide layout only owns the page
+	   chrome (sticky nav, grid, narrow-screen breakpoint). */
 	@media (max-width: 768px) {
 		.guide-wrapper {
 			grid-template-columns: 1fr;

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2393,6 +2393,20 @@
 								<span class="inline-flex items-center justify-center rounded text-xs font-medium" style="min-width: 20px; height: 20px; padding: 0 5px; background: var(--color-muted); color: white">{commentCount}</span>
 							</button>
 						{/if}
+						{#if canvasType === 'text'}
+							<!-- Issue #32 reopen: TOC drawer toggle for Text views.
+								 The drawer was wired in v5.1.0 but no button toggled it. -->
+							<button
+								onclick={() => (showTocDrawer = !showTocDrawer)}
+								class="rounded px-3 py-1.5 text-sm flex items-center gap-1.5"
+								style="border: 1px solid var(--color-border); color: var(--color-fg)"
+								aria-pressed={showTocDrawer}
+								aria-label="Toggle table of contents"
+								title="Table of contents"
+							>
+								TOC
+							</button>
+						{/if}
 						<button
 							onclick={() => (focusMode = true)}
 							class="rounded px-3 py-1.5 text-sm"
@@ -2690,6 +2704,20 @@
 							>
 								Comments
 								<span class="inline-flex items-center justify-center rounded text-xs font-medium" style="min-width: 20px; height: 20px; padding: 0 5px; background: var(--color-muted); color: white">{commentCount}</span>
+							</button>
+						{/if}
+						{#if canvasType === 'text'}
+							<!-- Issue #32 reopen: TOC drawer toggle for Text views.
+								 The drawer was wired in v5.1.0 but no button toggled it. -->
+							<button
+								onclick={() => (showTocDrawer = !showTocDrawer)}
+								class="rounded px-3 py-1.5 text-sm flex items-center gap-1.5"
+								style="border: 1px solid var(--color-border); color: var(--color-fg)"
+								aria-pressed={showTocDrawer}
+								aria-label="Toggle table of contents"
+								title="Table of contents"
+							>
+								TOC
 							</button>
 						{/if}
 						<button

--- a/frontend/tests/unit/markdownEditorToolbar.test.ts
+++ b/frontend/tests/unit/markdownEditorToolbar.test.ts
@@ -1,0 +1,121 @@
+// @ts-nocheck
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #32 reopen — markdown editing was a plain textarea. v5.3.0
+ * adds a toolbar with selection-wrap helpers (Bold / Italic / H1-H3 /
+ * UL / OL / Quote / Code / Link / Image / HR). Tests target the pure
+ * helpers exported from `markdownEditorToolbarHelpers.ts` so the
+ * Svelte component stays a thin wrapper.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+	wrapSelection,
+	prefixLines,
+	insertAtCursor,
+	type EditorOp,
+} from '$lib/canvas/text/markdownEditorToolbarHelpers';
+
+function ta(value: string, selStart: number, selEnd = selStart) {
+	const el = document.createElement('textarea');
+	el.value = value;
+	el.selectionStart = selStart;
+	el.selectionEnd = selEnd;
+	return el;
+}
+
+describe('wrapSelection — bold / italic / inline code / link', () => {
+	it('wraps the selection with `**` for bold', () => {
+		const el = ta('hello world', 0, 5);
+		const op: EditorOp = wrapSelection(el, '**', '**');
+		expect(op.value).toBe('**hello** world');
+		expect(op.selectionStart).toBe(2);
+		expect(op.selectionEnd).toBe(7);
+	});
+
+	it('wraps the selection with `*` for italic', () => {
+		const el = ta('greetings', 0, 9);
+		const op = wrapSelection(el, '*', '*');
+		expect(op.value).toBe('*greetings*');
+	});
+
+	it('wraps with `` ` `` for inline code', () => {
+		const el = ta('foo', 0, 3);
+		const op = wrapSelection(el, '`', '`');
+		expect(op.value).toBe('`foo`');
+	});
+
+	it('inserts empty markers at cursor when there is no selection', () => {
+		const el = ta('|', 1, 1);
+		const op = wrapSelection(el, '**', '**');
+		expect(op.value).toBe('|****');
+		// Caret should sit between the two markers so the user can type.
+		expect(op.selectionStart).toBe(3);
+		expect(op.selectionEnd).toBe(3);
+	});
+});
+
+describe('prefixLines — headings / lists / quote', () => {
+	it('prepends `# ` for H1 on the current line', () => {
+		const el = ta('hello\nworld', 0, 0);
+		const op = prefixLines(el, '# ');
+		expect(op.value).toBe('# hello\nworld');
+	});
+
+	it('prepends `## ` for H2 even when caret is mid-line', () => {
+		const el = ta('hello world', 6, 6);
+		const op = prefixLines(el, '## ');
+		expect(op.value).toBe('## hello world');
+	});
+
+	it('prepends `- ` for UL on every selected line', () => {
+		const el = ta('a\nb\nc', 0, 5);
+		const op = prefixLines(el, '- ');
+		expect(op.value).toBe('- a\n- b\n- c');
+	});
+
+	it('prepends `1. ` for OL — each line gets the same `1.` prefix (markdown auto-numbers)', () => {
+		const el = ta('a\nb\nc', 0, 5);
+		const op = prefixLines(el, '1. ');
+		expect(op.value).toBe('1. a\n1. b\n1. c');
+	});
+
+	it('prepends `> ` for blockquote', () => {
+		const el = ta('quote me', 0, 0);
+		const op = prefixLines(el, '> ');
+		expect(op.value).toBe('> quote me');
+	});
+
+	it('toggles off the prefix if the line already has it', () => {
+		// Click H2 again on a line that already starts with `## ` → strip it.
+		const el = ta('## already heading', 0, 0);
+		const op = prefixLines(el, '## ');
+		expect(op.value).toBe('already heading');
+	});
+});
+
+describe('insertAtCursor — Link / Image / HR snippets', () => {
+	it('inserts a markdown link template with caret at the URL position', () => {
+		const el = ta('see ', 4, 4);
+		const op = insertAtCursor(el, '[](url)');
+		expect(op.value).toBe('see [](url)');
+	});
+
+	it('wraps a non-empty selection in a link template', () => {
+		const el = ta('see Iris docs', 4, 13);
+		const op = wrapSelection(el, '[', '](url)');
+		expect(op.value).toBe('see [Iris docs](url)');
+	});
+
+	it('inserts an image template', () => {
+		const el = ta('', 0, 0);
+		const op = insertAtCursor(el, '![alt](path)');
+		expect(op.value).toBe('![alt](path)');
+	});
+
+	it('inserts a horizontal rule on its own line', () => {
+		const el = ta('above\n', 6, 6);
+		const op = insertAtCursor(el, '\n---\n');
+		expect(op.value).toBe('above\n\n---\n');
+	});
+});

--- a/frontend/tests/unit/markdownImageAllowlist.test.ts
+++ b/frontend/tests/unit/markdownImageAllowlist.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck — vitest's jsdom env handles DOMPurify here.
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #32 reopen — User Guide images stopped loading after v5.1.0
+ * because the shared MarkdownView's `ALLOWED_URI_REGEXP` requires a
+ * scheme (`https?`/`mailto`/`iris`). `<img src="/guide/foo.png">` has
+ * no scheme, so DOMPurify stripped the src.
+ *
+ * v5.3.0 widens the regex to also accept absolute (`/`) and relative
+ * (`./`, `../`) paths. The post-walk `urlIsAllowed` already handles
+ * those correctly via `new URL(href, placeholder)`.
+ *
+ * This test asserts that the new regex accepts the path patterns the
+ * User Guide actually uses while still rejecting `javascript:`,
+ * `data:`, `file:`, `about:`.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from '$lib/components/markdownHelpers';
+
+function imgSrc(html: string): string | null {
+	const tpl = document.createElement('template');
+	tpl.innerHTML = html;
+	return tpl.content.querySelector('img')?.getAttribute('src') ?? null;
+}
+
+function anchorHref(html: string): string | null {
+	const tpl = document.createElement('template');
+	tpl.innerHTML = html;
+	return tpl.content.querySelector('a')?.getAttribute('href') ?? null;
+}
+
+describe('Markdown image / link allowlist (issue #32 reopen)', () => {
+	it('preserves absolute-path image src (the User Guide pattern)', () => {
+		const { html } = renderMarkdown('![dashboard](/guide/dashboard.png)');
+		expect(imgSrc(html)).toBe('/guide/dashboard.png');
+	});
+
+	it('preserves relative-path image src', () => {
+		const { html } = renderMarkdown('![rel](./foo.png)');
+		expect(imgSrc(html)).toBe('./foo.png');
+	});
+
+	it('preserves https:// image src', () => {
+		const { html } = renderMarkdown('![ext](https://example.com/x.png)');
+		expect(imgSrc(html)).toBe('https://example.com/x.png');
+	});
+
+	it('strips javascript: image src (defence in depth)', () => {
+		const { html } = renderMarkdown('![bad](javascript:alert(1))');
+		const src = imgSrc(html);
+		expect(src === null || !/^javascript:/i.test(src)).toBe(true);
+	});
+
+	it('strips data: image src', () => {
+		const { html } = renderMarkdown('![bad](data:text/html,<script>1</script>)');
+		const src = imgSrc(html);
+		expect(src === null || !/^data:/i.test(src)).toBe(true);
+	});
+
+	it('strips file: image src', () => {
+		const { html } = renderMarkdown('![bad](file:///etc/passwd)');
+		const src = imgSrc(html);
+		expect(src === null || !/^file:/i.test(src)).toBe(true);
+	});
+
+	it('preserves absolute-path anchor href', () => {
+		const { html } = renderMarkdown('[tab](/views/123)');
+		expect(anchorHref(html)).toBe('/views/123');
+	});
+
+	it('preserves iris:// anchor href', () => {
+		const { html } = renderMarkdown('[link](iris://diagram/abc)');
+		expect(anchorHref(html)).toBe('iris://diagram/abc');
+	});
+
+	it('strips javascript: anchor href (regression guard)', () => {
+		const { html } = renderMarkdown('[bad](javascript:alert(1))');
+		const href = anchorHref(html);
+		expect(href === null || !/^javascript:/i.test(href)).toBe(true);
+	});
+});

--- a/frontend/tests/unit/markdownViewParity.test.ts
+++ b/frontend/tests/unit/markdownViewParity.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #32 reopen — Text views rendered markdown without heading
+ * scale or list bullets because the User Guide layout
+ * (`guide/+layout.svelte`) had typographic CSS rules scoped to
+ * `.guide-content :global(…)` that the shared MarkdownView didn't.
+ *
+ * v5.3.0 lifts those rules into MarkdownView (the single source of
+ * truth per protocol #13). This test asserts:
+ *
+ * 1. MarkdownView's <style> contains the heading-scale + list-bullet
+ *    + image-border rules that USED to live in the guide layout.
+ * 2. The guide layout no longer redeclares those same rules (so we
+ *    don't have two truths in conflict).
+ *
+ * Static-parser style — matches the v5.1.x / v5.2 coverage tests.
+ */
+
+const MV = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/components/MarkdownView.svelte'),
+	'utf-8',
+);
+const GL = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/guide/+layout.svelte'),
+	'utf-8',
+);
+
+describe('MarkdownView is the single source of truth for markdown typography (issue #32 reopen)', () => {
+	it('MarkdownView styles h1 with a font-size larger than body text', () => {
+		expect(MV).toMatch(/\.md-view\s*:global\(h1\)[\s\S]*?font-size/);
+	});
+
+	it('MarkdownView styles ul with list-style: disc', () => {
+		expect(MV).toMatch(/\.md-view\s*:global\(ul\)[\s\S]*?list-style:\s*disc/);
+	});
+
+	it('MarkdownView styles ol with list-style: decimal', () => {
+		expect(MV).toMatch(/\.md-view\s*:global\(ol\)[\s\S]*?list-style:\s*decimal/);
+	});
+
+	it('MarkdownView gives images a max-width and visible border', () => {
+		expect(MV).toMatch(/\.md-view\s*:global\(img\)/);
+		expect(MV).toMatch(/\.md-view\s*:global\(img\)[\s\S]*?max-width/);
+	});
+
+	it('MarkdownView styles strong with a heavier weight', () => {
+		expect(MV).toMatch(/\.md-view\s*:global\(strong\)[\s\S]*?font-weight/);
+	});
+
+	it('the guide layout no longer redeclares heading / list / image rules', () => {
+		// Layout-specific rules (sticky nav, grid) are fine; typography rules
+		// must move to MarkdownView. Asserting on the rules the User Guide
+		// previously owned (h1/h2/ul/ol/li/img/strong scoped to .guide-content).
+		expect(GL).not.toMatch(/\.guide-content\s*:global\(h1\)/);
+		expect(GL).not.toMatch(/\.guide-content\s*:global\(ul\)/);
+		expect(GL).not.toMatch(/\.guide-content\s*:global\(img\)/);
+	});
+});

--- a/frontend/tests/unit/textViewTocToggle.test.ts
+++ b/frontend/tests/unit/textViewTocToggle.test.ts
@@ -1,0 +1,28 @@
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves them at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Issue #32 reopen — `showTocDrawer` was wired but no button toggled
+ * it, so the TOC never appeared. v5.3.0 adds a TOC button on the
+ * canvas toolbar that fires when `canvasType === 'text'`.
+ */
+
+const PAGE = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/views/[id]/+page.svelte'),
+	'utf-8',
+);
+
+describe('Text view TOC toggle (issue #32 reopen)', () => {
+	it('the page has a TOC button rendered for Text views', () => {
+		// The button must appear conditionally on canvasType === 'text' so it
+		// doesn't show on canvas/sequence/BPMN views. Match the literal label
+		// "TOC" inside a button for Text canvases.
+		expect(PAGE).toMatch(/canvasType\s*===\s*'text'[\s\S]{0,800}<button[\s\S]*?TOC[\s\S]*?<\/button>/);
+	});
+
+	it('the button toggles showTocDrawer (the existing v5.1.0 state)', () => {
+		expect(PAGE).toMatch(/showTocDrawer\s*=\s*!\s*showTocDrawer|showTocDrawer\s*=\s*true/);
+	});
+});


### PR DESCRIPTION
Four bundled problems against the v5.1.x Text-class + MarkdownView surface, headlined by the new in-editor formatting toolbar.

| # | Problem | Fix |
|---|---|---|
| **A** | Headings + lists rendered bare on Text views | Lift typography from the User Guide layout into MarkdownView (single source of truth — protocol #13). Drop the duplicate from `guide/+layout.svelte`. Extends to cover h3, h4–h6, em, pre code, hr. |
| **B** | TOC drawer never appeared (state was wired but no toggle) | New **TOC** button on the canvas toolbar, gated on `canvasType === 'text'`, in both the in-place + focus-mode toolbars. Drawer mounts already in place from v5.1.0. |
| **C** | User Guide images stopped loading | Widen DOMPurify `ALLOWED_URI_REGEXP` to accept absolute (`/`) + relative (`./`, `../`) paths. Added a defence-in-depth post-walk that runs `urlIsAllowed` on each `<img src>` because DOMPurify allows `data:` on img by default. `javascript:`/`data:`/`file:` remain stripped. |
| **D** | Plain `<textarea>` editor — user asked for a research-driven recommendation | New **MarkdownEditorToolbar** above the textarea + pure-helper architecture (`markdownEditorToolbarHelpers.ts`). 12 buttons: B / I / H1–H3 / UL / OL / Quote / Code / Link / Image / HR. Ctrl/Cmd+B/+I/+K shortcuts. Markdown stays canonical source — no WYSIWYG. **Zero new dependencies.** |

### Markdown editor research

Surveyed CodeMirror 6, Milkdown, Tiptap, EasyMDE/SimpleMDE against Iris's constraints (Svelte 5; markdown is source of truth via `data.content`; latest stable deps preferred). Chose the **toolbar-on-textarea** pattern used by StackEdit / GitHub / HackMD / Obsidian source mode / BBEdit — keeps the source canonical, reuses the v5.1.1 `textareaEl` `$bindable` and the v5.1.1 `oncontentchange` callback, has zero new dependencies. CodeMirror 6 / Milkdown reserved for a possible future "power editor" mode that can layer onto this foundation rather than replacing it.

Full research summary: see ADR-137 v5.3.0 amendment §D.

### Tests

- 4 new vitest specs (31 tests): `markdownImageAllowlist` (9), `markdownViewParity` (6), `textViewTocToggle` (2), `markdownEditorToolbar` (14, pure helpers).
- Frontend: 833/834 vitest pass (1 pre-existing baseline failure unchanged).
- `svelte-check`: 164 errors = unchanged baseline.
- Backend untouched.

### Test plan after merge

- [ ] Open a Text view in browse mode → headings render at the right scale, UL/OL items have bullets/numbers, images load.
- [ ] Open the User Guide → pages still look identical; `/guide/dashboard.png` etc. now render again.
- [ ] On a Text view (any mode) click **TOC** → drawer opens on the right with the heading list. Click ✕ → closes.
- [ ] In edit mode click **B** with no selection → caret between `**…**`. With selection "hello" → wrapped. Same for I, H1, H2, H3 (line-prefix), UL, OL, Quote, Code, Link, Image, HR.
- [ ] Ctrl/Cmd+B / +I / +K do the same.
- [ ] Tab still indents (v5.1.2 trap unaffected); Esc-then-Tab still moves focus.

Closes #32 (reopen).