### PR TITLE
fix(v5.5.5): extension manager registry-wins source resolution (issue #55 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.5] - 2026-05-07
+
+Two small fixes around the extension manager UI for issue #55 and the
+v5.5.3 test-harness padding-left assertion.
+
+### Fixed
+
+- **Extension manager hides GitHub badge / Check Updates / Upgrade
+  buttons for extensions installed before v5.5.0** (issue #55
+  follow-up). Mnemos was installed when m048 didn't exist; when
+  m048 added the `source_method` column with default `'local'`, the
+  existing row got `'local'` rather than the registry's actual
+  `'github'`. The frontend's `installed?.source_method ?? known
+  .source_method` precedence let stale `'local'` win over the
+  registry's `'github'`, so the GitHub-only UI branch (badge / Check
+  Updates / Upgrade button) was hidden. Now uses an
+  `effectiveSourceMethod()` / `effectiveSourceUrl()` helper that
+  trusts the registry whenever it declares a non-local source —
+  source-of-truth-wins-over-stale-row.
+
+  After upgrading, the mnemos card on `/admin/settings/extensions`
+  shows the GitHub badge, source URL, "Check for updates" button,
+  and (after one click) the latest version + Upgrade-to-v2.0.0
+  button.
+
+### Test harness
+
+- Item 3 padding-left assertion (originally checked button bbox.x,
+  but block w-full buttons share an x even when padding differs).
+  Test now passes — the v5.5.3 inline-style indent fix is verified
+  on UAT.
+- Item 8 force-clicks the BPMN node (the .bpmn-activity body
+  intercepts pointer events on the underlying svelte-flow wrapper).
+- Item 9 uses `[data-handlepos="right"|"left"]` selectors and a
+  manual stepped mouse drag for xyflow's connection lifecycle.
+  Items 8 + 9 still fragile in headless but the underlying code
+  fixes (v5.4.1) are confirmed via static-parser tests.
+
 ## [5.5.4] - 2026-05-06
 
 Visual + layout fixes uncovered by the live UAT verification run.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.4",
+			"version": "5.5.5",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.4",
+			"version": "5.5.5",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.4",
+	"version": "5.5.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/admin/settings/extensions/+page.svelte
+++ b/frontend/src/routes/admin/settings/extensions/+page.svelte
@@ -139,6 +139,22 @@
 	let checkingUpdate = $state<string | null>(null);
 	let upgrading = $state<string | null>(null);
 
+	/**
+	 * v5.5.5 (issue #55 follow-up): the registry (KNOWN_EXTENSIONS) is the
+	 * canonical source for source_method / source_url. Installed-row values
+	 * can be stale — extensions installed before v5.5.0 have
+	 * source_method='local' (the m048 default) even though the registry
+	 * knows they're github-sourced. Prefer the registry whenever it
+	 * declares a non-local source.
+	 */
+	function effectiveSourceMethod(installed: Extension | undefined, known: KnownExtension): string {
+		if (known.source_method && known.source_method !== 'local') return known.source_method;
+		return installed?.source_method ?? known.source_method ?? 'local';
+	}
+	function effectiveSourceUrl(installed: Extension | undefined, known: KnownExtension): string | null {
+		return known.source_url ?? installed?.source_url ?? null;
+	}
+
 	async function checkForUpdates(extensionId: string) {
 		checkingUpdate = extensionId;
 		error = null;
@@ -228,7 +244,7 @@
 								{/if}
 							</span>
 							<!-- Source method badge -->
-							{#if (installed?.source_method ?? known.source_method) === 'github'}
+							{#if effectiveSourceMethod(installed, known) === 'github'}
 								<span
 									class="rounded-full px-2 py-0.5 text-xs font-medium"
 									style="background-color: rgba(59, 130, 246, 0.15); color: rgb(37, 99, 235)"
@@ -236,7 +252,7 @@
 								>
 									GitHub
 								</span>
-							{:else if (installed?.source_method ?? known.source_method) === 'npm'}
+							{:else if effectiveSourceMethod(installed, known) === 'npm'}
 								<span
 									class="rounded-full px-2 py-0.5 text-xs font-medium"
 									style="background-color: rgba(220, 38, 38, 0.15); color: rgb(220, 38, 38)"
@@ -284,15 +300,15 @@
 						<p class="mt-1 text-sm" style="color: var(--color-muted)">
 							{known.description}
 						</p>
-						{#if (installed?.source_url ?? known.source_url)}
+						{#if effectiveSourceUrl(installed, known)}
 							<p class="mt-1 text-xs">
 								<a
-									href={installed?.source_url ?? known.source_url ?? '#'}
+									href={effectiveSourceUrl(installed, known) ?? '#'}
 									target="_blank"
 									rel="noopener noreferrer"
 									style="color: var(--color-primary, #3b82f6)"
 								>
-									{installed?.source_url ?? known.source_url}
+									{effectiveSourceUrl(installed, known)}
 								</a>
 							</p>
 						{/if}
@@ -314,7 +330,7 @@
 								 for github-sourced extensions; Upgrade is available
 								 only when latest > installed AND the extension
 								 supports automated upgrade. -->
-							{#if (installed.source_method ?? known.source_method) === 'github'}
+							{#if effectiveSourceMethod(installed, known) === 'github'}
 								<button
 									onclick={() => checkForUpdates(known.id)}
 									disabled={checkingUpdate === known.id}


### PR DESCRIPTION
## Summary

PR #56 was merged with only the test-harness fixes — this is the missed second commit that fixes the actual UI bug.

## The bug

User on issue #55 expected to see GitHub badge + latest version + Upgrade button on the mnemos card at \`/admin/settings/extensions\`. None of those rendered.

**Root cause**: mnemos was installed before v5.5.0 (when the \`source_method\` column didn't exist). m048 added the column with default \`'local'\`. The existing row reports \`source_method='local'\` even though the registry knows it's github-sourced. The frontend's \`installed?.source_method ?? known.source_method\` made the stale \`'local'\` value win over the registry's \`'github'\` — hiding the GitHub-only branch of the UI.

## Fix

New \`effectiveSourceMethod()\` / \`effectiveSourceUrl()\` helpers trust the registry whenever it declares a non-local source. Source-of-truth-wins-over-stale-row.

After deploy + UAT redeploy:
- Mnemos card shows GitHub badge + clickable source URL.
- "Check for updates" button visible.
- One click populates \`latest_version\` from the GitHub API.
- "Update available" pill + "Upgrade to v2.0.0" button appear.

## Verification

- \`svelte-check\` baseline preserved (164 errors).
- 4-line frontend change, no backend impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)