### PR TITLE
fix(v5.5.2): pasted image markdown link uses absolute API URL (issue #46 item #4 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.2] - 2026-05-06
+
+Two follow-up fixes after applying v5.5.1's m049 to UAT surfaced the
+remaining edges in the markdown image paste flow.
+
+### Fixed
+
+- **Pasted image renders blank in browse mode** (issue #46 item #4
+  follow-up). `uploadPastedImage` returned a relative URL
+  `/api/images/<id>`. In Supabase mode the frontend
+  (iris-uat.chrisbarlow.nz) and the API (iris-api-*.onrender.com)
+  are on different origins, so the rendered `<img>` resolved the
+  relative path against the frontend origin and 404'd. Now prepends
+  `API_BASE_URL` so the markdown link is absolute when needed; in
+  self-hosted SQLite mode where API_BASE_URL is empty, the URL stays
+  relative and resolves to the same origin (unchanged behaviour).
+- **m049 migration fails on Postgres deploys with the v5.4.0
+  policies applied**. Postgres refuses to ALTER a column type while
+  a policy references it: 'cannot alter type of a column used in a
+  policy definition'. The original m049 hit this on `uploaded_by`
+  because the `images_delete` policy depends on it. m049 now drops
+  the policy, ALTERs both columns, and recreates the policy with
+  TEXT-aware casts. (PR #50 was merged before this commit pushed,
+  so main shipped without the fix; this PR re-applies it.)
+
+### Operator notes
+
+If you applied v5.5.1's m049 manually as I posted in chat, you've
+already got the policy-aware version on UAT. No further migration
+needed — but the file in main now reflects what you ran, so future
+deploys are correct.
+
 ## [5.5.1] - 2026-05-06
 
 Two concrete follow-up fixes for issue #46 found during the v5.5.0

--- a/backend/app/migrations/supabase/m049_images_uuid_to_text.sql
+++ b/backend/app/migrations/supabase/m049_images_uuid_to_text.sql
@@ -10,12 +10,22 @@
 -- catch (silent before v5.4.1; console.error after) swallowed the
 -- failure, and users saw "ctrl-v does nothing".
 --
--- Idempotent: ALTER … TYPE TEXT USING id::text. If the column is
+-- Postgres refuses to ALTER a column type while a policy references
+-- it, so we drop the images_delete policy (which references
+-- uploaded_by) before the ALTER and recreate it with an explicit
+-- ::text cast against auth.uid() afterward.
+--
+-- Idempotent: ALTER … TYPE TEXT USING …::text. If the column is
 -- already TEXT (e.g. on a fresh deploy that has only this migration
 -- and m046 in correct shape), the ALTER is a no-op.
 
 DO $$
 BEGIN
+    -- Drop the policies that depend on uploaded_by so we can ALTER.
+    -- DROP POLICY IF EXISTS is idempotent — safe if policies were
+    -- never created.
+    DROP POLICY IF EXISTS images_delete ON images;
+
     -- images.id: UUID → TEXT
     IF EXISTS (
         SELECT 1 FROM information_schema.columns
@@ -34,3 +44,15 @@ BEGIN
     END IF;
 END
 $$;
+
+-- Recreate the policy with TEXT-aware comparisons. `profiles.id` is
+-- UUID so the inner check compares UUID-to-UUID; `uploaded_by` is now
+-- TEXT so it compares against auth.uid()::text.
+CREATE POLICY images_delete ON images
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE id = auth.uid() AND role = 'admin'
+    )
+    OR uploaded_by = auth.uid()::text
+  );

--- a/backend/tests/test_migrations/test_images_uuid_to_text_schema.py
+++ b/backend/tests/test_migrations/test_images_uuid_to_text_schema.py
@@ -48,3 +48,14 @@ def test_idempotent_via_information_schema_guard() -> None:
     # re-running the migration on a TEXT-shaped table is a no-op.
     assert "information_schema.columns" in sql
     assert "data_type = 'uuid'" in sql
+
+
+def test_drops_and_recreates_images_delete_policy() -> None:
+    """Postgres refuses to ALTER a column referenced by a policy. The
+    migration must drop images_delete (which references uploaded_by)
+    before the ALTER and recreate it with the right TEXT/UUID casts."""
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "DROP POLICY IF EXISTS images_delete ON images" in sql
+    assert "CREATE POLICY images_delete ON images" in sql
+    # Recreated policy compares uploaded_by (TEXT) against auth.uid()::text.
+    assert "auth.uid()::text" in sql

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.1",
+			"version": "5.5.2",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.1",
+			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.1",
+	"version": "5.5.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
+++ b/frontend/src/lib/canvas/text/markdownEditorToolbarHelpers.ts
@@ -102,6 +102,7 @@ export function applyOp(ta: HTMLTextAreaElement, op: EditorOp) {
  * the v5.4.0 backend route expects. apiFetch wrapper handles auth.
  */
 import { apiFetch } from '$lib/utils/api';
+import { API_BASE_URL } from '$lib/config';
 
 interface UploadedImage {
 	id: string;
@@ -119,10 +120,17 @@ export async function uploadPastedImage(file: File): Promise<UploadedImage> {
 		'/api/images',
 		{ method: 'POST', body: form },
 	);
+	// v5.5.2 (issue #46 item #4 follow-up): the resulting markdown link
+	// must point at the API origin, not the frontend origin. In Supabase
+	// mode the frontend is at iris-uat.chrisbarlow.nz but the API is at
+	// iris-api-*.onrender.com — a relative `/api/images/<id>` URL would
+	// resolve against the frontend and 404. API_BASE_URL is '' in
+	// self-hosted SQLite mode (relative paths work) and the absolute
+	// API origin in Supabase mode.
 	return {
 		id: resp.id,
 		mime: resp.mime,
 		size_bytes: resp.size_bytes,
-		url: `/api/images/${resp.id}`,
+		url: `${API_BASE_URL}/api/images/${resp.id}`,
 	};
 }


### PR DESCRIPTION
## Summary

After applying v5.5.1's m049 to UAT, paste-image succeeded (markdown link inserted) but the rendered image was blank — the markdown link `/api/images/<id>` resolved against the frontend origin (`iris-uat.chrisbarlow.nz`) instead of the API origin (`iris-api-*.onrender.com`) and 404'd.

## Fixes

1. **Image link uses absolute API URL** — `uploadPastedImage` now prepends `API_BASE_URL` to the markdown link's URL. In Supabase mode where the frontend and API are on different origins, the URL becomes absolute. In self-hosted SQLite mode where `API_BASE_URL` is empty, the URL stays relative — unchanged behaviour.

2. **Restore the policy-aware m049 in main** — PR #50 was merged before the second commit (drop/recreate `images_delete` policy) pushed, so main's m049 still hits `cannot alter type of a column used in a policy definition` on Postgres deploys with v5.4.0's policy applied. The version that successfully ran on UAT (sent via chat) is now committed.

## Verification

- 6 backend pytest specs (test_images_uuid_to_text_schema), all green.
- svelte-check 164 baseline preserved.

## Operator notes

Existing UAT deploys that ran the chat-version of m049 are already correct — no migration re-run needed. This PR just makes main reflect what UAT runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)