### PR TITLE
fix(v5.5.4): view-detail hierarchy sidebar matches dashboard + BPMN shell height + harness fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.4] - 2026-05-06
+
+Visual + layout fixes uncovered by the live UAT verification run.
+
+### Fixed
+
+- **View-detail hierarchy sidebar buttons match the dashboard's
+  `+ New ▾` / `Show ▾` pattern** (issue #46 hierarchy-panel-match
+  follow-up). Pre-fix the sidebar showed `Diagrams` (a single
+  toggle) and `+ Child` (a primary button with a dropdown). The
+  dashboard's `HierarchyControls` uses the `+ New ▾` / `Show ▾`
+  visual; the sidebar now mirrors it: `+ New ▾` (with Package
+  unindented + View indented, child-create semantics) and
+  `Show ▾` (with the existing "Only with children" toggle and a
+  greyed "Views" section header — same shape as the dashboard).
+- **BPMN Problems panel falls below the fold**. The
+  `.bpmn-shell` height calc used `100vh - 230px`; the rest of
+  the canvases use `100vh - 317px`. The smaller constant left
+  87px of overflow that pushed the Problems panel below the
+  viewport bottom. Now matches the page chrome other canvases
+  account for.
+- **Item 11 test: BPMN palette is an accordion**. The Events
+  section is collapsed by default; the test now expands it via
+  the section heading before clicking Start Event.
+
 ## [5.5.3] - 2026-05-06
 
 Real runtime verification of issue #46 against UAT via the Playwright

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.3",
+			"version": "5.5.4",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.3",
+			"version": "5.5.4",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.3",
+	"version": "5.5.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -64,11 +64,26 @@ export default defineConfig({
 			},
 		},
 		{
+			// v5.5.4: ensures a BPMN view exists on UAT for the suite to
+			// drive (creates one in the "test" collection if none exists).
+			name: 'uat-ensure-fixtures',
+			testDir: 'tests/e2e/uat',
+			testMatch: /ensure-.*\.setup\.ts$/,
+			use: {
+				browserName: 'chromium',
+				baseURL: UAT_BASE_URL,
+				storageState: UAT_STORAGE_STATE,
+				viewport: { width: 1440, height: 900 },
+				ignoreHTTPSErrors: true,
+			},
+			dependencies: ['uat-setup'],
+		},
+		{
 			// v5.5.0: UAT verification suite — drives the live deployment to
 			// confirm released fixes actually landed correctly.
 			name: 'uat',
 			testDir: 'tests/e2e/uat',
-			testIgnore: /auth\.setup\.ts$/,
+			testIgnore: /\.setup\.ts$/,
 			use: {
 				browserName: 'chromium',
 				baseURL: UAT_BASE_URL,
@@ -77,7 +92,7 @@ export default defineConfig({
 				screenshot: 'only-on-failure',
 				ignoreHTTPSErrors: true,
 			},
-			dependencies: ['uat-setup'],
+			dependencies: ['uat-ensure-fixtures'],
 			retries: 0,
 		},
 	],

--- a/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
+++ b/frontend/src/lib/canvas/bpmn/BpmnAuthoringShell.svelte
@@ -780,7 +780,13 @@
 		min-height: 0;
 		min-width: 0;
 		gap: 8px;
-		height: calc(100vh - 230px);
+		/* v5.5.4 (#46 items #6/#7 follow-up): match the page-chrome
+		   constant the other canvases use (calc(100vh - 317px)) — the
+		   v5.2.0 230px was too small, leaving the Problems panel below
+		   the fold. flex-shrink: 0 on the panel is necessary but not
+		   sufficient — the parent shell itself has to fit in the
+		   viewport to begin with. */
+		height: calc(100vh - 317px);
 	}
 	.bpmn-shell__row {
 		display: grid;

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -222,6 +222,9 @@
 	let showCreateChildDialog = $state(false);
 	let showCreateChildPackageDialog = $state(false);
 	let showChildMenu = $state(false);
+	// v5.5.4 (#46 hierarchy-button-match): controls the new Show ▾ dropdown
+	// in the view-detail hierarchy sidebar.
+	let showHierarchyShowMenu = $state(false);
 	let childPackageName = $state('');
 	let childPackageDescription = $state('');
 	let showParentPicker = $state(false);
@@ -2016,24 +2019,22 @@
 		>
 			<div class="flex items-center justify-between p-3" style="border-bottom: 1px solid var(--color-border); flex-shrink: 0">
 				<span class="text-sm font-semibold" style="color: var(--color-fg)">Hierarchy</span>
-				<div class="flex items-center gap-1">
-					<button
-						onclick={() => (treeDiagramsOnly = !treeDiagramsOnly)}
-						class="rounded px-2 py-1 text-xs"
-						style="border: 1px solid {treeDiagramsOnly ? 'var(--color-primary)' : 'var(--color-border)'}; color: {treeDiagramsOnly ? 'var(--color-primary)' : 'var(--color-fg)'}; background: {treeDiagramsOnly ? 'var(--color-surface, transparent)' : 'transparent'}"
-						title="Show only items with child diagrams"
-						aria-pressed={treeDiagramsOnly}
-					>
-						Diagrams
-					</button>
+				<div class="flex items-center gap-2" style="position: relative">
+					<!-- v5.5.4 (#46 hierarchy-button-match): match the dashboard's
+						 "+ New ▾" / "Show ▾" pattern from HierarchyControls. The
+						 semantics here are child-create (Package / Diagram) rather
+						 than top-level, but visually they line up with the
+						 dashboard's hierarchy panel. -->
 					<div style="position: relative">
 						<button
-							onclick={() => (showChildMenu = !showChildMenu)}
-							class="rounded px-2 py-1 text-xs"
-							style="background: var(--color-primary); color: white; border: 1px solid var(--color-primary)"
-							title="Create child item"
+							type="button"
+							onclick={() => { showChildMenu = !showChildMenu; showHierarchyShowMenu = false; }}
+							class="rounded px-3 py-1 text-xs text-white"
+							style="background-color: var(--color-primary)"
+							aria-haspopup="menu"
+							aria-expanded={showChildMenu}
 						>
-							+ Child
+							+ New ▾
 						</button>
 						{#if showChildMenu}
 							<!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -2043,25 +2044,72 @@
 								onkeydown={(e) => { if (e.key === 'Escape') showChildMenu = false; }}
 							></div>
 							<div
-								style="position: absolute; top: 100%; right: 0; z-index: 10; min-width: 120px"
-								class="mt-1 rounded border shadow-md"
-								style:border-color="var(--color-border)"
-								style:background-color="var(--color-surface)"
+								role="menu"
+								class="absolute right-0 z-50 mt-1 min-w-[160px] rounded border py-1 shadow-lg"
+								style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
 							>
 								<button
-									onclick={() => { showCreateChildDialog = true; showChildMenu = false; }}
-									class="block w-full px-3 py-2 text-left text-xs hover:opacity-80"
-									style="color: var(--color-fg)"
-								>
-									Diagram
-								</button>
-								<button
+									role="menuitem"
 									onclick={() => { showCreateChildPackageDialog = true; showChildMenu = false; }}
-									class="block w-full px-3 py-2 text-left text-xs hover:opacity-80"
-									style="color: var(--color-fg); border-top: 1px solid var(--color-border)"
+									class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
+									style="color: var(--color-fg)"
 								>
 									Package
 								</button>
+								<button
+									role="menuitem"
+									onclick={() => { showCreateChildDialog = true; showChildMenu = false; }}
+									class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
+									style="color: var(--color-fg); padding-left: 2rem"
+								>
+									View
+								</button>
+							</div>
+						{/if}
+					</div>
+					<div style="position: relative">
+						<button
+							type="button"
+							onclick={() => { showHierarchyShowMenu = !showHierarchyShowMenu; showChildMenu = false; }}
+							class="rounded border px-3 py-1 text-xs"
+							style="border-color: var(--color-border); color: var(--color-fg)"
+							aria-haspopup="menu"
+							aria-expanded={showHierarchyShowMenu}
+						>
+							Show ▾
+						</button>
+						{#if showHierarchyShowMenu}
+							<!-- svelte-ignore a11y_no_static_element_interactions -->
+							<div
+								style="position: fixed; inset: 0; z-index: 9"
+								onclick={() => (showHierarchyShowMenu = false)}
+								onkeydown={(e) => { if (e.key === 'Escape') showHierarchyShowMenu = false; }}
+							></div>
+							<div
+								role="menu"
+								class="absolute right-0 z-50 mt-1 min-w-[180px] rounded border py-1 shadow-lg"
+								style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
+							>
+								<div
+									class="px-4 pb-0.5 pt-1 text-xs uppercase tracking-wide"
+									style="color: var(--color-muted); pointer-events: none"
+								>
+									Views
+								</div>
+								<label
+									class="flex cursor-pointer items-center gap-2 px-4 py-1.5 text-sm hover:opacity-80"
+									style="color: var(--color-fg)"
+								>
+									<input
+										type="checkbox"
+										checked={treeDiagramsOnly}
+										onchange={(e) => (treeDiagramsOnly = (e.target as HTMLInputElement).checked)}
+									/>
+									Only with children
+								</label>
+								<p class="mt-1 px-4 py-1 text-xs" style="color: var(--color-muted)">
+									Packages are always shown.
+								</p>
 							</div>
 						{/if}
 					</div>

--- a/frontend/tests/e2e/uat/ensure-bpmn-view.setup.ts
+++ b/frontend/tests/e2e/uat/ensure-bpmn-view.setup.ts
@@ -1,0 +1,115 @@
+/**
+ * v5.5.4 (issue #46 reopen, harness): ensure a BPMN view exists on UAT
+ * for the suite to drive. Creates one in the "test" collection if no
+ * BPMN view already exists.
+ *
+ * Idempotent — re-running the suite reuses an existing BPMN view; only
+ * creates a new one when needed.
+ */
+
+import { test as setup } from '@playwright/test';
+
+const API = 'https://iris-api-gtb3.onrender.com';
+
+async function getToken(page: import('@playwright/test').Page): Promise<string | null> {
+	return await page.evaluate(() => {
+		for (let i = 0; i < localStorage.length; i++) {
+			const k = localStorage.key(i);
+			if (k && k.includes('auth-token')) {
+				const raw = localStorage.getItem(k);
+				if (raw) {
+					try {
+						const parsed = JSON.parse(raw);
+						return parsed.access_token ?? null;
+					} catch { /* fall through */ }
+				}
+			}
+		}
+		return null;
+	});
+}
+
+setup('ensure a BPMN view exists', async ({ page }) => {
+	await page.goto('/');
+	await page.getByRole('heading', { name: 'Dashboard' }).waitFor({ timeout: 15_000 });
+	const token = await getToken(page);
+	if (!token) throw new Error('No auth token in localStorage after login');
+
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	// Already have a BPMN view? Done.
+	const listResp = await page.request.get(`${API}/api/diagrams?notation=bpmn&page_size=1`, { headers });
+	if (listResp.ok()) {
+		const body = await listResp.json();
+		if ((body.items ?? []).length > 0) {
+			console.log(`[ensure-bpmn] found existing BPMN view: ${body.items[0].id}`);
+			return;
+		}
+	}
+
+	// Find or use the "test" collection.
+	const collectionsResp = await page.request.get(`${API}/api/collections?page_size=50`, { headers });
+	if (!collectionsResp.ok()) throw new Error(`GET /api/collections failed: ${collectionsResp.status()}`);
+	const collections = (await collectionsResp.json()).items ?? [];
+	const testCollection = collections.find((c: { name: string }) => /test/i.test(c.name));
+	if (!testCollection) throw new Error('No "test" collection found on UAT — manual setup required.');
+
+	// Find or create a "test" set under it.
+	const setsResp = await page.request.get(
+		`${API}/api/sets?collection_id=${testCollection.id}&page_size=50`,
+		{ headers },
+	);
+	if (!setsResp.ok()) throw new Error(`GET /api/sets failed: ${setsResp.status()}`);
+	let sets = (await setsResp.json()).items ?? [];
+	let testSet = sets[0];
+	if (!testSet) {
+		const setCreate = await page.request.post(`${API}/api/sets`, {
+			headers,
+			data: { name: 'Test set', collection_id: testCollection.id },
+		});
+		if (!setCreate.ok()) throw new Error(`POST /api/sets failed: ${setCreate.status()} ${await setCreate.text()}`);
+		testSet = await setCreate.json();
+	}
+
+	// Create a BPMN diagram in that set.
+	const diagramCreate = await page.request.post(`${API}/api/diagrams`, {
+		headers,
+		data: {
+			name: 'UAT verification BPMN',
+			diagram_type: 'process',
+			notation: 'bpmn',
+			set_id: testSet.id,
+			data: {
+				nodes: [
+					{
+						id: 'start-1',
+						type: 'event_start',
+						position: { x: 100, y: 200 },
+						data: { label: 'Start', entityType: 'event_start' },
+					},
+					{
+						id: 'task-1',
+						type: 'task',
+						position: { x: 250, y: 200 },
+						data: { label: 'Do something', entityType: 'task' },
+					},
+					{
+						id: 'end-1',
+						type: 'event_end',
+						position: { x: 500, y: 200 },
+						data: { label: 'End', entityType: 'event_end' },
+					},
+				],
+				edges: [
+					{ id: 'e-start-task', source: 'start-1', target: 'task-1', type: 'sequence_flow' },
+					{ id: 'e-task-end', source: 'task-1', target: 'end-1', type: 'sequence_flow' },
+				],
+			},
+		},
+	});
+	if (!diagramCreate.ok()) {
+		throw new Error(`POST /api/diagrams failed: ${diagramCreate.status()} ${await diagramCreate.text()}`);
+	}
+	const created = await diagramCreate.json();
+	console.log(`[ensure-bpmn] created BPMN view: ${created.id}`);
+});

--- a/frontend/tests/e2e/uat/issue-46-verification.spec.ts
+++ b/frontend/tests/e2e/uat/issue-46-verification.spec.ts
@@ -375,8 +375,17 @@ test('issue #46 item 11: EventTriggerFlyout shows on Start Event drop', async ({
 		test.skip(true, 'Edit mode never activated (likely edit-lock contention).');
 	}
 
+	// The BPMN palette is an accordion — Activities is open by default,
+	// so we need to expand the Events section before its entries render.
+	const eventsHeading = page.getByRole('button', { name: /^Events$/ }).first();
+	await eventsHeading.waitFor({ timeout: 10_000 });
+	if ((await eventsHeading.getAttribute('aria-expanded')) !== 'true') {
+		await eventsHeading.click();
+	}
+
 	// Click Start Event in the palette.
-	const startEvent = page.getByRole('button', { name: /Start Event/i }).first();
+	const startEvent = page.locator('[data-key="event_start"]').first();
+	await startEvent.waitFor({ timeout: 10_000 });
 	await startEvent.click();
 
 	// Flyout should appear.


### PR DESCRIPTION
## Summary

Two confirmed visual/layout bugs found via running the Playwright UAT harness against the live deployment.

## Fixes

### 1. View-detail hierarchy sidebar matches dashboard pattern

User report: "the buttons in hierarchy view under /view page (diagramd and +child) still do not match the buttons for hierarchy under dashboard (New and Show). dashboard is correct."

The view-detail page (`/views/<id>`) has a left-side hierarchy sidebar. Pre-fix it had:
- `Diagrams` — single toggle button
- `+ Child` — primary button with Diagram/Package dropdown

Now mirrors the dashboard's `HierarchyControls` visual:
- `+ New ▾` — primary button, dropdown lists Package (unindented) + View (indented). Child-create semantics retained.
- `Show ▾` — secondary outlined button, dropdown shows greyed "Views" section header + "Only with children" checkbox + "Packages are always shown" footer.

### 2. BPMN Problems panel falls below the fold (issue #46 items #6/#7 follow-up)

The `.bpmn-shell` height calc was `100vh - 230px` while other canvases use `100vh - 317px`. The 87px discrepancy was exactly the overflow that pushed the Problems panel below the viewport bottom. Confirmed via Playwright screenshot — Problems panel was visible only after scrolling. Now matches the page chrome the other canvases account for.

## Harness improvements

- New `ensure-bpmn-view.setup.ts`: auto-creates a BPMN view in the "test" collection if none exists. Suite is now reproducible — running against a fresh tester account works without manual setup.
- Item 11 test now expands the BPMN palette's Events accordion section before clicking Start Event (palette opens with Activities expanded by default).

## Verification

- svelte-check baseline preserved (164 errors).
- After UAT redeploy: items 5+12 already pass; items 6/7 should pass with the height fix; item 11 should pass with the palette accordion fix; the hierarchy panel match is visible at `/views/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)