### PR TITLE
fix(v5.5.6): Dockerfile COPYs extensions/ so backend can read sources.json (issue #55 root cause)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.6] - 2026-05-07
+
+Backend deploy fix for issue #55.
+
+### Fixed
+
+- **`/api/extensions/{id}/check-update` returns "only supported for
+  github-sourced extensions" on UAT** (issue #55 root cause). The
+  Dockerfile copied `backend/`, `iris-client/`, `mcp/` but **not
+  `extensions/`** (where `sources.json` lives). At runtime
+  `get_source()` couldn't find the registry, so every extension's
+  `source_method` resolved to `None`, and the github-only branch
+  raised 400.
+
+  Fix: `COPY extensions/ extensions/` in the Dockerfile. Plus a
+  defensive `log.warning` in `sources.py::_load()` so any future
+  deploy that misses this directory surfaces the cause in iris-api
+  logs instead of silently failing.
+
+After UAT redeploys, clicking "Check for updates" on the mnemos
+card hits the GitHub API, populates `latest_version`, and the
+"Update available" pill + "Upgrade to v2.0.0" button render.
+
 ## [5.5.5] - 2026-05-07
 
 Two small fixes around the extension manager UI for issue #55 and the

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /opt/render/project/src
 COPY backend/ backend/
 COPY iris-client/ iris-client/
 COPY mcp/ mcp/
+# v5.5.6 (issue #55 follow-up): the extensions registry (sources.json /
+# manifest.json) lives at the repo root and is read by the backend at
+# runtime via Path(__file__).parents[3] / "extensions". Without this
+# copy, /api/extensions/{id}/check-update fails with "only supported
+# for github-sourced extensions" because get_source() can't find the
+# file.
+COPY extensions/ extensions/
 
 # Install Python dependencies. iris-client and iris-mcp install first
 # so backend's lazy `attach_mcp` import succeeds.

--- a/backend/app/extensions/sources.py
+++ b/backend/app/extensions/sources.py
@@ -13,15 +13,35 @@ repo to query for the latest release.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger("app.extensions.sources")
 
 # repo-root/extensions/sources.json — three levels up from this module.
 _SOURCES_PATH = Path(__file__).resolve().parents[3] / "extensions" / "sources.json"
 
+# v5.5.6 (issue #55 root cause): fail loud if the registry file isn't
+# found at runtime. Pre-fix the Dockerfile only copied backend/ +
+# iris-client/ + mcp/, missing extensions/ — so _load() returned {}
+# and the check-update endpoint reported every extension as
+# 'not github-sourced'. The Dockerfile now COPYs extensions/ too;
+# this warning surfaces any regression of that copy.
+_LOAD_WARNED = False
+
 
 def _load() -> dict[str, dict[str, Any]]:
+    global _LOAD_WARNED
     if not _SOURCES_PATH.is_file():
+        if not _LOAD_WARNED:
+            log.warning(
+                "extensions registry not found at %s — check-update will report "
+                "every extension as non-github. Verify the deploy includes the "
+                "extensions/ directory at the repo root.",
+                _SOURCES_PATH,
+            )
+            _LOAD_WARNED = True
         return {}
     with _SOURCES_PATH.open(encoding="utf-8") as f:
         data = json.load(f)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.5",
+			"version": "5.5.6",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.5",
+			"version": "5.5.6",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.5",
+	"version": "5.5.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary

Found why \"Check for updates\" returns \"only supported for github-sourced extensions\" on UAT.

## Root cause

The backend Dockerfile copies \`backend/\`, \`iris-client/\`, and \`mcp/\` — but NOT \`extensions/\`. The registry file (\`extensions/sources.json\`) lives at the repo root and is read by the backend at runtime via \`Path(__file__).parents[3] / \"extensions\" / \"sources.json\"\`. Without the COPY, the file is absent in the deployed container; \`get_source()\` returns \`{}\`; every extension is treated as \`source_method=None\`, and the github-only branch raises 400.

## Fix

- \`COPY extensions/ extensions/\` in \`backend/Dockerfile\` so the registry ships with the container.
- Defensive \`log.warning\` in \`sources.py::_load()\` so any future deploy that misses this directory surfaces the cause in iris-api logs instead of silently 400-ing.

## After deploy

Clicking \"Check for updates\" on the mnemos card hits the GitHub API, populates \`latest_version=v2.0.0\`, and the \"Update available\" pill + \"Upgrade to v2.0.0\" button render. Then clicking Upgrade triggers the auto-clone-and-restart flow shipped in v5.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)