### PR TITLE
fix(v5.5.8): m050 alters latest_version_checked_at to TIMESTAMPTZ on Postgres (issue #55 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.7] - 2026-05-07
+
+### Fixed
+
+- **GitHub API 403 from `/api/extensions/{id}/check-update`** (issue
+  #55 follow-up). Unauthenticated requests are limited to 60/hr per
+  IP; Render's shared egress hits the limit quickly. Now declares
+  `GITHUB_TOKEN` as a `sync: false` env var on the iris-api
+  service in `render.yaml`. With a fine-grained PAT scoped to
+  "Public Repositories (read-only)" set in the Render dashboard,
+  the limit jumps to 5000/hr.
+- **Helpful 403/429 error message**. The endpoint now surfaces
+  "GitHub API rate limit hit. Set GITHUB_TOKEN…" instead of bare
+  status code so users know what to do.
+
+### Operator notes (post-merge)
+
+1. Generate a fine-grained PAT on GitHub:
+   Settings → Developer settings → Personal access tokens →
+   Fine-grained tokens → Generate new token. Scope it to
+   "Public Repositories (read-only)" — no write access needed.
+2. In Render dashboard → iris-api → Environment, add
+   `GITHUB_TOKEN=<paste>`. Save → triggers redeploy.
+3. Click "Check for updates" on the mnemos card — should succeed
+   now.
+
 ## [5.5.6] - 2026-05-07
 
 Backend deploy fix for issue #55.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.5.8] - 2026-05-07
+
+### Fixed
+
+- **`/api/extensions/{id}/check-update` 500 on Postgres** (issue #55
+  follow-up). m048 declared `latest_version_checked_at` as TEXT
+  (matching SQLite), but the rest of the extensions table uses
+  TIMESTAMPTZ for `installed_at` / `updated_at`. The asyncpg adapter
+  auto-converts ISO datetime strings to Python datetime objects;
+  binding a datetime to a TEXT column raised
+  `asyncpg.exceptions.DataError: invalid input for query argument $2:
+  datetime.datetime(...) (expected str, got datetime)` and crashed
+  the worker mid-response, so the user saw a 500 with no CORS
+  headers.
+
+  New migration `m050_latest_version_checked_at_timestamptz.sql`
+  ALTERs the column to TIMESTAMPTZ to match the rest of the table.
+  Idempotent — guarded by an `information_schema` check.
+
+### Operator notes
+
+After merge, run on UAT/Supabase:
+
+```
+psql "$SUPABASE_DB_URL" -f backend/app/migrations/supabase/m050_latest_version_checked_at_timestamptz.sql
+```
+
+Then click "Check for updates" on mnemos again — should succeed.
+
 ## [5.5.7] - 2026-05-07
 
 ### Fixed

--- a/backend/app/extensions/router.py
+++ b/backend/app/extensions/router.py
@@ -293,6 +293,21 @@ async def check_update(
                 # Repo has no releases yet — leave latest unset and fall
                 # through. Not an error; just no upgrade available.
                 latest_tag = None
+            elif resp.status_code in (403, 429):  # noqa: PLR2004
+                # v5.5.7 (issue #55 follow-up): GitHub rate-limits
+                # unauthenticated requests at 60/hr per IP. Render's
+                # shared egress hits this quickly. Surface a hint at the
+                # GITHUB_TOKEN env var rather than a bare status code.
+                remaining = resp.headers.get("X-RateLimit-Remaining")
+                hint = (
+                    "GitHub API rate limit hit. Set GITHUB_TOKEN env var "
+                    "on the iris-api service to authenticated requests "
+                    "(5000/hr instead of 60/hr)."
+                ) if remaining == "0" else (
+                    "GitHub API returned 403 (likely missing auth). Set "
+                    "GITHUB_TOKEN env var on the iris-api service."
+                )
+                raise HTTPException(status_code=502, detail=hint)
             else:
                 raise HTTPException(
                     status_code=502,

--- a/backend/app/migrations/supabase/m050_latest_version_checked_at_timestamptz.sql
+++ b/backend/app/migrations/supabase/m050_latest_version_checked_at_timestamptz.sql
@@ -1,0 +1,39 @@
+-- Migration 050: Convert extensions.latest_version_checked_at from
+-- TEXT to TIMESTAMPTZ on Postgres.
+--
+-- v5.5.8 (issue #55 follow-up). m048 declared the column as TEXT
+-- (matching SQLite), but the rest of the extensions table uses
+-- TIMESTAMPTZ for installed_at / updated_at. The asyncpg adapter
+-- auto-converts ISO datetime strings to Python datetime objects;
+-- when the resulting datetime is bound to a TEXT column,
+-- asyncpg raises:
+--
+--   asyncpg.exceptions.DataError: invalid input for query argument
+--   $2: datetime.datetime(...) (expected str, got datetime)
+--
+-- ...and the worker crashes mid-response, so /api/extensions/{id}/
+-- check-update returned a 500 with no CORS headers.
+--
+-- Fix: align the column type with the rest of the table. ISO strings
+-- cast cleanly to TIMESTAMPTZ, so the existing service code works
+-- without changes.
+--
+-- Idempotent: ALTER … TYPE TIMESTAMPTZ USING …::timestamptz. If the
+-- column is already TIMESTAMPTZ, the ALTER is a no-op (guarded by an
+-- information_schema check).
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'extensions'
+          AND column_name = 'latest_version_checked_at'
+          AND data_type = 'text'
+    ) THEN
+        ALTER TABLE extensions
+            ALTER COLUMN latest_version_checked_at
+            TYPE TIMESTAMPTZ
+            USING latest_version_checked_at::timestamptz;
+    END IF;
+END
+$$;

--- a/backend/tests/test_migrations/test_latest_version_checked_at_schema.py
+++ b/backend/tests/test_migrations/test_latest_version_checked_at_schema.py
@@ -1,0 +1,34 @@
+"""v5.5.8 (issue #55 follow-up): static-parser test for the migration
+that converts extensions.latest_version_checked_at from TEXT to
+TIMESTAMPTZ.
+
+Pre-fix the column was TEXT but the asyncpg adapter auto-converts
+ISO strings to datetime objects; binding a datetime to a TEXT column
+raised DataError and crashed the worker mid-response, so
+/api/extensions/{id}/check-update returned a 500 with no CORS headers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "app" / "migrations" / "supabase" / "m050_latest_version_checked_at_timestamptz.sql"
+
+
+def test_migration_exists() -> None:
+    assert MIGRATION.is_file()
+
+
+def test_alters_column_to_timestamptz() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "ALTER TABLE extensions" in sql
+    assert "ALTER COLUMN latest_version_checked_at" in sql
+    assert "TYPE TIMESTAMPTZ" in sql
+    assert "USING latest_version_checked_at::timestamptz" in sql
+
+
+def test_idempotent_via_information_schema_guard() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "information_schema.columns" in sql
+    assert "data_type = 'text'" in sql

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.7",
+			"version": "5.5.8",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.7",
+			"version": "5.5.8",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.6",
+			"version": "5.5.7",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -3507,7 +3507,7 @@
 			}
 		},
 		"node_modules/iobuffer": {
-			"version": "5.5.6",
+			"version": "5.5.7",
 			"resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
 			"integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
 			"license": "MIT"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.7",
+	"version": "5.5.8",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.6",
+	"version": "5.5.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/render.yaml
+++ b/render.yaml
@@ -74,6 +74,14 @@ services:
         sync: false
       - key: IRIS_DEBUG
         value: "false"
+      # v5.5.7 (issue #55 follow-up): GitHub PAT used by
+      # POST /api/extensions/{id}/check-update to query releases.
+      # Without it, requests are unauthenticated (60/hr per IP) and
+      # Render's shared egress hits the limit quickly → 403. With it,
+      # the limit is 5000/hr per token. Use a fine-grained PAT scoped
+      # to "Public Repositories (read-only)" — no write access needed.
+      - key: GITHUB_TOKEN
+        sync: false
 
   # --- MCP server: standalone Streamable-HTTP MCP for AI agents ---
   # ADR-134: split out of iris-api so the API doesn't carry the MCP SDK


### PR DESCRIPTION
## Summary

The 500 from \"Check for updates\" is an asyncpg DataError surfaced by the Render logs:

\`\`\`
asyncpg.exceptions.DataError: invalid input for query argument $2: datetime.datetime(2026, 5, 6, 21, 3, 29,...) (expected str, got datetime)
\`\`\`

## Root cause

m048 declared \`extensions.latest_version_checked_at\` as TEXT (matching the SQLite migration). The rest of the extensions table uses TIMESTAMPTZ for \`installed_at\` / \`updated_at\`. The asyncpg adapter auto-converts ISO datetime strings → Python \`datetime\` objects (correct for TIMESTAMPTZ columns); binding a \`datetime\` to a TEXT column raises DataError, the worker crashes mid-response, and Render's edge proxy returns its own 500 page (no CORS headers, hence the CORS-blocked symptom in the browser).

## Fix

New \`m050_latest_version_checked_at_timestamptz.sql\` ALTERs the column to TIMESTAMPTZ to match the rest of the table. ISO strings cast cleanly via \`USING latest_version_checked_at::timestamptz\`. Idempotent — guarded by an \`information_schema\` data_type check.

## Operator (after merge)

\`\`\`
psql \"\$SUPABASE_DB_URL\" -f backend/app/migrations/supabase/m050_latest_version_checked_at_timestamptz.sql
\`\`\`

Then click \"Check for updates\" on mnemos — the GitHub API call succeeds, \`latest_version=v2.0.0\` is persisted, and the Update available pill + Upgrade button render.

## Verification

- 3 backend pytest specs for the new migration, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)