### PR TITLE
Merge main into render-supabase-uat — v5.3.1 hot-fix (canvas regression)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.3.1] - 2026-05-05
+
+Hot-fix for v5.2.0 (issue #37 reopen). Every canvas — not just BPMN —
+crashed on load with `Uncaught Error: To call useStore outside of
+<SvelteFlow /> you need to wrap your component in a
+<SvelteFlowProvider />`.
+
+### Fixed
+
+- **All canvases crash with "useStore outside of SvelteFlow"**
+  (ADR-136 v5.3.1 amendment, issue #37 reopen). v5.2.0 added
+  `useSvelteFlow()` at the script level of `UnifiedCanvas` to power
+  the BPMN palette drag-drop's coordinate projection. xyflow's hook
+  uses `getContext` at call time and only resolves inside
+  `<SvelteFlowProvider>` (or `<SvelteFlow>`). v5.2.0 also wrapped
+  UnifiedCanvas's *own template* in the provider — but Svelte's
+  lifecycle runs the script BEFORE the template mounts, so the hook
+  ran with no context above it and threw. Net effect: every
+  notation's canvas was broken in production, not just BPMN.
+  - Fix: extract a thin `CanvasDropArea` component that owns the
+    drop handlers and calls `useSvelteFlow()` from its own script.
+    Mount it inside the existing `<SvelteFlowProvider>` so its
+    initialisation happens *after* the provider is set up.
+  - Regression guard: `bpmnCanvasIntegration.test.ts` adds a test
+    asserting `UnifiedCanvas` does NOT call `useSvelteFlow` at
+    script level. Catches the exact pattern that broke v5.2.0.
+
 ## [5.3.0] - 2026-05-05
 
 Markdown experience overhaul (issue #32 reopen). Four bundled

--- a/docs/adrs/ADR-136-BPMN-Notation.md
+++ b/docs/adrs/ADR-136-BPMN-Notation.md
@@ -1,6 +1,6 @@
 # ADR-136: BPMN 2.0 notation
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33, #37)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33, #37, #37-reopen)
 
 ## Context
 
@@ -291,3 +291,69 @@ the shell behind the BPMN guard, UnifiedCanvas declares the three new
 hook props and wires them, and BpmnRenderer mounts ContextPad and
 reads the context handler. Same static-parser style as the v5.1.1 /
 v5.1.2 coverage tests.
+
+## Amendment 2026-05-05 — v5.3.1 hot-fix (issue #37 reopen)
+
+UAT against v5.2.0 / v5.3.0 surfaced a critical regression: every
+canvas — not just BPMN — crashed on load with
+
+> Uncaught Error: To call useStore outside of `<SvelteFlow />` you
+> need to wrap your component in a `<SvelteFlowProvider />`
+
+### Root cause
+
+v5.2.0 added `useSvelteFlow()` at the script level of
+`UnifiedCanvas` to power the BPMN palette drag-drop's coordinate
+projection (`flow.screenToFlowPosition`). xyflow's hook reads
+context via `getContext` AT CALL TIME. v5.2.0 *also* wrapped
+UnifiedCanvas's own template in `<SvelteFlowProvider>` to satisfy
+the hook — but Svelte's component lifecycle runs the script BEFORE
+the template mounts. So the hook ran with no provider above it and
+threw on every canvas mount, regardless of notation. Caught only in
+runtime UAT, not in `svelte-check` (which doesn't execute the hook).
+
+### Fix
+
+Extract a thin `CanvasDropArea` component (`src/lib/canvas/CanvasDropArea.svelte`)
+that owns the drop handlers AND calls `useSvelteFlow()` from its own
+script. Mount it inside the existing `<SvelteFlowProvider>` so its
+initialisation runs AFTER the provider sets up:
+
+```
+<SvelteFlowProvider>
+  <CanvasDropArea ondropentity={…}>
+    <div class="model-canvas">
+      <SvelteFlow ... />
+    </div>
+  </CanvasDropArea>
+</SvelteFlowProvider>
+```
+
+CanvasDropArea uses `display: contents` on its wrapper so the
+existing canvas layout is unchanged.
+
+### Regression guard
+
+`bpmnCanvasIntegration.test.ts` adds:
+
+```ts
+it('UnifiedCanvas does NOT call useSvelteFlow at script level (v5.3.1 regression guard)', () => {
+  expect(src).not.toMatch(/^\s*const\s+\w+\s*=\s*useSvelteFlow/m);
+  expect(src).not.toMatch(/import[\s\S]*?useSvelteFlow[\s\S]*?from\s+['"]@xyflow\/svelte['"]/);
+});
+```
+
+Catches exactly the v5.2.0 mistake — calling the hook from
+UnifiedCanvas's script (where the provider in the same template
+isn't yet mounted). Future drop-handler / flow-coord code must live
+in a child of `<SvelteFlowProvider>` or use `CanvasDropArea` as the
+established pattern.
+
+### Why this wasn't caught earlier
+
+- `svelte-check`: runs the type system, not the runtime; the hook's
+  return type is correct so type-check passed.
+- The vitest integration test in v5.2.0 was static-parser style,
+  asserting `useSvelteFlow` was *called* but not in what context.
+  v5.3.1 tightens the assertion to *forbid* the call at script level
+  in UnifiedCanvas — the right shape of regression guard.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.3.0",
+	"version": "5.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.3.0",
+			"version": "5.3.1",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.3.0",
+	"version": "5.3.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/CanvasDropArea.svelte
+++ b/frontend/src/lib/canvas/CanvasDropArea.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	/**
+	 * v5.3.1 hot-fix (issue #37 reopen): the drop handler that powers
+	 * the BPMN palette → canvas drag-and-drop needs `useSvelteFlow()`
+	 * to project the cursor coordinate. xyflow's hook reads context via
+	 * `getContext` at call time, which has to be **during component
+	 * initialisation** AND must be inside `<SvelteFlowProvider>` (or
+	 * inside `<SvelteFlow>` itself).
+	 *
+	 * v5.2.0 called `useSvelteFlow()` at the script level of
+	 * UnifiedCanvas — but UnifiedCanvas is also where the
+	 * `<SvelteFlowProvider>` is mounted in the template, so the script
+	 * ran *before* the provider existed and the hook threw
+	 * "To call useStore outside of <SvelteFlow /> you need to wrap
+	 * your component in a <SvelteFlowProvider />".
+	 *
+	 * This component is a thin descendant of SvelteFlowProvider — its
+	 * script runs after the provider is set up, so `useSvelteFlow()`
+	 * resolves correctly.
+	 */
+	import type { Snippet } from 'svelte';
+	import { useSvelteFlow } from '@xyflow/svelte';
+
+	interface Props {
+		ondropentity?: (entityKey: string, position: { x: number; y: number }) => void;
+		children: Snippet;
+	}
+
+	let { ondropentity, children }: Props = $props();
+
+	const flow = useSvelteFlow();
+
+	function handleDragOver(e: DragEvent) {
+		if (e.dataTransfer?.types.includes('application/iris-bpmn-entity')) {
+			e.preventDefault();
+			e.dataTransfer.dropEffect = 'copy';
+		}
+	}
+
+	function handleDrop(e: DragEvent) {
+		const key = e.dataTransfer?.getData('application/iris-bpmn-entity');
+		if (!key) return;
+		e.preventDefault();
+		const position = flow.screenToFlowPosition({ x: e.clientX, y: e.clientY });
+		ondropentity?.(key, position);
+	}
+</script>
+
+<!-- `display: contents` so this wrapper doesn't disturb the surrounding
+	 layout — the drop listeners attach to a stand-in element that
+	 covers the whole subtree. -->
+<div
+	class="canvas-drop-area"
+	ondragover={handleDragOver}
+	ondrop={handleDrop}
+	role="presentation"
+>
+	{@render children()}
+</div>
+
+<style>
+	.canvas-drop-area {
+		display: contents;
+	}
+</style>

--- a/frontend/src/lib/canvas/UnifiedCanvas.svelte
+++ b/frontend/src/lib/canvas/UnifiedCanvas.svelte
@@ -5,7 +5,7 @@
 	 * Supports both edit and browse modes.
 	 */
 	import { setContext } from 'svelte';
-	import { SvelteFlow, SvelteFlowProvider, Controls, Background, useSvelteFlow } from '@xyflow/svelte';
+	import { SvelteFlow, SvelteFlowProvider, Controls, Background } from '@xyflow/svelte';
 	import { ConnectionMode } from '@xyflow/system';
 	import type { Connection, Edge } from '@xyflow/svelte';
 	import '@xyflow/svelte/dist/style.css';
@@ -15,6 +15,7 @@
 	import FitViewTrigger from './FitViewTrigger.svelte';
 	import CanvasAnnouncer from './controls/CanvasAnnouncer.svelte';
 	import KeyboardHandler from './controls/KeyboardHandler.svelte';
+	import CanvasDropArea from './CanvasDropArea.svelte';
 	import type { CanvasNode, CanvasEdge, NotationType } from '$lib/types/canvas';
 
 	interface Props {
@@ -79,24 +80,12 @@
 	// renderer-level prop hop.
 	setContext('bpmnContextPadAction', oncontextpadaction);
 
-	const flow = useSvelteFlow();
-
-	function handleDragOver(e: DragEvent) {
-		// Required for the browser to fire `drop` — the default behaviour
-		// rejects the drop entirely.
-		if (e.dataTransfer?.types.includes('application/iris-bpmn-entity')) {
-			e.preventDefault();
-			e.dataTransfer.dropEffect = 'copy';
-		}
-	}
-
-	function handleDrop(e: DragEvent) {
-		const key = e.dataTransfer?.getData('application/iris-bpmn-entity');
-		if (!key) return;
-		e.preventDefault();
-		const position = flow.screenToFlowPosition({ x: e.clientX, y: e.clientY });
-		ondropentity?.(key, position);
-	}
+	// v5.3.1 hot-fix (issue #37 reopen): the v5.2.0 implementation called
+	// `useSvelteFlow()` here at script-level, which threw "useStore outside
+	// of <SvelteFlow />" because the script runs *before* the
+	// SvelteFlowProvider in this same component's template mounts. Drop
+	// handling now lives in <CanvasDropArea>, a child of the provider — its
+	// script runs after the provider sets up so the hook resolves.
 
 	let announcer: CanvasAnnouncer | undefined = $state();
 	let keyboardHandler: KeyboardHandler | undefined = $state();
@@ -264,11 +253,12 @@
 	}
 </script>
 
-<!-- v5.2.0 (issue #37): wrap in SvelteFlowProvider so the script-level
-	 useSvelteFlow() call (used by handleDrop's screenToFlowPosition) has a
-	 store to read. Required because the drop handler lives on the OUTER div,
-	 above <SvelteFlow>'s own implicit provider. -->
+<!-- v5.2.0 (issue #37): SvelteFlowProvider so descendants can use
+	 useSvelteFlow(). v5.3.1 hot-fix (issue #37 reopen): drop handler
+	 moved into <CanvasDropArea> (a provider descendant) so its hook
+	 call happens AFTER the provider mounts. -->
 <SvelteFlowProvider>
+<CanvasDropArea ondropentity={browseMode ? undefined : ondropentity}>
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
 	class="model-canvas{browseMode ? ' model-canvas--browse' : ''}"
@@ -276,8 +266,6 @@
 	aria-label="{notationLabel} diagram canvas{browseMode ? ' — browse mode (read-only)' : ''}{connectMode ? ' — connect mode active' : ''}"
 	aria-roledescription="interactive diagram{browseMode ? ', read-only' : ''}"
 	onkeydown={browseMode ? undefined : handleKeydown}
-	ondragover={browseMode ? undefined : handleDragOver}
-	ondrop={browseMode ? undefined : handleDrop}
 >
 	{#if browseMode}
 		<SvelteFlow
@@ -382,4 +370,5 @@
 
 	<CanvasAnnouncer bind:this={announcer} />
 </div>
+</CanvasDropArea>
 </SvelteFlowProvider>

--- a/frontend/tests/unit/bpmnCanvasIntegration.test.ts
+++ b/frontend/tests/unit/bpmnCanvasIntegration.test.ts
@@ -102,14 +102,35 @@ describe('UnifiedCanvas exposes the BPMN integration hooks', () => {
 		expect(src).toMatch(/isValidConnection=/);
 	});
 
-	it('hooks ondrop + ondragover for the palette drag-drop MIME', () => {
-		expect(src).toMatch(/ondragover=/);
-		expect(src).toMatch(/ondrop=/);
-		expect(src).toMatch(/application\/iris-bpmn-entity/);
+	it('forwards the palette drag-drop through CanvasDropArea (v5.3.1: hook moved out of UnifiedCanvas script)', () => {
+		expect(src).toMatch(/import\s+CanvasDropArea\b/);
+		expect(src).toMatch(/<CanvasDropArea\b[\s\S]*?ondropentity=/);
+		// CanvasDropArea must be a child of SvelteFlowProvider so its
+		// useSvelteFlow() call lands inside the provider.
+		const slice = src.match(/<SvelteFlowProvider[\s\S]*?<CanvasDropArea/);
+		expect(slice).toBeTruthy();
+	});
+
+	it('CanvasDropArea handles the palette MIME and calls useSvelteFlow inside SvelteFlowProvider', () => {
+		const drop = readFileSync(
+			resolve(ROOT, 'src/lib/canvas/CanvasDropArea.svelte'),
+			'utf-8',
+		);
+		expect(drop).toMatch(/useSvelteFlow/);
+		expect(drop).toMatch(/application\/iris-bpmn-entity/);
+		expect(drop).toMatch(/screenToFlowPosition/);
 	});
 
 	it('shares the ContextPad action handler via setContext so BpmnRenderer can call it', () => {
 		expect(src).toMatch(/setContext\(['"]bpmnContextPadAction['"]/);
+	});
+
+	it('UnifiedCanvas does NOT call useSvelteFlow at script level (v5.3.1 regression guard)', () => {
+		// useSvelteFlow at script level executes before the
+		// SvelteFlowProvider in the same component's template — that's
+		// the v5.2.0 bug that broke every canvas (issue #37 reopen).
+		expect(src).not.toMatch(/^\s*const\s+\w+\s*=\s*useSvelteFlow/m);
+		expect(src).not.toMatch(/import[\s\S]*?useSvelteFlow[\s\S]*?from\s+['"]@xyflow\/svelte['"]/);
 	});
 });
 


### PR DESCRIPTION
**URGENT** — Promotes v5.3.1 ([release](https://github.com/cgbarlow/iris/releases/tag/v5.3.1)) onto UAT. Fixes a critical regression introduced by v5.2.0 / v5.3.0 that **broke every canvas in production** (Simple, UML, ArchiMate, C4, DoView, Sequence, BPMN, Text — all of them) with:

\`\`\`
Uncaught Error: To call useStore outside of <SvelteFlow /> you need to
wrap your component in a <SvelteFlowProvider />
\`\`\`

Root cause + fix: see [v5.3.1 release notes](https://github.com/cgbarlow/iris/releases/tag/v5.3.1). One-line summary: \`useSvelteFlow()\` was being called at UnifiedCanvas's script level, which executes BEFORE the SvelteFlowProvider in the same component's template. Drop handling now lives in a new \`CanvasDropArea\` component that's a descendant of the provider.

Backend untouched.

### Test plan on UAT

- [ ] Open any non-BPMN view (Simple / UML / ArchiMate / C4 / DoView / Sequence / Text) — canvas loads, no console errors.
- [ ] Open a BPMN view in Edit mode — full v5.2.0 shell renders; palette drag-drop creates a node at the drop position; ContextPad on selected nodes; PropertyPanel updates on selection.
- [ ] Open a Text view — markdown editor toolbar (v5.3.0) appears; TOC button works; rendered markdown has proper heading + list styling.
- [ ] User Guide pages load with images (v5.3.0).