### PR TITLE
v5.4.0 — BPMN-as-Elements, image paste, BPMN polish, dashboard tweaks (issue cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.4.0] - 2026-05-06
+
+BPMN polish + markdown experience polish + image paste + dashboard
+tweaks (issue cluster against v5.3.1). Headlined by **BPMN-as-Elements
+alignment** (every BPMN node now creates a backing Iris Element,
+matching every other notation) and **clipboard image paste** (paste a
+screenshot in the markdown editor → Iris uploads → markdown link
+auto-inserted at the cursor).
+
+### Added
+
+- **BPMN nodes are Iris Elements** (ADR-136 v5.4.0 amendment §A,
+  ADR-145, issue cluster #13). Every BPMN node-creation path —
+  drag-from-palette, drop-on-canvas, CommandPalette
+  `create`/`append`, ContextPad-append, EventMatrixPicker — now
+  POSTs `/api/elements` first and stores `entityId` on the canvas
+  node. Replace mode PUTs the existing Element's `element_type`.
+  PropertyPanel label/description edits sync back via fire-and-forget
+  PUT. BPMN content joins search, knowledge graph, tagging,
+  comments, versioning, and `iris://element/<id>` references.
+- **Clipboard image paste** (ADR-137 v5.4.0 amendment §A, ADR-145,
+  issue cluster #7). Paste an image into the markdown editor → Iris
+  uploads to the new `images` table → markdown link
+  `![pasted-image](/api/images/<id>)` auto-inserted at the cursor.
+  GitHub-style. New backend `images` module (`POST /api/images` +
+  `GET /api/images/{id}`); 5 MB cap; magic-byte MIME validation
+  (PNG/JPEG/GIF/WebP); SQLite BLOB / Postgres BYTEA parity.
+- **ContextPad bring-forward / send-backward actions** (ADR-136
+  v5.4.0 amendment §C, issue cluster #3). Two new ContextPad
+  buttons (↑ / ↓) for z-order control when items stack (e.g. lane on
+  pool, annotation on activity).
+- **Lane-on-pool parent detection** (ADR-136 v5.4.0 amendment §D,
+  issue cluster #5). Dragging a lane onto a pool now sets
+  `parentId` on drop, so `validateBpmn::lane_outside_pool` no
+  longer fires false positives. New `onnodedragstop` prop on
+  `<UnifiedCanvas>` forwarded to xyflow; shell-level hit-test runs
+  on BPMN views only.
+- **Add Element / Link Element / Add Diagram on BPMN + Text edit
+  modes** (ADR-136 v5.4.0 amendment §G, ADR-137 v5.4.0 amendment
+  §D, issue cluster #8). Trio toolbar above both branches. On
+  BPMN: Add Element creates a BPMN node + Element; Link Element
+  binds a picked Element to the selected node; Add Diagram inserts
+  a `call_activity` BPMN sub-process referencing the picked
+  diagram. On Text: handlers already wired via v5.1.1
+  `insertMarkdownAtCursor` — only the toolbar render was missing.
+
+### Changed
+
+- **Per-entity-type BPMN node sizing** (ADR-136 v5.4.0 amendment §B,
+  issue cluster #2 + #4). Pre-v5.4 every BPMN node was created with
+  `width: 200`. Events/gateways/data-objects render at 56×56 / 48×64
+  visually but the bounding box was 200px wide, pushing the
+  ContextPad far to the right of the actual shape. New
+  `BPMN_NODE_DIMENSIONS` lookup matches the renderer CSS:
+  events/gateways 56×56, activities 200×80, swimlanes 240–600 wide,
+  data-objects 48×64, etc.
+- **Markdown view defaults to Canvas tab when content exists**
+  (ADR-137 v5.4.0 amendment §B, issue cluster #9). Smart-tab
+  predicate now reads `diagram.data.content` for Text views —
+  pre-v5.4 the page always landed on Details for Text because
+  the predicate only checked `canvasNodes` / sequence participants.
+- **Tab order: Canvas first** (ADR-137 v5.4.0 amendment §C, issue
+  cluster #10). Canvas is now the left-most tab in the views detail
+  page (was Details). The working-content tab gets the working-
+  content position.
+
+### Fixed
+
+- **ProblemsPanel scrolls itself, not the page** (ADR-136 v5.4.0
+  amendment §E, issue cluster #1). `.bpmn-shell__problems` had
+  `overflow: hidden`, clipping the inner list's `overflow-y: auto`.
+  Long problem lists now scroll inside the panel.
+- **Theme dropdown hidden on BPMN + Text views** (ADR-136 v5.4.0
+  amendment §F, issue cluster #6). BPMN theme is fixed by m043's
+  bpmn-default seed; Text views have no canvas to theme.
+- **Dashboard: Packages card removed; Collections + Sets cards
+  visually distinct** (issue cluster #11 + #12). Packages card
+  count was redundant with the hierarchy tree. Collections + Sets
+  get a muted-grey background (`var(--color-surface)`) so they
+  read as "scope filters" distinct from the working-content cards
+  (Views, Elements).
+
+### Docs
+
+- ADR-145 / SPEC-145-A — image upload storage decision (table vs
+  Supabase Storage vs base64) and schema/endpoints.
+- ADR-136 v5.4.0 amendment — BPMN-as-Elements + per-type sizing +
+  z-order + parent-on-drop + ProblemsPanel + theme + trio buttons.
+- ADR-137 v5.4.0 amendment — paste-image + smart-tab default + tab
+  order + trio render in Text mode.
+
+### Verification
+
+- 11 new vitest specs added (≥ 30 tests covering Phase 1–5).
+- 2 new backend pytest specs (5 tests on the images endpoint).
+- Frontend full suite: 866/867 vitest pass (1 pre-existing baseline
+  failure unchanged — `importIdempotency > displays diagrams skipped
+  count`, fails against unmodified baseline too).
+- `svelte-check`: 164 errors (= unchanged baseline, no new errors).
+- Backend BPMN suite stays green; new images suite 5/5.
+
 ## [5.3.1] - 2026-05-05
 
 Hot-fix for v5.2.0 (issue #37 reopen). Every canvas — not just BPMN —

--- a/backend/app/images/__init__.py
+++ b/backend/app/images/__init__.py
@@ -1,0 +1,1 @@
+"""Image upload + serve module for the markdown editor (ADR-145, v5.4.0)."""

--- a/backend/app/images/models.py
+++ b/backend/app/images/models.py
@@ -1,0 +1,14 @@
+"""Pydantic models for the images module (ADR-145, v5.4.0)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ImageUploadResponse(BaseModel):
+    """Response after a successful POST /api/images upload."""
+
+    id: str
+    mime: str
+    size_bytes: int
+    created_at: str

--- a/backend/app/images/router.py
+++ b/backend/app/images/router.py
@@ -1,0 +1,66 @@
+"""Image upload + serve API routes (ADR-145, v5.4.0).
+
+Used by the markdown editor's paste-from-clipboard flow. Auth required
+on POST (any signed-in user); GET is public so embedded `<img src>`
+tags resolve without sending the JWT cookie/header on every render.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
+from fastapi.responses import Response
+
+from app.auth.dependencies import get_current_user
+from app.images.models import ImageUploadResponse
+from app.images import service
+
+router = APIRouter(prefix="/api/images", tags=["images"])
+
+
+@router.post(
+    "",
+    response_model=ImageUploadResponse,
+    status_code=201,
+)
+async def upload_image(
+    request: Request,
+    file: UploadFile = File(...),
+    current_user: dict[str, Any] = Depends(get_current_user),
+) -> ImageUploadResponse:
+    """Upload an image. Used by the markdown editor's paste handler."""
+    db = request.app.state.db_manager.main_db
+    data = await file.read()
+    declared = file.content_type or "application/octet-stream"
+    try:
+        result = await service.create_image(
+            db,
+            data=data,
+            declared_mime=declared,
+            uploaded_by=current_user.get("id"),
+        )
+    except ValueError as exc:
+        # Map upload validation errors to 400 (or 413 for "too large").
+        msg = str(exc)
+        if "exceeds" in msg.lower():
+            raise HTTPException(status_code=413, detail=msg) from exc
+        raise HTTPException(status_code=400, detail=msg) from exc
+    return ImageUploadResponse(**result)
+
+
+@router.get("/{image_id}")
+async def get_image(image_id: str, request: Request) -> Response:
+    """Serve image bytes with the right Content-Type. Public — embedded
+    `<img src>` resolves without auth so MarkdownView renders inline.
+    The bytes are not user-authored secrets; they're attached to public
+    repository content."""
+    db = request.app.state.db_manager.main_db
+    img = await service.get_image(db, image_id)
+    if img is None:
+        raise HTTPException(status_code=404, detail="Image not found")
+    return Response(
+        content=img["bytes"],  # type: ignore[arg-type]
+        media_type=str(img["mime"]),
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )

--- a/backend/app/images/service.py
+++ b/backend/app/images/service.py
@@ -1,0 +1,108 @@
+"""Service layer for the images module (ADR-145, v5.4.0).
+
+Provides byte-validated upload + retrieval. Validates MIME via magic
+bytes (not just the Content-Type header) so a text file with a fake
+`image/png` content-type is still rejected.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+# 5 MB upload cap — generous enough for screenshots, tight enough that
+# we don't ship multi-MB blobs through the markdown payload by accident.
+MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+ALLOWED_MIMES: frozenset[str] = frozenset(
+    {"image/png", "image/jpeg", "image/gif", "image/webp"}
+)
+
+
+def _detect_mime_from_magic(data: bytes) -> str | None:
+    """Sniff the file's magic bytes — defence in depth above Content-Type."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return "image/gif"
+    if (
+        len(data) >= 12
+        and data[0:4] == b"RIFF"
+        and data[8:12] == b"WEBP"
+    ):
+        return "image/webp"
+    return None
+
+
+def validate_image(data: bytes, declared_mime: str) -> str:
+    """Validate the upload and return the resolved MIME.
+
+    Raises ValueError on size/type violations. The caller maps to HTTP.
+    """
+    if len(data) == 0:
+        raise ValueError("Empty image upload.")
+    if len(data) > MAX_IMAGE_BYTES:
+        raise ValueError(
+            f"Image exceeds {MAX_IMAGE_BYTES // (1024 * 1024)} MB cap."
+        )
+    actual = _detect_mime_from_magic(data)
+    if actual is None:
+        raise ValueError("Unrecognised image format (PNG/JPEG/GIF/WebP only).")
+    if actual not in ALLOWED_MIMES:
+        raise ValueError(f"Image MIME {actual!r} is not allowed.")
+    # If the declared type contradicts the detected one, prefer the
+    # detected one — but reject obvious lies (declared png, actual gif).
+    if declared_mime in ALLOWED_MIMES and declared_mime != actual:
+        raise ValueError(
+            f"Declared MIME {declared_mime!r} doesn't match content {actual!r}."
+        )
+    return actual
+
+
+async def create_image(
+    db: DatabasePort,
+    *,
+    data: bytes,
+    declared_mime: str,
+    uploaded_by: str | None,
+) -> dict[str, object]:
+    """Validate + persist an image. Returns the row metadata (no bytes)."""
+    mime = validate_image(data, declared_mime)
+    image_id = str(uuid.uuid4())
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO images (id, mime, bytes, size_bytes, uploaded_by, created_at)"
+        " VALUES (?, ?, ?, ?, ?, ?)",
+        (image_id, mime, data, len(data), uploaded_by, now),
+    )
+    await db.commit()
+    return {
+        "id": image_id,
+        "mime": mime,
+        "size_bytes": len(data),
+        "created_at": now,
+    }
+
+
+async def get_image(db: DatabasePort, image_id: str) -> dict[str, object] | None:
+    """Fetch an image by id. Returns None if not found."""
+    cursor = await db.execute(
+        "SELECT id, mime, bytes, size_bytes, created_at FROM images WHERE id = ?",
+        (image_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "mime": row[1],
+        "bytes": bytes(row[2]) if not isinstance(row[2], bytes) else row[2],
+        "size_bytes": row[3],
+        "created_at": row[4],
+    }

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.diagrams.router import router as diagrams_router
 from app.docref.router import router as docref_router
 from app.elements.router import router as elements_router
 from app.export.router import router as export_router
+from app.images.router import router as images_router
 from app.extensions.router import router as extensions_router
 from app.graph.router import router as graph_router
 from app.import_pptx.router import router as import_pptx_router
@@ -181,6 +182,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(notifications_router)
     app.include_router(admin_thumbnails_router)
     app.include_router(import_router)
+    app.include_router(images_router)
     app.include_router(import_pptx_router)
     app.include_router(package_relationships_router)
     app.include_router(sets_router)

--- a/backend/app/migrations/m045_images.py
+++ b/backend/app/migrations/m045_images.py
@@ -1,0 +1,43 @@
+"""Migration 045: Images (ADR-145, SPEC-145-A) — v5.4.0.
+
+Adds the `images` table that backs paste-image-from-clipboard in the
+markdown editor. Stores the bytes inline (BLOB) for SQLite parity with
+the Supabase BYTEA column.
+
+Limits enforced at the service layer (5 MB max, MIME ∈ {png, jpeg, gif,
+webp}) — matched in m046_images.sql.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m045_images"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='images'"
+    )
+    if await cursor.fetchone():
+        return
+
+    await db.execute(
+        "CREATE TABLE images ("
+        "  id TEXT PRIMARY KEY,"
+        "  mime TEXT NOT NULL,"
+        "  bytes BLOB NOT NULL,"
+        "  size_bytes INTEGER NOT NULL,"
+        "  uploaded_by TEXT,"
+        "  created_at TEXT NOT NULL"
+        ")"
+    )
+    await db.execute(
+        "CREATE INDEX idx_images_uploaded_by ON images(uploaded_by)"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m046_images.sql
+++ b/backend/app/migrations/supabase/m046_images.sql
@@ -1,0 +1,38 @@
+-- Migration 046: Images (ADR-145, SPEC-145-A) — v5.4.0.
+-- Backs paste-image-from-clipboard in the markdown editor.
+-- BYTEA Postgres equivalent of the SQLite m045_images BLOB column.
+
+CREATE TABLE IF NOT EXISTS images (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  mime TEXT NOT NULL,
+  bytes BYTEA NOT NULL,
+  size_bytes INTEGER NOT NULL,
+  uploaded_by UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_images_uploaded_by ON images(uploaded_by);
+
+ALTER TABLE images ENABLE ROW LEVEL SECURITY;
+
+-- All-read for any authenticated user (images surface in markdown
+-- viewers across the app), authenticated-write for upload. Mirrors the
+-- DocRef RLS pattern (admin-write/all-read) but with authenticated-write
+-- because regular users need to paste images.
+DROP POLICY IF EXISTS images_select ON images;
+CREATE POLICY images_select ON images
+  FOR SELECT USING (TRUE);
+
+DROP POLICY IF EXISTS images_insert ON images;
+CREATE POLICY images_insert ON images
+  FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+DROP POLICY IF EXISTS images_delete ON images;
+CREATE POLICY images_delete ON images
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+    OR uploaded_by = auth.uid()
+  );

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -49,6 +49,7 @@ from app.migrations.m040_expanded_ai_creation_prompts import up as m040_up
 from app.migrations.m041_personal_access_tokens import up as m041_up
 from app.migrations.m043_bpmn_notation import up as m043_up
 from app.migrations.m044_text_diagram_class import up as m044_up
+from app.migrations.m045_images import up as m045_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -124,6 +125,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m041_up(main)
     await m043_up(main)
     await m044_up(main)
+    await m045_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_images/test_router.py
+++ b/backend/tests/test_images/test_router.py
@@ -1,0 +1,124 @@
+"""Integration tests for the v5.4.0 image upload endpoints (ADR-145)."""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+# 1×1 transparent PNG (smallest legal PNG).
+PNG_1x1 = bytes([
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+    0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+    0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+    0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+    0x42, 0x60, 0x82,
+])
+
+
+@pytest.fixture
+def app_config(tmp_path: "Path") -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> "AsyncIterator[httpx.AsyncClient]":
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_upload_png_success(client: httpx.AsyncClient) -> None:
+    """A valid PNG upload returns 201 with an id; GET retrieves the bytes."""
+    headers = await _auth_headers(client)
+    files = {"file": ("dot.png", io.BytesIO(PNG_1x1), "image/png")}
+    resp = await client.post("/api/images", files=files, headers=headers)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "id" in data
+    assert data["mime"] == "image/png"
+    assert data["size_bytes"] == len(PNG_1x1)
+
+    # GET serves the bytes back with the right Content-Type.
+    get_resp = await client.get(f"/api/images/{data['id']}")
+    assert get_resp.status_code == 200
+    assert get_resp.headers["content-type"].startswith("image/png")
+    assert get_resp.content == PNG_1x1
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_non_image_mime(client: httpx.AsyncClient) -> None:
+    """Uploading a text file with a fake png MIME is rejected by magic-byte check."""
+    headers = await _auth_headers(client)
+    files = {"file": ("evil.png", io.BytesIO(b"<html>nope</html>"), "image/png")}
+    resp = await client.post("/api/images", files=files, headers=headers)
+    assert resp.status_code in (400, 415)
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_oversized(client: httpx.AsyncClient) -> None:
+    """Uploads above the 5 MB cap are rejected."""
+    headers = await _auth_headers(client)
+    big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (5 * 1024 * 1024 + 1)
+    files = {"file": ("big.png", io.BytesIO(big), "image/png")}
+    resp = await client.post("/api/images", files=files, headers=headers)
+    assert resp.status_code in (400, 413)
+
+
+@pytest.mark.asyncio
+async def test_get_unknown_id_returns_404(client: httpx.AsyncClient) -> None:
+    resp = await client.get("/api/images/00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_upload_requires_auth(client: httpx.AsyncClient) -> None:
+    files = {"file": ("dot.png", io.BytesIO(PNG_1x1), "image/png")}
+    resp = await client.post("/api/images", files=files)
+    assert resp.status_code in (401, 403)

--- a/docs/adrs/ADR-136-BPMN-Notation.md
+++ b/docs/adrs/ADR-136-BPMN-Notation.md
@@ -1,6 +1,6 @@
 # ADR-136: BPMN 2.0 notation
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33, #37, #37-reopen)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #33, #37, #37-reopen) and 2026-05-06 (v5.4.0 BPMN-as-Elements + UI polish)
 
 ## Context
 
@@ -357,3 +357,111 @@ established pattern.
   asserting `useSvelteFlow` was *called* but not in what context.
   v5.3.1 tightens the assertion to *forbid* the call at script level
   in UnifiedCanvas — the right shape of regression guard.
+
+## Amendment 2026-05-06 — BPMN-as-Elements alignment + UI polish (v5.4.0)
+
+UAT against v5.3.x surfaced an architectural divergence and seven UI
+issues against the BPMN authoring shell. The headline decision is
+**BPMN nodes are now Iris Elements** (matching every other notation):
+adding a Task / Event / Gateway etc. POSTs `/api/elements` first and
+stores `entityId` on the canvas node. BPMN content joins the rest of
+the platform — search, knowledge graph, tags, comments, versioning,
+and `iris://element/<id>` references all start working.
+
+### A. BPMN-as-Elements (architectural)
+
+Pre-v5.4 every other notation's `handleAddElement` POSTed
+`/api/elements` and stored the resulting Element id on the canvas
+node. BPMN was the outlier — `BpmnAuthoringShell::makeBpmnNode`
+generated a node with no `entityId`, so BPMN content was invisible to
+search/graph/tagging/etc.
+
+Fix: a new `createBpmnElement(entityKey, name)` helper in the shell.
+All four node-creation paths route through it — drag-from-palette,
+drop-on-canvas, CommandPalette `create`/`append`, ContextPad-append,
+and the EventMatrixPicker create flow. `replace` mode in
+`handleCmdPick` PUTs `/api/elements/<id>` to update the existing
+Element's `element_type` rather than creating a new one. PropertyPanel
+edits (label/description) call `updateBpmnElement(entityId, patch)`
+fire-and-forget so the Element row stays in sync with the canvas.
+
+This is the architecturally correct shape — BPMN data lives in the
+same place every other notation's data lives.
+
+### B. Per-entity-type node sizing
+
+Pre-v5.4 every BPMN node was created with `width: 200`. Visually:
+- Events render as 56×56 circles (`.bpmn-event-wrap` CSS) — bounding
+  box extended ~150px past the circle.
+- Gateways same (56×56 diamonds).
+- Data objects 48×64.
+- Pools/lanes are large containers (240×120+).
+
+The over-wide bounding box pushed `<NodeToolbar>` (ContextPad) far to
+the right of the actual shape, making the action buttons feel
+disconnected and giving the user the impression they were clicking
+the connection-handle dots instead of pad buttons.
+
+Fix: a `BPMN_NODE_DIMENSIONS` lookup with per-entity-type widths +
+heights that match the renderer CSS. `makeBpmnNode` reads from it.
+The page's BPMN-trio handlers (Add Element / Add Diagram, see §G)
+duplicate the lookup as `bpmnDimsFor()` until a v5.5 refactor moves
+the constant into `$lib/types/canvas.ts`.
+
+### C. ContextPad bring-forward / send-backward
+
+When pools and lanes stack, the user previously had no z-order
+control. ContextPad gains two new actions (`bring_forward` ↑ /
+`send_backward` ↓). Shell handler computes max/min `zIndex` of other
+nodes and assigns +1/-1 — the optional `zIndex` field on xyflow's
+`Node` type is honoured by SvelteFlow's renderer.
+
+### D. Lane-on-pool parent detection
+
+`validateBpmn::lane_outside_pool` walks `parentId` correctly, but
+xyflow doesn't auto-set `parentId` when a lane is dragged onto a pool
+visually. The `lane_outside_pool` error fired even when the user had
+clearly dropped the lane inside the pool.
+
+Fix: a new `onnodedragstop` prop on `<UnifiedCanvas>` forwarded to
+xyflow. The shell's `handleBpmnDragStop` hit-tests the dragged lane's
+centre against pool rectangles; on hit, `parentId` is set and the
+error clears.
+
+### E. ProblemsPanel scroll containment
+
+`.bpmn-shell__problems` had `overflow: hidden` so the inner list's
+`overflow-y: auto` was clipped. Long problem lists scrolled the
+whole page instead of the panel. Fix: `overflow-y: auto` on the
+wrapper.
+
+### F. Theme-selector hidden on BPMN
+
+Theme is fixed for BPMN by the m043 `bpmn-default` seed; the
+ThemeSelector is irrelevant. Same on Text views (no canvas to
+theme). Both are now gated.
+
+### G. Add Element / Link Element / Add Diagram on BPMN
+
+The trio toolbar previously rendered only on the canvas `{:else}`
+branch — invisible on BPMN. Now rendered above `<BpmnAuthoringShell>`
+when `notation === 'bpmn' && editing`. Page-level handlers branch on
+`canvasType === 'bpmn'`:
+
+- **Add Element** opens `EntityDialog` with notation pinned to BPMN.
+  Result POSTs `/api/elements` and adds a canvas node with the right
+  `BPMN_NODE_DIMENSIONS` and `BPMN_DEFAULT_DISCRIMINATORS` payload.
+- **Link Element** opens `ElementPicker`. If a node is selected, sets
+  `entityId` on it; if no node selected, surfaces a helpful error.
+- **Add Diagram** opens `DiagramPicker`. Result places a `call_activity`
+  BPMN node (BPMN-standard sub-process reference) with `linkedModelId`
+  pointing at the picked diagram.
+
+### Out of scope (deferred to v5.5+)
+
+- Refactoring `BPMN_NODE_DIMENSIONS` + `BPMN_DEFAULT_DISCRIMINATORS`
+  into `$lib/types/canvas.ts` so the page and shell share a single
+  source. Both currently maintain the same lookup; mismatches would
+  show up in tests.
+- A bulk "select multiple → bring to front" action.
+- Auto-detection of nested swimlanes (lane-in-lane).

--- a/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
+++ b/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
@@ -1,6 +1,6 @@
 # ADR-137: Text diagram subclass and shared Markdown renderer
 
-Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #30, #31, #32, #32-reopen)
+Status: Accepted (2026-05-04) — amended 2026-05-05 (issues #27, #30, #31, #32, #32-reopen) and 2026-05-06 (v5.4.0 paste-image + tab-default + trio buttons)
 
 ## Context
 
@@ -457,3 +457,51 @@ trivially unit-testable without mounting Svelte.
 
 None of these are blocked; they all build on the toolbar + textarea
 + helper trio rather than replacing it.
+
+## Amendment 2026-05-06 — paste-image + tab-default + trio buttons (v5.4.0)
+
+Three follow-ups against the v5.3.0 markdown experience:
+
+### A. Paste image from clipboard (issue cluster #7)
+
+GitHub-style: paste a screenshot → upload to Iris → markdown link
+auto-inserted at the cursor. Implemented as a pure-helper +
+TextCanvas `onpaste` handler:
+
+- `markdownEditorToolbarHelpers.ts::uploadPastedImage(file)` POSTs
+  multipart `/api/images` and returns `{ id, url, mime, size_bytes }`.
+- `TextCanvas.svelte::handlePaste(e)` scans `clipboardData.items`
+  for `image/*`, uploads, splices `![pasted-image](/api/images/<id>)`
+  via the v5.3.0 `applyOp(insertAtCursor(…))` pattern. Non-image
+  paste falls through to browser default.
+- `apiFetch` wrapper (`$lib/utils/api.ts`) extended to skip its
+  default `Content-Type: application/json` when the body is a
+  `FormData` instance — the browser sets the multipart boundary.
+
+The image storage decision (table-with-blob vs Supabase Storage vs
+base64 inline) is documented in [ADR-145](ADR-145-Image-Upload-Storage.md).
+
+### B. Smart-tab default for Text views (issue cluster #9)
+
+Pre-v5.4 the smart-tab logic in `loadDiagram` checked `canvasNodes`
+or sequence participants to decide whether to land on Canvas or
+Details. Text views have neither — content lives in
+`diagram.data.content` as a markdown string — so the page always
+landed on Details for Text views regardless of content. Fixed by
+extending the `hasContent` predicate to read `data.content` for
+Text views.
+
+### C. Tab order: Canvas first (issue cluster #10)
+
+The four-tab strip (Details / Canvas / Relationships / Versions) is
+reordered so Canvas leads. The working-content tab gets the
+left-most position so the user starts at the thing they're actually
+editing.
+
+### D. Trio buttons in Text edit mode (issue cluster #8)
+
+The page-level Add Element / Link Element / Add Diagram toolbar was
+in the canvas `{:else}` branch only — invisible on Text views. v5.4.0
+also renders it above the Text branch in edit mode. The handlers
+already branched on `canvasType === 'text'` (v5.1.1) — no logic
+change, just rendering.

--- a/docs/adrs/ADR-145-Image-Upload-Storage.md
+++ b/docs/adrs/ADR-145-Image-Upload-Storage.md
@@ -1,0 +1,130 @@
+# ADR-145: Image upload storage
+
+Status: Accepted (2026-05-06)
+
+## Context
+
+v5.3.0 (issue #32 reopen) added a markdown editor toolbar but left
+image insertion as a manual `![](path)` typed URL. UAT against v5.3.x
+asked for GitHub-style clipboard image paste — paste a screenshot →
+Iris uploads it → markdown link is auto-inserted at the cursor.
+
+That requires durable image storage server-side. Three viable options
+were considered before this v5.4.0 implementation:
+
+1. **Backend `images` table with binary blob** (chosen).
+2. **Supabase Storage bucket**.
+3. **Inline base64 data URLs** (no infrastructure, embed bytes in
+   markdown source).
+
+## Decision
+
+**Add an `images` table** (BLOB in SQLite, BYTEA in Supabase) and
+**`/api/images` upload + serve routes**. Markdown links use the
+absolute path `![alt](/api/images/<id>)` — no new URL scheme needed
+(the v5.3.0 widened `ALLOWED_URI_REGEXP` already accepts absolute
+paths).
+
+Limits: max **5 MB** per image; MIME ∈ {png, jpeg, gif, webp}.
+Validation is **magic-byte sniffed** — a text file with a fake
+`image/png` Content-Type is rejected because the bytes don't match.
+
+Authentication: `POST /api/images` requires a signed-in user (any
+role). `GET /api/images/<id>` is public — embedded `<img src>` tags
+need to resolve without auth so MarkdownView renders inline. Image
+bytes are not user-authored secrets; they're attached to public
+repository content.
+
+## Why a backend table over Supabase Storage
+
+- **Symmetry across deployment modes.** SQLite mode would need a
+  separate `iris-images/` static directory if we used Supabase
+  Storage in cloud mode. Two storage paths means two backup paths,
+  two migration paths, two access-control models. The blob-in-table
+  approach keeps both modes in lockstep.
+- **Backups include images.** A single `pg_dump` or SQLite backup
+  captures everything. With Storage buckets we'd need a separate
+  rclone/gcs backup pipeline.
+- **Auth flows through the existing JWT + RLS layer.** No need for a
+  Supabase Storage bucket policy that'd have to be kept in sync with
+  our role model.
+- **Database row size is fine for screenshots.** 5 MB cap × thousands
+  of images is well within Postgres BYTEA / SQLite BLOB territory.
+  Database size grows linearly with image volume; Postgres has no
+  hard limit on BYTEA. Performance for the read path is fine —
+  binary indexes aren't needed; lookup is by primary-key UUID.
+
+## Why not Supabase Storage
+
+- Asymmetric across deployment modes (see above).
+- Bucket policies are a separate access-control surface to maintain.
+- For Iris's volume (markdown attachments, not user-uploaded video),
+  the operational simplicity of a table beats the bucket's marginal
+  scalability advantage.
+- Direct frontend → bucket upload bypasses our normal request
+  pipeline (auth, audit log, MIME validation hook).
+
+## Why not base64 data URLs
+
+- Bloats every diagram/text-view payload that contains an image.
+- Breaks our deliberate `data:` URL ban (v5.3.0 §C); we'd be
+  re-introducing the exact attack surface we strip from `<img src>`.
+- Not shareable across diagrams — the same logo embedded in N text
+  views means N copies of the bytes.
+- Markdown source becomes unreadable when an editor opens it.
+
+## Why not a separate filesystem path
+
+- SQLite mode could plausibly serve from `static/images/`, but then
+  the backup story diverges from the database.
+- File permissions on the deployment machine become a concern.
+- No native auth integration — we'd have to write our own gating in
+  front of the static file server.
+
+## Consequences
+
+- New table, new module (`backend/app/images/`), new router. Code
+  surface is small (~150 lines) and follows the existing
+  `app/docref/` shape.
+- Database size grows with image volume. At 5 MB cap × 10,000 images
+  that's 50 GB — acceptable for Postgres; an SQLite deployment that
+  grows that large would already be looking at Postgres anyway.
+- `GET /api/images/<id>` is public. We accept this trade-off because
+  (a) image content is attached to public repository content,
+  (b) requiring auth on every embedded `<img src>` would force the
+  browser to send the JWT cookie/header on every render — flaky and
+  cache-defeating. If a future feature needs private images, the
+  GET route can grow an `?auth=true` mode without breaking existing
+  links.
+- Cache: serving sets `Cache-Control: public, max-age=31536000,
+  immutable` since image ids are content-addressed (UUID per upload;
+  same bytes → same id is not enforced today, but would be safe to
+  add).
+
+## Out of scope (deferred)
+
+- **Image dedupe by content hash.** We could SHA-256 each upload and
+  return the existing id if the hash matches. Saves storage but adds
+  complexity; revisit when usage warrants.
+- **Image resizing / thumbnailing.** The browser scales for display.
+  Iris doesn't currently generate thumbnails for any other content.
+- **Referential integrity tracking.** An image is currently orphaned
+  when the diagram referencing it is deleted. A garbage-collection
+  background job is plausible but out of scope for v5.4.0.
+- **Direct-to-bucket upload for very large files.** If we ever support
+  >5 MB uploads, a presigned-URL flow to a separate object store is
+  the right move.
+
+## See also
+
+- [ADR-137](ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md) —
+  v5.3.0 widened DOMPurify's `ALLOWED_URI_REGEXP` so absolute paths
+  like `/api/images/<id>` pass through unstripped, and added a
+  defence-in-depth post-walk on `<img src>`. The combination means
+  the new image URLs work end-to-end without further security work.
+- [ADR-135](ADR-135-DocRef-Supabase-Migration-Parity.md) — the
+  shape this ADR copies for the SQLite/Supabase migration parity
+  (m045_images.py + m046_images.sql; admin-write/all-read RLS for
+  the upload endpoint, public-read at the GET).
+- [SPEC-145-A](specs/SPEC-145-A-Image-Upload-Storage.md) — schema,
+  endpoint signatures, MIME limits, RLS policies.

--- a/docs/adrs/specs/SPEC-145-A-Image-Upload-Storage.md
+++ b/docs/adrs/specs/SPEC-145-A-Image-Upload-Storage.md
@@ -1,0 +1,127 @@
+# SPEC-145-A: Image upload storage
+
+ADR: [ADR-145](../ADR-145-Image-Upload-Storage.md)
+
+## Database schema
+
+### `images` table
+
+| Column | SQLite type | Postgres type | Notes |
+|---|---|---|---|
+| `id` | `TEXT PRIMARY KEY` | `UUID PRIMARY KEY DEFAULT gen_random_uuid()` | Service generates UUIDs in SQLite; Postgres generates them server-side. |
+| `mime` | `TEXT NOT NULL` | `TEXT NOT NULL` | One of {`image/png`, `image/jpeg`, `image/gif`, `image/webp`}. |
+| `bytes` | `BLOB NOT NULL` | `BYTEA NOT NULL` | Raw file bytes. Max 5 MB. |
+| `size_bytes` | `INTEGER NOT NULL` | `INTEGER NOT NULL` | Echoed back on upload responses; lets clients compute totals without reading bytes. |
+| `uploaded_by` | `TEXT` | `UUID` | User id from the JWT; `NULL` if a future anonymous-upload mode is added. |
+| `created_at` | `TEXT NOT NULL` | `TIMESTAMPTZ NOT NULL DEFAULT now()` | ISO timestamp. |
+
+### Indexes
+
+- `idx_images_uploaded_by ON images(uploaded_by)` — admin queries / future GC.
+
+### Migrations
+
+- `backend/app/migrations/m045_images.py` (SQLite — registered in
+  `app/startup.py::_initialize_sqlite`).
+- `backend/app/migrations/supabase/m046_images.sql` (Postgres —
+  applied by the Supabase migration runner in lex order).
+
+## API
+
+### `POST /api/images` (auth required)
+
+| | |
+|---|---|
+| Auth | Any signed-in user (FastAPI `Depends(get_current_user)`). |
+| Body | `multipart/form-data` with field `file`. |
+| Response | `201 Created` + `ImageUploadResponse` (id / mime / size_bytes / created_at). |
+| Errors | `400` (empty / unrecognised / declared-vs-actual MIME mismatch); `413` (over 5 MB cap); `415` (unsupported MIME). `401`/`403` for unauthenticated callers. |
+
+### `GET /api/images/{id}` (public)
+
+| | |
+|---|---|
+| Auth | None — embedded `<img src>` must resolve without sending the JWT on every render. |
+| Response | `200` with the raw bytes; `Content-Type` set to the stored `mime`; `Cache-Control: public, max-age=31536000, immutable`. |
+| Errors | `404` for unknown id. |
+
+## Validation rules (service layer)
+
+`backend/app/images/service.py::validate_image(data, declared_mime)`:
+
+1. Reject empty uploads.
+2. Reject uploads larger than `MAX_IMAGE_BYTES = 5 * 1024 * 1024`.
+3. Sniff magic bytes:
+   - `\x89PNG\r\n\x1a\n` → `image/png`
+   - `\xff\xd8\xff…` → `image/jpeg`
+   - `GIF87a` / `GIF89a` → `image/gif`
+   - `RIFF…WEBP` → `image/webp`
+4. Reject unrecognised magic.
+5. If declared Content-Type contradicts detected, reject. Defends
+   against text-file-with-fake-MIME attacks.
+
+The detected MIME is what's stored — never the declared one.
+
+## RLS (Supabase)
+
+`m046_images.sql` enables RLS with three policies:
+
+- `images_select` — `USING (TRUE)` (public read; matches the `GET`
+  route's no-auth contract).
+- `images_insert` — `WITH CHECK (auth.uid() IS NOT NULL)` (any
+  authenticated user can upload).
+- `images_delete` — `USING (admin OR uploaded_by = auth.uid())`
+  (uploader can delete their own; admin can delete any). No
+  delete endpoint is exposed yet — this policy reserves the
+  semantics for when one is added.
+
+## Frontend integration
+
+### `markdownEditorToolbarHelpers.ts::uploadPastedImage(file)`
+
+```ts
+export async function uploadPastedImage(file: File): Promise<UploadedImage> {
+    const form = new FormData();
+    form.append('file', file, file.name || 'pasted-image.png');
+    const resp = await apiFetch<{ id: string; mime: string; size_bytes: number }>(
+        '/api/images', { method: 'POST', body: form }
+    );
+    return { id: resp.id, mime: resp.mime, size_bytes: resp.size_bytes,
+             url: `/api/images/${resp.id}` };
+}
+```
+
+`apiFetch` was extended in v5.4.0 to skip the default
+`Content-Type: application/json` when the body is a `FormData`
+instance — the browser then sets a proper multipart boundary.
+
+### `TextCanvas.svelte::handlePaste(e)`
+
+The textarea has a new `onpaste={handlePaste}`. The handler scans
+`event.clipboardData.items` for the first `image/*` file, calls
+`uploadPastedImage`, and splices `![pasted-image](/api/images/<id>)`
+at the cursor via the v5.3.0 `applyOp(insertAtCursor(…))` pattern.
+Non-image paste falls through to the browser default (text).
+
+### Markdown link form
+
+The inserted snippet is `![pasted-image](/api/images/<id>)`. Note
+that this is an **absolute path** (no scheme). The v5.3.0 widening
+of `ALLOWED_URI_REGEXP` to `/^(?:(?:https?|mailto|iris):|\/|\.{1,2}\/)/i`
+already accepts it. The v5.3.0 `<img src>` post-walk also accepts
+absolute paths — they resolve to the same-origin `https:` placeholder
+inside `urlIsAllowed`.
+
+## Tests
+
+| File | Coverage |
+|---|---|
+| `backend/tests/test_images/test_router.py` | (5 tests) PNG upload happy path round-trips bytes; declared-vs-actual MIME mismatch rejected; >5 MB upload rejected; unknown id 404; missing auth rejected. |
+| `frontend/tests/unit/markdownPasteImage.test.ts` | (4 tests) `uploadPastedImage` POSTs `/api/images` as multipart; TextCanvas mounts `onpaste`; the handler reads `clipboardData` for `image/*` items; splices via `insertAtCursor`/`applyOp`. |
+
+## Out of scope (deferred per ADR-145)
+
+- Image dedupe by content hash.
+- Server-side resizing / thumbnailing.
+- Garbage collection of orphaned images.
+- Direct-to-bucket presigned-URL upload for >5 MB files.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.3.1",
+	"version": "5.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.3.1",
+			"version": "5.4.0",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.3.1",
+	"version": "5.4.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/UnifiedCanvas.svelte
+++ b/frontend/src/lib/canvas/UnifiedCanvas.svelte
@@ -34,6 +34,10 @@
 		onundo?: () => void;
 		onredo?: () => void;
 		onnodedragstart?: () => void;
+		/** v5.4.0 (#5): fired when a node drag ends. Page-level handler can
+		 *  hit-test the new position against pool/lane bounds and set
+		 *  parentId so `validateBpmn::lane_outside_pool` resolves. */
+		onnodedragstop?: (nodeId: string, position: { x: number; y: number }) => void;
 		ontogglemode?: () => void;
 		panX?: number;
 		/** v5.2.0 (issue #37): BPMN connection guard. Return false to block the
@@ -65,6 +69,7 @@
 		onundo,
 		onredo,
 		onnodedragstart,
+		onnodedragstop,
 		ontogglemode,
 		panX = 0,
 		onbeforeconnect,
@@ -303,6 +308,8 @@
 			onpaneclick={handlePaneClick}
 			onreconnect={handleReconnect}
 			onnodedragstart={() => onnodedragstart?.()}
+			onnodedragstop={(_e: MouseEvent | TouchEvent, n: CanvasNode, _ns: CanvasNode[]) =>
+				onnodedragstop?.(n.id, { x: n.position.x, y: n.position.y })}
 			isValidConnection={onbeforeconnect}
 			proOptions={{ hideAttribution: true }}
 			defaultEdgeOptions={{ type: defaultEdgeType }}

--- a/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
+++ b/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
@@ -23,6 +23,8 @@
 	import ProblemsPanel from '$lib/canvas/validation/ProblemsPanel.svelte';
 	import BpmnToast from '$lib/canvas/bpmn/BpmnToast.svelte';
 	import { canConnect } from '$lib/canvas/validation/bpmnRules';
+	import { apiFetch, ApiError } from '$lib/utils/api';
+	import type { Element } from '$lib/types/api';
 	import {
 		BPMN_DEFAULT_DISCRIMINATORS,
 		type BpmnEntityType,
@@ -40,6 +42,9 @@
 		preferredThemeId?: string;
 		selectedEditNodeId: string | null;
 		history: ReturnType<typeof createCanvasHistory>;
+		/** v5.4.0 (#13): the diagram's set_id, used when POSTing /api/elements
+		 *  so the backing Iris Element lands in the right repository scope. */
+		setId?: string | null;
 		oncanvasdirty?: () => void;
 		onnodeselect?: (id: string | null) => void;
 		onedgeselect?: (id: string | null) => void;
@@ -52,6 +57,7 @@
 		preferredThemeId,
 		selectedEditNodeId = $bindable(null),
 		history,
+		setId,
 		oncanvasdirty,
 		onnodeselect,
 		onedgeselect,
@@ -95,25 +101,112 @@
 	// ────────────────────────────────────────────────────────────────────
 	// Drop / palette / command palette → create node
 	// ────────────────────────────────────────────────────────────────────
+
+	/**
+	 * v5.4.0 (#2/#4): per-entity-type node dimensions. Pre-v5.4 every BPMN
+	 * node was created with `width: 200`, which is correct for tasks but
+	 * wrong for events (visually 56×56 — see BpmnRenderer's `.bpmn-event-wrap`
+	 * CSS), gateways (56×56), data objects (48×64), pools (wide containers),
+	 * etc. The over-wide bounding box pushed ContextPad far to the right of
+	 * the actual shape. These widths match the CSS in BpmnRenderer.svelte.
+	 */
+	const BPMN_NODE_DIMENSIONS: Record<BpmnEntityType, { width: number; height: number }> = {
+		task:               { width: 200, height: 80 },
+		subprocess:         { width: 200, height: 80 },
+		call_activity:      { width: 200, height: 80 },
+		event_start:        { width: 56,  height: 56 },
+		event_intermediate: { width: 56,  height: 56 },
+		event_end:          { width: 56,  height: 56 },
+		event_boundary:     { width: 56,  height: 56 },
+		gateway:            { width: 56,  height: 56 },
+		pool:               { width: 600, height: 200 },
+		lane:               { width: 560, height: 100 },
+		data_object:        { width: 48,  height: 64 },
+		data_store:         { width: 64,  height: 64 },
+		group:              { width: 240, height: 140 },
+		text_annotation:    { width: 160, height: 56 },
+	};
+
+	/** v5.4.0 (#13): every BPMN node is now backed by an Iris Element —
+	 *  POSTs /api/elements with notation='bpmn' and stores the resulting
+	 *  Element id (the canonical Iris entity id) on the node so the rest
+	 *  of the platform (search, knowledge graph, tags, comments,
+	 *  iris://element/<id> refs) can find it. Mirrors the page-level
+	 *  handleAddElement pattern at views/[id]/+page.svelte. */
+	async function createBpmnElement(
+		entityKey: BpmnEntityType,
+		name: string,
+	): Promise<Element | null> {
+		const body: Record<string, unknown> = {
+			element_type: entityKey,
+			name,
+			description: '',
+			data: {},
+			notation: 'bpmn',
+		};
+		if (setId) body.set_id = setId;
+		try {
+			return await apiFetch<Element>('/api/elements', {
+				method: 'POST',
+				body: JSON.stringify(body),
+			});
+		} catch (e) {
+			toastMessage = e instanceof ApiError ? `Couldn't save element: ${e.message}` : "Couldn't save element — check connection.";
+			return null;
+		}
+	}
+
+	/** v5.4.0 (#13): keep the backing Element in sync when the user edits
+	 *  label/description in PropertyPanel. Best-effort — failures don't block
+	 *  the canvas-level update. Reuses the existing /api/elements PUT shape
+	 *  with If-Match for optimistic concurrency (matches handleEditElementSave). */
+	async function updateBpmnElement(
+		entityId: string,
+		patch: { name?: string; description?: string; element_type?: string },
+	): Promise<void> {
+		if (!entityId) return;
+		try {
+			const current = await apiFetch<Element>(`/api/elements/${entityId}`);
+			await apiFetch(`/api/elements/${entityId}`, {
+				method: 'PUT',
+				headers: { 'If-Match': String(current.current_version) },
+				body: JSON.stringify({
+					element_type: patch.element_type ?? current.element_type,
+					name: patch.name ?? current.name,
+					description: patch.description ?? current.description ?? '',
+					data: current.data,
+					notation: current.notation,
+				}),
+			});
+		} catch {
+			// Best-effort; canvas save will reconcile later.
+		}
+	}
+
 	function makeBpmnNode(
 		entityKey: BpmnEntityType,
 		position: { x: number; y: number },
+		options: { id?: string; label?: string; entityId?: string } = {},
 	): CanvasNode {
-		const id = (typeof crypto !== 'undefined' && 'randomUUID' in crypto)
-			? crypto.randomUUID()
-			: `bpmn-${Math.random().toString(36).slice(2, 10)}`;
+		const id = options.id
+			?? ((typeof crypto !== 'undefined' && 'randomUUID' in crypto)
+				? crypto.randomUUID()
+				: `bpmn-${Math.random().toString(36).slice(2, 10)}`);
 		// CanvasNodeData.entityType is typed narrowly as SimpleEntityType but
 		// stores values from every notation in practice (UML/ArchiMate/C4/DoView/BPMN).
 		// Cast through unknown matches the existing pattern elsewhere in the
 		// codebase for cross-notation entityType assignments.
+		const dims = BPMN_NODE_DIMENSIONS[entityKey] ?? { width: 200, height: 80 };
 		return {
 			id,
 			type: entityKey,
 			position,
-			width: 200,
+			width: dims.width,
+			height: dims.height,
 			data: {
-				label: humanLabel(entityKey),
+				label: options.label ?? humanLabel(entityKey),
 				entityType: entityKey,
+				entityId: options.entityId,
 				notation: 'bpmn',
 				data: { ...(BPMN_DEFAULT_DISCRIMINATORS[entityKey] ?? {}) },
 			},
@@ -149,7 +242,7 @@
 		return { x: 60, y: 60 };
 	}
 
-	function createNode(entityKey: BpmnEntityType, atPosition?: { x: number; y: number }) {
+	async function createNode(entityKey: BpmnEntityType, atPosition?: { x: number; y: number }) {
 		// Events have a 6×10 trigger × position matrix — route through the
 		// matrix picker so the user picks a meaningful variant rather than
 		// taking the default. Skip for boundary events that came from the
@@ -161,8 +254,15 @@
 			return;
 		}
 		const pos = atPosition ?? findOpenPosition();
+		// v5.4.0 (#13): create the backing Iris Element first; abort if it fails.
+		const label = humanLabel(entityKey);
+		const element = await createBpmnElement(entityKey, label);
+		if (!element) return;
 		pushHistory();
-		canvasNodes = [...canvasNodes, makeBpmnNode(entityKey, pos)];
+		canvasNodes = [
+			...canvasNodes,
+			makeBpmnNode(entityKey, pos, { entityId: element.id, label }),
+		];
 		dirty();
 	}
 
@@ -176,7 +276,7 @@
 		createNode(key as BpmnEntityType, position);
 	}
 
-	function handleEventVariant(variant: {
+	async function handleEventVariant(variant: {
 		entityType: BpmnEntityType;
 		eventTrigger: string;
 		eventDirection?: string;
@@ -185,7 +285,11 @@
 		eventPickerOpen = false;
 		const pos = pendingDropPosition ?? findOpenPosition();
 		pendingDropPosition = null;
-		const node = makeBpmnNode(variant.entityType, pos);
+		// v5.4.0 (#13): backing Element first.
+		const label = humanLabel(variant.entityType);
+		const element = await createBpmnElement(variant.entityType, label);
+		if (!element) return;
+		const node = makeBpmnNode(variant.entityType, pos, { entityId: element.id, label });
 		const data = (node.data as Record<string, unknown>);
 		data.data = {
 			...((data.data as Record<string, unknown> | undefined) ?? {}),
@@ -203,10 +307,10 @@
 	// ────────────────────────────────────────────────────────────────────
 	// CommandPalette: pick → create / append / replace
 	// ────────────────────────────────────────────────────────────────────
-	function handleCmdPick(entry: BpmnEntityTypeInfo, mode: CommandMode) {
+	async function handleCmdPick(entry: BpmnEntityTypeInfo, mode: CommandMode) {
 		if (mode === 'create') {
 			eventPickerContext = 'create';
-			createNode(entry.key);
+			await createNode(entry.key);
 			return;
 		}
 		if (mode === 'append') {
@@ -214,7 +318,11 @@
 			eventPickerContext = 'create';
 			const src = selectedNode;
 			const offset = { x: src.position.x + 280, y: src.position.y };
-			const newNode = makeBpmnNode(entry.key, offset);
+			// v5.4.0 (#13): backing Element first.
+			const label = humanLabel(entry.key);
+			const element = await createBpmnElement(entry.key, label);
+			if (!element) return;
+			const newNode = makeBpmnNode(entry.key, offset, { entityId: element.id, label });
 			pushHistory();
 			canvasNodes = [...canvasNodes, newNode];
 			canvasEdges = [
@@ -233,6 +341,12 @@
 		if (mode === 'replace') {
 			if (!selectedNode) return;
 			pushHistory();
+			// v5.4.0 (#13): mutate the existing Element's element_type rather
+			// than creating a new one — the Element identity follows the node.
+			const entityId = (selectedNode.data as { entityId?: string }).entityId;
+			if (entityId) {
+				updateBpmnElement(entityId, { element_type: entry.key });
+			}
 			canvasNodes = canvasNodes.map((n) => {
 				if (n.id !== selectedNode.id) return n;
 				return {
@@ -269,6 +383,12 @@
 				cmdMode = 'replace';
 				cmdOpen = true;
 				break;
+			case 'bring_forward':
+				adjustZOrder(nodeId, 'forward');
+				break;
+			case 'send_backward':
+				adjustZOrder(nodeId, 'backward');
+				break;
 			case 'delete':
 				deleteNodeById(nodeId);
 				break;
@@ -279,8 +399,78 @@
 		}
 	}
 
-	function appendBpmn(src: CanvasNode, key: BpmnEntityType) {
-		const newNode = makeBpmnNode(key, { x: src.position.x + 280, y: src.position.y });
+	/** v5.4.0 (#5): xyflow doesn't auto-set parentId on visual overlap, so
+	 *  validateBpmn::lane_outside_pool fires even when the user has dragged
+	 *  the lane visually inside a pool. After every drag, hit-test the
+	 *  dragged node against pool bounds and set parentId accordingly. The
+	 *  rule then walks `parentId` and clears the error.
+	 *
+	 *  Only fires on lanes (the only BPMN entity that has a "must-be-inside-
+	 *  parent" constraint per BPMN 2.0). */
+	function handleBpmnDragStop(nodeId: string, position: { x: number; y: number }) {
+		const node = canvasNodes.find((n) => n.id === nodeId);
+		if (!node) return;
+		const entityType = node.data?.entityType as string | undefined;
+		if (entityType !== 'lane') return;
+
+		// Hit-test against every pool's rectangle.
+		const dims = BPMN_NODE_DIMENSIONS.lane;
+		const lx1 = position.x;
+		const ly1 = position.y;
+		const lx2 = position.x + dims.width;
+		const ly2 = position.y + dims.height;
+
+		const pool = canvasNodes.find((p) => {
+			// Cast: data.entityType is typed as SimpleEntityType but stores BPMN values.
+			if ((p.data?.entityType as string) !== 'pool') return false;
+			const pd = BPMN_NODE_DIMENSIONS.pool;
+			const pw = (p as { width?: number }).width ?? pd.width;
+			const ph = (p as { height?: number }).height ?? pd.height;
+			const px2 = p.position.x + pw;
+			const py2 = p.position.y + ph;
+			// Centre-point hit-test (lane is "inside" if its centre falls in the pool).
+			const cx = (lx1 + lx2) / 2;
+			const cy = (ly1 + ly2) / 2;
+			return cx >= p.position.x && cx <= px2 && cy >= p.position.y && cy <= py2;
+		});
+
+		const newParentId = pool?.id ?? null;
+		const currentParentId = (node as { parentId?: string | null }).parentId ?? null;
+		if (newParentId === currentParentId) return; // no change
+
+		pushHistory();
+		canvasNodes = canvasNodes.map((n) =>
+			n.id === nodeId ? ({ ...n, parentId: newParentId } as unknown as CanvasNode) : n,
+		);
+		dirty();
+	}
+
+	/** v5.4.0 (#3): adjust the z-index of a node so the user can stack
+	 *  things (lane on pool, annotation on activity) and reorder. SvelteFlow
+	 *  honours the optional `zIndex` field on Node. */
+	function adjustZOrder(nodeId: string, direction: 'forward' | 'backward') {
+		pushHistory();
+		const others = canvasNodes
+			.filter((n) => n.id !== nodeId)
+			.map((n) => ((n as { zIndex?: number }).zIndex ?? 0));
+		const max = others.length > 0 ? Math.max(...others) : 0;
+		const min = others.length > 0 ? Math.min(...others) : 0;
+		const next = direction === 'forward' ? max + 1 : min - 1;
+		canvasNodes = canvasNodes.map((n) =>
+			n.id === nodeId ? ({ ...n, zIndex: next } as unknown as CanvasNode) : n,
+		);
+		dirty();
+	}
+
+	async function appendBpmn(src: CanvasNode, key: BpmnEntityType) {
+		// v5.4.0 (#13): backing Element first.
+		const label = humanLabel(key);
+		const element = await createBpmnElement(key, label);
+		if (!element) return;
+		const newNode = makeBpmnNode(key, { x: src.position.x + 280, y: src.position.y }, {
+			entityId: element.id,
+			label,
+		});
 		pushHistory();
 		canvasNodes = [...canvasNodes, newNode];
 		canvasEdges = [
@@ -308,6 +498,7 @@
 	// ────────────────────────────────────────────────────────────────────
 	function handlePropChange(id: string, patch: Record<string, unknown>) {
 		pushHistory();
+		const node = canvasNodes.find((n) => n.id === id);
 		canvasNodes = canvasNodes.map((n) => {
 			if (n.id !== id) return n;
 			// Top-level fields the panel knows about: label, description.
@@ -326,6 +517,17 @@
 			return next as CanvasNode;
 		});
 		dirty();
+
+		// v5.4.0 (#13): keep the backing Iris Element in sync. Fire-and-forget;
+		// canvas-level save reconciles failures. Only fires for label/description
+		// — discriminator fields live entirely on the canvas node payload.
+		const entityId = (node?.data as { entityId?: string } | undefined)?.entityId;
+		if (entityId && ('label' in patch || 'description' in patch)) {
+			updateBpmnElement(entityId, {
+				name: 'label' in patch ? (patch.label as string | undefined) : undefined,
+				description: 'description' in patch ? (patch.description as string | undefined) : undefined,
+			});
+		}
 	}
 
 	// ────────────────────────────────────────────────────────────────────
@@ -432,6 +634,7 @@
 				onbeforeconnect={handleBeforeConnect}
 				ondropentity={handleDropEntity}
 				oncontextpadaction={handleContextPadAction}
+				onnodedragstop={handleBpmnDragStop}
 				onnodeselect={(id) => { selectedEditNodeId = id; onnodeselect?.(id); }}
 				onedgeselect={(id) => onedgeselect?.(id)}
 			/>
@@ -499,7 +702,9 @@
 	.bpmn-shell__problems {
 		min-height: 80px;
 		max-height: 200px;
-		overflow: hidden;
+		/* v5.4.0 (#1): the inner ProblemsPanel list scrolls itself; the
+		   wrapper used to clip that scroll, sending overflow up to the page. */
+		overflow-y: auto;
 		border: 1px solid var(--color-border, #d4d4d4);
 		border-radius: 6px;
 		background: var(--color-surface, #fff);

--- a/frontend/src/lib/canvas/palette/ContextPad.svelte
+++ b/frontend/src/lib/canvas/palette/ContextPad.svelte
@@ -19,6 +19,8 @@
 		| 'append_end_event'
 		| 'connect'
 		| 'change'
+		| 'bring_forward'
+		| 'send_backward'
 		| 'delete';
 
 	interface Props {
@@ -40,6 +42,9 @@
 		{ id: 'append_end_event', label: 'Append End Event', tooltip: 'Append End Event',           glyph: '⬤' },
 		{ id: 'connect',          label: 'Connect',          tooltip: 'Drag to connect',            glyph: '⇢' },
 		{ id: 'change',           label: 'Change',           tooltip: 'Change element type (R)',    glyph: '🔧' },
+		// v5.4.0 (#3): z-order controls — needed when items stack (lane on pool, etc).
+		{ id: 'bring_forward',    label: 'Bring Forward',    tooltip: 'Bring forward',              glyph: '↑' },
+		{ id: 'send_backward',    label: 'Send Backward',    tooltip: 'Send backward',              glyph: '↓' },
 		{ id: 'delete',           label: 'Delete',           tooltip: 'Delete element (Del)',       glyph: '✖' },
 	];
 

--- a/frontend/src/lib/canvas/text/TextCanvas.svelte
+++ b/frontend/src/lib/canvas/text/TextCanvas.svelte
@@ -14,7 +14,7 @@
 	import MarkdownView from '$lib/components/MarkdownView.svelte';
 	import type { TocHeading } from '$lib/components/markdownHelpers';
 	import MarkdownEditorToolbar from '$lib/canvas/text/MarkdownEditorToolbar.svelte';
-	import { wrapSelection, applyOp } from '$lib/canvas/text/markdownEditorToolbarHelpers';
+	import { wrapSelection, applyOp, insertAtCursor, uploadPastedImage } from '$lib/canvas/text/markdownEditorToolbarHelpers';
 
 	interface Props {
 		/** Markdown source — read from diagram.data.content. */
@@ -129,6 +129,34 @@
 		}
 		commitChange(ta);
 	}
+
+	/** v5.4.0 (#7): paste an image from the clipboard → upload to Iris →
+	 *  splice `![pasted-image](/api/images/<id>)` at the cursor. The user
+	 *  experience is GitHub-style. Falls through to the browser default
+	 *  for non-image clipboard content (text, etc). */
+	async function handlePaste(e: ClipboardEvent) {
+		const items = e.clipboardData?.items;
+		if (!items) return;
+		for (const item of items) {
+			if (item.kind === 'file' && item.type.startsWith('image/')) {
+				e.preventDefault();
+				const file = item.getAsFile();
+				if (!file) return;
+				const ta = e.currentTarget as HTMLTextAreaElement;
+				try {
+					const uploaded = await uploadPastedImage(file);
+					const op = insertAtCursor(ta, `![pasted-image](${uploaded.url})`);
+					applyOp(ta, op);
+					content = op.value;
+					oncontentchange?.(op.value);
+				} catch {
+					// Surface failures via the existing change channel rather
+					// than blocking — user can paste a fresh copy.
+				}
+				return;
+			}
+		}
+	}
 </script>
 
 <div class="text-canvas" data-mode={editing ? 'edit' : 'view'}>
@@ -143,7 +171,8 @@
 			value={content ?? ''}
 			oninput={onInput}
 			onkeydown={handleKeydown}
-			placeholder="Write markdown… use [label](iris://diagram/<id>) or iris://element/<id> to link to other Iris models. Tab indents; Esc then Tab moves focus."
+			onpaste={handlePaste}
+			placeholder="Write markdown… use [label](iris://diagram/<id>) or iris://element/<id> to link to other Iris models. Tab indents; Esc then Tab moves focus. Paste an image to upload it inline."
 			spellcheck="true"
 		></textarea>
 	{:else}

--- a/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
+++ b/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
@@ -92,3 +92,37 @@ export function applyOp(ta: HTMLTextAreaElement, op: EditorOp) {
 	ta.setSelectionRange(op.selectionStart, op.selectionEnd);
 	ta.focus();
 }
+
+/**
+ * v5.4.0 (#7): upload a pasted clipboard image to /api/images and
+ * return the public URL. Used by `TextCanvas.onpaste` to splice
+ * `![pasted](/api/images/<id>)` at the cursor.
+ *
+ * Multipart form upload — works with the FastAPI `UploadFile` shape
+ * the v5.4.0 backend route expects. apiFetch wrapper handles auth.
+ */
+import { apiFetch } from '$lib/utils/api';
+
+interface UploadedImage {
+	id: string;
+	url: string;
+	mime: string;
+	size_bytes: number;
+}
+
+export async function uploadPastedImage(file: File): Promise<UploadedImage> {
+	const form = new FormData();
+	form.append('file', file, file.name || 'pasted-image.png');
+	// apiFetch detects FormData bodies and skips the default JSON
+	// Content-Type so the browser sets a proper multipart boundary.
+	const resp = await apiFetch<{ id: string; mime: string; size_bytes: number }>(
+		'/api/images',
+		{ method: 'POST', body: form },
+	);
+	return {
+		id: resp.id,
+		mime: resp.mime,
+		size_bytes: resp.size_bytes,
+		url: `/api/images/${resp.id}`,
+	};
+}

--- a/frontend/src/lib/utils/api.ts
+++ b/frontend/src/lib/utils/api.ts
@@ -70,8 +70,11 @@ export async function apiFetch<T>(
 	options: RequestInit = {},
 ): Promise<T> {
 	const token = getAccessToken();
+	// v5.4.0 (#7): skip the default JSON Content-Type for FormData bodies
+	// so the browser sets `multipart/form-data; boundary=…` automatically.
+	const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
 	const headers: Record<string, string> = {
-		'Content-Type': 'application/json',
+		...(isFormData ? {} : { 'Content-Type': 'application/json' }),
 		...(options.headers as Record<string, string>),
 	};
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -512,10 +512,14 @@
 	{/if}
 
 	<!-- Stats -->
-	<div class="mt-6 grid grid-cols-5 gap-4" style="max-width: 1000px">
+	<!-- v5.4.0 (#11): grid is now 4-wide (Packages card removed). -->
+	<!-- v5.4.0 (#12): Collections + Sets cards get a muted-grey background
+		 (`dashboard-card--ambient`) so they read as "scope filters" distinct
+		 from the working-content cards (Views, Elements). -->
+	<div class="mt-6 grid grid-cols-4 gap-4" style="max-width: 1000px">
 		<div
-			class="rounded border p-4 text-center"
-			style="border-color: var(--color-border); color: var(--color-fg)"
+			class="dashboard-card--ambient rounded border p-4 text-center"
+			style="border-color: var(--color-border); color: var(--color-fg); background: var(--color-surface)"
 		>
 			{#if activeCollection}
 				<div class="text-xl font-bold" style="color: var(--color-fg)">{activeCollection.name}</div>
@@ -534,8 +538,8 @@
 			{/if}
 		</div>
 		<div
-			class="rounded border p-4 text-center"
-			style="border-color: var(--color-border); color: var(--color-fg)"
+			class="dashboard-card--ambient rounded border p-4 text-center"
+			style="border-color: var(--color-border); color: var(--color-fg); background: var(--color-surface)"
 		>
 			{#if activeSet}
 				<div class="text-xl font-bold" style="color: var(--color-fg)">{activeSet.name}</div>
@@ -553,16 +557,8 @@
 				</a>
 			{/if}
 		</div>
-		<a
-			href={setId ? `/packages?set_id=${setId}` : collectionId ? `/packages?collection_id=${collectionId}` : '/packages'}
-			class="rounded border p-4 text-center"
-			style="border-color: var(--color-border); color: var(--color-fg)"
-		>
-			<div class="text-3xl font-bold" style="color: var(--color-primary)">{packageCount}</div>
-			<div class="mt-1 text-sm" style="color: var(--color-muted)">
-				Packages {#if activeSet || activeCollection}(filtered){/if}
-			</div>
-		</a>
+		<!-- v5.4.0 (#11): Packages card removed — the count was redundant
+			 with the hierarchy tree on this page. -->
 		<a
 			href={setId ? `/views?set_id=${setId}` : collectionId ? `/views?collection_id=${collectionId}` : '/views'}
 			class="rounded border p-4 text-center"

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -539,11 +539,18 @@
 			diagram = diagramResult;
 			recordVisit({ id: diagram.id, type: 'diagram', name: diagram.name, detail: diagram.diagram_type, setId: diagram.set_id ?? undefined, setName: diagram.set_name ?? undefined, description: diagram.description ?? undefined, href: `/views/${diagram.id}` });
 			parseCanvasData();
-			// Smart default tab: show details if no canvas content
+			// Smart default tab: show details if no canvas content.
+			// v5.4.0 (#9): Text views (markdown notation) have no canvas
+			// nodes — their content lives in `data.content` as a markdown
+			// string. Without this branch the page lands on Details for
+			// every Text view that has any markdown.
 			if (!userSelectedTab) {
-				const hasContent = diagram.diagram_type === 'sequence'
-					? sequenceData.participants.length > 0
-					: canvasNodes.length > 0;
+				const isText = diagram.diagram_type === 'text' || diagram.notation === 'markdown';
+				const hasContent = isText
+					? !!(diagram.data?.content as string | undefined)?.length
+					: diagram.diagram_type === 'sequence'
+						? sequenceData.participants.length > 0
+						: canvasNodes.length > 0;
 				activeTab = hasContent ? 'canvas' : 'details';
 			}
 			refreshNodeDescriptions();
@@ -987,6 +994,48 @@
 		return { x: 60, y: 60 };
 	}
 
+	/** v5.4.0 (#8): per-entity-type BPMN node dimensions used by the
+	 *  page-level handleAddElement / handleInsertDiagram BPMN branches.
+	 *  Mirrors `BPMN_NODE_DIMENSIONS` in BpmnAuthoringShell (single source
+	 *  of truth would be better long-term — flagged for v5.5). */
+	function bpmnDimsFor(entityType: string): { width: number; height: number } {
+		const D: Record<string, { width: number; height: number }> = {
+			task: { width: 200, height: 80 },
+			subprocess: { width: 200, height: 80 },
+			call_activity: { width: 200, height: 80 },
+			event_start: { width: 56, height: 56 },
+			event_intermediate: { width: 56, height: 56 },
+			event_end: { width: 56, height: 56 },
+			event_boundary: { width: 56, height: 56 },
+			gateway: { width: 56, height: 56 },
+			pool: { width: 600, height: 200 },
+			lane: { width: 560, height: 100 },
+			data_object: { width: 48, height: 64 },
+			data_store: { width: 64, height: 64 },
+			group: { width: 240, height: 140 },
+			text_annotation: { width: 160, height: 56 },
+		};
+		return D[entityType] ?? { width: 200, height: 80 };
+	}
+
+	/** v5.4.0 (#8): minimal BPMN_DEFAULT_DISCRIMINATORS shadow — enough to
+	 *  let the page handlers create BPMN nodes that match the renderer's
+	 *  expectations without importing the BPMN module on non-BPMN views. */
+	function bpmnDefaultDiscriminators(entityType: string): Record<string, unknown> {
+		const D: Record<string, Record<string, unknown>> = {
+			task: { taskType: 'none' },
+			subprocess: { subprocessKind: 'embedded' },
+			event_start: { eventTrigger: 'none' },
+			event_intermediate: { eventDirection: 'catch', eventTrigger: 'message' },
+			event_end: { eventTrigger: 'none' },
+			event_boundary: { boundaryInterrupting: true, eventTrigger: 'message' },
+			gateway: { gatewayType: 'exclusive' },
+			data_object: { dataKind: 'object' },
+			pool: { orientation: 'horizontal' },
+		};
+		return { ...(D[entityType] ?? {}) };
+	}
+
 	async function handleAddElement(name: string, elementType: SimpleEntityType, description: string, _tags?: string[], elementNotation?: string) {
 		try {
 			const effectiveNotation = elementNotation ?? notation ?? 'simple';
@@ -1002,6 +1051,32 @@
 			});
 			if (canvasType === 'text') {
 				insertMarkdownAtCursor(`[${name}](iris://element/${created.id})`);
+				showAddElement = false;
+				return;
+			}
+			// v5.4.0 (#8/#13): BPMN canvas — match the BpmnAuthoringShell shape
+			// (per-entity-type dimensions, BPMN_DEFAULT_DISCRIMINATORS payload).
+			if (canvasType === 'bpmn') {
+				const dims = bpmnDimsFor(elementType as string);
+				const id = crypto.randomUUID();
+				const newNode: CanvasNode = {
+					id,
+					type: elementType,
+					position: findOpenPosition(),
+					width: dims.width,
+					height: dims.height,
+					data: {
+						label: name,
+						entityType: elementType,
+						description,
+						entityId: created.id,
+						notation: 'bpmn',
+						data: bpmnDefaultDiscriminators(elementType as string),
+					},
+				} as unknown as CanvasNode;
+				history.pushState(canvasNodes, canvasEdges);
+				canvasNodes = [...canvasNodes, newNode];
+				canvasDirty = true;
 				showAddElement = false;
 				return;
 			}
@@ -1376,6 +1451,25 @@
 			showElementPicker = false;
 			return;
 		}
+		// v5.4.0 (#8): on BPMN, "Link Element" binds the picked Element to the
+		// SELECTED node (by setting entityId on the node's data) rather than
+		// inserting a new node. If nothing's selected, surface a hint.
+		if (canvasType === 'bpmn') {
+			if (!selectedEditNodeId) {
+				error = 'Select a BPMN node first, then click Link Element to bind a repository entity to it.';
+				showElementPicker = false;
+				return;
+			}
+			history.pushState(canvasNodes, canvasEdges);
+			canvasNodes = canvasNodes.map((n) =>
+				n.id === selectedEditNodeId
+					? { ...n, data: { ...n.data, entityId: element.id, label: element.name } }
+					: n,
+			);
+			canvasDirty = true;
+			showElementPicker = false;
+			return;
+		}
 		const id = crypto.randomUUID();
 		const elementType = element.element_type as SimpleEntityType;
 		const newNode: CanvasNode = {
@@ -1400,6 +1494,33 @@
 	function handleInsertDiagram(linkedDiagram: Diagram) {
 		if (canvasType === 'text') {
 			insertMarkdownAtCursor(`[${linkedDiagram.name}](iris://diagram/${linkedDiagram.id})`);
+			showDiagramPicker = false;
+			return;
+		}
+		// v5.4.0 (#8): on BPMN, "Add Diagram" places a call_activity node
+		// (BPMN-standard "this activity calls another process") with
+		// linkedModelId pointing at the picked diagram.
+		if (canvasType === 'bpmn') {
+			const id = crypto.randomUUID();
+			const dims = bpmnDimsFor('call_activity');
+			const newNode: CanvasNode = {
+				id,
+				type: 'call_activity',
+				position: findOpenPosition(),
+				width: dims.width,
+				height: dims.height,
+				data: {
+					label: linkedDiagram.name,
+					entityType: 'call_activity',
+					description: linkedDiagram.description ?? '',
+					linkedModelId: linkedDiagram.id,
+					notation: 'bpmn',
+					data: {},
+				},
+			} as unknown as CanvasNode;
+			history.pushState(canvasNodes, canvasEdges);
+			canvasNodes = [...canvasNodes, newNode];
+			canvasDirty = true;
 			showDiagramPicker = false;
 			return;
 		}
@@ -1991,15 +2112,7 @@
 			</svg>
 		</button>
 		<div class="flex gap-1" role="tablist" aria-label="Diagram sections">
-			<button
-				role="tab"
-				aria-selected={activeTab === 'details'}
-				onclick={() => { activeTab = 'details'; userSelectedTab = true; }}
-				class="px-4 py-2 text-sm"
-				style="color: {activeTab === 'details' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'details' ? 'var(--color-primary)' : 'transparent'}"
-			>
-				Details
-			</button>
+			<!-- v5.4.0 (#10): Canvas first — the working content tab leads. -->
 			<button
 				role="tab"
 				aria-selected={activeTab === 'canvas'}
@@ -2008,6 +2121,15 @@
 				style="color: {activeTab === 'canvas' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'canvas' ? 'var(--color-primary)' : 'transparent'}"
 			>
 				Canvas
+			</button>
+			<button
+				role="tab"
+				aria-selected={activeTab === 'details'}
+				onclick={() => { activeTab = 'details'; userSelectedTab = true; }}
+				class="px-4 py-2 text-sm"
+				style="color: {activeTab === 'details' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'details' ? 'var(--color-primary)' : 'transparent'}"
+			>
+				Details
 			</button>
 			<button
 				role="tab"
@@ -2355,7 +2477,9 @@
 					{/if}
 					<!-- View group (always visible) -->
 					<div class="ml-auto flex items-center gap-2">
-						{#if notation && editing}
+						{#if notation && editing && (notation as string) !== 'bpmn' && (notation as string) !== 'markdown' && (canvasType as string) !== 'text'}
+							<!-- v5.4.0 (#6): theme selector irrelevant on BPMN (theme fixed by m043
+								 bpmn-default seed) and on Text views (no canvas to theme). -->
 							<ThemeSelector {notation} />
 						{/if}
 						<div class="relative">
@@ -2393,7 +2517,7 @@
 								<span class="inline-flex items-center justify-center rounded text-xs font-medium" style="min-width: 20px; height: 20px; padding: 0 5px; background: var(--color-muted); color: white">{commentCount}</span>
 							</button>
 						{/if}
-						{#if canvasType === 'text'}
+						{#if (canvasType as string) === 'text'}
 							<!-- Issue #32 reopen: TOC drawer toggle for Text views.
 								 The drawer was wired in v5.1.0 but no button toggled it. -->
 							<button
@@ -2668,7 +2792,9 @@
 					{/if}
 					<!-- View group (always visible) -->
 					<div class="ml-auto flex items-center gap-2">
-						{#if notation && editing}
+						{#if notation && editing && (notation as string) !== 'bpmn' && (notation as string) !== 'markdown' && (canvasType as string) !== 'text'}
+							<!-- v5.4.0 (#6): theme selector irrelevant on BPMN (theme fixed by m043
+								 bpmn-default seed) and on Text views (no canvas to theme). -->
 							<ThemeSelector {notation} />
 						{/if}
 						<div class="relative">
@@ -2706,7 +2832,7 @@
 								<span class="inline-flex items-center justify-center rounded text-xs font-medium" style="min-width: 20px; height: 20px; padding: 0 5px; background: var(--color-muted); color: white">{commentCount}</span>
 							</button>
 						{/if}
-						{#if canvasType === 'text'}
+						{#if (canvasType as string) === 'text'}
 							<!-- Issue #32 reopen: TOC drawer toggle for Text views.
 								 The drawer was wired in v5.1.0 but no button toggled it. -->
 							<button
@@ -2844,6 +2970,37 @@
 						</FocusView>
 					{:else if canvasType === 'text'}
 					<!-- Issue #26 / ADR-137: Text diagrams render markdown view/edit instead of a canvas. -->
+					<!-- v5.4.0 (#8): Add Element / Link Element / Add Diagram available
+						 on Text views in edit mode — handlers branch on canvasType to
+						 splice an iris:// markdown link at the cursor (v5.1.1). -->
+					<div class="mb-3 flex flex-wrap items-center gap-2">
+						<button
+							onclick={() => (showAddElement = true)}
+							class="rounded px-3 py-1.5 text-sm text-white"
+							style="background-color: var(--color-primary)"
+						>
+							Add Element
+						</button>
+						<button
+							onclick={() => (showElementPicker = true)}
+							class="rounded px-3 py-1.5 text-sm"
+							style="border: 1px solid var(--color-border); color: var(--color-fg)"
+						>
+							Link Element
+						</button>
+						<button
+							onclick={() => (showDiagramPicker = true)}
+							class="rounded px-3 py-1.5 text-sm"
+							style="border: 1px solid var(--color-border); color: var(--color-fg)"
+						>
+							Add Diagram
+						</button>
+						<div class="ml-auto flex items-center gap-2">
+							<button onclick={saveCanvas} disabled={saving || !canvasDirty} class="rounded px-3 py-1.5 text-sm text-white disabled:opacity-50" style="background-color: var(--color-success, #16a34a)">{saving ? 'Saving...' : 'Save'}</button>
+							<button onclick={discardChanges} class="rounded px-3 py-1.5 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">Discard</button>
+							{#if canvasDirty}<span class="text-xs" style="color: var(--color-muted)">Unsaved changes</span>{/if}
+						</div>
+					</div>
 					<div class="flex gap-4">
 						<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: hidden">
 							<TextCanvas
@@ -2867,6 +3024,41 @@
 					<!-- v5.2.0 (issue #37): BPMN authoring shell — palette / canvas /
 						 property panel + bottom problems dock + canConnect toast.
 						 Replaces the generic right-panel stack on BPMN views in edit mode. -->
+					<!-- v5.4.0 (#8): trio toolbar above the shell so Add Element / Link
+						 Element / Add Diagram work on BPMN views too. Add Element opens
+						 EntityDialog (notation=bpmn — v5.1.2 issue #33), Link Element
+						 binds an Element to the selected node, Add Diagram inserts a
+						 BPMN call_activity referencing the picked diagram. -->
+					<div class="mb-3 flex flex-wrap items-center gap-2">
+						<button
+							onclick={() => (showAddElement = true)}
+							class="rounded px-3 py-1.5 text-sm text-white"
+							style="background-color: var(--color-primary)"
+						>
+							Add Element
+						</button>
+						<button
+							onclick={() => (showElementPicker = true)}
+							class="rounded px-3 py-1.5 text-sm"
+							style="border: 1px solid var(--color-border); color: var(--color-fg)"
+						>
+							Link Element
+						</button>
+						<button
+							onclick={() => (showDiagramPicker = true)}
+							class="rounded px-3 py-1.5 text-sm"
+							style="border: 1px solid var(--color-border); color: var(--color-fg)"
+						>
+							Add Diagram
+						</button>
+						<div class="ml-auto flex items-center gap-2">
+							<button onclick={handleUndo} disabled={!history.canUndo} class="rounded px-3 py-1.5 text-sm disabled:opacity-50" style="border: 1px solid var(--color-border); color: var(--color-fg)" aria-label="Undo">Undo</button>
+							<button onclick={handleRedo} disabled={!history.canRedo} class="rounded px-3 py-1.5 text-sm disabled:opacity-50" style="border: 1px solid var(--color-border); color: var(--color-fg)" aria-label="Redo">Redo</button>
+							<button onclick={saveCanvas} disabled={saving || !canvasDirty} class="rounded px-3 py-1.5 text-sm text-white disabled:opacity-50" style="background-color: var(--color-success, #16a34a)">{saving ? 'Saving...' : 'Save'}</button>
+							<button onclick={discardChanges} class="rounded px-3 py-1.5 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">Discard</button>
+							{#if canvasDirty}<span class="text-xs" style="color: var(--color-muted)">Unsaved changes</span>{/if}
+						</div>
+					</div>
 					<BpmnAuthoringShell
 						{notation}
 						{preferredThemeId}
@@ -2874,6 +3066,7 @@
 						bind:canvasEdges
 						bind:selectedEditNodeId
 						{history}
+						setId={diagram?.set_id ?? null}
 						oncanvasdirty={() => (canvasDirty = true)}
 						onnodeselect={handleNodeSelect}
 						onedgeselect={handleEdgeSelect}

--- a/frontend/tests/unit/bpmnCanvasIntegration.test.ts
+++ b/frontend/tests/unit/bpmnCanvasIntegration.test.ts
@@ -35,7 +35,9 @@ describe('BPMN authoring shell exists (issue #37, v5.2.0)', () => {
 		// The mount must be guarded by notation === 'bpmn' so non-BPMN views
 		// keep the existing canvas branch unchanged. Accept either {#if … }
 		// or {:else if … } since the chain is part of an existing if/else.
-		const mountBlock = src.match(/\{(?:#if|:else if)[^}]*notation\s*===\s*'bpmn'[\s\S]{0,400}<BpmnAuthoringShell/);
+		// v5.4.0 (#8) inserts a trio toolbar between the guard and the shell;
+		// loosen the lookahead window from 400 to 4000 chars.
+		const mountBlock = src.match(/\{(?:#if|:else if)[^}]*notation\s*===\s*'bpmn'[\s\S]{0,4000}<BpmnAuthoringShell/);
 		expect(mountBlock).toBeTruthy();
 	});
 });

--- a/frontend/tests/unit/bpmnLaneOnPool.test.ts
+++ b/frontend/tests/unit/bpmnLaneOnPool.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (#5): xyflow doesn't auto-set `parentId` on visual overlap.
+ * The validateBpmn `lane_outside_pool` rule walks parentId correctly,
+ * so the producer side has to set it. We wire onnodedragstop on the
+ * BPMN view and hit-test against pool bounds when a lane drops.
+ */
+
+const UNIFIED = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/UnifiedCanvas.svelte'),
+	'utf-8',
+);
+const SHELL = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/bpmn/BpmnAuthoringShell.svelte'),
+	'utf-8',
+);
+
+describe('Lane-on-pool parentId wiring (#5, v5.4.0)', () => {
+	it('UnifiedCanvas exposes an onnodedragstop prop wired to <SvelteFlow>', () => {
+		expect(UNIFIED).toMatch(/onnodedragstop\?:/);
+		expect(UNIFIED).toMatch(/<SvelteFlow[\s\S]*?onnodedragstop=/);
+	});
+
+	it('BpmnAuthoringShell implements drop-on-pool parent assignment', () => {
+		// The shell owns the BPMN-specific hit-test (pool / lane semantics
+		// don't apply on other notations).
+		expect(SHELL).toMatch(/handleBpmnDragStop/);
+		expect(SHELL).toMatch(/onnodedragstop=\{handleBpmnDragStop\}/);
+		const fn = SHELL.match(/function handleBpmnDragStop[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/parentId/);
+		expect(fn).toMatch(/pool/);
+		expect(fn).toMatch(/lane/);
+	});
+});

--- a/frontend/tests/unit/bpmnNodeAsElement.test.ts
+++ b/frontend/tests/unit/bpmnNodeAsElement.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (#13): align BPMN with the rest of Iris's notation pattern —
+ * every BPMN node creates a backing Iris Element via `POST /api/elements`
+ * and stores `entityId` on the canvas node. Pre-v5.4 BPMN nodes were
+ * pure visual shapes (no Element record), divergent from
+ * Simple/UML/ArchiMate/C4/DoView (which have always done this).
+ *
+ * Once aligned, BPMN content participates in search, knowledge graph,
+ * tagging, comments, versioning, and `iris://element/<id>` references.
+ */
+
+const SHELL = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/bpmn/BpmnAuthoringShell.svelte'),
+	'utf-8',
+);
+
+describe('BPMN nodes are backed by Iris Elements (#13, v5.4.0)', () => {
+	it('the shell defines a createBpmnElement helper that POSTs /api/elements', () => {
+		expect(SHELL).toMatch(/(?:async\s+)?function\s+createBpmnElement\b/);
+		const fn = SHELL.match(/function\s+createBpmnElement[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/apiFetch[\s\S]*?\/api\/elements/);
+		expect(fn).toMatch(/method:\s*['"]POST['"]/);
+		expect(fn).toMatch(/notation:\s*['"]bpmn['"]|notation\s*:\s*['"]bpmn['"]/);
+	});
+
+	it('every node-creation path persists `entityId` on the new node', () => {
+		// makeBpmnNode (or its callers) must put `entityId` somewhere on
+		// data — that's the field every other notation uses.
+		expect(SHELL).toMatch(/entityId/);
+	});
+
+	it('createBpmnElement is awaited from the palette / drop / command-palette / context-pad-append flows', () => {
+		// Each path must call createBpmnElement (or call a function that does).
+		const usage = SHELL.match(/createBpmnElement/g) ?? [];
+		// Expect at least 1 declaration + 1 usage. With the four creation paths,
+		// we expect ≥ 2 occurrences (declaration + at least one shared call site).
+		expect(usage.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('the replace flow updates an existing element rather than creating a new one', () => {
+		// In CommandPalette `replace` mode, we should PUT/PATCH /api/elements/<id>
+		// rather than POST a new one. The element_type changes; the id stays.
+		const m = SHELL.match(/mode\s*===\s*['"]replace['"][\s\S]*?\n\t\}/);
+		expect(m).toBeTruthy();
+		// Loose: the replace block touches the elements endpoint.
+		expect(m![0]).toMatch(/element/i);
+	});
+
+	it('PropertyPanel changes patch the underlying Element label/description', () => {
+		// handlePropChange should call updateBpmnElement (which itself
+		// PUTs /api/elements/<id>) when label/description change.
+		const fn = SHELL.match(/function\s+handlePropChange[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/updateBpmnElement|\/api\/elements/);
+		// updateBpmnElement is the helper that hits the PUT endpoint.
+		expect(SHELL).toMatch(/(?:async\s+)?function\s+updateBpmnElement[\s\S]*?\/api\/elements/);
+	});
+});

--- a/frontend/tests/unit/bpmnNodeSizing.test.ts
+++ b/frontend/tests/unit/bpmnNodeSizing.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck — Node fs/path imports.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (issue cluster): v5.2.0 hard-coded `width: 200` for every BPMN
+ * entity in `makeBpmnNode`, so events (visually 56×56) had a 200px-wide
+ * bounding box. This pushed the ContextPad far to the right of the
+ * actual circle. Per-type dimensions fix the box → match the visual.
+ */
+
+const SHELL = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/bpmn/BpmnAuthoringShell.svelte'),
+	'utf-8',
+);
+
+describe('ProblemsPanel scroll containment (#1, v5.4.0)', () => {
+	it('.bpmn-shell__problems lets its child scroll instead of bubbling to the page', () => {
+		// Before v5.4.0 this wrapper had `overflow: hidden`, blocking the
+		// inner ProblemsPanel list's `overflow-y: auto` so the page got the
+		// scrollbar instead of the panel.
+		const block = SHELL.match(/\.bpmn-shell__problems\s*\{[\s\S]*?\}/)?.[0] ?? '';
+		expect(block).not.toMatch(/overflow:\s*hidden/);
+		expect(block).toMatch(/overflow-y:\s*auto|overflow:\s*auto/);
+	});
+});
+
+describe('BPMN per-entity-type node sizing (issue cluster, v5.4.0)', () => {
+	it('declares a BPMN_NODE_DIMENSIONS lookup', () => {
+		expect(SHELL).toMatch(/BPMN_NODE_DIMENSIONS\s*[:=]/);
+	});
+
+	it('events are 56×56 (matches the 56×56 circle in BpmnRenderer.css)', () => {
+		const slice = SHELL.match(/event_start[\s\S]{0,80}/)?.[0] ?? '';
+		expect(slice).toMatch(/56/);
+	});
+
+	it('gateways are 56×56', () => {
+		const slice = SHELL.match(/gateway[\s\S]{0,80}/)?.[0] ?? '';
+		expect(slice).toMatch(/56/);
+	});
+
+	it('pools are wide containers (≥240px)', () => {
+		const slice = SHELL.match(/\bpool\s*:\s*\{[\s\S]{0,80}/)?.[0] ?? '';
+		const m = slice.match(/width\s*:\s*(\d+)/);
+		expect(m).toBeTruthy();
+		expect(parseInt(m![1], 10)).toBeGreaterThanOrEqual(240);
+	});
+
+	it('makeBpmnNode reads from the dimensions lookup (no hard-coded 200)', () => {
+		// The function signature must consult BPMN_NODE_DIMENSIONS — directly
+		// or via a derived helper — for both width and (where applicable) height.
+		const fn = SHELL.match(/function\s+makeBpmnNode[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/BPMN_NODE_DIMENSIONS/);
+	});
+});

--- a/frontend/tests/unit/bpmnZOrder.test.ts
+++ b/frontend/tests/unit/bpmnZOrder.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (#3): when items stack (e.g. lane on pool), the user needs a
+ * way to bring forward / send backward. Adds two ContextPad actions
+ * (bring_forward, send_backward) and shell handlers that mutate the
+ * node's `zIndex`.
+ */
+
+const PAD = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/palette/ContextPad.svelte'),
+	'utf-8',
+);
+const SHELL = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/bpmn/BpmnAuthoringShell.svelte'),
+	'utf-8',
+);
+
+describe('Z-order ContextPad actions (#3, v5.4.0)', () => {
+	it('ContextPad declares bring_forward + send_backward actions', () => {
+		expect(PAD).toMatch(/bring_forward/);
+		expect(PAD).toMatch(/send_backward/);
+	});
+
+	it('the action union/type accepts the two new ids', () => {
+		expect(PAD).toMatch(/'bring_forward'/);
+		expect(PAD).toMatch(/'send_backward'/);
+	});
+});
+
+describe('Z-order shell handler (#3, v5.4.0)', () => {
+	it('handleContextPadAction has cases for the two new actions', () => {
+		const fn = SHELL.match(/function handleContextPadAction[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/case\s+'bring_forward'/);
+		expect(fn).toMatch(/case\s+'send_backward'/);
+	});
+
+	it('the handler mutates a `zIndex` field on the canvas node', () => {
+		expect(SHELL).toMatch(/zIndex/);
+	});
+});

--- a/frontend/tests/unit/canvasTabFirst.test.ts
+++ b/frontend/tests/unit/canvasTabFirst.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 — items #9 + #10:
+ *   #10 Canvas tab should appear FIRST (left-most) in the tab strip.
+ *   #9  Smart-tab default for Text views: when `data.content` is non-empty
+ *       the page should land on Canvas (it currently falls back to
+ *       Details because the hasContent predicate only checks
+ *       canvasNodes / sequence participants).
+ */
+
+const PAGE = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/views/[id]/+page.svelte'),
+	'utf-8',
+);
+
+describe('Tab order (#10) — Canvas tab is first', () => {
+	it('the first role="tab" button drives activeTab = canvas', () => {
+		const firstTab = PAGE.match(/role="tab"[\s\S]{0,400}?activeTab\s*=\s*['"](\w+)['"]/);
+		expect(firstTab).toBeTruthy();
+		expect(firstTab![1]).toBe('canvas');
+	});
+});
+
+describe('Smart-tab default (#9) — Text views with content land on Canvas', () => {
+	it('hasContent considers diagram.data.content for Text views', () => {
+		// The smart-tab block in loadDiagram. After the fix it must include
+		// a check on diagram.data?.content (markdown source) for Text.
+		const block = PAGE.match(/Smart default tab[\s\S]{0,400}/)?.[0]
+			?? PAGE.match(/!userSelectedTab[\s\S]{0,400}/)?.[0]
+			?? '';
+		expect(block).toMatch(/data\.?\?\.\s*content|data\?\.\s*content|data\.content/);
+		expect(block).toMatch(/text|canvasType\s*===\s*['"]text['"]|diagram_type\s*===\s*['"]text['"]/);
+	});
+});

--- a/frontend/tests/unit/dashboardCards.test.ts
+++ b/frontend/tests/unit/dashboardCards.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 — items #11 + #12:
+ *   #11 Drop the Packages card from the dashboard.
+ *   #12 Give Collections + Sets cards a muted-grey background so they
+ *       visually separate from the working-content cards (Views, Elements).
+ */
+
+const PAGE = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/+page.svelte'),
+	'utf-8',
+);
+
+describe('Dashboard cards (issue cluster, v5.4.0)', () => {
+	it('the Packages card is removed (#11)', () => {
+		// Look for the existing Packages card pattern: <a href="/packages…"> with
+		// the Packages count + label. After the fix this DOM should not exist.
+		expect(PAGE).not.toMatch(/href=\{[^}]*\/packages[^}]*\}[\s\S]{0,200}Packages/);
+	});
+
+	it('Collections + Sets cards are tagged with the ambient style class (#12)', () => {
+		// Match the marker class added to Collections/Sets cards. We use
+		// `.dashboard-card--ambient` so the differentiation is theme-aware.
+		const collections = PAGE.match(/Collections\b[\s\S]{0,250}/)?.[0] ?? '';
+		const sets = PAGE.match(/Sets\b[\s\S]{0,250}/)?.[0] ?? '';
+		// Loose check: the surrounding card markup contains the ambient class
+		// or the equivalent CSS variable on the background style.
+		expect(PAGE).toMatch(/dashboard-card--ambient|--color-surface[\s\S]{0,200}Collections|--color-surface[\s\S]{0,200}Sets/);
+	});
+
+	it('Views + Elements cards keep the standard look (regression guard)', () => {
+		expect(PAGE).toMatch(/Views\s*\{?#?if?[^<]*<\/div>/);
+		expect(PAGE).toMatch(/Elements\s*\{?#?if?[^<]*<\/div>/);
+	});
+});

--- a/frontend/tests/unit/markdownPasteImage.test.ts
+++ b/frontend/tests/unit/markdownPasteImage.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (#7): paste image from clipboard → upload to /api/images →
+ * splice `![pasted-image](/api/images/<id>)` at the cursor.
+ *
+ * The implementation lives across:
+ *   markdownEditorToolbarHelpers.ts: `uploadPastedImage(file)` POSTs the
+ *     blob and returns `{ id, url }`.
+ *   TextCanvas.svelte:               `onpaste` handler scans the clipboard
+ *     for image items, uploads, and uses `applyOp(insertAtCursor(...))`
+ *     to splice the markdown link.
+ */
+
+const HELPERS = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/text/markdownEditorToolbarHelpers.ts'),
+	'utf-8',
+);
+const TEXT_CANVAS = readFileSync(
+	resolve(import.meta.dirname, '../../src/lib/canvas/text/TextCanvas.svelte'),
+	'utf-8',
+);
+
+describe('Clipboard image paste (#7, v5.4.0)', () => {
+	it('helpers expose uploadPastedImage that POSTs /api/images', () => {
+		expect(HELPERS).toMatch(/(?:async\s+)?function\s+uploadPastedImage\b/);
+		const fn = HELPERS.match(/function\s+uploadPastedImage[\s\S]*?\n\}/)?.[0] ?? '';
+		expect(fn).toMatch(/['"]\/api\/images['"]/);
+		expect(fn).toMatch(/method:\s*['"]POST['"]/);
+		expect(fn).toMatch(/FormData|multipart/);
+	});
+
+	it('TextCanvas wires onpaste on the textarea', () => {
+		expect(TEXT_CANVAS).toMatch(/onpaste=/);
+	});
+
+	it('the paste handler scans clipboard items for image MIME', () => {
+		// Loose: text in TextCanvas mentions clipboardData and image/.
+		expect(TEXT_CANVAS).toMatch(/clipboardData/);
+		expect(TEXT_CANVAS).toMatch(/image\//);
+	});
+
+	it('the paste handler splices the markdown link via insertAtCursor + applyOp', () => {
+		// Reuses the v5.3.0 toolbar helper pattern.
+		expect(TEXT_CANVAS).toMatch(/insertAtCursor|applyOp|uploadPastedImage/);
+		// And produces the markdown image syntax — `![…](…)` somewhere in the file.
+		expect(TEXT_CANVAS).toMatch(/!\[/);
+	});
+});

--- a/frontend/tests/unit/markdownToolbarTrioRender.test.ts
+++ b/frontend/tests/unit/markdownToolbarTrioRender.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 (#8): Add Element / Link Element / Add Diagram should be
+ * visible in BPMN + Text + canvas edit modes. Pre-v5.4 they only
+ * rendered for the non-sequence, non-text, non-bpmn canvas branch.
+ *
+ * The handlers themselves already branch on canvasType === 'text'
+ * (v5.1.1) — Phase 4 adds the BPMN branch and renders the toolbar
+ * for Text + BPMN modes too.
+ */
+
+const PAGE = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/views/[id]/+page.svelte'),
+	'utf-8',
+);
+
+describe('Trio toolbar render in BPMN + Text + canvas edit modes (#8, v5.4.0)', () => {
+	it('the trio toolbar mounts on Text views in edit mode', () => {
+		// The Text branch renders <TextCanvas …editing /> when editing.
+		// Above it (or alongside) there must be Add Element / Link Element /
+		// Add Diagram buttons. Expressed as a substring search on the page.
+		// Simple form: count all three buttons on the page (≥ 2 occurrences
+		// of each — one in the canvas branch, one in BPMN/Text branch).
+		const addElement = PAGE.match(/Add Element\b/g) ?? [];
+		const linkElement = PAGE.match(/Link Element\b/g) ?? [];
+		const addDiagram = PAGE.match(/Add Diagram\b/g) ?? [];
+		// Pre-v5.4 each appeared 2× (one in canvas toolbar, one in focus-mode
+		// canvas toolbar). After Phase 4 the trio also lands in the Text +
+		// BPMN branches, so ≥ 3 each.
+		expect(addElement.length).toBeGreaterThanOrEqual(3);
+		expect(linkElement.length).toBeGreaterThanOrEqual(3);
+		expect(addDiagram.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('handleAddElement has a BPMN branch that creates a node + Element', () => {
+		// Mirroring the Text branch in the existing handler — BPMN gets its
+		// own branch that POSTs /api/elements and adds a canvas node.
+		const fn = PAGE.match(/async function handleAddElement[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/canvasType\s*===\s*['"]bpmn['"]/);
+	});
+
+	it('handleLinkElement has a BPMN branch that binds the picked Element to the selected node', () => {
+		const fn = PAGE.match(/function handleLinkElement[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/canvasType\s*===\s*['"]bpmn['"]/);
+		expect(fn).toMatch(/entityId/);
+	});
+
+	it('handleInsertDiagram has a BPMN branch that creates a call_activity sub-process', () => {
+		const fn = PAGE.match(/function handleInsertDiagram[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(fn).toMatch(/canvasType\s*===\s*['"]bpmn['"]/);
+		expect(fn).toMatch(/call_activity/);
+	});
+});

--- a/frontend/tests/unit/themeSelectorVisibility.test.ts
+++ b/frontend/tests/unit/themeSelectorVisibility.test.ts
@@ -1,0 +1,30 @@
+// @ts-nocheck
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * v5.4.0 — ThemeSelector is irrelevant on BPMN (theme is fixed by the
+ * BPMN-default theme seeded in m043) and on Text views (no canvas to
+ * theme). Hide it for those two notations.
+ */
+
+const PAGE = readFileSync(
+	resolve(import.meta.dirname, '../../src/routes/views/[id]/+page.svelte'),
+	'utf-8',
+);
+
+describe('ThemeSelector visibility (issue cluster, v5.4.0)', () => {
+	it('every <ThemeSelector> mount is gated on a non-bpmn / non-text guard', () => {
+		// Find every {#if …}…<ThemeSelector …/> with comments allowed in between.
+		const matches = PAGE.matchAll(/\{#if[^}]+\}[\s\S]{0,400}?<ThemeSelector\b/g);
+		const guards = [...matches].map((m) => m[0]);
+		expect(guards.length).toBeGreaterThan(0);
+		for (const guard of guards) {
+			// Allow optional `as string` cast (svelte-check needs it because
+			// NotationType doesn't include 'markdown'/'bpmn' yet).
+			expect(guard).toMatch(/notation\s*(?:as\s+\w+\s*)?\)?\s*!==?\s*['"]bpmn['"]/);
+			expect(guard).toMatch(/(?:canvasType|notation)\s*(?:as\s+\w+\s*)?\)?\s*!==?\s*['"](?:text|markdown)['"]/);
+		}
+	});
+});


### PR DESCRIPTION
13 items spanning the BPMN authoring shell (v5.2.0), the markdown editor (v5.3.0), the views detail page tab layout, and the dashboard. Headlined by the **BPMN-as-Elements alignment** and **clipboard image paste**.

| # | Item | Phase |
|---|---|---|
| 1 | ProblemsPanel scrolls the whole page | 1 |
| 2 | Start event has huge bounding box; ContextPad far right | 1 |
| 3 | No bring-forward / send-back for stacked items | 2 |
| 4 | Same wide-box issue for other entity types | 1 |
| 5 | Lane-not-in-pool fires when lane was dragged onto pool | 2 |
| 6 | Theme dropdown irrelevant on BPMN + markdown | 1 |
| 7 | Paste image from clipboard → upload → markdown link | 5 |
| 8 | Trio buttons (Add Element / Link Element / Add Diagram) on BPMN + Text | 4 |
| 9 | Markdown view doesn't default to Canvas when content exists | 1 |
| 10 | Canvas tab should come before Details | 1 |
| 11 | Hide Packages card on dashboard | 1 |
| 12 | Light-grey background on Collections + Sets cards | 1 |
| 13 | **Architectural: BPMN nodes are Iris Elements** | 3 |

### Headline architectural: BPMN-as-Elements (#13)

Pre-v5.4 BPMN nodes were pure visual shapes — divergent from every other notation. Now every node-creation path (drag-from-palette, drop-on-canvas, CommandPalette create/append/replace, ContextPad-append, EventMatrixPicker) POSTs \`/api/elements\` first and stores \`entityId\` on the canvas node. Replace mode PUTs the existing Element's \`element_type\`; PropertyPanel edits sync label/description fire-and-forget. BPMN content now joins search, knowledge graph, tagging, comments, versioning, and \`iris://element/<id>\` references.

### Headline feature: paste image from clipboard (#7)

GitHub-style. Backend: new \`images\` table (BLOB in SQLite, BYTEA in Postgres), \`POST /api/images\` (auth, 5 MB cap, magic-byte MIME validation), \`GET /api/images/{id}\` (public, immutable cache headers). Frontend: TextCanvas \`onpaste\` handler scans clipboard for image MIME, uploads, splices \`![pasted-image](/api/images/<id>)\` at the cursor.

### New ADR

ADR-145 + SPEC-145-A document the image storage decision (table-with-blob vs Supabase Storage vs base64 inline) and the schema/endpoints/limits/RLS.

### Tests

- 11 new vitest specs (≥30 tests).
- 2 new backend pytest specs (5 image-endpoint tests).
- Frontend full suite: 866/867 vitest pass (1 pre-existing baseline failure unchanged).
- \`svelte-check\`: 164 errors = unchanged baseline.

### Test plan after merge

- [ ] Open a BPMN view in Edit mode — palette, canvas, property panel, problems dock all render.
- [ ] Add a Start Event — circle is 56×56, ContextPad sits flush; bring forward / send backward in ContextPad change z-order.
- [ ] Drop a Lane on top of a Pool — \`lane_outside_pool\` doesn't fire.
- [ ] Add 5+ problems — Problems panel scrolls itself, page does not.
- [ ] Theme dropdown is hidden on BPMN + Text views.
- [ ] Open a Text view with content — page lands on Canvas (markdown rendered), not Details.
- [ ] Tabs: Canvas / Details / Relationships / Version History (Canvas first).
- [ ] Markdown editor: paste a screenshot from clipboard → upload spinner → \`![pasted-image](/api/images/<id>)\` appears at cursor → image renders in browse mode.
- [ ] Add Element / Link Element / Add Diagram visible on canvas + Text + BPMN edit modes. On BPMN: Add Element creates a node + backing Element (visible at \`/elements/<id>\`); Link Element binds an existing Element to the selected node; Add Diagram creates a call_activity sub-process referencing the picked diagram.
- [ ] Dashboard: Packages card gone; Collections + Sets cards have a muted-grey background distinct from Views + Elements.