### PR TITLE
fix(v5.5.7): GITHUB_TOKEN env var for /api/extensions check-update (issue #55 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.7] - 2026-05-07
+
+### Fixed
+
+- **GitHub API 403 from `/api/extensions/{id}/check-update`** (issue
+  #55 follow-up). Unauthenticated requests are limited to 60/hr per
+  IP; Render's shared egress hits the limit quickly. Now declares
+  `GITHUB_TOKEN` as a `sync: false` env var on the iris-api
+  service in `render.yaml`. With a fine-grained PAT scoped to
+  "Public Repositories (read-only)" set in the Render dashboard,
+  the limit jumps to 5000/hr.
+- **Helpful 403/429 error message**. The endpoint now surfaces
+  "GitHub API rate limit hit. Set GITHUB_TOKEN…" instead of bare
+  status code so users know what to do.
+
+### Operator notes (post-merge)
+
+1. Generate a fine-grained PAT on GitHub:
+   Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens → Generate new token. Scope it to
+   "Public Repositories (read-only)" — no write access needed.
+2. In Render dashboard → iris-api → Environment, add
+   `GITHUB_TOKEN=<paste>`. Save → triggers redeploy.
+3. Click "Check for updates" on the mnemos card — should succeed
+   now.
+
 ## [5.5.6] - 2026-05-07
 
 Backend deploy fix for issue #55.

--- a/backend/app/extensions/router.py
+++ b/backend/app/extensions/router.py
@@ -293,6 +293,21 @@ async def check_update(
                 # Repo has no releases yet — leave latest unset and fall
                 # through. Not an error; just no upgrade available.
                 latest_tag = None
+            elif resp.status_code in (403, 429):  # noqa: PLR2004
+                # v5.5.7 (issue #55 follow-up): GitHub rate-limits
+                # unauthenticated requests at 60/hr per IP. Render's
+                # shared egress hits this quickly. Surface a hint at the
+                # GITHUB_TOKEN env var rather than a bare status code.
+                remaining = resp.headers.get("X-RateLimit-Remaining")
+                hint = (
+                    "GitHub API rate limit hit. Set GITHUB_TOKEN env var "
+                    "on the iris-api service to authenticated requests "
+                    "(5000/hr instead of 60/hr)."
+                ) if remaining == "0" else (
+                    "GitHub API returned 403 (likely missing auth). Set "
+                    "GITHUB_TOKEN env var on the iris-api service."
+                )
+                raise HTTPException(status_code=502, detail=hint)
             else:
                 raise HTTPException(
                     status_code=502,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.6",
+			"version": "5.5.7",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.6",
+			"version": "5.5.7",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.6",
+	"version": "5.5.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/render.yaml
+++ b/render.yaml
@@ -74,6 +74,14 @@ services:
         sync: false
       - key: IRIS_DEBUG
         value: "false"
+      # v5.5.7 (issue #55 follow-up): GitHub PAT used by
+      # POST /api/extensions/{id}/check-update to query releases.
+      # Without it, requests are unauthenticated (60/hr per IP) and
+      # Render's shared egress hits the limit quickly → 403. With it,
+      # the limit is 5000/hr per token. Use a fine-grained PAT scoped
+      # to "Public Repositories (read-only)" — no write access needed.
+      - key: GITHUB_TOKEN
+        sync: false
 
   # --- MCP server: standalone Streamable-HTTP MCP for AI agents ---
   # ADR-134: split out of iris-api so the API doesn't carry the MCP SDK


### PR DESCRIPTION
## Summary

After v5.5.6 fixed the missing registry, clicking \"Check for updates\" on mnemos now reaches the GitHub API but returns 403 — GitHub rate-limits unauthenticated requests at 60/hr per IP, and Render's shared egress hits that fast.

## Fix

- \`render.yaml\` declares \`GITHUB_TOKEN\` as a \`sync: false\` env var on iris-api. With a fine-grained PAT scoped to \"Public Repositories (read-only)\" set in the Render dashboard, the limit jumps to 5000/hr.
- Router's 403/429 branch surfaces a helpful hint (\"Set GITHUB_TOKEN env var…\") instead of bare status.

## Operator setup (after merge + redeploy)

1. **Generate PAT on GitHub** → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token. Scope it to **\"Public Repositories (read-only)\"** — no write access needed. Set a sensible expiration.
2. **In Render dashboard** → iris-api service → Environment → Add env var \`GITHUB_TOKEN=<paste>\` → Save (triggers redeploy).
3. Click \"Check for updates\" on the mnemos card — should succeed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)