### PR TITLE
Promote v5.6.0 to UAT (ArchiMate Open Exchange XML import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.0] - 2026-05-07
+
+### Added
+
+- **ArchiMate Open Exchange XML import** (issue #52) — iris now imports
+  ArchiMate models in the format published by The Open Group at
+  http://www.opengroup.org/xsd/archimate/, supporting the 3.0, 3.1, and
+  3.2 namespace variants. New endpoint `POST /api/import/archimate`
+  accepts `.xml`, `.archimate`, and `.oex` uploads; the import page
+  dropzone has been extended to advertise the format and route uploads
+  to the new endpoint.
+
+  - 40+ ArchiMate element types map to native iris types via the
+    existing `ARCHIMATE_STEREOTYPE_MAP` (DRY — single source of truth
+    shared with the SparxEA importer).
+  - 12 ArchiMate relationship types (Composition, Aggregation,
+    Assignment, Realization, Serving, Triggering, Flow, Specialization,
+    Access, Influence, Association, plus the legacy `Used`/`UsedBy`
+    aliases).
+  - **Auto-generated Overview diagram** when the source OEX file is
+    model-only (no embedded views) — common in real-world exports.
+    Layout is a type-grouped grid with edges drawn from the iris
+    relationship table. An `auto_layout` warning records that the
+    diagram was synthesised.
+  - Nested `<node>` containment (compound nodes) is flattened to
+    absolute coordinates on import.
+  - Two committed fixtures: `docs/reference/ArchiMate/sample-with-view.xml`
+    (hand-authored, 3/2/1) and `docs/reference/ArchiMate/msd-map.xml`
+    (real-world: 127 elements, 977 relationships, 0 views).
+  - New UAT Playwright spec
+    `frontend/tests/e2e/uat/issue-52-archimate-import.spec.ts` drives
+    end-to-end import of the MSD fixture against the live UAT
+    deployment.
+- **ADR-148** + **SPEC-148-A** documenting the format support, mapping
+  tables, auto-layout strategy, and accepted file extensions.
+
 ## [5.5.10] - 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Four colour modes with WCAG-compliant contrast ratios:
 - Node removal dialog: "Remove from this model" or "Delete entity and all relationships" (cascade deletion)
 - SparxEA import (.qea and .eap): full coverage — Note/Boundary elements, NoteLink connectors, self-references, Package-to-Package dependencies as model relationships
 - DoView PPTX import (.pptx): structural compliance validation, shape classification, column-based causal link inference, cross-diagram navigation, colour preservation
+- ArchiMate Open Exchange XML import (.xml, .archimate, .oex): full element + relationship + view import for ArchiMate 3.0 / 3.1 / 3.2 (The Open Group standard exchange format). Auto-generates an Overview diagram with type-grouped grid layout when the source file has no embedded views.
 - Import change summary in version history ("Imported from SparxEA" / "Imported from DoView PPTX")
 - Entity CRUD with optimistic concurrency via If-Match headers
 - Model CRUD with type filter on list page (Simple, Component, Sequence, UML, ArchiMate)

--- a/backend/app/import_archimate/mapper.py
+++ b/backend/app/import_archimate/mapper.py
@@ -1,0 +1,78 @@
+"""xsi:type → iris type maps for ArchiMate Open Exchange import.
+
+Element-type lookup delegates to the SparxEA importer's
+``ARCHIMATE_STEREOTYPE_MAP`` (single source of truth for ArchiMate→Iris
+element types) by prefixing the unprefixed OEX type with ``ArchiMate_``.
+
+Relationship-type and a small set of structural types (Junction, Note)
+are local — they aren't part of the SparxEA stereotype universe.
+"""
+
+from __future__ import annotations
+
+from app.import_sparx.mapper import ARCHIMATE_STEREOTYPE_MAP
+
+OEX_NAMESPACES: tuple[str, ...] = (
+    "http://www.opengroup.org/xsd/archimate/3.0/",
+    "http://www.opengroup.org/xsd/archimate/3.1/",
+    "http://www.opengroup.org/xsd/archimate/3.2/",
+)
+
+# ArchiMate 3.x relationship taxonomy → Iris relationship_type.
+# "Used" (legacy from 2.x → 3.0 transition) folds into "serving".
+RELATIONSHIP_TYPE_MAP: dict[str, str] = {
+    "Composition": "composition",
+    "Aggregation": "aggregation",
+    "Assignment": "assignment",
+    "Realization": "realization",
+    "Realisation": "realization",
+    "Serving": "serving",
+    "Used": "serving",
+    "UsedBy": "serving",
+    "Triggering": "triggering",
+    "Flow": "flow",
+    "Specialization": "specialization",
+    "Specialisation": "specialization",
+    "Access": "access",
+    "Influence": "influence",
+    "Association": "association",
+}
+
+# Structural / annotation xsi:types that aren't in ARCHIMATE_STEREOTYPE_MAP.
+_LOCAL_ELEMENT_TYPE_MAP: dict[str, str] = {
+    "Note": "note",
+    "Group": "boundary",
+    "Junction": "junction",
+    "AndJunction": "junction",
+    "OrJunction": "junction",
+}
+
+
+def map_oex_element_type(xsi_type: str | None) -> str | None:
+    """Map an OEX element xsi:type (e.g. ``BusinessActor``) to an iris type.
+
+    Returns None if the type is unrecognised.
+    """
+    if not xsi_type:
+        return None
+    xsi_type = xsi_type.strip()
+    if not xsi_type:
+        return None
+    if xsi_type in _LOCAL_ELEMENT_TYPE_MAP:
+        return _LOCAL_ELEMENT_TYPE_MAP[xsi_type]
+    return ARCHIMATE_STEREOTYPE_MAP.get(f"ArchiMate_{xsi_type}")
+
+
+def map_oex_relationship_type(xsi_type: str | None) -> str | None:
+    """Map an OEX relationship xsi:type (e.g. ``Serving``) to an iris type."""
+    if not xsi_type:
+        return None
+    return RELATIONSHIP_TYPE_MAP.get(xsi_type.strip())
+
+
+__all__ = [
+    "OEX_NAMESPACES",
+    "RELATIONSHIP_TYPE_MAP",
+    "map_oex_element_type",
+    "map_oex_relationship_type",
+]

--- a/backend/app/import_archimate/reader.py
+++ b/backend/app/import_archimate/reader.py
@@ -1,0 +1,230 @@
+"""ArchiMate Open Exchange File Format (OEX) reader.
+
+Parses the XML serialisation defined by The Open Group at
+http://www.opengroup.org/xsd/archimate/ and produces dataclasses that the
+import service can walk. We use stdlib ``xml.etree.ElementTree`` to avoid a
+new dependency.
+
+Supports the 3.0 / 3.1 / 3.2 family — the namespace URI is checked by
+prefix so future minor revisions don't break the parser.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+
+# Open Group namespaces published for OEX. The 3.0 URI is shared by 3.1 and
+# 3.2 in practice (Archi tool emits the 3.0 URI for all of them).
+_NS_PREFIX_RE = re.compile(r"^http://www\.opengroup\.org/xsd/archimate/3\.\d+/?$")
+_NS_3_0 = "http://www.opengroup.org/xsd/archimate/3.0/"
+_XML_LANG = "{http://www.w3.org/XML/1998/namespace}lang"
+_XSI_TYPE = "{http://www.w3.org/2001/XMLSchema-instance}type"
+
+
+@dataclass
+class OexElement:
+    identifier: str
+    xsi_type: str
+    name: str
+    documentation: str | None = None
+
+
+@dataclass
+class OexRelationship:
+    identifier: str
+    source: str
+    target: str
+    xsi_type: str
+    name: str | None = None
+
+
+@dataclass
+class OexNode:
+    identifier: str
+    element_ref: str | None
+    x: int
+    y: int
+    w: int
+    h: int
+    children: list["OexNode"] = field(default_factory=list)
+
+
+@dataclass
+class OexConnection:
+    identifier: str
+    relationship_ref: str | None
+    source: str
+    target: str
+
+
+@dataclass
+class OexView:
+    identifier: str
+    name: str
+    nodes: list[OexNode] = field(default_factory=list)
+    connections: list[OexConnection] = field(default_factory=list)
+
+
+@dataclass
+class OexModel:
+    name: str
+    documentation: str | None
+    elements: list[OexElement] = field(default_factory=list)
+    relationships: list[OexRelationship] = field(default_factory=list)
+    views: list[OexView] = field(default_factory=list)
+
+
+def _ns(tree_root: ET.Element) -> str:
+    """Extract and validate the OEX namespace from the root element tag."""
+    tag = tree_root.tag
+    if not (tag.startswith("{") and "}" in tag):
+        raise ValueError("not an ArchiMate Open Exchange file (no namespace)")
+    ns = tag[1 : tag.index("}")]
+    if not _NS_PREFIX_RE.match(ns):
+        raise ValueError(f"unsupported ArchiMate OEX namespace: {ns}")
+    if not tag.endswith("}model"):
+        raise ValueError("not an ArchiMate Open Exchange file (root is not <model>)")
+    return ns
+
+
+def _q(ns: str, name: str) -> str:
+    return f"{{{ns}}}{name}"
+
+
+def _localised_text(parent: ET.Element, ns: str, tag: str) -> str | None:
+    """Return text from a child <name>/<documentation>; prefer xml:lang='en'."""
+    candidates = parent.findall(_q(ns, tag))
+    if not candidates:
+        return None
+    en = next((c for c in candidates if c.get(_XML_LANG) == "en"), None)
+    chosen = en if en is not None else candidates[0]
+    return (chosen.text or "").strip() or None
+
+
+def _int_attr(node: ET.Element, name: str, default: int = 0) -> int:
+    raw = node.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_nodes(parent: ET.Element, ns: str) -> list[OexNode]:
+    out: list[OexNode] = []
+    for n in parent.findall(_q(ns, "node")):
+        node = OexNode(
+            identifier=n.get("identifier") or "",
+            element_ref=n.get("elementRef"),
+            x=_int_attr(n, "x"),
+            y=_int_attr(n, "y"),
+            w=_int_attr(n, "w", default=120),
+            h=_int_attr(n, "h", default=60),
+            children=_parse_nodes(n, ns),
+        )
+        out.append(node)
+    return out
+
+
+def parse_oex(path: str) -> OexModel:
+    """Parse an OEX file and return an OexModel.
+
+    Raises ``ValueError`` if the file is not a valid ArchiMate OEX document.
+    """
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as exc:
+        raise ValueError(f"file is not valid XML: {exc}") from exc
+    root = tree.getroot()
+    ns = _ns(root)
+
+    name = _localised_text(root, ns, "name") or "ArchiMate Model"
+    documentation = _localised_text(root, ns, "documentation")
+
+    elements: list[OexElement] = []
+    elements_parent = root.find(_q(ns, "elements"))
+    if elements_parent is not None:
+        for el in elements_parent.findall(_q(ns, "element")):
+            elements.append(
+                OexElement(
+                    identifier=el.get("identifier") or "",
+                    xsi_type=(el.get(_XSI_TYPE) or "").strip(),
+                    name=_localised_text(el, ns, "name") or "",
+                    documentation=_localised_text(el, ns, "documentation"),
+                )
+            )
+
+    relationships: list[OexRelationship] = []
+    rels_parent = root.find(_q(ns, "relationships"))
+    if rels_parent is not None:
+        for rel in rels_parent.findall(_q(ns, "relationship")):
+            relationships.append(
+                OexRelationship(
+                    identifier=rel.get("identifier") or "",
+                    source=rel.get("source") or "",
+                    target=rel.get("target") or "",
+                    xsi_type=(rel.get(_XSI_TYPE) or "").strip(),
+                    name=_localised_text(rel, ns, "name"),
+                )
+            )
+
+    views: list[OexView] = []
+    views_parent = root.find(_q(ns, "views"))
+    if views_parent is not None:
+        # ArchiMate 3.x wraps views inside <diagrams>; older drafts wrote
+        # <view> directly under <views>. Accept both.
+        diagrams_parent = views_parent.find(_q(ns, "diagrams"))
+        if diagrams_parent is None:
+            diagrams_parent = views_parent
+        for v in diagrams_parent.findall(_q(ns, "view")):
+            connections: list[OexConnection] = []
+            for c in v.findall(_q(ns, "connection")):
+                connections.append(
+                    OexConnection(
+                        identifier=c.get("identifier") or "",
+                        relationship_ref=c.get("relationshipRef"),
+                        source=c.get("source") or "",
+                        target=c.get("target") or "",
+                    )
+                )
+            views.append(
+                OexView(
+                    identifier=v.get("identifier") or "",
+                    name=_localised_text(v, ns, "name") or "View",
+                    nodes=_parse_nodes(v, ns),
+                    connections=connections,
+                )
+            )
+
+    return OexModel(
+        name=name,
+        documentation=documentation,
+        elements=elements,
+        relationships=relationships,
+        views=views,
+    )
+
+
+def is_oex_file(path: str) -> bool:
+    """Cheap content sniff used by the router to reject non-OEX uploads."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(4096)
+    except OSError:
+        return False
+    return _NS_3_0.encode("utf-8") in head or b"http://www.opengroup.org/xsd/archimate/3." in head
+
+
+__all__ = [
+    "OexConnection",
+    "OexElement",
+    "OexModel",
+    "OexNode",
+    "OexRelationship",
+    "OexView",
+    "is_oex_file",
+    "parse_oex",
+]

--- a/backend/app/import_archimate/router.py
+++ b/backend/app/import_archimate/router.py
@@ -1,0 +1,91 @@
+"""API router for ArchiMate Open Exchange XML (OEX) import."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import tempfile
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request, UploadFile
+
+from app.auth.dependencies import get_current_user
+from app.import_archimate.reader import is_oex_file
+from app.import_archimate.service import import_oex_file
+
+router = APIRouter(prefix="/api/import", tags=["import"])
+
+_ACCEPTED_SUFFIXES = (".xml", ".archimate", ".oex")
+
+
+@router.post("/archimate")
+async def import_archimate(
+    file: UploadFile,
+    request: Request,
+    current_user: dict = Depends(get_current_user),  # noqa: B008
+    set_id: str | None = Form(default=None),  # noqa: B008
+) -> dict:
+    """Import an ArchiMate Open Exchange XML file."""
+    if not file.filename or not file.filename.lower().endswith(_ACCEPTED_SUFFIXES):
+        raise HTTPException(
+            status_code=400,
+            detail="File must have .xml, .archimate, or .oex extension",
+        )
+
+    suffix = os.path.splitext(file.filename)[1].lower() or ".xml"
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        content = await file.read()
+        tmp.write(content)
+        tmp_path = tmp.name
+
+    try:
+        if not is_oex_file(tmp_path):
+            raise HTTPException(
+                status_code=400,
+                detail="File is not an ArchiMate Open Exchange XML document.",
+            )
+
+        db = request.app.state.db_manager.main_db
+
+        from app.db.adapter import SupabaseAdapter  # noqa: PLC0415
+
+        hold_ctx = (
+            db.hold_connection()
+            if isinstance(db, SupabaseAdapter)
+            else contextlib.nullcontext()
+        )
+        async with hold_ctx:
+            if set_id:
+                cursor = await db.execute(
+                    "SELECT id FROM sets WHERE id = ? AND is_deleted = 0",
+                    (set_id,),
+                )
+                if await cursor.fetchone() is None:
+                    raise HTTPException(status_code=400, detail="Invalid set_id")
+
+            try:
+                summary = await import_oex_file(
+                    db,
+                    tmp_path,
+                    imported_by=current_user["id"],
+                    set_id=set_id,
+                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "packages_created": summary.packages_created,
+            "elements_created": summary.elements_created,
+            "elements_skipped": summary.elements_skipped,
+            "relationships_created": summary.relationships_created,
+            "relationships_skipped": summary.relationships_skipped,
+            "diagrams_created": summary.diagrams_created,
+            "warnings": [
+                {"category": w.category, "message": w.message}
+                for w in summary.warnings
+            ],
+        }
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass

--- a/backend/app/import_archimate/service.py
+++ b/backend/app/import_archimate/service.py
@@ -1,0 +1,354 @@
+"""Orchestrator for ArchiMate Open Exchange XML (OEX) import.
+
+Reads an OEX file, materialises elements and relationships, and either
+ports the embedded views to iris diagrams or — if the file is model-only —
+auto-generates a single Overview diagram with a type-grouped grid layout
+so the user has something to look at after import.
+
+Mirrors the structural shape of ``import_sparx/service.py`` but is much
+smaller: OEX is a clean schema and we delegate type lookup to the existing
+``ARCHIMATE_STEREOTYPE_MAP`` in import_sparx/mapper.py.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from app.diagrams.service import create_diagram
+from app.elements.service import create_element
+from app.import_archimate.mapper import (
+    map_oex_element_type,
+    map_oex_relationship_type,
+)
+from app.import_archimate.reader import OexModel, OexNode, OexView, parse_oex
+from app.import_common import ImportWarning
+from app.packages.service import create_package
+from app.relationships.service import create_relationship
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+@dataclass
+class ArchimateImportSummary:
+    packages_created: int = 0
+    elements_created: int = 0
+    elements_skipped: int = 0
+    relationships_created: int = 0
+    relationships_skipped: int = 0
+    diagrams_created: int = 0
+    warnings: list[ImportWarning] = field(default_factory=list)
+
+
+# Auto-layout: cell size accommodates the standard ArchiMate node footprint
+# (120×60) plus padding for label rendering and edge clearance.
+_GRID_CELL_W = 220
+_GRID_CELL_H = 140
+
+
+async def import_oex_file(
+    db: "DatabasePort",
+    path: str,
+    *,
+    imported_by: str,
+    set_id: str | None = None,
+) -> ArchimateImportSummary:
+    """Import an OEX file, returning a summary of what was created."""
+    summary = ArchimateImportSummary()
+    model = parse_oex(path)
+
+    pkg_name = model.name or os.path.splitext(os.path.basename(path))[0]
+    package = await create_package(
+        db,
+        name=pkg_name,
+        description=model.documentation,
+        created_by=imported_by,
+        set_id=set_id,
+    )
+    summary.packages_created += 1
+    package_id = str(package["id"])
+
+    # ---- elements ----
+    element_id_by_oex: dict[str, str] = {}
+    element_type_by_iris: dict[str, str] = {}
+    element_name_by_iris: dict[str, str] = {}
+    for oe in model.elements:
+        iris_type = map_oex_element_type(oe.xsi_type)
+        if not iris_type:
+            summary.elements_skipped += 1
+            summary.warnings.append(
+                ImportWarning(
+                    category="unmapped_element_type",
+                    message=f"{oe.identifier}: unknown xsi:type '{oe.xsi_type}'",
+                )
+            )
+            continue
+        elem = await create_element(
+            db,
+            element_type=iris_type,
+            name=oe.name or oe.identifier,
+            description=oe.documentation,
+            data={},
+            created_by=imported_by,
+            set_id=set_id,
+            notation="archimate",
+        )
+        elem_id = str(elem["id"])
+        element_id_by_oex[oe.identifier] = elem_id
+        element_type_by_iris[elem_id] = iris_type
+        element_name_by_iris[elem_id] = oe.name or oe.identifier
+        summary.elements_created += 1
+
+    # ---- relationships ----
+    rel_id_by_oex: dict[str, str] = {}
+    for orel in model.relationships:
+        iris_type = map_oex_relationship_type(orel.xsi_type)
+        src = element_id_by_oex.get(orel.source)
+        tgt = element_id_by_oex.get(orel.target)
+        if not iris_type or not src or not tgt:
+            summary.relationships_skipped += 1
+            summary.warnings.append(
+                ImportWarning(
+                    category="unmapped_relationship"
+                    if not iris_type
+                    else "dangling_relationship",
+                    message=f"{orel.identifier}: skipped ({orel.xsi_type})",
+                )
+            )
+            continue
+        rel = await create_relationship(
+            db,
+            source_element_id=src,
+            target_element_id=tgt,
+            relationship_type=iris_type,
+            label=orel.name,
+            description=None,
+            data={},
+            created_by=imported_by,
+        )
+        rel_id_by_oex[orel.identifier] = str(rel["id"])
+        summary.relationships_created += 1
+
+    # ---- views (or auto-generated overview) ----
+    if model.views:
+        for view in model.views:
+            await _create_diagram_from_view(
+                db,
+                view=view,
+                model=model,
+                package_id=package_id,
+                element_id_by_oex=element_id_by_oex,
+                element_type_by_iris=element_type_by_iris,
+                element_name_by_iris=element_name_by_iris,
+                imported_by=imported_by,
+                set_id=set_id,
+                summary=summary,
+            )
+    elif element_id_by_oex:
+        await _create_auto_overview(
+            db,
+            model_name=model.name,
+            package_id=package_id,
+            element_id_by_oex=element_id_by_oex,
+            element_type_by_iris=element_type_by_iris,
+            element_name_by_iris=element_name_by_iris,
+            imported_by=imported_by,
+            set_id=set_id,
+            summary=summary,
+        )
+        summary.warnings.append(
+            ImportWarning(
+                category="auto_layout",
+                message="No views in source file — auto-generated Overview diagram.",
+            )
+        )
+
+    return summary
+
+
+async def _create_diagram_from_view(
+    db: "DatabasePort",
+    *,
+    view: OexView,
+    model: OexModel,
+    package_id: str,
+    element_id_by_oex: dict[str, str],
+    element_type_by_iris: dict[str, str],
+    element_name_by_iris: dict[str, str],
+    imported_by: str,
+    set_id: str | None,
+    summary: ArchimateImportSummary,
+) -> None:
+    """Build canvas data from an OEX view and persist as an iris diagram."""
+    nodes: list[dict[str, object]] = []
+    edges: list[dict[str, object]] = []
+    canvas_node_id_by_oex: dict[str, str] = {}
+
+    def emit_node(oex: OexNode, dx: int, dy: int) -> None:
+        if not oex.element_ref:
+            return
+        elem_id = element_id_by_oex.get(oex.element_ref)
+        if not elem_id:
+            return
+        iris_type = element_type_by_iris.get(elem_id, "component")
+        canvas_id = str(uuid.uuid4())
+        canvas_node_id_by_oex[oex.identifier] = canvas_id
+        nodes.append(
+            {
+                "id": canvas_id,
+                "type": iris_type,
+                "position": {"x": oex.x + dx, "y": oex.y + dy},
+                "data": {
+                    "label": element_name_by_iris.get(elem_id, ""),
+                    "entityType": iris_type,
+                    "entityId": elem_id,
+                    "visual": {"width": oex.w, "height": oex.h},
+                },
+                "measured": {"width": oex.w, "height": oex.h},
+            }
+        )
+        # Flatten any nested <node> children to absolute coords.
+        for child in oex.children:
+            emit_node(child, dx + oex.x, dy + oex.y)
+
+    for n in view.nodes:
+        emit_node(n, 0, 0)
+
+    for c in view.connections:
+        src = canvas_node_id_by_oex.get(c.source)
+        tgt = canvas_node_id_by_oex.get(c.target)
+        if not src or not tgt:
+            continue
+        edges.append(
+            {
+                "id": c.identifier or str(uuid.uuid4()),
+                "source": src,
+                "target": tgt,
+                "type": "default",
+                "data": {},
+            }
+        )
+
+    await create_diagram(
+        db,
+        diagram_type="free_form",
+        name=view.name or "View",
+        description=None,
+        data={"nodes": nodes, "edges": edges},
+        created_by=imported_by,
+        parent_package_id=package_id,
+        set_id=set_id,
+        notation="archimate",
+    )
+    summary.diagrams_created += 1
+
+
+async def _create_auto_overview(
+    db: "DatabasePort",
+    *,
+    model_name: str,
+    package_id: str,
+    element_id_by_oex: dict[str, str],
+    element_type_by_iris: dict[str, str],
+    element_name_by_iris: dict[str, str],
+    imported_by: str,
+    set_id: str | None,
+    summary: ArchimateImportSummary,
+) -> None:
+    """Synthesise an Overview diagram with a type-grouped grid layout."""
+    # Sort by iris type so nodes of the same kind cluster together.
+    sorted_elem_ids = sorted(
+        element_id_by_oex.values(),
+        key=lambda eid: (element_type_by_iris.get(eid, ""), element_name_by_iris.get(eid, "")),
+    )
+    n = len(sorted_elem_ids)
+    cols = max(1, int(math.ceil(math.sqrt(n))))
+
+    nodes: list[dict[str, object]] = []
+    canvas_node_by_elem: dict[str, str] = {}
+    for idx, elem_id in enumerate(sorted_elem_ids):
+        row, col = divmod(idx, cols)
+        iris_type = element_type_by_iris.get(elem_id, "component")
+        canvas_id = str(uuid.uuid4())
+        canvas_node_by_elem[elem_id] = canvas_id
+        nodes.append(
+            {
+                "id": canvas_id,
+                "type": iris_type,
+                "position": {
+                    "x": col * _GRID_CELL_W,
+                    "y": row * _GRID_CELL_H,
+                },
+                "data": {
+                    "label": element_name_by_iris.get(elem_id, ""),
+                    "entityType": iris_type,
+                    "entityId": elem_id,
+                    "visual": {"width": 120, "height": 60},
+                },
+                "measured": {"width": 120, "height": 60},
+            }
+        )
+
+    # Build edges from the iris relationship graph rather than from OEX —
+    # this way we don't need to thread relationship handles through and we
+    # benefit from already-de-duplicated relationship data.
+    edges = await _edges_from_relationships(db, canvas_node_by_elem)
+
+    await create_diagram(
+        db,
+        diagram_type="free_form",
+        name=f"{model_name or 'Imported'} — Overview",
+        description="Auto-generated overview of the imported ArchiMate model.",
+        data={"nodes": nodes, "edges": edges},
+        created_by=imported_by,
+        parent_package_id=package_id,
+        set_id=set_id,
+        notation="archimate",
+    )
+    summary.diagrams_created += 1
+
+
+async def _edges_from_relationships(
+    db: "DatabasePort",
+    canvas_node_by_elem: dict[str, str],
+) -> list[dict[str, object]]:
+    """Pull all relationships among the given element ids and turn them into
+    canvas edges. Done in one query rather than per-element to keep the cost
+    O(R) for R relationships."""
+    if not canvas_node_by_elem:
+        return []
+    elem_ids = list(canvas_node_by_elem.keys())
+    placeholders = ",".join(["?"] * len(elem_ids))
+    sql = (
+        f"SELECT id, source_element_id, target_element_id, relationship_type "
+        f"FROM relationships WHERE is_deleted = 0 "
+        f"AND source_element_id IN ({placeholders}) "
+        f"AND target_element_id IN ({placeholders})"
+    )
+    cursor = await db.execute(sql, (*elem_ids, *elem_ids))
+    rows = await cursor.fetchall()
+
+    edges: list[dict[str, object]] = []
+    for row in rows:
+        rel_id = row[0]
+        src_node = canvas_node_by_elem.get(row[1])
+        tgt_node = canvas_node_by_elem.get(row[2])
+        if not src_node or not tgt_node:
+            continue
+        edges.append(
+            {
+                "id": str(rel_id),
+                "source": src_node,
+                "target": tgt_node,
+                "type": "default",
+                "data": {"relationshipType": row[3]},
+            }
+        )
+    return edges
+
+
+__all__ = ["ArchimateImportSummary", "import_oex_file"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from app.export.router import router as export_router
 from app.images.router import router as images_router
 from app.extensions.router import router as extensions_router
 from app.graph.router import router as graph_router
+from app.import_archimate.router import router as import_archimate_router
 from app.import_pptx.router import router as import_pptx_router
 from app.import_sparx.router import router as import_router
 from app.locks.router import admin_router as admin_locks_router
@@ -184,6 +185,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(import_router)
     app.include_router(images_router)
     app.include_router(import_pptx_router)
+    app.include_router(import_archimate_router)
     app.include_router(package_relationships_router)
     app.include_router(sets_router)
     app.include_router(collections_router)

--- a/backend/tests/test_import_archimate/test_mapper.py
+++ b/backend/tests/test_import_archimate/test_mapper.py
@@ -1,0 +1,77 @@
+"""Tests for the OEX xsi:type → iris type mappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.import_archimate.mapper import (
+    RELATIONSHIP_TYPE_MAP,
+    map_oex_element_type,
+    map_oex_relationship_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("xsi_type", "expected"),
+    [
+        ("BusinessActor", "business_actor"),
+        ("BusinessProcess", "business_process"),
+        ("BusinessObject", "business_object"),
+        ("BusinessService", "business_service"),
+        ("BusinessFunction", "business_function"),
+        ("ApplicationComponent", "application_component"),
+        ("ApplicationService", "application_service"),
+        ("TechnologyNode", "technology_node"),
+        ("Stakeholder", "stakeholder"),
+        ("Constraint", "constraint_archimate"),
+    ],
+)
+def test_element_types_round_trip_via_archimate_stereotype_map(
+    xsi_type: str, expected: str,
+) -> None:
+    assert map_oex_element_type(xsi_type) == expected
+
+
+def test_local_overrides() -> None:
+    assert map_oex_element_type("Note") == "note"
+    assert map_oex_element_type("Group") == "boundary"
+    assert map_oex_element_type("Junction") == "junction"
+
+
+def test_unknown_element_type_returns_none() -> None:
+    assert map_oex_element_type("CompletelyMadeUp") is None
+    assert map_oex_element_type("") is None
+    assert map_oex_element_type(None) is None
+
+
+def test_all_archimate_3x_relationship_types_map() -> None:
+    canonical = {
+        "Composition", "Aggregation", "Assignment", "Realization", "Serving",
+        "Triggering", "Flow", "Specialization", "Access", "Influence",
+        "Association",
+    }
+    for name in canonical:
+        assert map_oex_relationship_type(name) is not None, name
+
+
+def test_relationship_legacy_used_alias_maps_to_serving() -> None:
+    assert map_oex_relationship_type("Used") == "serving"
+    assert map_oex_relationship_type("UsedBy") == "serving"
+    assert map_oex_relationship_type("Serving") == "serving"
+
+
+def test_relationship_british_spelling_aliases() -> None:
+    assert map_oex_relationship_type("Realisation") == "realization"
+    assert map_oex_relationship_type("Specialisation") == "specialization"
+
+
+def test_relationship_unknown_returns_none() -> None:
+    assert map_oex_relationship_type("Bogus") is None
+    assert map_oex_relationship_type(None) is None
+
+
+def test_relationship_map_keys_lowercase_iris_types() -> None:
+    # iris relationship_type strings are snake_case lowercase.
+    for v in RELATIONSHIP_TYPE_MAP.values():
+        assert v == v.lower()
+        assert " " not in v

--- a/backend/tests/test_import_archimate/test_reader.py
+++ b/backend/tests/test_import_archimate/test_reader.py
@@ -1,0 +1,93 @@
+"""Tests for the ArchiMate OEX reader."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app.import_archimate.reader import is_oex_file, parse_oex
+
+REF = Path(__file__).resolve().parents[3] / "docs" / "reference" / "ArchiMate"
+SAMPLE = str(REF / "sample-with-view.xml")
+MSD = str(REF / "msd-map.xml")
+
+
+def test_sample_with_view_parses() -> None:
+    model = parse_oex(SAMPLE)
+    assert model.name == "Iris Sample (with view)"
+    assert len(model.elements) == 3
+    assert len(model.relationships) == 2
+    assert len(model.views) == 1
+    view = model.views[0]
+    assert view.name == "Overview"
+    assert len(view.nodes) == 3
+    assert len(view.connections) == 2
+    # Position parsing is integer-typed
+    assert view.nodes[0].x == 40
+    assert view.nodes[0].y == 40
+    assert view.nodes[0].w == 120
+    assert view.nodes[0].h == 60
+    # xsi:type is preserved unprefixed
+    types = {e.xsi_type for e in model.elements}
+    assert types == {"BusinessActor", "BusinessProcess", "ApplicationService"}
+    rel_types = {r.xsi_type for r in model.relationships}
+    assert rel_types == {"Serving", "Realization"}
+
+
+def test_msd_map_parses_real_world() -> None:
+    """The user-supplied MSD fixture: 127 elements, 977 relationships, 0 views."""
+    model = parse_oex(MSD)
+    assert len(model.elements) == 127
+    assert len(model.relationships) == 977
+    assert len(model.views) == 0
+    seen_xsi = {e.xsi_type for e in model.elements}
+    assert seen_xsi == {
+        "BusinessService", "BusinessObject", "BusinessProcess",
+        "BusinessFunction", "Constraint",
+    }
+    rel_xsi = {r.xsi_type for r in model.relationships}
+    assert rel_xsi == {"Association", "Influence", "Serving"}
+
+
+def test_non_oex_xml_raises(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    p = tmp_path / "bogus.xml"
+    p.write_text('<?xml version="1.0"?><root xmlns="urn:other"><foo/></root>')
+    with pytest.raises(ValueError, match="ArchiMate"):
+        parse_oex(str(p))
+
+
+def test_empty_file_raises(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    p = tmp_path / "empty.xml"
+    p.write_text("")
+    with pytest.raises(ValueError):
+        parse_oex(str(p))
+
+
+def test_namespace_tolerance(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """3.1 and 3.2 namespace URIs must parse identically to 3.0."""
+    for variant in ("3.1", "3.2"):
+        p = tmp_path / f"v{variant}.xml"
+        p.write_text(
+            f'<?xml version="1.0"?>'
+            f'<model xmlns="http://www.opengroup.org/xsd/archimate/{variant}/" '
+            f'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="m">'
+            f'<name>Tiny</name>'
+            f'<elements><element identifier="e1" xsi:type="BusinessActor">'
+            f'<name>A</name></element></elements>'
+            f'</model>'
+        )
+        m = parse_oex(str(p))
+        assert len(m.elements) == 1
+        assert m.elements[0].xsi_type == "BusinessActor"
+
+
+def test_is_oex_file_sniff_positive_and_negative(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    assert is_oex_file(SAMPLE) is True
+    assert is_oex_file(MSD) is True
+    other = tmp_path / "other.xml"
+    other.write_text("<?xml version='1.0'?><root xmlns='urn:elsewhere'/>")
+    assert is_oex_file(str(other)) is False
+    # Non-existent files don't blow up
+    assert is_oex_file(os.path.join(str(tmp_path), "missing.xml")) is False

--- a/backend/tests/test_import_archimate/test_router.py
+++ b/backend/tests/test_import_archimate/test_router.py
@@ -1,0 +1,142 @@
+"""Tests for POST /api/import/archimate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+REF = Path(__file__).resolve().parents[3] / "docs" / "reference" / "ArchiMate"
+SAMPLE = str(REF / "sample-with-view.xml")
+MSD = str(REF / "msd-map.xml")
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> "AsyncIterator[httpx.AsyncClient]":
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def test_uploads_oex_file_and_returns_summary(
+    client: httpx.AsyncClient,
+) -> None:
+    headers = await _auth(client)
+    with open(SAMPLE, "rb") as fh:
+        resp = await client.post(
+            "/api/import/archimate",
+            headers=headers,
+            files={"file": ("sample.xml", fh.read(), "application/xml")},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["elements_created"] == 3
+    assert body["relationships_created"] == 2
+    assert body["diagrams_created"] == 1
+    assert isinstance(body["warnings"], list)
+
+
+async def test_uploads_msd_real_world_file(client: httpx.AsyncClient) -> None:
+    headers = await _auth(client)
+    with open(MSD, "rb") as fh:
+        resp = await client.post(
+            "/api/import/archimate",
+            headers=headers,
+            files={"file": ("msd.xml", fh.read(), "application/xml")},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["elements_created"] == 127
+    assert body["relationships_created"] == 977
+    assert body["diagrams_created"] == 1
+
+
+async def test_rejects_non_oex_xml(client: httpx.AsyncClient) -> None:
+    headers = await _auth(client)
+    resp = await client.post(
+        "/api/import/archimate",
+        headers=headers,
+        files={
+            "file": (
+                "bogus.xml",
+                b'<?xml version="1.0"?><root xmlns="urn:other"/>',
+                "application/xml",
+            )
+        },
+    )
+    assert resp.status_code == 400
+    assert "ArchiMate" in resp.json()["detail"]
+
+
+async def test_rejects_disallowed_extension(client: httpx.AsyncClient) -> None:
+    headers = await _auth(client)
+    resp = await client.post(
+        "/api/import/archimate",
+        headers=headers,
+        files={"file": ("model.txt", b"<model/>", "text/plain")},
+    )
+    assert resp.status_code == 400
+
+
+async def test_rejects_bogus_set_id(client: httpx.AsyncClient) -> None:
+    headers = await _auth(client)
+    with open(SAMPLE, "rb") as fh:
+        resp = await client.post(
+            "/api/import/archimate",
+            headers=headers,
+            data={"set_id": "nonexistent-set-id"},
+            files={"file": ("sample.xml", fh.read(), "application/xml")},
+        )
+    assert resp.status_code == 400
+    assert "set_id" in resp.json()["detail"].lower()
+
+
+async def test_requires_auth(client: httpx.AsyncClient) -> None:
+    with open(SAMPLE, "rb") as fh:
+        resp = await client.post(
+            "/api/import/archimate",
+            files={"file": ("sample.xml", fh.read(), "application/xml")},
+        )
+    assert resp.status_code in (401, 403)

--- a/backend/tests/test_import_archimate/test_service.py
+++ b/backend/tests/test_import_archimate/test_service.py
@@ -1,0 +1,178 @@
+"""End-to-end tests for the OEX import service.
+
+Spins up a real iris app with a fresh sqlite db (per-test tmp dir), runs
+``import_oex_file`` against the committed fixtures, and asserts on the
+persisted state.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.import_archimate.service import import_oex_file
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+REF = Path(__file__).resolve().parents[3] / "docs" / "reference" / "ArchiMate"
+SAMPLE = str(REF / "sample-with-view.xml")
+MSD = str(REF / "msd-map.xml")
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> "AsyncIterator[httpx.AsyncClient]":
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    await db_manager.close()
+
+
+async def _user_id(client: httpx.AsyncClient) -> str:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+    cursor = await db.execute("SELECT id FROM users WHERE username = 'admin'")
+    row = await cursor.fetchone()
+    return row[0]
+
+
+async def test_imports_sample_with_view_using_provided_layout(
+    client: httpx.AsyncClient,
+) -> None:
+    user_id = await _user_id(client)
+    db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+
+    summary = await import_oex_file(db, SAMPLE, imported_by=user_id)
+
+    assert summary.elements_created == 3
+    assert summary.relationships_created == 2
+    assert summary.diagrams_created == 1
+    assert summary.elements_skipped == 0
+    assert summary.relationships_skipped == 0
+    # No auto-layout warning when source had a view.
+    assert not any(w.category == "auto_layout" for w in summary.warnings)
+
+    # Verify the diagram persisted with correct notation + node entityType.
+    cursor = await db.execute(
+        "SELECT dv.data, d.notation FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "AND d.current_version = dv.version "
+        "WHERE d.is_deleted = 0"
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    data = json.loads(row[0])
+    assert row[1] == "archimate"
+    assert len(data["nodes"]) == 3
+    assert len(data["edges"]) == 2
+    entity_types = {n["data"]["entityType"] for n in data["nodes"]}
+    assert entity_types == {
+        "business_actor", "business_process", "application_service",
+    }
+    # Coordinates from the OEX file are preserved (not auto-laid-out).
+    customer_node = next(
+        n for n in data["nodes"] if n["data"]["entityType"] == "business_actor"
+    )
+    assert customer_node["position"] == {"x": 40, "y": 40}
+
+
+async def test_imports_msd_real_world_with_auto_overview(
+    client: httpx.AsyncClient,
+) -> None:
+    """Model-only OEX (no views) → one auto-generated Overview diagram."""
+    user_id = await _user_id(client)
+    db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+
+    summary = await import_oex_file(db, MSD, imported_by=user_id)
+
+    assert summary.elements_created == 127
+    assert summary.relationships_created == 977
+    assert summary.diagrams_created == 1
+    assert summary.elements_skipped == 0
+    # Auto-layout warning recorded.
+    assert any(w.category == "auto_layout" for w in summary.warnings)
+
+    # Pull the synthesised Overview and assert structure.
+    cursor = await db.execute(
+        "SELECT dv.name, dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "AND d.current_version = dv.version "
+        "WHERE d.is_deleted = 0"
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    name = row[0]
+    data = json.loads(row[1])
+    assert "Overview" in name
+    # Every imported element gets a node.
+    assert len(data["nodes"]) == 127
+    # Every imported relationship becomes an edge.
+    assert len(data["edges"]) == 977
+    # Grid layout: ceil(sqrt(127)) == 12 columns; positions are deterministic
+    # multiples of the cell size.
+    xs = [n["position"]["x"] for n in data["nodes"]]
+    ys = [n["position"]["y"] for n in data["nodes"]]
+    assert max(xs) == 11 * 220  # 0..11 columns => x ∈ {0, 220, ..., 11*220}
+    assert min(xs) == 0
+    assert min(ys) == 0
+    # All five distinct iris element types are represented.
+    iris_types = {n["data"]["entityType"] for n in data["nodes"]}
+    assert iris_types == {
+        "business_service", "business_object", "business_process",
+        "business_function", "constraint_archimate",
+    }
+
+
+async def test_unmapped_element_type_is_warned_not_fatal(
+    client: httpx.AsyncClient, tmp_path: Path,
+) -> None:
+    user_id = await _user_id(client)
+    db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+
+    fixture = tmp_path / "with_unknown.xml"
+    fixture.write_text(
+        '<?xml version="1.0"?>'
+        '<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" identifier="m">'
+        '<name>Mixed</name>'
+        '<elements>'
+        '<element identifier="ok" xsi:type="BusinessActor"><name>A</name></element>'
+        '<element identifier="bad" xsi:type="MadeUpType"><name>B</name></element>'
+        '</elements></model>'
+    )
+    summary = await import_oex_file(db, str(fixture), imported_by=user_id)
+    assert summary.elements_created == 1
+    assert summary.elements_skipped == 1
+    assert any(
+        w.category == "unmapped_element_type" for w in summary.warnings
+    )

--- a/docs/adrs/ADR-148-ArchiMate-OEX-Import.md
+++ b/docs/adrs/ADR-148-ArchiMate-OEX-Import.md
@@ -1,0 +1,114 @@
+# ADR-148: ArchiMate Open Exchange XML Import
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-148 |
+| **Initiative** | Issue #52 — make ArchiMate OEX a first-class import in iris |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-07 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** users wanting to bring ArchiMate models authored
+in other tools (Archi, Sparx EA, Visual Paradigm, BiZZdesign) into iris
+as first-class diagrams, alongside the existing `.qea`/`.eap` (SparxEA)
+and `.pptx` (DoView) import paths,
+
+**facing** that The Open Group's ArchiMate® Model Exchange File Format
+(OEX) is the de-facto interoperability standard for ArchiMate 3.x and
+that iris already has rich ArchiMate plumbing (40+ entity types, the
+`ARCHIMATE_STEREOTYPE_MAP` in `import_sparx/mapper.py`, automatic
+notation detection) but no XML reader to feed it,
+
+**we decided to**:
+1. Add a new backend module `app/import_archimate/` (reader + mapper +
+   service + router) that parses OEX 3.0 / 3.1 / 3.2 files using the
+   stdlib `xml.etree.ElementTree` (no new dependency) and produces
+   iris elements, relationships, and diagrams.
+2. Reuse `ARCHIMATE_STEREOTYPE_MAP` as the single source of truth for
+   element-type mapping — the OEX mapper prefixes the unprefixed
+   `xsi:type` (e.g. `BusinessActor`) with `ArchiMate_` and delegates
+   (DRY, protocol #13).
+3. Define a small new `RELATIONSHIP_TYPE_MAP` for the 12 ArchiMate
+   relationship types (Composition, Aggregation, Assignment,
+   Realization, Serving, Triggering, Flow, Specialization, Access,
+   Influence, Association, plus the legacy `Used`/`UsedBy` aliases).
+4. **Auto-generate a single Overview diagram** when the source OEX file
+   has no embedded views (model-only). Layout: type-grouped grid
+   (`ceil(sqrt(n))` columns × 220×140 cell spacing). Without this,
+   model-only imports — which are common in real-world OEX — would
+   land 100s of orphaned elements with nothing to render.
+5. Extend the existing `/import` page dropzone to accept `.xml`,
+   `.archimate`, and `.oex` extensions with content sniffing on upload
+   (the OEX namespace must appear in the first 4 KiB or the request
+   is rejected with 400).
+6. Cover the path with a real-world UAT Playwright spec that imports
+   the user-supplied
+   [MSD Business Architecture model](https://github.com/1punchtan/msd-business-architecture/blob/main/workspace/msd-map.xml)
+   — 127 elements, 977 relationships, 0 views — and asserts the
+   resulting Overview diagram renders ≥100 nodes without throwing.
+
+**to achieve** a polished, low-friction import for ArchiMate users
+that puts iris on equal footing with established ArchiMate tools while
+keeping the implementation minimal: net new lines are the parser,
+12-row relationship map, and grid-layout helper.
+
+**accepting** that:
+- This release is **import only**. OEX export (writing iris diagrams
+  back to OEX) is deferred until users ask for round-trip — the
+  use-cases we've heard so far are one-way (migrate into iris, then
+  iterate in iris).
+- The grid layout is simple and dense for 100+ nodes. Users will
+  rearrange manually for any non-trivial model. A future ADR may add
+  a force-directed layout if friction emerges.
+- Nested `<node>` containment (compound nodes) is **flattened** to
+  absolute coordinates on import — iris diagrams don't model parent-
+  child node nesting today.
+- We accept the broader `.xml` extension (not just `.archimate` /
+  `.oex`) because Archi tool's official export uses `.xml`; we sniff
+  for the OEX namespace before importing to avoid accidentally
+  ingesting a non-OEX XML.
+
+---
+
+## Rejected alternatives
+
+- **Add `lxml` for XML schema validation.** Overkill — OEX files in
+  the wild are often slightly out-of-spec (missing `xml:lang` on
+  `<name>`, mixing 3.0/3.1 namespaces). Permissive parsing via stdlib
+  is a better fit, and avoids a C-build dependency on Render.
+- **Define a separate ArchiMate-specific data model.** Iris elements,
+  relationships, and diagrams already represent ArchiMate concepts
+  (notation auto-detection tags `archimate` when the data shows it).
+  No table changes needed.
+- **Duplicate `ARCHIMATE_STEREOTYPE_MAP`** in the new module.
+  Violates DRY (#13). The existing 40-row map already covers every
+  type the OEX format defines.
+- **Skip auto-layout when no views exist.** Tested with the MSD
+  fixture — 127 silent elements with no diagram is a poor outcome;
+  the user wouldn't see anything on `/views` and would have to build
+  the visualisation manually. Auto-layout is the higher-value default.
+- **Open up batch upload like `.pptx`.** OEX files tend to be a
+  single canonical model per repo. Single-file flow keeps the UX
+  simple and matches the SparxEA pattern.
+
+---
+
+## Dependencies
+
+- Depends on the existing `ARCHIMATE_STEREOTYPE_MAP`
+  ([backend/app/import_sparx/mapper.py:47-97](../../backend/app/import_sparx/mapper.py#L47-L97)).
+- Depends on the existing element / relationship / diagram services
+  for persistence.
+- Depends on the existing notation auto-detection
+  ([backend/app/diagrams/notation_detection.py](../../backend/app/diagrams/notation_detection.py))
+  to tag the imported diagram as `notation: "archimate"`.
+- Depends on ADR-147 (UAT Playwright harness) for the e2e
+  verification project.
+
+## Related specs
+
+- [SPEC-148-A: ArchiMate OEX Import](specs/SPEC-148-A-ArchiMate-OEX-Import.md)

--- a/docs/adrs/specs/SPEC-148-A-ArchiMate-OEX-Import.md
+++ b/docs/adrs/specs/SPEC-148-A-ArchiMate-OEX-Import.md
@@ -1,0 +1,224 @@
+# SPEC-148-A: ArchiMate Open Exchange XML Import
+
+| Field | Value |
+|-------|-------|
+| **Spec ID** | SPEC-148-A |
+| **Implements** | [ADR-148](../ADR-148-ArchiMate-OEX-Import.md) |
+| **Status** | Implemented (v5.6.0) |
+| **Date** | 2026-05-07 |
+
+---
+
+## Scope
+
+Backend reader, mapper, service, and router for The Open Group ArchiMate®
+Model Exchange File Format (OEX), versions 3.0 / 3.1 / 3.2; frontend file
+picker extension; UAT Playwright verification spec.
+
+Out of scope: OEX export.
+
+---
+
+## File format reference
+
+```xml
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       identifier="model-id">
+  <name>...</name>
+  <documentation>...</documentation>
+  <elements>
+    <element identifier="el-1" xsi:type="BusinessActor">
+      <name>...</name>
+      <documentation>...</documentation>
+    </element>
+  </elements>
+  <relationships>
+    <relationship identifier="rel-1" source="el-1" target="el-2" xsi:type="Serving"/>
+  </relationships>
+  <organizations> ... </organizations>     <!-- ignored -->
+  <views>
+    <diagrams>
+      <view identifier="v-1" xsi:type="Diagram">
+        <name>...</name>
+        <node identifier="n-1" elementRef="el-1" x="..." y="..." w="..." h="..."/>
+        <connection identifier="c-1" relationshipRef="rel-1" source="n-1" target="n-2"/>
+      </view>
+    </diagrams>
+  </views>
+</model>
+```
+
+Accepted namespaces (regex `^http://www\.opengroup\.org/xsd/archimate/3\.\d+/?$`):
+
+- `http://www.opengroup.org/xsd/archimate/3.0/`
+- `http://www.opengroup.org/xsd/archimate/3.1/`
+- `http://www.opengroup.org/xsd/archimate/3.2/`
+
+---
+
+## Element type mapping
+
+OEX `xsi:type` values are unprefixed (e.g. `BusinessActor`). The mapper
+prefixes them with `ArchiMate_` and delegates to the existing
+[`ARCHIMATE_STEREOTYPE_MAP`](../../backend/app/import_sparx/mapper.py)
+for the 40+ ArchiMate types. Local overrides for non-stereotype xsi types:
+
+| OEX `xsi:type` | iris element_type |
+|---|---|
+| `Note` | `note` |
+| `Group` | `boundary` |
+| `Junction` | `junction` |
+| `AndJunction` | `junction` |
+| `OrJunction` | `junction` |
+
+Unknown types yield an `unmapped_element_type` warning and are skipped.
+
+---
+
+## Relationship type mapping
+
+`backend/app/import_archimate/mapper.py:RELATIONSHIP_TYPE_MAP`:
+
+| OEX `xsi:type` | iris relationship_type |
+|---|---|
+| `Composition` | `composition` |
+| `Aggregation` | `aggregation` |
+| `Assignment` | `assignment` |
+| `Realization` / `Realisation` | `realization` |
+| `Serving` / `Used` / `UsedBy` | `serving` |
+| `Triggering` | `triggering` |
+| `Flow` | `flow` |
+| `Specialization` / `Specialisation` | `specialization` |
+| `Access` | `access` |
+| `Influence` | `influence` |
+| `Association` | `association` |
+
+Unknown relationship types yield an `unmapped_relationship` warning and
+are skipped. Relationships whose source or target element wasn't created
+yield a `dangling_relationship` warning.
+
+---
+
+## View import
+
+For each OEX `<view>`:
+
+1. Walk every `<node>` (recursively — nested children represent
+   ArchiMate compound nodes); flatten to absolute coordinates by summing
+   parent offsets.
+2. Map `elementRef` → already-created iris element id; build a canvas
+   node `{id, type, position: {x, y}, data: {label, entityType, entityId, visual: {width, height}}, measured}`.
+3. For each `<connection>` with both endpoints resolvable: build a
+   canvas edge `{id, source, target, type: "default", data}`.
+4. Persist via `create_diagram(...)` with `notation="archimate"`,
+   `diagram_type="free_form"`, parented under the per-import package.
+
+## Auto-generated Overview (model-only OEX)
+
+When `model.views` is empty:
+
+1. Sort imported element ids by `(iris_type, name)` so same-type
+   elements cluster.
+2. Compute `cols = ceil(sqrt(n))`.
+3. Place node `i` at `(col=i%cols, row=i//cols)` with cell size
+   220×140 px. Default node size 120×60.
+4. Build edges from the iris `relationships` table for the imported
+   element ids — one SQL query, O(R).
+5. Persist as `"<model name> — Overview"` with notation `archimate`.
+6. Emit an `auto_layout` warning so the operator knows the diagram
+   was synthesised.
+
+---
+
+## API
+
+### `POST /api/import/archimate`
+
+| Field | Value |
+|---|---|
+| Auth | Required (Bearer JWT) |
+| Body | `multipart/form-data` |
+| Form fields | `file` (the .xml/.archimate/.oex), `set_id` (optional) |
+
+Behaviour:
+- Reject 400 if filename does not end with `.xml`, `.archimate`, or `.oex`.
+- Reject 400 if the OEX namespace string isn't in the first 4 KiB of the
+  file (content sniff guards against accidental SVG/XHTML/etc upload).
+- Reject 400 if `set_id` is supplied but doesn't reference an existing
+  set.
+- On success, return JSON:
+  ```json
+  {
+    "packages_created": 1,
+    "elements_created": 127,
+    "elements_skipped": 0,
+    "relationships_created": 977,
+    "relationships_skipped": 0,
+    "diagrams_created": 1,
+    "warnings": [
+      { "category": "auto_layout", "message": "..." }
+    ]
+  }
+  ```
+
+---
+
+## Frontend
+
+`frontend/src/routes/import/+page.svelte` extended:
+- File `<input>` `accept` attribute lists `.xml,.archimate,.oex` in
+  addition to the existing `.qea,.eap,.pptx`.
+- Help text mentions "ArchiMate Open Exchange (.xml, .archimate, .oex)".
+- Single-file selection routes to `/api/import/archimate` via a new
+  `isArchimate` derived state.
+
+---
+
+## Test fixtures
+
+Both committed under `docs/reference/ArchiMate/`:
+
+- `sample-with-view.xml` — hand-authored, 3 elements / 2 relationships /
+  1 view. Exercises the view-import path.
+- `msd-map.xml` — snapshot of
+  https://github.com/1punchtan/msd-business-architecture (CC0 / public
+  MSD policy material). 127 elements, 977 relationships, 0 views.
+  Exercises the auto-layout path and proves the importer scales.
+
+---
+
+## Verification
+
+Backend:
+
+```bash
+cd backend && .venv/bin/python -m pytest tests/test_import_archimate -q
+```
+
+Expected: ~32 tests green.
+
+Frontend (run from a Node ≥20 environment — vite-plugin-svelte requires
+`node:util.styleText`):
+
+```bash
+cd frontend && npm run test:unit -- importPageAcceptsArchimate
+```
+
+UAT (post-promotion):
+
+```bash
+cd frontend && npm run test:uat -- issue-52-archimate-import
+```
+
+Expected: 3 specs green; screenshots under
+`frontend/tests/e2e/uat/screenshots/52-*.png` show the 127-node
+Overview diagram and a populated elements list.
+
+Manual smoke (local dev):
+
+1. Start the backend + frontend.
+2. Drag `docs/reference/ArchiMate/msd-map.xml` onto `/import`.
+3. Pick a target set, click Import.
+4. Click "Browse Views" → open the imported "MSD MAP Business
+   Architecture — Overview" diagram → 127 nodes render in a grid.

--- a/docs/reference/ArchiMate/msd-map.xml
+++ b/docs/reference/ArchiMate/msd-map.xml
@@ -1,0 +1,1493 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengroup.org/xsd/archimate/3.0/ archimate3_Diagram.xsd" identifier="model-msd-map">
+  <name>MSD MAP Business Architecture</name>
+  <elements>
+    <element identifier="community-services-card" xsi:type="BusinessService">
+      <name>Community Services Card</name>
+      <documentation>The Community Services Card is a card-based assistance product that provides holders with subsidised access to primary health organisation services, public transport (Community Connect), and other health services.</documentation>
+    </element>
+    <element identifier="supergold-card" xsi:type="BusinessService">
+      <name>SuperGold Card</name>
+      <documentation>The SuperGold Card is a card service providing concessions and assistance to eligible New Zealand Superannuation clients, Veterans Pension clients, and main benefit clients.</documentation>
+    </element>
+    <element identifier="child-support-income" xsi:type="BusinessObject">
+      <name>Child Support income</name>
+      <documentation>Defines how Child Support payments are treated as income for benefit purposes, covering both information share and non-information share Child Support payments with automated income charging rules, deemed receipt, payment cycles, manual income charging rules for historical periods, exemptions, changes and reviews, deprivation, and offsetting provisions.</documentation>
+    </element>
+    <element identifier="definition-of-income" xsi:type="BusinessObject">
+      <name>Definition of income</name>
+      <documentation>A structured policy guide defining what constitutes income for benefit assessment purposes, including capital payments, income-related purpose guidelines, inclusions and exclusions, partner income considerations, income from assets, and verification requirements.</documentation>
+    </element>
+    <element identifier="employment-related-income" xsi:type="BusinessObject">
+      <name>Employment related income</name>
+      <documentation>Employment related income covers how various employment-related payments are treated for clients already receiving a benefit, as distinct from treatment at commencement of benefit.</documentation>
+    </element>
+    <element identifier="end-of-school-year" xsi:type="BusinessObject">
+      <name>End of school year</name>
+      <documentation>A policy guide covering procedures and considerations related to the end of the school year, including when a child leaves school and the implications for income support.</documentation>
+    </element>
+    <element identifier="income-related-rent-debt" xsi:type="BusinessObject">
+      <name>Income Related Rent debt</name>
+      <documentation>Guidance on the establishment, liability, repayment, and review of Income Related Rent debt, including circumstances arising from late notice of changes, undeclared circumstances, fraud, insolvency, and refunds.</documentation>
+    </element>
+    <element identifier="income" xsi:type="BusinessObject">
+      <name>Income</name>
+      <documentation>A policy guidance manual that helps determine what constitutes income for benefit and pension purposes administered by MSD, and how that income should be treated in assessing client entitlements.</documentation>
+    </element>
+    <element identifier="payments-from-overseas" xsi:type="BusinessObject">
+      <name>Payments from overseas</name>
+      <documentation>A contents/index page covering the topic of payments from overseas, including overseas pensions, reciprocal agreements, exchange rates, couples receiving overseas pensions, interactions with New Zealand Superannuation and Veterans Pension, and related taxation and accommodation supplement considerations.</documentation>
+    </element>
+    <element identifier="residence" xsi:type="BusinessObject">
+      <name>Residence</name>
+      <documentation>A structured policy guide covering residence criteria required for income support eligibility in New Zealand.</documentation>
+    </element>
+    <element identifier="types-of-income" xsi:type="BusinessObject">
+      <name>Types of income</name>
+      <documentation>A comprehensive reference guide covering the full range of income types recognised under MSD social development policy.</documentation>
+    </element>
+    <element identifier="care-and-protection-concerns-for-a-child-or-young-person" xsi:type="Constraint">
+      <name>Care and protection concerns for a child or young person</name>
+      <documentation>Guidance on when MSD must refer cases to Oranga Tamariki due to care and protection concerns for a child or young person, including indicators of risk such as age, stability of care, conflict, abuse, and caregiver capacity.</documentation>
+    </element>
+    <element identifier="child-support" xsi:type="Constraint">
+      <name>Child Support</name>
+      <documentation>Policy governing Child Support arrangements for clients of Work and Income, covering carers receiving child support, liable parents, formula assessments, exemptions from applying, private and voluntary arrangements, and special circumstances such as risk of violence, deceased liable parents, or conception through incest or sexual violation.</documentation>
+    </element>
+    <element identifier="general-portability" xsi:type="Constraint">
+      <name>General portability</name>
+      <documentation>Policy framework governing the portability of New Zealand benefits and pensions for clients travelling or residing overseas, including eligibility criteria, rates of payment, obligations, and administrative processes.</documentation>
+    </element>
+    <element identifier="portability" xsi:type="Constraint">
+      <name>Portability</name>
+      <documentation>Policy governing continued payment of NZ Superannuation or Veteran's Pension to clients who are overseas, subject to specific conditions relating to country of residence, duration of travel, and applicable social security agreements.</documentation>
+    </element>
+    <element identifier="pre-benefit-requirements" xsi:type="Constraint">
+      <name>Pre-benefit requirements</name>
+      <documentation>Policy governing the pre-benefit requirements that clients and partners must satisfy prior to benefit grant, including activities, job interview and offer requirements, Jobseeker Profile completion, and associated timeframes and review rights.</documentation>
+    </element>
+    <element identifier="reciprocal-agreements" xsi:type="Constraint">
+      <name>Reciprocal Agreements</name>
+      <documentation>New Zealand has 10 Reciprocal Agreements which cover 11 countries, enabling former residents to access certain benefits and pensions under the other country's social security system.</documentation>
+    </element>
+    <element identifier="reciprocal-australia" xsi:type="Constraint">
+      <name>Reciprocal Australia</name>
+      <documentation>The Social Security Agreement between New Zealand and Australia governs reciprocal entitlements for clients moving between the two countries.</documentation>
+    </element>
+    <element identifier="reciprocal-canada" xsi:type="Constraint">
+      <name>Reciprocal Canada</name>
+      <documentation>The Social Security Agreement between New Zealand and Canada governs the reciprocal entitlements and obligations for clients moving between or residing in either country.</documentation>
+    </element>
+    <element identifier="reciprocal-denmark" xsi:type="Constraint">
+      <name>Reciprocal Denmark</name>
+      <documentation>Policy guidance for the reciprocal social security agreement with Denmark, covering entitlements, calculations, payment methods, and administrative processes for clients moving between or residing in New Zealand and Denmark.</documentation>
+    </element>
+    <element identifier="reciprocal-hellenic-republic" xsi:type="Constraint">
+      <name>Reciprocal Hellenic Republic</name>
+      <documentation>Reciprocal social security agreement between New Zealand and the Hellenic Republic (Greece), covering portability of NZ benefits and pensions, Greek pension clients in NZ, and associated administrative processes.</documentation>
+    </element>
+    <element identifier="reciprocal-ireland" xsi:type="Constraint">
+      <name>Reciprocal Ireland</name>
+      <documentation>The Social Security Agreement between New Zealand and Ireland governing reciprocal benefit and pension entitlements, portability, and administration for clients in both countries.</documentation>
+    </element>
+    <element identifier="reciprocal-jersey-guernsey" xsi:type="Constraint">
+      <name>Reciprocal Jersey Guernsey</name>
+      <documentation>A reciprocal social security agreement between New Zealand and Jersey/Guernsey governing the portability and entitlement of New Zealand benefits and pensions for clients residing in or moving to Jersey/Guernsey, and the recognition of Jersey/Guernsey pensions or benefits in New Zealand.</documentation>
+    </element>
+    <element identifier="reciprocal-malta" xsi:type="Constraint">
+      <name>Reciprocal Malta</name>
+      <documentation>The reciprocal agreement between New Zealand and Malta governing the treatment of New Zealand benefits and pensions for clients in Malta, and Maltese pensions for clients in New Zealand.</documentation>
+    </element>
+    <element identifier="reciprocal-netherlands" xsi:type="Constraint">
+      <name>Reciprocal Netherlands</name>
+      <documentation>Contents index for the Social Security Agreement between New Zealand and the Netherlands, covering benefit portability, payment arrangements, debt recovery, and review processes for clients in both countries.</documentation>
+    </element>
+    <element identifier="reciprocal-republic-of-korea" xsi:type="Constraint">
+      <name>Reciprocal Republic of Korea</name>
+      <documentation>Reciprocal social security agreement between New Zealand and the Republic of Korea, covering totalisation provisions for New Zealand Superannuation and Veterans Pension, handling of Korean benefits in New Zealand, client obligations, payment processes, and procedures for clients moving between the two countries.</documentation>
+    </element>
+    <element identifier="reciprocal-united-kingdom" xsi:type="Constraint">
+      <name>Reciprocal United Kingdom</name>
+      <documentation>This page provides the policy framework and operational guidance for the Social Security Agreement (reciprocal agreement) between New Zealand and the United Kingdom.</documentation>
+    </element>
+    <element identifier="relationship-debt-sharing" xsi:type="Constraint">
+      <name>Relationship debt sharing</name>
+      <documentation>Policy governing relationship debt sharing, including joint and several liability for partners, prosecution of partners, recklessness provisions, and review of decisions related to relationship debt sharing.</documentation>
+    </element>
+    <element identifier="relationship-status-for-benefit" xsi:type="Constraint">
+      <name>Relationship status for benefit</name>
+      <documentation>Policy governing how relationship status is determined for benefit purposes, covering married, civil union, de facto, and living apart situations, including definitions of de facto relationships, emotional commitment, financial interdependence, and family violence considerations.</documentation>
+    </element>
+    <element identifier="special-portability" xsi:type="Constraint">
+      <name>Special Portability</name>
+      <documentation>Policy governing special portability arrangements for NZ Superannuation and Veterans Pension recipients in specified Pacific countries, including eligibility, application, obligations, and payment rules.</documentation>
+    </element>
+    <element identifier="use-of-social-housing-benefit-and-student-information" xsi:type="Constraint">
+      <name>Use of social housing benefit and student information</name>
+      <documentation>Policy governing the use and sharing of social housing, benefit, and student information across MSD functions, including what benefit or student information can be used for housing purposes, what housing information can be used for benefit or student purposes, and how to deal with conflicting information.</documentation>
+    </element>
+    <element identifier="warrant-to-arrest" xsi:type="Constraint">
+      <name>Warrant to Arrest</name>
+      <documentation>Policy governing the criteria and procedures for suspending or affecting client benefits when a warrant to arrest has been issued.</documentation>
+    </element>
+    <element identifier="application-for-assistance" xsi:type="BusinessProcess">
+      <name>Application for assistance</name>
+      <documentation>Defines the process and requirements for clients applying for financial assistance, including verbal and written request rules, timeframes, and handling of expired applications.</documentation>
+    </element>
+    <element identifier="application-for-benefit" xsi:type="BusinessProcess">
+      <name>Application for benefit</name>
+      <documentation>Guidelines and procedures for processing applications for benefit, including rules around application forms, date of first contact, supporting evidence requirements, IRD number requirements, and investigation of applications.</documentation>
+    </element>
+    <element identifier="assessment-of-eligibility" xsi:type="BusinessProcess">
+      <name>Assessment of eligibility</name>
+      <documentation>A comprehensive process for assessing eligibility for social housing, covering qualifications, household composition, bedroom allocation, housing need priority ratings, fast-track provisions, assessments for current tenants, transfers, and reviews and appeals.</documentation>
+    </element>
+    <element identifier="current-client-debt" xsi:type="BusinessProcess">
+      <name>Current client debt</name>
+      <documentation>A comprehensive policy and process guide covering the management of current client debt within MSD, including debt establishment, types, repayment negotiation, recovery maximums, write-off criteria and processes, provisional write-offs, debt review, transfer between benefits, debt at cancellation, third party and non-beneficiary debt, and related system processes (TRACE, SWIFTT).</documentation>
+    </element>
+    <element identifier="duty-to-advise-of-changes-in-circumstances" xsi:type="BusinessProcess">
+      <name>Duty to advise of changes in circumstances</name>
+      <documentation>Outlines the obligations of social housing tenants to advise MSD of changes in their circumstances, including changes in income, assets, household members, housing requirements, benefit status, and the consequences of not advising of changes.</documentation>
+    </element>
+    <element identifier="re-assessing-previous-applications" xsi:type="BusinessProcess">
+      <name>Re-assessing previous applications</name>
+      <documentation>Guidelines and procedures for re-assessing previous applications for financial assistance, including determining whether an application has been made, outcomes of investigations, commencement dates for main benefits, backdating, correction power procedures, delegated authority levels, and review rights.</documentation>
+    </element>
+    <element identifier="redirection-of-benefit-payment" xsi:type="BusinessProcess">
+      <name>Redirection of benefit payment</name>
+      <documentation>Policy and decision guidelines governing the redirection of benefit payments, including redirection for social housing, essential services, accommodation costs for vulnerable tenants, priority needs, emergency housing contributions, and redirection without client consent.</documentation>
+    </element>
+    <element identifier="register-management-and-referrals" xsi:type="BusinessProcess">
+      <name>Register management and referrals</name>
+      <documentation>A comprehensive process covering the management of the social housing register and referrals to housing providers.</documentation>
+    </element>
+    <element identifier="requests-for-financial-assistance" xsi:type="BusinessProcess">
+      <name>Requests for financial assistance</name>
+      <documentation>Process for handling client requests for financial assistance, including determining whether the request relates to a benefit or other assistance, and the obligations of both the Ministry and the client.</documentation>
+    </element>
+    <element identifier="reviews-and-appeals" xsi:type="BusinessProcess">
+      <name>Reviews and Appeals</name>
+      <documentation>Index page for the Reviews and Appeals process, covering benefit review committees, Medical Appeals Board, Social Security Appeal Authority, and related client rights and procedures.</documentation>
+    </element>
+    <element identifier="students--agents" xsi:type="BusinessProcess">
+      <name>Agents</name>
+      <documentation>Covers the processes and rules around agents acting on behalf of students, including court-appointed agents, Power of Attorney, Enduring Power of Attorney, appointing agents without informed consent, and how organisations or companies act as agents.</documentation>
+    </element>
+    <element identifier="tenancy-reviews" xsi:type="BusinessProcess">
+      <name>Tenancy reviews</name>
+      <documentation>Tenancy reviews cover the process of reviewing whether a social housing tenant continues to qualify for social housing, including triggers, assessment criteria, property suitability checks, outcomes, notifications, and review of decision procedures.</documentation>
+    </element>
+    <element identifier="youth-service-information-sharing" xsi:type="BusinessProcess">
+      <name>Youth service information sharing</name>
+      <documentation>Describes the information sharing arrangements between Work and Income and Youth Service providers (NEET and Payment), including third party agencies and organisations sharing information about young people involved in youth services.</documentation>
+    </element>
+    <element identifier="accommodation-costs-arrears-grant" xsi:type="BusinessService">
+      <name>Accommodation Costs Arrears Grant</name>
+      <documentation>A grant providing financial assistance to clients at risk of losing accommodation due to arrears, covering situations under and outside the Residential Tenancies Act 1986, subject to income limits, cash asset limits, residence requirements, and assessments of need and suitability.</documentation>
+    </element>
+    <element identifier="accommodation-costs-in-advance-grant" xsi:type="BusinessService">
+      <name>Accommodation Costs in Advance Grant</name>
+      <documentation>A housing support product that provides financial assistance to clients who need help paying accommodation costs in advance, assessed against income limits, cash asset limits, and situational factors.</documentation>
+    </element>
+    <element identifier="accommodation-security-cover-grant" xsi:type="BusinessService">
+      <name>Accommodation Security Cover Grant</name>
+      <documentation>A grant to assist clients with outstanding accommodation costs and expenses, assessed against income and cash asset limits, applicable where the Residential Tenancies Act 1986 applies or does not apply.</documentation>
+    </element>
+    <element identifier="accommodation-supplement" xsi:type="BusinessService">
+      <name>Accommodation Supplement</name>
+      <documentation>A weekly payment to assist with accommodation costs (rent, board, or home ownership) for eligible beneficiaries and non-beneficiaries, subject to income, asset, and residence criteria with mandatory periodic reviews.</documentation>
+    </element>
+    <element identifier="advance-payment-of-benefit" xsi:type="BusinessService">
+      <name>Advance Payment of Benefit</name>
+      <documentation>A financial assistance product that advances benefit payments to eligible clients to meet immediate and essential needs across a range of specified categories, subject to qualification, income, asset, and hardship obligation requirements.</documentation>
+    </element>
+    <element identifier="apprenticeship-boost" xsi:type="BusinessService">
+      <name>Apprenticeship Boost</name>
+      <documentation>Apprenticeship Boost is an employment assistance product providing financial support to employers who take on apprentices.</documentation>
+    </element>
+    <element identifier="away-from-home-allowance" xsi:type="BusinessService">
+      <name>Away From Home Allowance</name>
+      <documentation>A financial allowance for principal caregivers with dependent children living away from home, addressing eligibility, payment rates, overpayments, changes in circumstances, and deductions.</documentation>
+    </element>
+    <element identifier="best-start-tax-credit" xsi:type="BusinessService">
+      <name>Best Start tax credit</name>
+      <documentation>A tax credit supporting families with young children, administered by the Ministry of Social Development or Inland Revenue, covering eligibility, payment, protected rates while on a main benefit, absence from New Zealand, changes in circumstances, and overpayments.</documentation>
+    </element>
+    <element identifier="bond-grant" xsi:type="BusinessService">
+      <name>Bond Grant</name>
+      <documentation>A grant to assist eligible clients with bond costs when securing accommodation, subject to income, cash asset, and residence criteria under the Housing Support Products framework.</documentation>
+    </element>
+    <element identifier="child-disability-allowance" xsi:type="BusinessService">
+      <name>Child Disability Allowance</name>
+      <documentation>Child Disability Allowance is a payment for caregivers of children with serious disabilities requiring constant care and attention.</documentation>
+    </element>
+    <element identifier="christchurch-mosques-attack-assistance" xsi:type="BusinessService">
+      <name>Christchurch Mosques Attack Assistance</name>
+      <documentation>A special assistance product for people affected by the Christchurch Mosques Attack, covering those who are affected persons, experiencing mental trauma, or related to someone injured, killed or present at the attack.</documentation>
+    </element>
+    <element identifier="civilian-amputee-assistance" xsi:type="BusinessService">
+      <name>Civilian Amputee Assistance</name>
+      <documentation>Civilian Amputee Assistance is an extra help product that provides financial support to civilian amputees, covering costs related to limb centre appointments including travel expenses, accommodation costs, meals, loss of earnings, and attendant costs.</documentation>
+    </element>
+    <element identifier="clothing-allowance" xsi:type="BusinessService">
+      <name>Clothing Allowance</name>
+      <documentation>A clothing assistance payment for caregivers of orphans and unsupported children, with rules covering eligibility, payment, caregiver and child changes, and reviews.</documentation>
+    </element>
+    <element identifier="community-costs" xsi:type="BusinessService">
+      <name>Community Costs</name>
+      <documentation>Community Costs is an extra help product that provides financial assistance to eligible clients covering allowable costs such as storage costs, childcare costs, and other approved expenses with qualification criteria and review mechanisms.</documentation>
+    </element>
+    <element identifier="cost-of-living-payment" xsi:type="BusinessService">
+      <name>Cost of Living Payments</name>
+      <documentation>Cost of Living Payments are paid by Inland Revenue to individuals who meet set eligibility criteria, including having net income of $70,000 or less in the 2021/22 tax year.</documentation>
+    </element>
+    <element identifier="covid-19-leave-support-scheme" xsi:type="BusinessService">
+      <name>COVID-19 Leave Support Scheme</name>
+      <documentation>A wage subsidy scheme providing financial support to businesses for employees unable to work due to COVID-19 self-isolation requirements or related health circumstances.</documentation>
+    </element>
+    <element identifier="covid-19-resurgence-wage-subsidy-scheme" xsi:type="BusinessService">
+      <name>COVID-19 Resurgence Wage Subsidy Scheme</name>
+      <documentation>A wage subsidy scheme designed to support employers affected by COVID-19 resurgence events by providing financial assistance to eligible employers who experience a decline in revenue due to COVID-19 resurgence public health restrictions.</documentation>
+    </element>
+    <element identifier="covid-19-short-term-absence-payment" xsi:type="BusinessService">
+      <name>COVID-19 Short-Term Absence Payment</name>
+      <documentation>A payment scheme providing financial support for businesses and self-employed workers who cannot work because they or a dependant are required to stay home while awaiting a COVID-19 PCR test result.</documentation>
+    </element>
+    <element identifier="covid-19-wage-subsidy-modified" xsi:type="BusinessService">
+      <name>COVID-19 wage subsidy (modified)</name>
+      <documentation>Employment support product providing wage subsidies to eligible employers who experienced a decline in revenue due to COVID-19 public health restrictions.</documentation>
+    </element>
+    <element identifier="covid-19-wage-subsidy-scheme-august-2021" xsi:type="BusinessService">
+      <name>COVID-19 Wage Subsidy Scheme (August 2021)</name>
+      <documentation>A wage subsidy scheme providing financial support to eligible businesses affected by the August 2021 COVID-19 alert level escalation.</documentation>
+    </element>
+    <element identifier="covid-19-wage-subsidy-scheme-extension" xsi:type="BusinessService">
+      <name>COVID-19 Wage Subsidy Scheme Extension</name>
+      <documentation>A wage subsidy scheme extending COVID-19 employment support to eligible New Zealand employers and self-employed individuals who experienced a 40% revenue decline, with obligations to retain staff and pay employees.</documentation>
+    </element>
+    <element identifier="covid-19-wage-subsidy-scheme-march-2021" xsi:type="BusinessService">
+      <name>COVID-19 Wage Subsidy Scheme (March 2021)</name>
+      <documentation>The COVID-19 Wage Subsidy Scheme (March 2021) provides financial assistance to eligible businesses experiencing a decline in revenue due to a current escalation in COVID-19 Alert Levels.</documentation>
+    </element>
+    <element identifier="disability-allowance" xsi:type="BusinessService">
+      <name>Disability Allowance</name>
+      <documentation>The Disability Allowance is a financial assistance product that provides support to eligible individuals to help cover the additional costs associated with disability.</documentation>
+    </element>
+    <element identifier="early-learning-payment" xsi:type="BusinessService">
+      <name>Early Learning Payment</name>
+      <documentation>Financial assistance product that helps cover the cost of early childhood education for dependent children, including eligibility, fees, absences, and interactions with other childcare assistance.</documentation>
+    </element>
+    <element identifier="emergency-benefit" xsi:type="BusinessService">
+      <name>Emergency Benefit</name>
+      <documentation>A last-resort financial assistance benefit for clients in hardship who cannot qualify for another benefit, with comprehensive eligibility, obligations, payment, and review provisions.</documentation>
+    </element>
+    <element identifier="emergency-housing" xsi:type="BusinessService">
+      <name>Emergency Housing</name>
+      <documentation>Emergency Housing provides grants to clients who have an immediate emergency housing need and cannot access other adequate accommodation.</documentation>
+    </element>
+    <element identifier="emergency-maintenance-allowance" xsi:type="BusinessService">
+      <name>Emergency Maintenance Allowance</name>
+      <documentation>A main benefit providing financial assistance to eligible sole parents and caregivers with detailed rules around qualifications, social obligations, payment, conditions, and mandatory reviews.</documentation>
+    </element>
+    <element identifier="employment-and-work-readiness-assistance" xsi:type="BusinessService">
+      <name>Employment and work readiness assistance</name>
+      <documentation>A comprehensive employment and work readiness assistance framework covering qualifications, residence requirements, income and asset limits, various forms of employment assistance including wage subsidies, Mana in Mahi incentives, work readiness support, career guidance, education and training costs, and related decision-making processes.</documentation>
+    </element>
+    <element identifier="employment-transition-assistance" xsi:type="BusinessService">
+      <name>Employment Transition Assistance</name>
+      <documentation>Employment Transition Assistance is a payment providing financial support during employment transitions with detailed rules around eligibility, income assessment, payment levels, reviews, and debt management.</documentation>
+    </element>
+    <element identifier="extraordinary-care-fund" xsi:type="BusinessService">
+      <name>Extraordinary Care Fund</name>
+      <documentation>A financial assistance fund providing extraordinary care support within the Orphans Benefit and Unsupported Child's Benefit suite, covering eligibility qualifications, applications, payment, and reconsideration of decisions.</documentation>
+    </element>
+    <element identifier="family-tax-credit" xsi:type="BusinessService">
+      <name>Family Tax Credit</name>
+      <documentation>Family Tax Credit is a payment provided to families with dependent children, covering qualifications, payment arrangements, shared care, absence from New Zealand, and appeal rights.</documentation>
+    </element>
+    <element identifier="familyboost-tax-credit" xsi:type="BusinessService">
+      <name>FamilyBoost Tax Credit</name>
+      <documentation>An Inland Revenue tax credit assisting eligible parents and caregivers with remaining early childhood education costs after 20 hours of free ECE and MSD childcare assistance deductions.</documentation>
+    </element>
+    <element identifier="flexi-wage-subsidy" xsi:type="BusinessService">
+      <name>Flexi-wage Subsidy</name>
+      <documentation>An employment assistance product that provides wage subsidies to employers to support clients facing barriers to employment, with payment structured across bands based on disadvantage level and risk.</documentation>
+    </element>
+    <element identifier="flexible-childcare-assistance" xsi:type="BusinessService">
+      <name>Flexible Childcare Assistance</name>
+      <documentation>Flexible Childcare Assistance is an extra help product providing childcare assistance to eligible clients based on residence, age, shared care arrangements, risk of long-term benefit receipt, childcare arrangements, and specified employment activity.</documentation>
+    </element>
+    <element identifier="flexible-funding-assistance" xsi:type="BusinessService">
+      <name>Flexible Funding Assistance</name>
+      <documentation>Financial assistance for clients in emergency housing to address immediate wellbeing needs, subject to income, asset, and residential criteria, governed by the Flexible Funding Programme.</documentation>
+    </element>
+    <element identifier="funeral-grant" xsi:type="BusinessService">
+      <name>Funeral Grant</name>
+      <documentation>A financial assistance product that helps cover reasonable funeral expenses subject to asset and income tests, applicable in various circumstances including overseas deaths and different family situations.</documentation>
+    </element>
+    <element identifier="guaranteed-childcare-assistance-payment" xsi:type="BusinessService">
+      <name>Guaranteed Childcare Assistance Payment</name>
+      <documentation>A childcare assistance payment for young parents, covering qualifications, residence, activity requirements, eligible children, approved early childhood education programmes, payment calculations, absences, debts, and ending conditions.</documentation>
+    </element>
+    <element identifier="holiday-allowance-and-birthday-allowance" xsi:type="BusinessService">
+      <name>Holiday Allowance and Birthday Allowance</name>
+      <documentation>Additional allowances (Holiday and Birthday) provided to eligible caregivers under the Orphans Benefit and Unsupported Child's Benefit products, covering entitlement conditions, payment rules, rates, and review processes.</documentation>
+    </element>
+    <element identifier="home-help" xsi:type="BusinessService">
+      <name>Home Help</name>
+      <documentation>Home Help is an assistance product that provides domestic support to eligible clients through multiple support categories with financial assessment and review processes.</documentation>
+    </element>
+    <element identifier="house-modification-funding" xsi:type="BusinessService">
+      <name>House Modification Funding</name>
+      <documentation>House Modification Funding is an extra help product providing financial assistance for home modifications, subject to income and asset testing with defined qualification criteria and review processes.</documentation>
+    </element>
+    <element identifier="housing-support-products" xsi:type="BusinessService">
+      <name>Housing Support Products</name>
+      <documentation>Housing Support Products are individual financial assistance products for clients needing help to obtain and retain accommodation.</documentation>
+    </element>
+    <element identifier="in-work-tax-credit" xsi:type="BusinessService">
+      <name>In-work tax credit</name>
+      <documentation>A tax credit available to working families with specific exclusions and a grace period provision.</documentation>
+    </element>
+    <element identifier="jobseeker-support-student-hardship" xsi:type="BusinessService">
+      <name>Jobseeker Support Student Hardship</name>
+      <documentation>A hardship-based benefit for students experiencing financial hardship, covering eligibility, obligations, hardship criteria, sanctions, and payment rules under the Jobseeker Support framework.</documentation>
+    </element>
+    <element identifier="jobseeker-support" xsi:type="BusinessService">
+      <name>Jobseeker Support</name>
+      <documentation>A comprehensive main benefit for job seekers and those with health conditions, injuries or disabilities who cannot work, covering eligibility, obligations, sanctions, payment, and reapplication requirements.</documentation>
+    </element>
+    <element identifier="mana-in-mahi" xsi:type="BusinessService">
+      <name>Mana in Mahi</name>
+      <documentation>Mana in Mahi is a specific employment-related assistance product covering qualifications, target group identification, risk assessment for long-term benefit receipt, and assistance for both participants and employers.</documentation>
+    </element>
+    <element identifier="moving-costs-grant" xsi:type="BusinessService">
+      <name>Moving Costs Grant</name>
+      <documentation>The Moving Costs Grant is a financial assistance product that helps eligible clients cover the costs of moving to new accommodation.</documentation>
+    </element>
+    <element identifier="new-employment-transition-grant" xsi:type="BusinessService">
+      <name>New Employment Transition Grant</name>
+      <documentation>A grant providing financial assistance for employment transitions, with criteria around residency, qualifying period, cash assets, sick leave, childcare, and self-employment.</documentation>
+    </element>
+    <element identifier="new-zealand-superannuation" xsi:type="BusinessService">
+      <name>New Zealand Superannuation</name>
+      <documentation>New Zealand Superannuation is a universal superannuation benefit available to eligible New Zealand residents who meet age and residency qualifications, covering eligibility, payment rates, obligations, and mandatory review processes.</documentation>
+    </element>
+    <element identifier="orphans-benefit-and-unsupported-childs-benefit-products" xsi:type="BusinessService">
+      <name>Orphans Benefit and Unsupported Childs Benefit products</name>
+      <documentation>A suite of additional assistance products available to caregivers who meet specific qualifications and are receiving Orphans Benefit or Unsupported Childs Benefit.</documentation>
+    </element>
+    <element identifier="orphans-benefit-and-unsupported-childs-benefit" xsi:type="BusinessService">
+      <name>Orphans Benefit and Unsupported Childs Benefit</name>
+      <documentation>A benefit for caregivers of orphaned or unsupported children that provides financial assistance with detailed rules around qualifications, residence, Oranga Tamariki involvement, payment, obligations, and change management.</documentation>
+    </element>
+    <element identifier="recoverable-assistance-payment" xsi:type="BusinessService">
+      <name>Recoverable Assistance Payment</name>
+      <documentation>A recoverable financial assistance payment for clients with immediate and essential needs, covering diverse categories from clothing and school costs to emergency items, subject to eligibility criteria and hardship obligations.</documentation>
+    </element>
+    <element identifier="relocate-for-work-support" xsi:type="BusinessService">
+      <name>Relocate for Work Support</name>
+      <documentation>Relocate for Work Support provides financial assistance to help eligible clients relocate for work, covering travel and moving expenses subject to eligibility criteria and conditions of grant.</documentation>
+    </element>
+    <element identifier="residential-care-loan" xsi:type="BusinessService">
+      <name>Residential Care Loan</name>
+      <documentation>A loan product providing financial assistance for residential care costs, covering eligibility criteria, loan terms and conditions, repayment, write-off, deferment, and application processes.</documentation>
+    </element>
+    <element identifier="residential-care-subsidy" xsi:type="BusinessService">
+      <name>Residential Care Subsidy</name>
+      <documentation>A subsidy to help eligible people meet the costs of residential (rest home) care, assessed through financial means testing of assets and income, with rules covering gifting, trusts, deprivation, partner situations, and ongoing review processes.</documentation>
+    </element>
+    <element identifier="residential-support-subsidy" xsi:type="BusinessService">
+      <name>Residential Support Subsidy</name>
+      <documentation>Financial assistance product for clients receiving residential support services, covering qualifications, payment structures, application processes, and related extra help entitlements.</documentation>
+    </element>
+    <element identifier="school-and-year-start-up-payment" xsi:type="BusinessService">
+      <name>School and Year Start-up Payment</name>
+      <documentation>A payment available under the Orphans Benefit and Unsupported Child's Benefit products, covering introduction, qualifications, payment details, and changes and reviews.</documentation>
+    </element>
+    <element identifier="seasonal-work-assistance" xsi:type="BusinessService">
+      <name>Seasonal Work Assistance</name>
+      <documentation>Financial assistance for people undertaking seasonal work, particularly in the horticultural and viticultural industries, subject to income and asset testing and a qualifying period.</documentation>
+    </element>
+    <element identifier="social-rehabilitation-assistance" xsi:type="BusinessService">
+      <name>Social Rehabilitation Assistance</name>
+      <documentation>Financial assistance for clients participating in approved social rehabilitation programmes, with income testing, area-based programme approvals, and associated payment and review processes.</documentation>
+    </element>
+    <element identifier="sole-parent-support" xsi:type="BusinessService">
+      <name>Sole Parent Support</name>
+      <documentation>Sole Parent Support is a main benefit providing financial assistance to sole parents caring for dependent children.</documentation>
+    </element>
+    <element identifier="special-benefit" xsi:type="BusinessService">
+      <name>Special Benefit</name>
+      <documentation>A hardship-based financial assistance benefit addressing income deficiency for eligible clients, assessed against allowable costs and chargeable income, with provisions for students, self-employed, non-beneficiaries, and various life circumstances.</documentation>
+    </element>
+    <element identifier="special-disability-allowance" xsi:type="BusinessService">
+      <name>Special Disability Allowance</name>
+      <documentation>A financial allowance paid to a benefit or pension recipient whose partner is hospitalised and receiving a reduced benefit rate, to help cover extra costs associated with their partner's hospitalisation.</documentation>
+    </element>
+    <element identifier="special-needs-grant" xsi:type="BusinessService">
+      <name>Special Needs Grant</name>
+      <documentation>A financial assistance grant providing support for essential and emergency needs including food, dental treatment, health travel, bedding, driver licences, re-establishment grants for refugees and protected persons, civil defence payments, family violence programme payments, and rural assistance.</documentation>
+    </element>
+    <element identifier="special-transfer-allowance" xsi:type="BusinessService">
+      <name>Special Transfer Allowance</name>
+      <documentation>A supplementary allowance providing financial assistance under specific transfer circumstances, with detailed rules around eligibility, payment, and changes in client circumstances.</documentation>
+    </element>
+    <element identifier="specific-employment-related-assistance" xsi:type="BusinessService">
+      <name>Specific employment-related assistance</name>
+      <documentation>Products and services targeted towards moving clients into or helping clients stay in employment, provided in specific situations.</documentation>
+    </element>
+    <element identifier="student-allowance-transfer-grant" xsi:type="BusinessService">
+      <name>Student Allowance Transfer Grant</name>
+      <documentation>A grant providing financial assistance for students transitioning off student allowance, with eligibility based on income, assets, and hardship criteria.</documentation>
+    </element>
+    <element identifier="student-allowance" xsi:type="BusinessService">
+      <name>Student allowance</name>
+      <documentation>The Student Allowance is a financial assistance product providing income support to eligible students in New Zealand, covering eligibility criteria, payment structures, obligations, and review processes.</documentation>
+    </element>
+    <element identifier="student-loan" xsi:type="BusinessService">
+      <name>Student loan</name>
+      <documentation>A government-administered lending product available to eligible students to cover compulsory fees, course-related costs, and living costs, governed by the Student Loan Scheme Act and administered in conjunction with Inland Revenue.</documentation>
+    </element>
+    <element identifier="supported-living-payment" xsi:type="BusinessService">
+      <name>Supported Living Payment</name>
+      <documentation>Main benefit providing financial assistance to clients with permanent and severe health conditions, injuries or disabilities, or those caring full-time for a person requiring full-time care and attention.</documentation>
+    </element>
+    <element identifier="temporary-accommodation-assistance-niwe" xsi:type="BusinessService">
+      <name>Temporary Accommodation Assistance</name>
+      <documentation>Temporary Accommodation Assistance provides financial support to homeowners whose homes have been affected by a natural disaster or weather event, leaving them with temporary accommodation costs.</documentation>
+    </element>
+    <element identifier="temporary-additional-support" xsi:type="BusinessService">
+      <name>Temporary Additional Support</name>
+      <documentation>A formula-assessed financial assistance product providing supplementary support where a client's allowable essential costs exceed their chargeable income and standard costs, subject to eligibility criteria including residency, cash assets test, and dependent child requirements.</documentation>
+    </element>
+    <element identifier="tenancy-costs-cover" xsi:type="BusinessService">
+      <name>Tenancy Costs Cover</name>
+      <documentation>Tenancy Costs Cover is a housing support product providing financial assistance to clients experiencing difficulty obtaining or retaining alternative housing, covering specific tenancy costs for accommodation subject to the Residential Tenancies Act 1986.</documentation>
+    </element>
+    <element identifier="training-incentive-allowance" xsi:type="BusinessService">
+      <name>Training Incentive Allowance</name>
+      <documentation>Financial assistance provided to eligible clients to help cover costs associated with studying a recognised course of study.</documentation>
+    </element>
+    <element identifier="transition-to-alternative-housing-grant" xsi:type="BusinessService">
+      <name>Transition to Alternative Housing Grant</name>
+      <documentation>A grant to assist clients in transitioning to alternative housing covered by the Residential Tenancies Act 1986.</documentation>
+    </element>
+    <element identifier="vehicle-modification-funding" xsi:type="BusinessService">
+      <name>Vehicle Modification Funding</name>
+      <documentation>Financial assistance product for vehicle modifications, subject to income and asset tests, with defined qualifications and payment rules.</documentation>
+    </element>
+    <element identifier="veterans-pension" xsi:type="BusinessService">
+      <name>Veterans Pension</name>
+      <documentation>The Veterans Pension is a main benefit available under the Veterans Support Act 2014 for eligible veterans and their partners, covering qualifications, payment rates, and comprehensive provisions for changes, reviews, absence, obligations, deductions, taxation, and death.</documentation>
+    </element>
+    <element identifier="winter-energy-payment" xsi:type="BusinessService">
+      <name>Winter Energy Payment</name>
+      <documentation>A seasonal payment made to eligible benefit recipients to assist with energy costs during winter, with specific rules around qualifications, rates, circumstances, absences, deductions and interactions with other assistance.</documentation>
+    </element>
+    <element identifier="work-bonus" xsi:type="BusinessService">
+      <name>Work Bonus</name>
+      <documentation>Work Bonus is an employment-related assistance product for clients transitioning into paid employment, covering qualifications, benefit eligibility, payment rules, income exemptions, interaction with other assistance, debt recovery at cancellation, and client re-application provisions.</documentation>
+    </element>
+    <element identifier="young-parent-payment" xsi:type="BusinessService">
+      <name>Young Parent Payment</name>
+      <documentation>A welfare benefit for young parents under 20 with dependent children, subject to activity obligations and youth money management, with provisions for exemptions, sanctions, and transitions.</documentation>
+    </element>
+    <element identifier="youth-payment" xsi:type="BusinessService">
+      <name>Youth Payment</name>
+      <documentation>A financial assistance product for eligible young people, incorporating activity obligations, youth money management, incentive payments, and comprehensive rules around qualifications, income, residence, absences, and sanctions.</documentation>
+    </element>
+    <element identifier="childcare-assistance-programme" xsi:type="BusinessFunction">
+      <name>Childcare Assistance Programme</name>
+      <documentation>A programme providing financial assistance for childcare costs through the Childcare Subsidy and OSCAR Subsidy, including rules on eligibility, income testing, payment, absences, and reviews.</documentation>
+    </element>
+    <element identifier="income-related-rent-subsidy" xsi:type="BusinessService">
+      <name>Income Related Rent Subsidy</name>
+      <documentation>A subsidy paid to social housing providers covering the gap between a tenant's income-related rent and the market or agreed rent rate.</documentation>
+    </element>
+    <element identifier="income-related-rent" xsi:type="BusinessService">
+      <name>Income Related Rent</name>
+      <documentation>Income Related Rent (IRR) is a social housing service that calculates and manages rent charged to eligible tenants based on their income rather than market rates.</documentation>
+    </element>
+  </elements>
+  <relationships>
+    <relationship identifier="rel-community-services-card--new-zealand-superannuation--association" xsi:type="Association" source="community-services-card" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-community-services-card--definition-of-income--association" xsi:type="Association" source="community-services-card" target="definition-of-income"/>
+    <relationship identifier="rel-community-services-card--residence--association" xsi:type="Association" source="community-services-card" target="residence"/>
+    <relationship identifier="rel-community-services-card--income--association" xsi:type="Association" source="community-services-card" target="income"/>
+    <relationship identifier="rel-supergold-card--new-zealand-superannuation--association" xsi:type="Association" source="supergold-card" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-supergold-card--veterans-pension--association" xsi:type="Association" source="supergold-card" target="veterans-pension"/>
+    <relationship identifier="rel-supergold-card--reviews-and-appeals--serving" xsi:type="Serving" source="supergold-card" target="reviews-and-appeals"/>
+    <relationship identifier="rel-child-support-income--child-support--association" xsi:type="Association" source="child-support-income" target="child-support"/>
+    <relationship identifier="rel-child-support-income--income--association" xsi:type="Association" source="child-support-income" target="income"/>
+    <relationship identifier="rel-child-support-income--types-of-income--association" xsi:type="Association" source="child-support-income" target="types-of-income"/>
+    <relationship identifier="rel-child-support-income--definition-of-income--association" xsi:type="Association" source="child-support-income" target="definition-of-income"/>
+    <relationship identifier="rel-child-support-income--sole-parent-support--association" xsi:type="Association" source="child-support-income" target="sole-parent-support"/>
+    <relationship identifier="rel-child-support-income--jobseeker-support--association" xsi:type="Association" source="child-support-income" target="jobseeker-support"/>
+    <relationship identifier="rel-child-support-income--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="child-support-income" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-definition-of-income--income--association" xsi:type="Association" source="definition-of-income" target="income"/>
+    <relationship identifier="rel-definition-of-income--types-of-income--association" xsi:type="Association" source="definition-of-income" target="types-of-income"/>
+    <relationship identifier="rel-definition-of-income--employment-related-income--association" xsi:type="Association" source="definition-of-income" target="employment-related-income"/>
+    <relationship identifier="rel-definition-of-income--child-support-income--association" xsi:type="Association" source="definition-of-income" target="child-support-income"/>
+    <relationship identifier="rel-employment-related-income--income--association" xsi:type="Association" source="employment-related-income" target="income"/>
+    <relationship identifier="rel-employment-related-income--types-of-income--association" xsi:type="Association" source="employment-related-income" target="types-of-income"/>
+    <relationship identifier="rel-employment-related-income--definition-of-income--association" xsi:type="Association" source="employment-related-income" target="definition-of-income"/>
+    <relationship identifier="rel-income-related-rent-debt--duty-to-advise-of-changes-in-circumstances--association" xsi:type="Association" source="income-related-rent-debt" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-income-related-rent-debt--reviews-and-appeals--association" xsi:type="Association" source="income-related-rent-debt" target="reviews-and-appeals"/>
+    <relationship identifier="rel-income-related-rent-debt--income-related-rent--association" xsi:type="Association" source="income-related-rent-debt" target="income-related-rent"/>
+    <relationship identifier="rel-income-related-rent-debt--income-related-rent-subsidy--association" xsi:type="Association" source="income-related-rent-debt" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-income--definition-of-income--association" xsi:type="Association" source="income" target="definition-of-income"/>
+    <relationship identifier="rel-income--types-of-income--association" xsi:type="Association" source="income" target="types-of-income"/>
+    <relationship identifier="rel-income--employment-related-income--association" xsi:type="Association" source="income" target="employment-related-income"/>
+    <relationship identifier="rel-income--child-support-income--association" xsi:type="Association" source="income" target="child-support-income"/>
+    <relationship identifier="rel-payments-from-overseas--new-zealand-superannuation--association" xsi:type="Association" source="payments-from-overseas" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-payments-from-overseas--veterans-pension--association" xsi:type="Association" source="payments-from-overseas" target="veterans-pension"/>
+    <relationship identifier="rel-payments-from-overseas--accommodation-supplement--association" xsi:type="Association" source="payments-from-overseas" target="accommodation-supplement"/>
+    <relationship identifier="rel-payments-from-overseas--payments-from-overseas--association" xsi:type="Association" source="payments-from-overseas" target="payments-from-overseas"/>
+    <relationship identifier="rel-payments-from-overseas--reciprocal-agreements--association" xsi:type="Association" source="payments-from-overseas" target="reciprocal-agreements"/>
+    <relationship identifier="rel-residence--pre-benefit-requirements--association" xsi:type="Association" source="residence" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-residence--relationship-status-for-benefit--association" xsi:type="Association" source="residence" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-residence--application-for-benefit--association" xsi:type="Association" source="residence" target="application-for-benefit"/>
+    <relationship identifier="rel-residence--assessment-of-eligibility--association" xsi:type="Association" source="residence" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-residence--reciprocal-agreements--association" xsi:type="Association" source="residence" target="reciprocal-agreements"/>
+    <relationship identifier="rel-types-of-income--accommodation-supplement--association" xsi:type="Association" source="types-of-income" target="accommodation-supplement"/>
+    <relationship identifier="rel-types-of-income--child-disability-allowance--association" xsi:type="Association" source="types-of-income" target="child-disability-allowance"/>
+    <relationship identifier="rel-types-of-income--disability-allowance--association" xsi:type="Association" source="types-of-income" target="disability-allowance"/>
+    <relationship identifier="rel-types-of-income--temporary-additional-support--association" xsi:type="Association" source="types-of-income" target="temporary-additional-support"/>
+    <relationship identifier="rel-types-of-income--special-benefit--association" xsi:type="Association" source="types-of-income" target="special-benefit"/>
+    <relationship identifier="rel-types-of-income--residential-care-subsidy--association" xsi:type="Association" source="types-of-income" target="residential-care-subsidy"/>
+    <relationship identifier="rel-types-of-income--cost-of-living-payment--association" xsi:type="Association" source="types-of-income" target="cost-of-living-payment"/>
+    <relationship identifier="rel-types-of-income--income--association" xsi:type="Association" source="types-of-income" target="income"/>
+    <relationship identifier="rel-types-of-income--definition-of-income--association" xsi:type="Association" source="types-of-income" target="definition-of-income"/>
+    <relationship identifier="rel-types-of-income--employment-related-income--association" xsi:type="Association" source="types-of-income" target="employment-related-income"/>
+    <relationship identifier="rel-types-of-income--child-support-income--association" xsi:type="Association" source="types-of-income" target="child-support-income"/>
+    <relationship identifier="rel-child-support--child-support-income--influence" xsi:type="Influence" source="child-support" target="child-support-income"/>
+    <relationship identifier="rel-child-support--income--influence" xsi:type="Influence" source="child-support" target="income"/>
+    <relationship identifier="rel-child-support--types-of-income--influence" xsi:type="Influence" source="child-support" target="types-of-income"/>
+    <relationship identifier="rel-general-portability--new-zealand-superannuation--influence" xsi:type="Influence" source="general-portability" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-general-portability--veterans-pension--influence" xsi:type="Influence" source="general-portability" target="veterans-pension"/>
+    <relationship identifier="rel-general-portability--portability--influence" xsi:type="Influence" source="general-portability" target="portability"/>
+    <relationship identifier="rel-general-portability--special-portability--influence" xsi:type="Influence" source="general-portability" target="special-portability"/>
+    <relationship identifier="rel-general-portability--reciprocal-agreements--influence" xsi:type="Influence" source="general-portability" target="reciprocal-agreements"/>
+    <relationship identifier="rel-general-portability--reviews-and-appeals--influence" xsi:type="Influence" source="general-portability" target="reviews-and-appeals"/>
+    <relationship identifier="rel-general-portability--residence--association" xsi:type="Association" source="general-portability" target="residence"/>
+    <relationship identifier="rel-general-portability--payments-from-overseas--association" xsi:type="Association" source="general-portability" target="payments-from-overseas"/>
+    <relationship identifier="rel-portability--new-zealand-superannuation--influence" xsi:type="Influence" source="portability" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-portability--veterans-pension--influence" xsi:type="Influence" source="portability" target="veterans-pension"/>
+    <relationship identifier="rel-portability--general-portability--influence" xsi:type="Influence" source="portability" target="general-portability"/>
+    <relationship identifier="rel-portability--special-portability--influence" xsi:type="Influence" source="portability" target="special-portability"/>
+    <relationship identifier="rel-portability--reciprocal-agreements--influence" xsi:type="Influence" source="portability" target="reciprocal-agreements"/>
+    <relationship identifier="rel-pre-benefit-requirements--jobseeker-support--influence" xsi:type="Influence" source="pre-benefit-requirements" target="jobseeker-support"/>
+    <relationship identifier="rel-pre-benefit-requirements--assessment-of-eligibility--influence" xsi:type="Influence" source="pre-benefit-requirements" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-pre-benefit-requirements--reviews-and-appeals--influence" xsi:type="Influence" source="pre-benefit-requirements" target="reviews-and-appeals"/>
+    <relationship identifier="rel-pre-benefit-requirements--application-for-benefit--influence" xsi:type="Influence" source="pre-benefit-requirements" target="application-for-benefit"/>
+    <relationship identifier="rel-reciprocal-agreements--portability--influence" xsi:type="Influence" source="reciprocal-agreements" target="portability"/>
+    <relationship identifier="rel-reciprocal-agreements--payments-from-overseas--association" xsi:type="Association" source="reciprocal-agreements" target="payments-from-overseas"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-australia--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-australia"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-canada--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-canada"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-denmark--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-denmark"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-hellenic-republic--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-hellenic-republic"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-ireland--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-ireland"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-jersey-guernsey--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-jersey-guernsey"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-republic-of-korea--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-republic-of-korea"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-malta--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-malta"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-netherlands--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-netherlands"/>
+    <relationship identifier="rel-reciprocal-agreements--reciprocal-united-kingdom--influence" xsi:type="Influence" source="reciprocal-agreements" target="reciprocal-united-kingdom"/>
+    <relationship identifier="rel-reciprocal-australia--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-australia" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-australia--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-australia" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-australia--veterans-pension--influence" xsi:type="Influence" source="reciprocal-australia" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-australia--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-australia" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-australia--portability--influence" xsi:type="Influence" source="reciprocal-australia" target="portability"/>
+    <relationship identifier="rel-reciprocal-australia--general-portability--influence" xsi:type="Influence" source="reciprocal-australia" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-australia--special-portability--influence" xsi:type="Influence" source="reciprocal-australia" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-australia--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-australia" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-australia--payments-from-overseas--association" xsi:type="Association" source="reciprocal-australia" target="payments-from-overseas"/>
+    <relationship identifier="rel-reciprocal-canada--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-canada" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-canada--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-canada" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-canada--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-canada" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-canada--veterans-pension--influence" xsi:type="Influence" source="reciprocal-canada" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-canada--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-canada" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-canada--portability--influence" xsi:type="Influence" source="reciprocal-canada" target="portability"/>
+    <relationship identifier="rel-reciprocal-canada--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-canada" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-denmark--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-denmark" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-denmark--veterans-pension--influence" xsi:type="Influence" source="reciprocal-denmark" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-denmark--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-denmark" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-denmark--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-denmark" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-denmark--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-denmark" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-denmark--portability--influence" xsi:type="Influence" source="reciprocal-denmark" target="portability"/>
+    <relationship identifier="rel-reciprocal-denmark--general-portability--influence" xsi:type="Influence" source="reciprocal-denmark" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-denmark--special-portability--influence" xsi:type="Influence" source="reciprocal-denmark" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-denmark--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-denmark" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--veterans-pension--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--orphans-benefit-and-unsupported-childs-benefit--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--funeral-grant--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="funeral-grant"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--portability--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="portability"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--general-portability--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--special-portability--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-hellenic-republic--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-hellenic-republic" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-ireland--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-ireland" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-ireland--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-ireland" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-ireland--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-ireland" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-ireland--orphans-benefit-and-unsupported-childs-benefit--influence" xsi:type="Influence" source="reciprocal-ireland" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-reciprocal-ireland--veterans-pension--influence" xsi:type="Influence" source="reciprocal-ireland" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-ireland--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-ireland" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-ireland--portability--influence" xsi:type="Influence" source="reciprocal-ireland" target="portability"/>
+    <relationship identifier="rel-reciprocal-ireland--general-portability--influence" xsi:type="Influence" source="reciprocal-ireland" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-ireland--special-portability--influence" xsi:type="Influence" source="reciprocal-ireland" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-ireland--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-ireland" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--jobseeker-support--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="jobseeker-support"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--veterans-pension--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--general-portability--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--special-portability--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--portability--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="portability"/>
+    <relationship identifier="rel-reciprocal-jersey-guernsey--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-jersey-guernsey" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-malta--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-malta" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-malta--veterans-pension--influence" xsi:type="Influence" source="reciprocal-malta" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-malta--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-malta" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-malta--portability--influence" xsi:type="Influence" source="reciprocal-malta" target="portability"/>
+    <relationship identifier="rel-reciprocal-netherlands--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-netherlands" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-netherlands--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-netherlands" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-netherlands--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-netherlands" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-netherlands--veterans-pension--influence" xsi:type="Influence" source="reciprocal-netherlands" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-netherlands--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-netherlands" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-netherlands--portability--influence" xsi:type="Influence" source="reciprocal-netherlands" target="portability"/>
+    <relationship identifier="rel-reciprocal-netherlands--general-portability--influence" xsi:type="Influence" source="reciprocal-netherlands" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-netherlands--special-portability--influence" xsi:type="Influence" source="reciprocal-netherlands" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-republic-of-korea--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-republic-of-korea" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-republic-of-korea--veterans-pension--influence" xsi:type="Influence" source="reciprocal-republic-of-korea" target="veterans-pension"/>
+    <relationship identifier="rel-reciprocal-republic-of-korea--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-republic-of-korea" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-republic-of-korea--portability--influence" xsi:type="Influence" source="reciprocal-republic-of-korea" target="portability"/>
+    <relationship identifier="rel-reciprocal-republic-of-korea--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-republic-of-korea" target="reviews-and-appeals"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--jobseeker-support--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="jobseeker-support"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--supported-living-payment--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="supported-living-payment"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--new-zealand-superannuation--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--sole-parent-support--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="sole-parent-support"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--reciprocal-agreements--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="reciprocal-agreements"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--portability--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="portability"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--general-portability--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="general-portability"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--special-portability--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="special-portability"/>
+    <relationship identifier="rel-reciprocal-united-kingdom--reviews-and-appeals--influence" xsi:type="Influence" source="reciprocal-united-kingdom" target="reviews-and-appeals"/>
+    <relationship identifier="rel-relationship-status-for-benefit--jobseeker-support--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="jobseeker-support"/>
+    <relationship identifier="rel-relationship-status-for-benefit--sole-parent-support--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="sole-parent-support"/>
+    <relationship identifier="rel-relationship-status-for-benefit--supported-living-payment--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="supported-living-payment"/>
+    <relationship identifier="rel-relationship-status-for-benefit--emergency-benefit--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="emergency-benefit"/>
+    <relationship identifier="rel-relationship-status-for-benefit--new-zealand-superannuation--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-relationship-status-for-benefit--veterans-pension--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="veterans-pension"/>
+    <relationship identifier="rel-relationship-status-for-benefit--young-parent-payment--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="young-parent-payment"/>
+    <relationship identifier="rel-relationship-status-for-benefit--youth-payment--influence" xsi:type="Influence" source="relationship-status-for-benefit" target="youth-payment"/>
+    <relationship identifier="rel-special-portability--new-zealand-superannuation--influence" xsi:type="Influence" source="special-portability" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-special-portability--veterans-pension--influence" xsi:type="Influence" source="special-portability" target="veterans-pension"/>
+    <relationship identifier="rel-special-portability--portability--influence" xsi:type="Influence" source="special-portability" target="portability"/>
+    <relationship identifier="rel-special-portability--general-portability--influence" xsi:type="Influence" source="special-portability" target="general-portability"/>
+    <relationship identifier="rel-special-portability--reciprocal-agreements--influence" xsi:type="Influence" source="special-portability" target="reciprocal-agreements"/>
+    <relationship identifier="rel-use-of-social-housing-benefit-and-student-information--income-related-rent--influence" xsi:type="Influence" source="use-of-social-housing-benefit-and-student-information" target="income-related-rent"/>
+    <relationship identifier="rel-use-of-social-housing-benefit-and-student-information--income-related-rent-subsidy--influence" xsi:type="Influence" source="use-of-social-housing-benefit-and-student-information" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-use-of-social-housing-benefit-and-student-information--student-allowance--influence" xsi:type="Influence" source="use-of-social-housing-benefit-and-student-information" target="student-allowance"/>
+    <relationship identifier="rel-use-of-social-housing-benefit-and-student-information--student-loan--influence" xsi:type="Influence" source="use-of-social-housing-benefit-and-student-information" target="student-loan"/>
+    <relationship identifier="rel-use-of-social-housing-benefit-and-student-information--assessment-of-eligibility--influence" xsi:type="Influence" source="use-of-social-housing-benefit-and-student-information" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-warrant-to-arrest--jobseeker-support--influence" xsi:type="Influence" source="warrant-to-arrest" target="jobseeker-support"/>
+    <relationship identifier="rel-warrant-to-arrest--sole-parent-support--influence" xsi:type="Influence" source="warrant-to-arrest" target="sole-parent-support"/>
+    <relationship identifier="rel-warrant-to-arrest--supported-living-payment--influence" xsi:type="Influence" source="warrant-to-arrest" target="supported-living-payment"/>
+    <relationship identifier="rel-warrant-to-arrest--orphans-benefit-and-unsupported-childs-benefit--influence" xsi:type="Influence" source="warrant-to-arrest" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-warrant-to-arrest--new-zealand-superannuation--influence" xsi:type="Influence" source="warrant-to-arrest" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-warrant-to-arrest--emergency-benefit--influence" xsi:type="Influence" source="warrant-to-arrest" target="emergency-benefit"/>
+    <relationship identifier="rel-application-for-assistance--requests-for-financial-assistance--association" xsi:type="Association" source="application-for-assistance" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-application-for-assistance--application-for-benefit--association" xsi:type="Association" source="application-for-assistance" target="application-for-benefit"/>
+    <relationship identifier="rel-application-for-assistance--re-assessing-previous-applications--association" xsi:type="Association" source="application-for-assistance" target="re-assessing-previous-applications"/>
+    <relationship identifier="rel-application-for-assistance--reviews-and-appeals--association" xsi:type="Association" source="application-for-assistance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-application-for-benefit--pre-benefit-requirements--influence" xsi:type="Influence" source="application-for-benefit" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-application-for-benefit--requests-for-financial-assistance--association" xsi:type="Association" source="application-for-benefit" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-application-for-benefit--application-for-assistance--association" xsi:type="Association" source="application-for-benefit" target="application-for-assistance"/>
+    <relationship identifier="rel-application-for-benefit--re-assessing-previous-applications--association" xsi:type="Association" source="application-for-benefit" target="re-assessing-previous-applications"/>
+    <relationship identifier="rel-assessment-of-eligibility--emergency-housing--serving" xsi:type="Serving" source="assessment-of-eligibility" target="emergency-housing"/>
+    <relationship identifier="rel-assessment-of-eligibility--orphans-benefit-and-unsupported-childs-benefit--serving" xsi:type="Serving" source="assessment-of-eligibility" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-assessment-of-eligibility--income-related-rent--association" xsi:type="Association" source="assessment-of-eligibility" target="income-related-rent"/>
+    <relationship identifier="rel-assessment-of-eligibility--income-related-rent-debt--association" xsi:type="Association" source="assessment-of-eligibility" target="income-related-rent-debt"/>
+    <relationship identifier="rel-assessment-of-eligibility--income-related-rent-subsidy--association" xsi:type="Association" source="assessment-of-eligibility" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-assessment-of-eligibility--register-management-and-referrals--association" xsi:type="Association" source="assessment-of-eligibility" target="register-management-and-referrals"/>
+    <relationship identifier="rel-assessment-of-eligibility--tenancy-reviews--association" xsi:type="Association" source="assessment-of-eligibility" target="tenancy-reviews"/>
+    <relationship identifier="rel-assessment-of-eligibility--reviews-and-appeals--association" xsi:type="Association" source="assessment-of-eligibility" target="reviews-and-appeals"/>
+    <relationship identifier="rel-assessment-of-eligibility--duty-to-advise-of-changes-in-circumstances--association" xsi:type="Association" source="assessment-of-eligibility" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-assessment-of-eligibility--residence--association" xsi:type="Association" source="assessment-of-eligibility" target="residence"/>
+    <relationship identifier="rel-assessment-of-eligibility--income--association" xsi:type="Association" source="assessment-of-eligibility" target="income"/>
+    <relationship identifier="rel-assessment-of-eligibility--child-support-income--association" xsi:type="Association" source="assessment-of-eligibility" target="child-support-income"/>
+    <relationship identifier="rel-current-client-debt--reviews-and-appeals--association" xsi:type="Association" source="current-client-debt" target="reviews-and-appeals"/>
+    <relationship identifier="rel-current-client-debt--relationship-debt-sharing--association" xsi:type="Association" source="current-client-debt" target="relationship-debt-sharing"/>
+    <relationship identifier="rel-current-client-debt--income-related-rent-debt--association" xsi:type="Association" source="current-client-debt" target="income-related-rent-debt"/>
+    <relationship identifier="rel-current-client-debt--redirection-of-benefit-payment--association" xsi:type="Association" source="current-client-debt" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--assessment-of-eligibility--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--tenancy-reviews--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="tenancy-reviews"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--register-management-and-referrals--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="register-management-and-referrals"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--child-support-income--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="child-support-income"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--income-related-rent--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="income-related-rent"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--income-related-rent-debt--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="income-related-rent-debt"/>
+    <relationship identifier="rel-duty-to-advise-of-changes-in-circumstances--income-related-rent-subsidy--association" xsi:type="Association" source="duty-to-advise-of-changes-in-circumstances" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-re-assessing-previous-applications--requests-for-financial-assistance--association" xsi:type="Association" source="re-assessing-previous-applications" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-re-assessing-previous-applications--application-for-assistance--association" xsi:type="Association" source="re-assessing-previous-applications" target="application-for-assistance"/>
+    <relationship identifier="rel-re-assessing-previous-applications--application-for-benefit--association" xsi:type="Association" source="re-assessing-previous-applications" target="application-for-benefit"/>
+    <relationship identifier="rel-re-assessing-previous-applications--reviews-and-appeals--association" xsi:type="Association" source="re-assessing-previous-applications" target="reviews-and-appeals"/>
+    <relationship identifier="rel-redirection-of-benefit-payment--emergency-housing--association" xsi:type="Association" source="redirection-of-benefit-payment" target="emergency-housing"/>
+    <relationship identifier="rel-redirection-of-benefit-payment--income-related-rent--association" xsi:type="Association" source="redirection-of-benefit-payment" target="income-related-rent"/>
+    <relationship identifier="rel-redirection-of-benefit-payment--reviews-and-appeals--association" xsi:type="Association" source="redirection-of-benefit-payment" target="reviews-and-appeals"/>
+    <relationship identifier="rel-register-management-and-referrals--emergency-housing--serving" xsi:type="Serving" source="register-management-and-referrals" target="emergency-housing"/>
+    <relationship identifier="rel-register-management-and-referrals--warrant-to-arrest--influence" xsi:type="Influence" source="register-management-and-referrals" target="warrant-to-arrest"/>
+    <relationship identifier="rel-register-management-and-referrals--assessment-of-eligibility--association" xsi:type="Association" source="register-management-and-referrals" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-register-management-and-referrals--duty-to-advise-of-changes-in-circumstances--association" xsi:type="Association" source="register-management-and-referrals" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-register-management-and-referrals--reviews-and-appeals--association" xsi:type="Association" source="register-management-and-referrals" target="reviews-and-appeals"/>
+    <relationship identifier="rel-register-management-and-referrals--income-related-rent-debt--association" xsi:type="Association" source="register-management-and-referrals" target="income-related-rent-debt"/>
+    <relationship identifier="rel-register-management-and-referrals--income-related-rent--serving" xsi:type="Serving" source="register-management-and-referrals" target="income-related-rent"/>
+    <relationship identifier="rel-register-management-and-referrals--income-related-rent-subsidy--serving" xsi:type="Serving" source="register-management-and-referrals" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-requests-for-financial-assistance--application-for-assistance--association" xsi:type="Association" source="requests-for-financial-assistance" target="application-for-assistance"/>
+    <relationship identifier="rel-requests-for-financial-assistance--application-for-benefit--association" xsi:type="Association" source="requests-for-financial-assistance" target="application-for-benefit"/>
+    <relationship identifier="rel-requests-for-financial-assistance--definition-of-income--association" xsi:type="Association" source="requests-for-financial-assistance" target="definition-of-income"/>
+    <relationship identifier="rel-reviews-and-appeals--child-support--influence" xsi:type="Influence" source="reviews-and-appeals" target="child-support"/>
+    <relationship identifier="rel-reviews-and-appeals--reciprocal-agreements--association" xsi:type="Association" source="reviews-and-appeals" target="reciprocal-agreements"/>
+    <relationship identifier="rel-tenancy-reviews--assessment-of-eligibility--association" xsi:type="Association" source="tenancy-reviews" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-tenancy-reviews--register-management-and-referrals--association" xsi:type="Association" source="tenancy-reviews" target="register-management-and-referrals"/>
+    <relationship identifier="rel-tenancy-reviews--duty-to-advise-of-changes-in-circumstances--association" xsi:type="Association" source="tenancy-reviews" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-tenancy-reviews--reviews-and-appeals--association" xsi:type="Association" source="tenancy-reviews" target="reviews-and-appeals"/>
+    <relationship identifier="rel-tenancy-reviews--income-related-rent--serving" xsi:type="Serving" source="tenancy-reviews" target="income-related-rent"/>
+    <relationship identifier="rel-tenancy-reviews--income-related-rent-subsidy--serving" xsi:type="Serving" source="tenancy-reviews" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-youth-service-information-sharing--youth-payment--serving" xsi:type="Serving" source="youth-service-information-sharing" target="youth-payment"/>
+    <relationship identifier="rel-youth-service-information-sharing--young-parent-payment--serving" xsi:type="Serving" source="youth-service-information-sharing" target="young-parent-payment"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--housing-support-products--association" xsi:type="Association" source="accommodation-costs-arrears-grant" target="housing-support-products"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--accommodation-supplement--association" xsi:type="Association" source="accommodation-costs-arrears-grant" target="accommodation-supplement"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--recoverable-assistance-payment--association" xsi:type="Association" source="accommodation-costs-arrears-grant" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--reviews-and-appeals--serving" xsi:type="Serving" source="accommodation-costs-arrears-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--tenancy-reviews--serving" xsi:type="Serving" source="accommodation-costs-arrears-grant" target="tenancy-reviews"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--residence--association" xsi:type="Association" source="accommodation-costs-arrears-grant" target="residence"/>
+    <relationship identifier="rel-accommodation-costs-arrears-grant--income--association" xsi:type="Association" source="accommodation-costs-arrears-grant" target="income"/>
+    <relationship identifier="rel-accommodation-costs-in-advance-grant--housing-support-products--association" xsi:type="Association" source="accommodation-costs-in-advance-grant" target="housing-support-products"/>
+    <relationship identifier="rel-accommodation-costs-in-advance-grant--reviews-and-appeals--serving" xsi:type="Serving" source="accommodation-costs-in-advance-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-accommodation-costs-in-advance-grant--residence--association" xsi:type="Association" source="accommodation-costs-in-advance-grant" target="residence"/>
+    <relationship identifier="rel-accommodation-costs-in-advance-grant--income--association" xsi:type="Association" source="accommodation-costs-in-advance-grant" target="income"/>
+    <relationship identifier="rel-accommodation-security-cover-grant--housing-support-products--association" xsi:type="Association" source="accommodation-security-cover-grant" target="housing-support-products"/>
+    <relationship identifier="rel-accommodation-security-cover-grant--accommodation-supplement--association" xsi:type="Association" source="accommodation-security-cover-grant" target="accommodation-supplement"/>
+    <relationship identifier="rel-accommodation-security-cover-grant--reviews-and-appeals--serving" xsi:type="Serving" source="accommodation-security-cover-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-accommodation-security-cover-grant--residence--association" xsi:type="Association" source="accommodation-security-cover-grant" target="residence"/>
+    <relationship identifier="rel-accommodation-security-cover-grant--income--association" xsi:type="Association" source="accommodation-security-cover-grant" target="income"/>
+    <relationship identifier="rel-accommodation-supplement--housing-support-products--association" xsi:type="Association" source="accommodation-supplement" target="housing-support-products"/>
+    <relationship identifier="rel-accommodation-supplement--temporary-additional-support--association" xsi:type="Association" source="accommodation-supplement" target="temporary-additional-support"/>
+    <relationship identifier="rel-accommodation-supplement--emergency-housing--association" xsi:type="Association" source="accommodation-supplement" target="emergency-housing"/>
+    <relationship identifier="rel-accommodation-supplement--jobseeker-support--association" xsi:type="Association" source="accommodation-supplement" target="jobseeker-support"/>
+    <relationship identifier="rel-accommodation-supplement--sole-parent-support--association" xsi:type="Association" source="accommodation-supplement" target="sole-parent-support"/>
+    <relationship identifier="rel-accommodation-supplement--supported-living-payment--association" xsi:type="Association" source="accommodation-supplement" target="supported-living-payment"/>
+    <relationship identifier="rel-accommodation-supplement--new-zealand-superannuation--association" xsi:type="Association" source="accommodation-supplement" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-accommodation-supplement--veterans-pension--association" xsi:type="Association" source="accommodation-supplement" target="veterans-pension"/>
+    <relationship identifier="rel-accommodation-supplement--emergency-benefit--association" xsi:type="Association" source="accommodation-supplement" target="emergency-benefit"/>
+    <relationship identifier="rel-accommodation-supplement--income-related-rent--association" xsi:type="Association" source="accommodation-supplement" target="income-related-rent"/>
+    <relationship identifier="rel-accommodation-supplement--special-benefit--association" xsi:type="Association" source="accommodation-supplement" target="special-benefit"/>
+    <relationship identifier="rel-accommodation-supplement--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="accommodation-supplement" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-accommodation-supplement--young-parent-payment--association" xsi:type="Association" source="accommodation-supplement" target="young-parent-payment"/>
+    <relationship identifier="rel-accommodation-supplement--student-allowance--association" xsi:type="Association" source="accommodation-supplement" target="student-allowance"/>
+    <relationship identifier="rel-accommodation-supplement--child-disability-allowance--association" xsi:type="Association" source="accommodation-supplement" target="child-disability-allowance"/>
+    <relationship identifier="rel-accommodation-supplement--winter-energy-payment--association" xsi:type="Association" source="accommodation-supplement" target="winter-energy-payment"/>
+    <relationship identifier="rel-accommodation-supplement--relationship-status-for-benefit--influence" xsi:type="Influence" source="accommodation-supplement" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-accommodation-supplement--reviews-and-appeals--serving" xsi:type="Serving" source="accommodation-supplement" target="reviews-and-appeals"/>
+    <relationship identifier="rel-accommodation-supplement--requests-for-financial-assistance--serving" xsi:type="Serving" source="accommodation-supplement" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-accommodation-supplement--application-for-assistance--serving" xsi:type="Serving" source="accommodation-supplement" target="application-for-assistance"/>
+    <relationship identifier="rel-accommodation-supplement--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="accommodation-supplement" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-accommodation-supplement--current-client-debt--serving" xsi:type="Serving" source="accommodation-supplement" target="current-client-debt"/>
+    <relationship identifier="rel-accommodation-supplement--residence--association" xsi:type="Association" source="accommodation-supplement" target="residence"/>
+    <relationship identifier="rel-accommodation-supplement--income--association" xsi:type="Association" source="accommodation-supplement" target="income"/>
+    <relationship identifier="rel-accommodation-supplement--reciprocal-agreements--association" xsi:type="Association" source="accommodation-supplement" target="reciprocal-agreements"/>
+    <relationship identifier="rel-accommodation-supplement--portability--association" xsi:type="Association" source="accommodation-supplement" target="portability"/>
+    <relationship identifier="rel-accommodation-supplement--general-portability--association" xsi:type="Association" source="accommodation-supplement" target="general-portability"/>
+    <relationship identifier="rel-advance-payment-of-benefit--income-related-rent-debt--association" xsi:type="Association" source="advance-payment-of-benefit" target="income-related-rent-debt"/>
+    <relationship identifier="rel-advance-payment-of-benefit--recoverable-assistance-payment--association" xsi:type="Association" source="advance-payment-of-benefit" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-advance-payment-of-benefit--special-needs-grant--association" xsi:type="Association" source="advance-payment-of-benefit" target="special-needs-grant"/>
+    <relationship identifier="rel-advance-payment-of-benefit--temporary-additional-support--association" xsi:type="Association" source="advance-payment-of-benefit" target="temporary-additional-support"/>
+    <relationship identifier="rel-advance-payment-of-benefit--young-parent-payment--association" xsi:type="Association" source="advance-payment-of-benefit" target="young-parent-payment"/>
+    <relationship identifier="rel-advance-payment-of-benefit--youth-payment--association" xsi:type="Association" source="advance-payment-of-benefit" target="youth-payment"/>
+    <relationship identifier="rel-advance-payment-of-benefit--jobseeker-support--association" xsi:type="Association" source="advance-payment-of-benefit" target="jobseeker-support"/>
+    <relationship identifier="rel-advance-payment-of-benefit--sole-parent-support--association" xsi:type="Association" source="advance-payment-of-benefit" target="sole-parent-support"/>
+    <relationship identifier="rel-advance-payment-of-benefit--supported-living-payment--association" xsi:type="Association" source="advance-payment-of-benefit" target="supported-living-payment"/>
+    <relationship identifier="rel-advance-payment-of-benefit--emergency-benefit--association" xsi:type="Association" source="advance-payment-of-benefit" target="emergency-benefit"/>
+    <relationship identifier="rel-advance-payment-of-benefit--requests-for-financial-assistance--serving" xsi:type="Serving" source="advance-payment-of-benefit" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-advance-payment-of-benefit--application-for-assistance--serving" xsi:type="Serving" source="advance-payment-of-benefit" target="application-for-assistance"/>
+    <relationship identifier="rel-apprenticeship-boost--specific-employment-related-assistance--association" xsi:type="Association" source="apprenticeship-boost" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-apprenticeship-boost--employment-and-work-readiness-assistance--association" xsi:type="Association" source="apprenticeship-boost" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-apprenticeship-boost--flexi-wage-subsidy--association" xsi:type="Association" source="apprenticeship-boost" target="flexi-wage-subsidy"/>
+    <relationship identifier="rel-apprenticeship-boost--mana-in-mahi--association" xsi:type="Association" source="apprenticeship-boost" target="mana-in-mahi"/>
+    <relationship identifier="rel-apprenticeship-boost--reviews-and-appeals--serving" xsi:type="Serving" source="apprenticeship-boost" target="reviews-and-appeals"/>
+    <relationship identifier="rel-away-from-home-allowance--advance-payment-of-benefit--association" xsi:type="Association" source="away-from-home-allowance" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-away-from-home-allowance--child-support--influence" xsi:type="Influence" source="away-from-home-allowance" target="child-support"/>
+    <relationship identifier="rel-away-from-home-allowance--duty-to-advise-of-changes-in-circumstances--influence" xsi:type="Influence" source="away-from-home-allowance" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-away-from-home-allowance--income--association" xsi:type="Association" source="away-from-home-allowance" target="income"/>
+    <relationship identifier="rel-away-from-home-allowance--student-loan--association" xsi:type="Association" source="away-from-home-allowance" target="student-loan"/>
+    <relationship identifier="rel-away-from-home-allowance--family-tax-credit--association" xsi:type="Association" source="away-from-home-allowance" target="family-tax-credit"/>
+    <relationship identifier="rel-best-start-tax-credit--child-disability-allowance--association" xsi:type="Association" source="best-start-tax-credit" target="child-disability-allowance"/>
+    <relationship identifier="rel-best-start-tax-credit--family-tax-credit--association" xsi:type="Association" source="best-start-tax-credit" target="family-tax-credit"/>
+    <relationship identifier="rel-best-start-tax-credit--in-work-tax-credit--association" xsi:type="Association" source="best-start-tax-credit" target="in-work-tax-credit"/>
+    <relationship identifier="rel-best-start-tax-credit--sole-parent-support--association" xsi:type="Association" source="best-start-tax-credit" target="sole-parent-support"/>
+    <relationship identifier="rel-best-start-tax-credit--jobseeker-support--association" xsi:type="Association" source="best-start-tax-credit" target="jobseeker-support"/>
+    <relationship identifier="rel-best-start-tax-credit--supported-living-payment--association" xsi:type="Association" source="best-start-tax-credit" target="supported-living-payment"/>
+    <relationship identifier="rel-best-start-tax-credit--new-zealand-superannuation--association" xsi:type="Association" source="best-start-tax-credit" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-best-start-tax-credit--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="best-start-tax-credit" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-best-start-tax-credit--reviews-and-appeals--serving" xsi:type="Serving" source="best-start-tax-credit" target="reviews-and-appeals"/>
+    <relationship identifier="rel-best-start-tax-credit--residence--association" xsi:type="Association" source="best-start-tax-credit" target="residence"/>
+    <relationship identifier="rel-best-start-tax-credit--income--association" xsi:type="Association" source="best-start-tax-credit" target="income"/>
+    <relationship identifier="rel-bond-grant--housing-support-products--association" xsi:type="Association" source="bond-grant" target="housing-support-products"/>
+    <relationship identifier="rel-bond-grant--accommodation-supplement--association" xsi:type="Association" source="bond-grant" target="accommodation-supplement"/>
+    <relationship identifier="rel-bond-grant--reviews-and-appeals--serving" xsi:type="Serving" source="bond-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-bond-grant--residence--association" xsi:type="Association" source="bond-grant" target="residence"/>
+    <relationship identifier="rel-bond-grant--income--association" xsi:type="Association" source="bond-grant" target="income"/>
+    <relationship identifier="rel-child-disability-allowance--disability-allowance--association" xsi:type="Association" source="child-disability-allowance" target="disability-allowance"/>
+    <relationship identifier="rel-child-disability-allowance--special-disability-allowance--association" xsi:type="Association" source="child-disability-allowance" target="special-disability-allowance"/>
+    <relationship identifier="rel-child-disability-allowance--sole-parent-support--association" xsi:type="Association" source="child-disability-allowance" target="sole-parent-support"/>
+    <relationship identifier="rel-child-disability-allowance--young-parent-payment--association" xsi:type="Association" source="child-disability-allowance" target="young-parent-payment"/>
+    <relationship identifier="rel-child-disability-allowance--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="child-disability-allowance" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-child-disability-allowance--application-for-assistance--serving" xsi:type="Serving" source="child-disability-allowance" target="application-for-assistance"/>
+    <relationship identifier="rel-child-disability-allowance--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="child-disability-allowance" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-child-disability-allowance--reviews-and-appeals--serving" xsi:type="Serving" source="child-disability-allowance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-child-disability-allowance--residence--association" xsi:type="Association" source="child-disability-allowance" target="residence"/>
+    <relationship identifier="rel-christchurch-mosques-attack-assistance--best-start-tax-credit--association" xsi:type="Association" source="christchurch-mosques-attack-assistance" target="best-start-tax-credit"/>
+    <relationship identifier="rel-christchurch-mosques-attack-assistance--emergency-benefit--association" xsi:type="Association" source="christchurch-mosques-attack-assistance" target="emergency-benefit"/>
+    <relationship identifier="rel-christchurch-mosques-attack-assistance--family-tax-credit--association" xsi:type="Association" source="christchurch-mosques-attack-assistance" target="family-tax-credit"/>
+    <relationship identifier="rel-christchurch-mosques-attack-assistance--temporary-additional-support--association" xsi:type="Association" source="christchurch-mosques-attack-assistance" target="temporary-additional-support"/>
+    <relationship identifier="rel-christchurch-mosques-attack-assistance--winter-energy-payment--association" xsi:type="Association" source="christchurch-mosques-attack-assistance" target="winter-energy-payment"/>
+    <relationship identifier="rel-clothing-allowance--orphans-benefit-and-unsupported-childs-benefit-products--association" xsi:type="Association" source="clothing-allowance" target="orphans-benefit-and-unsupported-childs-benefit-products"/>
+    <relationship identifier="rel-clothing-allowance--advance-payment-of-benefit--association" xsi:type="Association" source="clothing-allowance" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-clothing-allowance--special-needs-grant--association" xsi:type="Association" source="clothing-allowance" target="special-needs-grant"/>
+    <relationship identifier="rel-clothing-allowance--student-allowance--association" xsi:type="Association" source="clothing-allowance" target="student-allowance"/>
+    <relationship identifier="rel-clothing-allowance--student-loan--association" xsi:type="Association" source="clothing-allowance" target="student-loan"/>
+    <relationship identifier="rel-clothing-allowance--orphans-benefit-and-unsupported-childs-benefit--influence" xsi:type="Influence" source="clothing-allowance" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-clothing-allowance--child-support--influence" xsi:type="Influence" source="clothing-allowance" target="child-support"/>
+    <relationship identifier="rel-clothing-allowance--reciprocal-agreements--influence" xsi:type="Influence" source="clothing-allowance" target="reciprocal-agreements"/>
+    <relationship identifier="rel-community-costs--special-benefit--association" xsi:type="Association" source="community-costs" target="special-benefit"/>
+    <relationship identifier="rel-community-costs--income--association" xsi:type="Association" source="community-costs" target="income"/>
+    <relationship identifier="rel-community-costs--residence--association" xsi:type="Association" source="community-costs" target="residence"/>
+    <relationship identifier="rel-cost-of-living-payment--winter-energy-payment--association" xsi:type="Association" source="cost-of-living-payment" target="winter-energy-payment"/>
+    <relationship identifier="rel-cost-of-living-payment--accommodation-supplement--association" xsi:type="Association" source="cost-of-living-payment" target="accommodation-supplement"/>
+    <relationship identifier="rel-cost-of-living-payment--advance-payment-of-benefit--association" xsi:type="Association" source="cost-of-living-payment" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-cost-of-living-payment--childcare-assistance-programme--association" xsi:type="Association" source="cost-of-living-payment" target="childcare-assistance-programme"/>
+    <relationship identifier="rel-cost-of-living-payment--community-costs--association" xsi:type="Association" source="cost-of-living-payment" target="community-costs"/>
+    <relationship identifier="rel-cost-of-living-payment--disability-allowance--association" xsi:type="Association" source="cost-of-living-payment" target="disability-allowance"/>
+    <relationship identifier="rel-cost-of-living-payment--employment-and-work-readiness-assistance--association" xsi:type="Association" source="cost-of-living-payment" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-cost-of-living-payment--flexible-funding-assistance--association" xsi:type="Association" source="cost-of-living-payment" target="flexible-funding-assistance"/>
+    <relationship identifier="rel-cost-of-living-payment--housing-support-products--association" xsi:type="Association" source="cost-of-living-payment" target="housing-support-products"/>
+    <relationship identifier="rel-cost-of-living-payment--recoverable-assistance-payment--association" xsi:type="Association" source="cost-of-living-payment" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-cost-of-living-payment--residential-care-subsidy--association" xsi:type="Association" source="cost-of-living-payment" target="residential-care-subsidy"/>
+    <relationship identifier="rel-cost-of-living-payment--residential-support-subsidy--association" xsi:type="Association" source="cost-of-living-payment" target="residential-support-subsidy"/>
+    <relationship identifier="rel-cost-of-living-payment--social-rehabilitation-assistance--association" xsi:type="Association" source="cost-of-living-payment" target="social-rehabilitation-assistance"/>
+    <relationship identifier="rel-cost-of-living-payment--special-benefit--association" xsi:type="Association" source="cost-of-living-payment" target="special-benefit"/>
+    <relationship identifier="rel-cost-of-living-payment--special-needs-grant--association" xsi:type="Association" source="cost-of-living-payment" target="special-needs-grant"/>
+    <relationship identifier="rel-cost-of-living-payment--student-allowance--association" xsi:type="Association" source="cost-of-living-payment" target="student-allowance"/>
+    <relationship identifier="rel-cost-of-living-payment--student-allowance-transfer-grant--association" xsi:type="Association" source="cost-of-living-payment" target="student-allowance-transfer-grant"/>
+    <relationship identifier="rel-cost-of-living-payment--temporary-additional-support--association" xsi:type="Association" source="cost-of-living-payment" target="temporary-additional-support"/>
+    <relationship identifier="rel-cost-of-living-payment--new-zealand-superannuation--association" xsi:type="Association" source="cost-of-living-payment" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-cost-of-living-payment--veterans-pension--association" xsi:type="Association" source="cost-of-living-payment" target="veterans-pension"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--employment-and-work-readiness-assistance--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-leave-support-scheme--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-leave-support-scheme" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-resurgence-wage-subsidy-scheme--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-resurgence-wage-subsidy-scheme" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-short-term-absence-payment--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-short-term-absence-payment" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--employment-and-work-readiness-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-modified--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-wage-subsidy-modified" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--employment-and-work-readiness-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-august-2021--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-august-2021" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--employment-and-work-readiness-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-wage-subsidy-scheme-march-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-wage-subsidy-scheme-march-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-extension--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-extension" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--specific-employment-related-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--employment-and-work-readiness-assistance--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-wage-subsidy-modified--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-wage-subsidy-modified"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-wage-subsidy-scheme-august-2021--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-wage-subsidy-scheme-august-2021"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-wage-subsidy-scheme-extension--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-wage-subsidy-scheme-extension"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-resurgence-wage-subsidy-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-resurgence-wage-subsidy-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-leave-support-scheme--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-leave-support-scheme"/>
+    <relationship identifier="rel-covid-19-wage-subsidy-scheme-march-2021--covid-19-short-term-absence-payment--association" xsi:type="Association" source="covid-19-wage-subsidy-scheme-march-2021" target="covid-19-short-term-absence-payment"/>
+    <relationship identifier="rel-disability-allowance--special-disability-allowance--association" xsi:type="Association" source="disability-allowance" target="special-disability-allowance"/>
+    <relationship identifier="rel-disability-allowance--child-disability-allowance--association" xsi:type="Association" source="disability-allowance" target="child-disability-allowance"/>
+    <relationship identifier="rel-disability-allowance--new-zealand-superannuation--association" xsi:type="Association" source="disability-allowance" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-disability-allowance--veterans-pension--association" xsi:type="Association" source="disability-allowance" target="veterans-pension"/>
+    <relationship identifier="rel-disability-allowance--student-allowance--association" xsi:type="Association" source="disability-allowance" target="student-allowance"/>
+    <relationship identifier="rel-disability-allowance--student-loan--association" xsi:type="Association" source="disability-allowance" target="student-loan"/>
+    <relationship identifier="rel-disability-allowance--supported-living-payment--association" xsi:type="Association" source="disability-allowance" target="supported-living-payment"/>
+    <relationship identifier="rel-disability-allowance--reviews-and-appeals--serving" xsi:type="Serving" source="disability-allowance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-disability-allowance--residence--association" xsi:type="Association" source="disability-allowance" target="residence"/>
+    <relationship identifier="rel-disability-allowance--income--association" xsi:type="Association" source="disability-allowance" target="income"/>
+    <relationship identifier="rel-early-learning-payment--flexible-childcare-assistance--association" xsi:type="Association" source="early-learning-payment" target="flexible-childcare-assistance"/>
+    <relationship identifier="rel-early-learning-payment--guaranteed-childcare-assistance-payment--association" xsi:type="Association" source="early-learning-payment" target="guaranteed-childcare-assistance-payment"/>
+    <relationship identifier="rel-early-learning-payment--childcare-assistance-programme--association" xsi:type="Association" source="early-learning-payment" target="childcare-assistance-programme"/>
+    <relationship identifier="rel-early-learning-payment--residence--association" xsi:type="Association" source="early-learning-payment" target="residence"/>
+    <relationship identifier="rel-emergency-benefit--jobseeker-support--association" xsi:type="Association" source="emergency-benefit" target="jobseeker-support"/>
+    <relationship identifier="rel-emergency-benefit--supported-living-payment--association" xsi:type="Association" source="emergency-benefit" target="supported-living-payment"/>
+    <relationship identifier="rel-emergency-benefit--sole-parent-support--association" xsi:type="Association" source="emergency-benefit" target="sole-parent-support"/>
+    <relationship identifier="rel-emergency-benefit--new-zealand-superannuation--association" xsi:type="Association" source="emergency-benefit" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-emergency-benefit--veterans-pension--association" xsi:type="Association" source="emergency-benefit" target="veterans-pension"/>
+    <relationship identifier="rel-emergency-benefit--young-parent-payment--association" xsi:type="Association" source="emergency-benefit" target="young-parent-payment"/>
+    <relationship identifier="rel-emergency-benefit--youth-payment--association" xsi:type="Association" source="emergency-benefit" target="youth-payment"/>
+    <relationship identifier="rel-emergency-benefit--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="emergency-benefit" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-emergency-benefit--emergency-maintenance-allowance--association" xsi:type="Association" source="emergency-benefit" target="emergency-maintenance-allowance"/>
+    <relationship identifier="rel-emergency-benefit--special-disability-allowance--association" xsi:type="Association" source="emergency-benefit" target="special-disability-allowance"/>
+    <relationship identifier="rel-emergency-benefit--disability-allowance--association" xsi:type="Association" source="emergency-benefit" target="disability-allowance"/>
+    <relationship identifier="rel-emergency-benefit--accommodation-supplement--association" xsi:type="Association" source="emergency-benefit" target="accommodation-supplement"/>
+    <relationship identifier="rel-emergency-benefit--temporary-additional-support--association" xsi:type="Association" source="emergency-benefit" target="temporary-additional-support"/>
+    <relationship identifier="rel-emergency-benefit--special-benefit--association" xsi:type="Association" source="emergency-benefit" target="special-benefit"/>
+    <relationship identifier="rel-emergency-benefit--special-needs-grant--association" xsi:type="Association" source="emergency-benefit" target="special-needs-grant"/>
+    <relationship identifier="rel-emergency-benefit--recoverable-assistance-payment--association" xsi:type="Association" source="emergency-benefit" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-emergency-benefit--advance-payment-of-benefit--association" xsi:type="Association" source="emergency-benefit" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-emergency-benefit--family-tax-credit--association" xsi:type="Association" source="emergency-benefit" target="family-tax-credit"/>
+    <relationship identifier="rel-emergency-benefit--winter-energy-payment--association" xsi:type="Association" source="emergency-benefit" target="winter-energy-payment"/>
+    <relationship identifier="rel-emergency-benefit--child-disability-allowance--association" xsi:type="Association" source="emergency-benefit" target="child-disability-allowance"/>
+    <relationship identifier="rel-emergency-benefit--community-services-card--association" xsi:type="Association" source="emergency-benefit" target="community-services-card"/>
+    <relationship identifier="rel-emergency-benefit--relationship-status-for-benefit--influence" xsi:type="Influence" source="emergency-benefit" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-emergency-benefit--application-for-benefit--serving" xsi:type="Serving" source="emergency-benefit" target="application-for-benefit"/>
+    <relationship identifier="rel-emergency-benefit--reviews-and-appeals--serving" xsi:type="Serving" source="emergency-benefit" target="reviews-and-appeals"/>
+    <relationship identifier="rel-emergency-benefit--redirection-of-benefit-payment--serving" xsi:type="Serving" source="emergency-benefit" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-emergency-benefit--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="emergency-benefit" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-emergency-benefit--portability--serving" xsi:type="Serving" source="emergency-benefit" target="portability"/>
+    <relationship identifier="rel-emergency-benefit--reciprocal-agreements--serving" xsi:type="Serving" source="emergency-benefit" target="reciprocal-agreements"/>
+    <relationship identifier="rel-emergency-benefit--residence--association" xsi:type="Association" source="emergency-benefit" target="residence"/>
+    <relationship identifier="rel-emergency-benefit--income--association" xsi:type="Association" source="emergency-benefit" target="income"/>
+    <relationship identifier="rel-emergency-housing--housing-support-products--association" xsi:type="Association" source="emergency-housing" target="housing-support-products"/>
+    <relationship identifier="rel-emergency-housing--jobseeker-support--association" xsi:type="Association" source="emergency-housing" target="jobseeker-support"/>
+    <relationship identifier="rel-emergency-housing--new-zealand-superannuation--association" xsi:type="Association" source="emergency-housing" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-emergency-housing--veterans-pension--association" xsi:type="Association" source="emergency-housing" target="veterans-pension"/>
+    <relationship identifier="rel-emergency-housing--family-tax-credit--association" xsi:type="Association" source="emergency-housing" target="family-tax-credit"/>
+    <relationship identifier="rel-emergency-housing--requests-for-financial-assistance--serving" xsi:type="Serving" source="emergency-housing" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-emergency-housing--income--association" xsi:type="Association" source="emergency-housing" target="income"/>
+    <relationship identifier="rel-emergency-housing--residence--association" xsi:type="Association" source="emergency-housing" target="residence"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--sole-parent-support--association" xsi:type="Association" source="emergency-maintenance-allowance" target="sole-parent-support"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--young-parent-payment--association" xsi:type="Association" source="emergency-maintenance-allowance" target="young-parent-payment"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--youth-payment--association" xsi:type="Association" source="emergency-maintenance-allowance" target="youth-payment"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--jobseeker-support--association" xsi:type="Association" source="emergency-maintenance-allowance" target="jobseeker-support"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--emergency-benefit--association" xsi:type="Association" source="emergency-maintenance-allowance" target="emergency-benefit"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="emergency-maintenance-allowance" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--supported-living-payment--association" xsi:type="Association" source="emergency-maintenance-allowance" target="supported-living-payment"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--child-disability-allowance--association" xsi:type="Association" source="emergency-maintenance-allowance" target="child-disability-allowance"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--accommodation-supplement--association" xsi:type="Association" source="emergency-maintenance-allowance" target="accommodation-supplement"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--special-needs-grant--association" xsi:type="Association" source="emergency-maintenance-allowance" target="special-needs-grant"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--temporary-additional-support--association" xsi:type="Association" source="emergency-maintenance-allowance" target="temporary-additional-support"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--advance-payment-of-benefit--association" xsi:type="Association" source="emergency-maintenance-allowance" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--student-allowance--association" xsi:type="Association" source="emergency-maintenance-allowance" target="student-allowance"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--student-loan--association" xsi:type="Association" source="emergency-maintenance-allowance" target="student-loan"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--relationship-status-for-benefit--influence" xsi:type="Influence" source="emergency-maintenance-allowance" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--child-support--influence" xsi:type="Influence" source="emergency-maintenance-allowance" target="child-support"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--reviews-and-appeals--serving" xsi:type="Serving" source="emergency-maintenance-allowance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--application-for-benefit--serving" xsi:type="Serving" source="emergency-maintenance-allowance" target="application-for-benefit"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="emergency-maintenance-allowance" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--income--association" xsi:type="Association" source="emergency-maintenance-allowance" target="income"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--residence--association" xsi:type="Association" source="emergency-maintenance-allowance" target="residence"/>
+    <relationship identifier="rel-emergency-maintenance-allowance--community-services-card--association" xsi:type="Association" source="emergency-maintenance-allowance" target="community-services-card"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--mana-in-mahi--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="mana-in-mahi"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--work-bonus--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="work-bonus"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--training-incentive-allowance--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="training-incentive-allowance"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--flexi-wage-subsidy--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="flexi-wage-subsidy"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--employment-transition-assistance--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="employment-transition-assistance"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--new-employment-transition-grant--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="new-employment-transition-grant"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--relocate-for-work-support--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="relocate-for-work-support"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--seasonal-work-assistance--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="seasonal-work-assistance"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--specific-employment-related-assistance--serving" xsi:type="Serving" source="employment-and-work-readiness-assistance" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--residence--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="residence"/>
+    <relationship identifier="rel-employment-and-work-readiness-assistance--income--association" xsi:type="Association" source="employment-and-work-readiness-assistance" target="income"/>
+    <relationship identifier="rel-employment-transition-assistance--specific-employment-related-assistance--association" xsi:type="Association" source="employment-transition-assistance" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-employment-transition-assistance--employment-and-work-readiness-assistance--association" xsi:type="Association" source="employment-transition-assistance" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-employment-transition-assistance--employment-transition-assistance--association" xsi:type="Association" source="employment-transition-assistance" target="employment-transition-assistance"/>
+    <relationship identifier="rel-extraordinary-care-fund--orphans-benefit-and-unsupported-childs-benefit-products--association" xsi:type="Association" source="extraordinary-care-fund" target="orphans-benefit-and-unsupported-childs-benefit-products"/>
+    <relationship identifier="rel-extraordinary-care-fund--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="extraordinary-care-fund" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-family-tax-credit--in-work-tax-credit--association" xsi:type="Association" source="family-tax-credit" target="in-work-tax-credit"/>
+    <relationship identifier="rel-family-tax-credit--best-start-tax-credit--association" xsi:type="Association" source="family-tax-credit" target="best-start-tax-credit"/>
+    <relationship identifier="rel-family-tax-credit--reviews-and-appeals--serving" xsi:type="Serving" source="family-tax-credit" target="reviews-and-appeals"/>
+    <relationship identifier="rel-familyboost-tax-credit--childcare-assistance-programme--association" xsi:type="Association" source="familyboost-tax-credit" target="childcare-assistance-programme"/>
+    <relationship identifier="rel-familyboost-tax-credit--early-learning-payment--association" xsi:type="Association" source="familyboost-tax-credit" target="early-learning-payment"/>
+    <relationship identifier="rel-familyboost-tax-credit--guaranteed-childcare-assistance-payment--association" xsi:type="Association" source="familyboost-tax-credit" target="guaranteed-childcare-assistance-payment"/>
+    <relationship identifier="rel-familyboost-tax-credit--accommodation-supplement--association" xsi:type="Association" source="familyboost-tax-credit" target="accommodation-supplement"/>
+    <relationship identifier="rel-familyboost-tax-credit--advance-payment-of-benefit--association" xsi:type="Association" source="familyboost-tax-credit" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-familyboost-tax-credit--disability-allowance--association" xsi:type="Association" source="familyboost-tax-credit" target="disability-allowance"/>
+    <relationship identifier="rel-familyboost-tax-credit--flexible-funding-assistance--association" xsi:type="Association" source="familyboost-tax-credit" target="flexible-funding-assistance"/>
+    <relationship identifier="rel-familyboost-tax-credit--funeral-grant--association" xsi:type="Association" source="familyboost-tax-credit" target="funeral-grant"/>
+    <relationship identifier="rel-familyboost-tax-credit--home-help--association" xsi:type="Association" source="familyboost-tax-credit" target="home-help"/>
+    <relationship identifier="rel-familyboost-tax-credit--housing-support-products--association" xsi:type="Association" source="familyboost-tax-credit" target="housing-support-products"/>
+    <relationship identifier="rel-familyboost-tax-credit--income-related-rent--association" xsi:type="Association" source="familyboost-tax-credit" target="income-related-rent"/>
+    <relationship identifier="rel-familyboost-tax-credit--recoverable-assistance-payment--association" xsi:type="Association" source="familyboost-tax-credit" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-familyboost-tax-credit--residential-care-subsidy--association" xsi:type="Association" source="familyboost-tax-credit" target="residential-care-subsidy"/>
+    <relationship identifier="rel-familyboost-tax-credit--special-benefit--association" xsi:type="Association" source="familyboost-tax-credit" target="special-benefit"/>
+    <relationship identifier="rel-familyboost-tax-credit--special-needs-grant--association" xsi:type="Association" source="familyboost-tax-credit" target="special-needs-grant"/>
+    <relationship identifier="rel-familyboost-tax-credit--student-allowance--association" xsi:type="Association" source="familyboost-tax-credit" target="student-allowance"/>
+    <relationship identifier="rel-familyboost-tax-credit--student-allowance-transfer-grant--association" xsi:type="Association" source="familyboost-tax-credit" target="student-allowance-transfer-grant"/>
+    <relationship identifier="rel-familyboost-tax-credit--temporary-additional-support--association" xsi:type="Association" source="familyboost-tax-credit" target="temporary-additional-support"/>
+    <relationship identifier="rel-familyboost-tax-credit--new-zealand-superannuation--association" xsi:type="Association" source="familyboost-tax-credit" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-familyboost-tax-credit--veterans-pension--association" xsi:type="Association" source="familyboost-tax-credit" target="veterans-pension"/>
+    <relationship identifier="rel-familyboost-tax-credit--training-incentive-allowance--association" xsi:type="Association" source="familyboost-tax-credit" target="training-incentive-allowance"/>
+    <relationship identifier="rel-familyboost-tax-credit--community-costs--association" xsi:type="Association" source="familyboost-tax-credit" target="community-costs"/>
+    <relationship identifier="rel-familyboost-tax-credit--employment-and-work-readiness-assistance--association" xsi:type="Association" source="familyboost-tax-credit" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-familyboost-tax-credit--new-employment-transition-grant--association" xsi:type="Association" source="familyboost-tax-credit" target="new-employment-transition-grant"/>
+    <relationship identifier="rel-familyboost-tax-credit--seasonal-work-assistance--association" xsi:type="Association" source="familyboost-tax-credit" target="seasonal-work-assistance"/>
+    <relationship identifier="rel-familyboost-tax-credit--social-rehabilitation-assistance--association" xsi:type="Association" source="familyboost-tax-credit" target="social-rehabilitation-assistance"/>
+    <relationship identifier="rel-flexi-wage-subsidy--specific-employment-related-assistance--association" xsi:type="Association" source="flexi-wage-subsidy" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-flexi-wage-subsidy--employment-and-work-readiness-assistance--association" xsi:type="Association" source="flexi-wage-subsidy" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-flexi-wage-subsidy--employment-transition-assistance--association" xsi:type="Association" source="flexi-wage-subsidy" target="employment-transition-assistance"/>
+    <relationship identifier="rel-flexi-wage-subsidy--residence--association" xsi:type="Association" source="flexi-wage-subsidy" target="residence"/>
+    <relationship identifier="rel-flexi-wage-subsidy--mana-in-mahi--association" xsi:type="Association" source="flexi-wage-subsidy" target="mana-in-mahi"/>
+    <relationship identifier="rel-flexible-childcare-assistance--early-learning-payment--association" xsi:type="Association" source="flexible-childcare-assistance" target="early-learning-payment"/>
+    <relationship identifier="rel-flexible-childcare-assistance--childcare-assistance-programme--association" xsi:type="Association" source="flexible-childcare-assistance" target="childcare-assistance-programme"/>
+    <relationship identifier="rel-flexible-childcare-assistance--residence--association" xsi:type="Association" source="flexible-childcare-assistance" target="residence"/>
+    <relationship identifier="rel-flexible-funding-assistance--emergency-housing--association" xsi:type="Association" source="flexible-funding-assistance" target="emergency-housing"/>
+    <relationship identifier="rel-flexible-funding-assistance--warrant-to-arrest--influence" xsi:type="Influence" source="flexible-funding-assistance" target="warrant-to-arrest"/>
+    <relationship identifier="rel-flexible-funding-assistance--reviews-and-appeals--serving" xsi:type="Serving" source="flexible-funding-assistance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-flexible-funding-assistance--income--association" xsi:type="Association" source="flexible-funding-assistance" target="income"/>
+    <relationship identifier="rel-flexible-funding-assistance--residence--association" xsi:type="Association" source="flexible-funding-assistance" target="residence"/>
+    <relationship identifier="rel-funeral-grant--requests-for-financial-assistance--serving" xsi:type="Serving" source="funeral-grant" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-funeral-grant--application-for-assistance--serving" xsi:type="Serving" source="funeral-grant" target="application-for-assistance"/>
+    <relationship identifier="rel-guaranteed-childcare-assistance-payment--early-learning-payment--association" xsi:type="Association" source="guaranteed-childcare-assistance-payment" target="early-learning-payment"/>
+    <relationship identifier="rel-guaranteed-childcare-assistance-payment--flexible-childcare-assistance--association" xsi:type="Association" source="guaranteed-childcare-assistance-payment" target="flexible-childcare-assistance"/>
+    <relationship identifier="rel-guaranteed-childcare-assistance-payment--childcare-assistance-programme--association" xsi:type="Association" source="guaranteed-childcare-assistance-payment" target="childcare-assistance-programme"/>
+    <relationship identifier="rel-guaranteed-childcare-assistance-payment--young-parent-payment--association" xsi:type="Association" source="guaranteed-childcare-assistance-payment" target="young-parent-payment"/>
+    <relationship identifier="rel-guaranteed-childcare-assistance-payment--youth-payment--association" xsi:type="Association" source="guaranteed-childcare-assistance-payment" target="youth-payment"/>
+    <relationship identifier="rel-holiday-allowance-and-birthday-allowance--orphans-benefit-and-unsupported-childs-benefit-products--association" xsi:type="Association" source="holiday-allowance-and-birthday-allowance" target="orphans-benefit-and-unsupported-childs-benefit-products"/>
+    <relationship identifier="rel-holiday-allowance-and-birthday-allowance--reciprocal-agreements--influence" xsi:type="Influence" source="holiday-allowance-and-birthday-allowance" target="reciprocal-agreements"/>
+    <relationship identifier="rel-holiday-allowance-and-birthday-allowance--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="holiday-allowance-and-birthday-allowance" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-home-help--community-services-card--association" xsi:type="Association" source="home-help" target="community-services-card"/>
+    <relationship identifier="rel-house-modification-funding--reviews-and-appeals--serving" xsi:type="Serving" source="house-modification-funding" target="reviews-and-appeals"/>
+    <relationship identifier="rel-house-modification-funding--income--association" xsi:type="Association" source="house-modification-funding" target="income"/>
+    <relationship identifier="rel-housing-support-products--moving-costs-grant--association" xsi:type="Association" source="housing-support-products" target="moving-costs-grant"/>
+    <relationship identifier="rel-housing-support-products--bond-grant--association" xsi:type="Association" source="housing-support-products" target="bond-grant"/>
+    <relationship identifier="rel-housing-support-products--accommodation-costs-in-advance-grant--association" xsi:type="Association" source="housing-support-products" target="accommodation-costs-in-advance-grant"/>
+    <relationship identifier="rel-housing-support-products--accommodation-costs-arrears-grant--association" xsi:type="Association" source="housing-support-products" target="accommodation-costs-arrears-grant"/>
+    <relationship identifier="rel-housing-support-products--tenancy-costs-cover--association" xsi:type="Association" source="housing-support-products" target="tenancy-costs-cover"/>
+    <relationship identifier="rel-housing-support-products--transition-to-alternative-housing-grant--association" xsi:type="Association" source="housing-support-products" target="transition-to-alternative-housing-grant"/>
+    <relationship identifier="rel-housing-support-products--accommodation-security-cover-grant--association" xsi:type="Association" source="housing-support-products" target="accommodation-security-cover-grant"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--jobseeker-support--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="jobseeker-support"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--student-allowance--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="student-allowance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--student-loan--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="student-loan"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--supported-living-payment--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="supported-living-payment"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--sole-parent-support--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="sole-parent-support"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--young-parent-payment--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="young-parent-payment"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--youth-payment--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="youth-payment"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--special-disability-allowance--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="special-disability-allowance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--accommodation-supplement--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="accommodation-supplement"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--temporary-additional-support--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="temporary-additional-support"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--special-needs-grant--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="special-needs-grant"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--away-from-home-allowance--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="away-from-home-allowance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--training-incentive-allowance--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="training-incentive-allowance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--mana-in-mahi--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="mana-in-mahi"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--pre-benefit-requirements--influence" xsi:type="Influence" source="jobseeker-support-student-hardship" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--relationship-status-for-benefit--influence" xsi:type="Influence" source="jobseeker-support-student-hardship" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--child-support--influence" xsi:type="Influence" source="jobseeker-support-student-hardship" target="child-support"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--relationship-debt-sharing--influence" xsi:type="Influence" source="jobseeker-support-student-hardship" target="relationship-debt-sharing"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--warrant-to-arrest--influence" xsi:type="Influence" source="jobseeker-support-student-hardship" target="warrant-to-arrest"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--application-for-benefit--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="application-for-benefit"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--application-for-assistance--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="application-for-assistance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--reviews-and-appeals--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="reviews-and-appeals"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--redirection-of-benefit-payment--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--current-client-debt--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="current-client-debt"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--requests-for-financial-assistance--serving" xsi:type="Serving" source="jobseeker-support-student-hardship" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--income--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="income"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--definition-of-income--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="definition-of-income"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--types-of-income--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="types-of-income"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--employment-related-income--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="employment-related-income"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--child-support-income--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="child-support-income"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--residence--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="residence"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--portability--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="portability"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--general-portability--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="general-portability"/>
+    <relationship identifier="rel-jobseeker-support-student-hardship--community-services-card--association" xsi:type="Association" source="jobseeker-support-student-hardship" target="community-services-card"/>
+    <relationship identifier="rel-jobseeker-support--sole-parent-support--association" xsi:type="Association" source="jobseeker-support" target="sole-parent-support"/>
+    <relationship identifier="rel-jobseeker-support--supported-living-payment--association" xsi:type="Association" source="jobseeker-support" target="supported-living-payment"/>
+    <relationship identifier="rel-jobseeker-support--emergency-benefit--association" xsi:type="Association" source="jobseeker-support" target="emergency-benefit"/>
+    <relationship identifier="rel-jobseeker-support--youth-payment--association" xsi:type="Association" source="jobseeker-support" target="youth-payment"/>
+    <relationship identifier="rel-jobseeker-support--young-parent-payment--association" xsi:type="Association" source="jobseeker-support" target="young-parent-payment"/>
+    <relationship identifier="rel-jobseeker-support--new-zealand-superannuation--association" xsi:type="Association" source="jobseeker-support" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-jobseeker-support--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="jobseeker-support" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-jobseeker-support--jobseeker-support-student-hardship--association" xsi:type="Association" source="jobseeker-support" target="jobseeker-support-student-hardship"/>
+    <relationship identifier="rel-jobseeker-support--special-needs-grant--association" xsi:type="Association" source="jobseeker-support" target="special-needs-grant"/>
+    <relationship identifier="rel-jobseeker-support--accommodation-supplement--association" xsi:type="Association" source="jobseeker-support" target="accommodation-supplement"/>
+    <relationship identifier="rel-jobseeker-support--temporary-additional-support--association" xsi:type="Association" source="jobseeker-support" target="temporary-additional-support"/>
+    <relationship identifier="rel-jobseeker-support--disability-allowance--association" xsi:type="Association" source="jobseeker-support" target="disability-allowance"/>
+    <relationship identifier="rel-jobseeker-support--special-disability-allowance--association" xsi:type="Association" source="jobseeker-support" target="special-disability-allowance"/>
+    <relationship identifier="rel-jobseeker-support--child-disability-allowance--association" xsi:type="Association" source="jobseeker-support" target="child-disability-allowance"/>
+    <relationship identifier="rel-jobseeker-support--family-tax-credit--association" xsi:type="Association" source="jobseeker-support" target="family-tax-credit"/>
+    <relationship identifier="rel-jobseeker-support--advance-payment-of-benefit--association" xsi:type="Association" source="jobseeker-support" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-jobseeker-support--recoverable-assistance-payment--association" xsi:type="Association" source="jobseeker-support" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-jobseeker-support--training-incentive-allowance--association" xsi:type="Association" source="jobseeker-support" target="training-incentive-allowance"/>
+    <relationship identifier="rel-jobseeker-support--community-services-card--association" xsi:type="Association" source="jobseeker-support" target="community-services-card"/>
+    <relationship identifier="rel-jobseeker-support--pre-benefit-requirements--influence" xsi:type="Influence" source="jobseeker-support" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-jobseeker-support--reciprocal-agreements--serving" xsi:type="Serving" source="jobseeker-support" target="reciprocal-agreements"/>
+    <relationship identifier="rel-jobseeker-support--reviews-and-appeals--serving" xsi:type="Serving" source="jobseeker-support" target="reviews-and-appeals"/>
+    <relationship identifier="rel-jobseeker-support--application-for-benefit--serving" xsi:type="Serving" source="jobseeker-support" target="application-for-benefit"/>
+    <relationship identifier="rel-jobseeker-support--redirection-of-benefit-payment--serving" xsi:type="Serving" source="jobseeker-support" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-jobseeker-support--employment-and-work-readiness-assistance--serving" xsi:type="Serving" source="jobseeker-support" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-jobseeker-support--residence--association" xsi:type="Association" source="jobseeker-support" target="residence"/>
+    <relationship identifier="rel-jobseeker-support--income--association" xsi:type="Association" source="jobseeker-support" target="income"/>
+    <relationship identifier="rel-mana-in-mahi--specific-employment-related-assistance--association" xsi:type="Association" source="mana-in-mahi" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-moving-costs-grant--housing-support-products--association" xsi:type="Association" source="moving-costs-grant" target="housing-support-products"/>
+    <relationship identifier="rel-moving-costs-grant--accommodation-supplement--association" xsi:type="Association" source="moving-costs-grant" target="accommodation-supplement"/>
+    <relationship identifier="rel-moving-costs-grant--reviews-and-appeals--serving" xsi:type="Serving" source="moving-costs-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-moving-costs-grant--residence--association" xsi:type="Association" source="moving-costs-grant" target="residence"/>
+    <relationship identifier="rel-moving-costs-grant--income--association" xsi:type="Association" source="moving-costs-grant" target="income"/>
+    <relationship identifier="rel-new-employment-transition-grant--specific-employment-related-assistance--association" xsi:type="Association" source="new-employment-transition-grant" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-new-employment-transition-grant--employment-and-work-readiness-assistance--association" xsi:type="Association" source="new-employment-transition-grant" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-new-zealand-superannuation--special-disability-allowance--association" xsi:type="Association" source="new-zealand-superannuation" target="special-disability-allowance"/>
+    <relationship identifier="rel-new-zealand-superannuation--family-tax-credit--association" xsi:type="Association" source="new-zealand-superannuation" target="family-tax-credit"/>
+    <relationship identifier="rel-new-zealand-superannuation--best-start-tax-credit--association" xsi:type="Association" source="new-zealand-superannuation" target="best-start-tax-credit"/>
+    <relationship identifier="rel-new-zealand-superannuation--accommodation-supplement--association" xsi:type="Association" source="new-zealand-superannuation" target="accommodation-supplement"/>
+    <relationship identifier="rel-new-zealand-superannuation--reciprocal-agreements--influence" xsi:type="Influence" source="new-zealand-superannuation" target="reciprocal-agreements"/>
+    <relationship identifier="rel-new-zealand-superannuation--portability--influence" xsi:type="Influence" source="new-zealand-superannuation" target="portability"/>
+    <relationship identifier="rel-new-zealand-superannuation--general-portability--influence" xsi:type="Influence" source="new-zealand-superannuation" target="general-portability"/>
+    <relationship identifier="rel-new-zealand-superannuation--special-portability--influence" xsi:type="Influence" source="new-zealand-superannuation" target="special-portability"/>
+    <relationship identifier="rel-new-zealand-superannuation--reviews-and-appeals--serving" xsi:type="Serving" source="new-zealand-superannuation" target="reviews-and-appeals"/>
+    <relationship identifier="rel-new-zealand-superannuation--residence--association" xsi:type="Association" source="new-zealand-superannuation" target="residence"/>
+    <relationship identifier="rel-new-zealand-superannuation--income--association" xsi:type="Association" source="new-zealand-superannuation" target="income"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit-products--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit-products" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit-products--clothing-allowance--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit-products" target="clothing-allowance"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit-products--extraordinary-care-fund--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit-products" target="extraordinary-care-fund"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit-products--holiday-allowance-and-birthday-allowance--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit-products" target="holiday-allowance-and-birthday-allowance"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit-products--school-and-year-start-up-payment--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit-products" target="school-and-year-start-up-payment"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--orphans-benefit-and-unsupported-childs-benefit-products--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit" target="orphans-benefit-and-unsupported-childs-benefit-products"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--child-support--influence" xsi:type="Influence" source="orphans-benefit-and-unsupported-childs-benefit" target="child-support"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--application-for-benefit--serving" xsi:type="Serving" source="orphans-benefit-and-unsupported-childs-benefit" target="application-for-benefit"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="orphans-benefit-and-unsupported-childs-benefit" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--reviews-and-appeals--serving" xsi:type="Serving" source="orphans-benefit-and-unsupported-childs-benefit" target="reviews-and-appeals"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--child-support-income--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit" target="child-support-income"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--residence--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit" target="residence"/>
+    <relationship identifier="rel-orphans-benefit-and-unsupported-childs-benefit--income--association" xsi:type="Association" source="orphans-benefit-and-unsupported-childs-benefit" target="income"/>
+    <relationship identifier="rel-recoverable-assistance-payment--requests-for-financial-assistance--serving" xsi:type="Serving" source="recoverable-assistance-payment" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-recoverable-assistance-payment--income--association" xsi:type="Association" source="recoverable-assistance-payment" target="income"/>
+    <relationship identifier="rel-recoverable-assistance-payment--residence--association" xsi:type="Association" source="recoverable-assistance-payment" target="residence"/>
+    <relationship identifier="rel-relocate-for-work-support--specific-employment-related-assistance--association" xsi:type="Association" source="relocate-for-work-support" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-relocate-for-work-support--employment-and-work-readiness-assistance--association" xsi:type="Association" source="relocate-for-work-support" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-relocate-for-work-support--jobseeker-support--association" xsi:type="Association" source="relocate-for-work-support" target="jobseeker-support"/>
+    <relationship identifier="rel-relocate-for-work-support--sole-parent-support--association" xsi:type="Association" source="relocate-for-work-support" target="sole-parent-support"/>
+    <relationship identifier="rel-relocate-for-work-support--supported-living-payment--association" xsi:type="Association" source="relocate-for-work-support" target="supported-living-payment"/>
+    <relationship identifier="rel-relocate-for-work-support--student-allowance--association" xsi:type="Association" source="relocate-for-work-support" target="student-allowance"/>
+    <relationship identifier="rel-residential-care-loan--residential-care-subsidy--association" xsi:type="Association" source="residential-care-loan" target="residential-care-subsidy"/>
+    <relationship identifier="rel-residential-care-subsidy--special-disability-allowance--association" xsi:type="Association" source="residential-care-subsidy" target="special-disability-allowance"/>
+    <relationship identifier="rel-residential-care-subsidy--clothing-allowance--association" xsi:type="Association" source="residential-care-subsidy" target="clothing-allowance"/>
+    <relationship identifier="rel-residential-care-subsidy--advance-payment-of-benefit--association" xsi:type="Association" source="residential-care-subsidy" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-residential-care-subsidy--disability-allowance--association" xsi:type="Association" source="residential-care-subsidy" target="disability-allowance"/>
+    <relationship identifier="rel-residential-care-subsidy--residential-care-loan--association" xsi:type="Association" source="residential-care-subsidy" target="residential-care-loan"/>
+    <relationship identifier="rel-residential-care-subsidy--accommodation-supplement--association" xsi:type="Association" source="residential-care-subsidy" target="accommodation-supplement"/>
+    <relationship identifier="rel-residential-care-subsidy--reviews-and-appeals--serving" xsi:type="Serving" source="residential-care-subsidy" target="reviews-and-appeals"/>
+    <relationship identifier="rel-residential-care-subsidy--income--association" xsi:type="Association" source="residential-care-subsidy" target="income"/>
+    <relationship identifier="rel-residential-care-subsidy--definition-of-income--association" xsi:type="Association" source="residential-care-subsidy" target="definition-of-income"/>
+    <relationship identifier="rel-residential-care-subsidy--types-of-income--association" xsi:type="Association" source="residential-care-subsidy" target="types-of-income"/>
+    <relationship identifier="rel-residential-support-subsidy--disability-allowance--association" xsi:type="Association" source="residential-support-subsidy" target="disability-allowance"/>
+    <relationship identifier="rel-residential-support-subsidy--accommodation-supplement--association" xsi:type="Association" source="residential-support-subsidy" target="accommodation-supplement"/>
+    <relationship identifier="rel-residential-support-subsidy--advance-payment-of-benefit--association" xsi:type="Association" source="residential-support-subsidy" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-residential-support-subsidy--special-needs-grant--association" xsi:type="Association" source="residential-support-subsidy" target="special-needs-grant"/>
+    <relationship identifier="rel-residential-support-subsidy--training-incentive-allowance--association" xsi:type="Association" source="residential-support-subsidy" target="training-incentive-allowance"/>
+    <relationship identifier="rel-school-and-year-start-up-payment--orphans-benefit-and-unsupported-childs-benefit-products--association" xsi:type="Association" source="school-and-year-start-up-payment" target="orphans-benefit-and-unsupported-childs-benefit-products"/>
+    <relationship identifier="rel-school-and-year-start-up-payment--orphans-benefit-and-unsupported-childs-benefit--influence" xsi:type="Influence" source="school-and-year-start-up-payment" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-seasonal-work-assistance--specific-employment-related-assistance--association" xsi:type="Association" source="seasonal-work-assistance" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-seasonal-work-assistance--employment-and-work-readiness-assistance--association" xsi:type="Association" source="seasonal-work-assistance" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--accommodation-supplement--association" xsi:type="Association" source="social-rehabilitation-assistance" target="accommodation-supplement"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--advance-payment-of-benefit--association" xsi:type="Association" source="social-rehabilitation-assistance" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--disability-allowance--association" xsi:type="Association" source="social-rehabilitation-assistance" target="disability-allowance"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--special-benefit--association" xsi:type="Association" source="social-rehabilitation-assistance" target="special-benefit"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--special-needs-grant--association" xsi:type="Association" source="social-rehabilitation-assistance" target="special-needs-grant"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--temporary-additional-support--association" xsi:type="Association" source="social-rehabilitation-assistance" target="temporary-additional-support"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--new-zealand-superannuation--association" xsi:type="Association" source="social-rehabilitation-assistance" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-social-rehabilitation-assistance--veterans-pension--association" xsi:type="Association" source="social-rehabilitation-assistance" target="veterans-pension"/>
+    <relationship identifier="rel-sole-parent-support--emergency-maintenance-allowance--association" xsi:type="Association" source="sole-parent-support" target="emergency-maintenance-allowance"/>
+    <relationship identifier="rel-sole-parent-support--jobseeker-support--association" xsi:type="Association" source="sole-parent-support" target="jobseeker-support"/>
+    <relationship identifier="rel-sole-parent-support--supported-living-payment--association" xsi:type="Association" source="sole-parent-support" target="supported-living-payment"/>
+    <relationship identifier="rel-sole-parent-support--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="sole-parent-support" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-sole-parent-support--young-parent-payment--association" xsi:type="Association" source="sole-parent-support" target="young-parent-payment"/>
+    <relationship identifier="rel-sole-parent-support--youth-payment--association" xsi:type="Association" source="sole-parent-support" target="youth-payment"/>
+    <relationship identifier="rel-sole-parent-support--accommodation-supplement--association" xsi:type="Association" source="sole-parent-support" target="accommodation-supplement"/>
+    <relationship identifier="rel-sole-parent-support--temporary-additional-support--association" xsi:type="Association" source="sole-parent-support" target="temporary-additional-support"/>
+    <relationship identifier="rel-sole-parent-support--special-needs-grant--association" xsi:type="Association" source="sole-parent-support" target="special-needs-grant"/>
+    <relationship identifier="rel-sole-parent-support--recoverable-assistance-payment--association" xsi:type="Association" source="sole-parent-support" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-sole-parent-support--advance-payment-of-benefit--association" xsi:type="Association" source="sole-parent-support" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-sole-parent-support--training-incentive-allowance--association" xsi:type="Association" source="sole-parent-support" target="training-incentive-allowance"/>
+    <relationship identifier="rel-sole-parent-support--child-disability-allowance--association" xsi:type="Association" source="sole-parent-support" target="child-disability-allowance"/>
+    <relationship identifier="rel-sole-parent-support--disability-allowance--association" xsi:type="Association" source="sole-parent-support" target="disability-allowance"/>
+    <relationship identifier="rel-sole-parent-support--community-services-card--association" xsi:type="Association" source="sole-parent-support" target="community-services-card"/>
+    <relationship identifier="rel-sole-parent-support--winter-energy-payment--association" xsi:type="Association" source="sole-parent-support" target="winter-energy-payment"/>
+    <relationship identifier="rel-sole-parent-support--student-allowance--association" xsi:type="Association" source="sole-parent-support" target="student-allowance"/>
+    <relationship identifier="rel-sole-parent-support--student-loan--association" xsi:type="Association" source="sole-parent-support" target="student-loan"/>
+    <relationship identifier="rel-sole-parent-support--relationship-status-for-benefit--influence" xsi:type="Influence" source="sole-parent-support" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-sole-parent-support--pre-benefit-requirements--influence" xsi:type="Influence" source="sole-parent-support" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-sole-parent-support--child-support--influence" xsi:type="Influence" source="sole-parent-support" target="child-support"/>
+    <relationship identifier="rel-sole-parent-support--application-for-benefit--serving" xsi:type="Serving" source="sole-parent-support" target="application-for-benefit"/>
+    <relationship identifier="rel-sole-parent-support--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="sole-parent-support" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-sole-parent-support--reviews-and-appeals--serving" xsi:type="Serving" source="sole-parent-support" target="reviews-and-appeals"/>
+    <relationship identifier="rel-sole-parent-support--redirection-of-benefit-payment--serving" xsi:type="Serving" source="sole-parent-support" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-sole-parent-support--income--association" xsi:type="Association" source="sole-parent-support" target="income"/>
+    <relationship identifier="rel-sole-parent-support--residence--association" xsi:type="Association" source="sole-parent-support" target="residence"/>
+    <relationship identifier="rel-sole-parent-support--reciprocal-agreements--association" xsi:type="Association" source="sole-parent-support" target="reciprocal-agreements"/>
+    <relationship identifier="rel-special-benefit--family-tax-credit--association" xsi:type="Association" source="special-benefit" target="family-tax-credit"/>
+    <relationship identifier="rel-special-benefit--best-start-tax-credit--association" xsi:type="Association" source="special-benefit" target="best-start-tax-credit"/>
+    <relationship identifier="rel-special-benefit--social-rehabilitation-assistance--association" xsi:type="Association" source="special-benefit" target="social-rehabilitation-assistance"/>
+    <relationship identifier="rel-special-benefit--disability-allowance--association" xsi:type="Association" source="special-benefit" target="disability-allowance"/>
+    <relationship identifier="rel-special-benefit--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="special-benefit" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-special-benefit--student-allowance--association" xsi:type="Association" source="special-benefit" target="student-allowance"/>
+    <relationship identifier="rel-special-benefit--temporary-additional-support--association" xsi:type="Association" source="special-benefit" target="temporary-additional-support"/>
+    <relationship identifier="rel-special-benefit--child-support--influence" xsi:type="Influence" source="special-benefit" target="child-support"/>
+    <relationship identifier="rel-special-benefit--reviews-and-appeals--serving" xsi:type="Serving" source="special-benefit" target="reviews-and-appeals"/>
+    <relationship identifier="rel-special-benefit--residence--association" xsi:type="Association" source="special-benefit" target="residence"/>
+    <relationship identifier="rel-special-benefit--income--association" xsi:type="Association" source="special-benefit" target="income"/>
+    <relationship identifier="rel-special-benefit--definition-of-income--association" xsi:type="Association" source="special-benefit" target="definition-of-income"/>
+    <relationship identifier="rel-special-disability-allowance--disability-allowance--association" xsi:type="Association" source="special-disability-allowance" target="disability-allowance"/>
+    <relationship identifier="rel-special-disability-allowance--new-zealand-superannuation--association" xsi:type="Association" source="special-disability-allowance" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-special-disability-allowance--supported-living-payment--association" xsi:type="Association" source="special-disability-allowance" target="supported-living-payment"/>
+    <relationship identifier="rel-special-disability-allowance--emergency-benefit--association" xsi:type="Association" source="special-disability-allowance" target="emergency-benefit"/>
+    <relationship identifier="rel-special-disability-allowance--veterans-pension--association" xsi:type="Association" source="special-disability-allowance" target="veterans-pension"/>
+    <relationship identifier="rel-special-disability-allowance--residential-care-subsidy--association" xsi:type="Association" source="special-disability-allowance" target="residential-care-subsidy"/>
+    <relationship identifier="rel-special-needs-grant--temporary-additional-support--association" xsi:type="Association" source="special-needs-grant" target="temporary-additional-support"/>
+    <relationship identifier="rel-special-needs-grant--recoverable-assistance-payment--association" xsi:type="Association" source="special-needs-grant" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-special-needs-grant--advance-payment-of-benefit--association" xsi:type="Association" source="special-needs-grant" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-special-needs-grant--accommodation-supplement--association" xsi:type="Association" source="special-needs-grant" target="accommodation-supplement"/>
+    <relationship identifier="rel-special-needs-grant--disability-allowance--association" xsi:type="Association" source="special-needs-grant" target="disability-allowance"/>
+    <relationship identifier="rel-special-needs-grant--new-zealand-superannuation--association" xsi:type="Association" source="special-needs-grant" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-special-needs-grant--veterans-pension--association" xsi:type="Association" source="special-needs-grant" target="veterans-pension"/>
+    <relationship identifier="rel-special-needs-grant--jobseeker-support--association" xsi:type="Association" source="special-needs-grant" target="jobseeker-support"/>
+    <relationship identifier="rel-special-needs-grant--sole-parent-support--association" xsi:type="Association" source="special-needs-grant" target="sole-parent-support"/>
+    <relationship identifier="rel-special-needs-grant--supported-living-payment--association" xsi:type="Association" source="special-needs-grant" target="supported-living-payment"/>
+    <relationship identifier="rel-special-needs-grant--young-parent-payment--association" xsi:type="Association" source="special-needs-grant" target="young-parent-payment"/>
+    <relationship identifier="rel-special-needs-grant--youth-payment--association" xsi:type="Association" source="special-needs-grant" target="youth-payment"/>
+    <relationship identifier="rel-special-needs-grant--application-for-assistance--serving" xsi:type="Serving" source="special-needs-grant" target="application-for-assistance"/>
+    <relationship identifier="rel-special-needs-grant--requests-for-financial-assistance--serving" xsi:type="Serving" source="special-needs-grant" target="requests-for-financial-assistance"/>
+    <relationship identifier="rel-special-needs-grant--income--association" xsi:type="Association" source="special-needs-grant" target="income"/>
+    <relationship identifier="rel-special-needs-grant--residence--association" xsi:type="Association" source="special-needs-grant" target="residence"/>
+    <relationship identifier="rel-special-transfer-allowance--accommodation-supplement--association" xsi:type="Association" source="special-transfer-allowance" target="accommodation-supplement"/>
+    <relationship identifier="rel-specific-employment-related-assistance--employment-and-work-readiness-assistance--association" xsi:type="Association" source="specific-employment-related-assistance" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-specific-employment-related-assistance--apprenticeship-boost--association" xsi:type="Association" source="specific-employment-related-assistance" target="apprenticeship-boost"/>
+    <relationship identifier="rel-specific-employment-related-assistance--employment-transition-assistance--association" xsi:type="Association" source="specific-employment-related-assistance" target="employment-transition-assistance"/>
+    <relationship identifier="rel-specific-employment-related-assistance--flexi-wage-subsidy--association" xsi:type="Association" source="specific-employment-related-assistance" target="flexi-wage-subsidy"/>
+    <relationship identifier="rel-specific-employment-related-assistance--mana-in-mahi--association" xsi:type="Association" source="specific-employment-related-assistance" target="mana-in-mahi"/>
+    <relationship identifier="rel-specific-employment-related-assistance--new-employment-transition-grant--association" xsi:type="Association" source="specific-employment-related-assistance" target="new-employment-transition-grant"/>
+    <relationship identifier="rel-specific-employment-related-assistance--relocate-for-work-support--association" xsi:type="Association" source="specific-employment-related-assistance" target="relocate-for-work-support"/>
+    <relationship identifier="rel-specific-employment-related-assistance--seasonal-work-assistance--association" xsi:type="Association" source="specific-employment-related-assistance" target="seasonal-work-assistance"/>
+    <relationship identifier="rel-specific-employment-related-assistance--training-incentive-allowance--association" xsi:type="Association" source="specific-employment-related-assistance" target="training-incentive-allowance"/>
+    <relationship identifier="rel-specific-employment-related-assistance--work-bonus--association" xsi:type="Association" source="specific-employment-related-assistance" target="work-bonus"/>
+    <relationship identifier="rel-student-allowance-transfer-grant--special-needs-grant--association" xsi:type="Association" source="student-allowance-transfer-grant" target="special-needs-grant"/>
+    <relationship identifier="rel-student-allowance-transfer-grant--student-allowance--association" xsi:type="Association" source="student-allowance-transfer-grant" target="student-allowance"/>
+    <relationship identifier="rel-student-allowance-transfer-grant--temporary-additional-support--association" xsi:type="Association" source="student-allowance-transfer-grant" target="temporary-additional-support"/>
+    <relationship identifier="rel-student-allowance--student-allowance-transfer-grant--association" xsi:type="Association" source="student-allowance" target="student-allowance-transfer-grant"/>
+    <relationship identifier="rel-student-allowance--jobseeker-support-student-hardship--association" xsi:type="Association" source="student-allowance" target="jobseeker-support-student-hardship"/>
+    <relationship identifier="rel-student-allowance--student-loan--association" xsi:type="Association" source="student-allowance" target="student-loan"/>
+    <relationship identifier="rel-student-allowance--young-parent-payment--association" xsi:type="Association" source="student-allowance" target="young-parent-payment"/>
+    <relationship identifier="rel-student-allowance--youth-payment--association" xsi:type="Association" source="student-allowance" target="youth-payment"/>
+    <relationship identifier="rel-student-allowance--christchurch-mosques-attack-assistance--association" xsi:type="Association" source="student-allowance" target="christchurch-mosques-attack-assistance"/>
+    <relationship identifier="rel-student-allowance--away-from-home-allowance--association" xsi:type="Association" source="student-allowance" target="away-from-home-allowance"/>
+    <relationship identifier="rel-student-allowance--reviews-and-appeals--serving" xsi:type="Serving" source="student-allowance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-student-allowance--students--agents--serving" xsi:type="Serving" source="student-allowance" target="students--agents"/>
+    <relationship identifier="rel-student-allowance--income--association" xsi:type="Association" source="student-allowance" target="income"/>
+    <relationship identifier="rel-student-allowance--definition-of-income--association" xsi:type="Association" source="student-allowance" target="definition-of-income"/>
+    <relationship identifier="rel-student-allowance--residence--association" xsi:type="Association" source="student-allowance" target="residence"/>
+    <relationship identifier="rel-student-loan--student-allowance--association" xsi:type="Association" source="student-loan" target="student-allowance"/>
+    <relationship identifier="rel-student-loan--jobseeker-support-student-hardship--association" xsi:type="Association" source="student-loan" target="jobseeker-support-student-hardship"/>
+    <relationship identifier="rel-student-loan--christchurch-mosques-attack-assistance--association" xsi:type="Association" source="student-loan" target="christchurch-mosques-attack-assistance"/>
+    <relationship identifier="rel-student-loan--application-for-assistance--serving" xsi:type="Serving" source="student-loan" target="application-for-assistance"/>
+    <relationship identifier="rel-student-loan--residence--association" xsi:type="Association" source="student-loan" target="residence"/>
+    <relationship identifier="rel-supported-living-payment--jobseeker-support--association" xsi:type="Association" source="supported-living-payment" target="jobseeker-support"/>
+    <relationship identifier="rel-supported-living-payment--sole-parent-support--association" xsi:type="Association" source="supported-living-payment" target="sole-parent-support"/>
+    <relationship identifier="rel-supported-living-payment--emergency-benefit--association" xsi:type="Association" source="supported-living-payment" target="emergency-benefit"/>
+    <relationship identifier="rel-supported-living-payment--new-zealand-superannuation--association" xsi:type="Association" source="supported-living-payment" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-supported-living-payment--veterans-pension--association" xsi:type="Association" source="supported-living-payment" target="veterans-pension"/>
+    <relationship identifier="rel-supported-living-payment--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="supported-living-payment" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-supported-living-payment--young-parent-payment--association" xsi:type="Association" source="supported-living-payment" target="young-parent-payment"/>
+    <relationship identifier="rel-supported-living-payment--youth-payment--association" xsi:type="Association" source="supported-living-payment" target="youth-payment"/>
+    <relationship identifier="rel-supported-living-payment--special-disability-allowance--association" xsi:type="Association" source="supported-living-payment" target="special-disability-allowance"/>
+    <relationship identifier="rel-supported-living-payment--disability-allowance--association" xsi:type="Association" source="supported-living-payment" target="disability-allowance"/>
+    <relationship identifier="rel-supported-living-payment--child-disability-allowance--association" xsi:type="Association" source="supported-living-payment" target="child-disability-allowance"/>
+    <relationship identifier="rel-supported-living-payment--accommodation-supplement--association" xsi:type="Association" source="supported-living-payment" target="accommodation-supplement"/>
+    <relationship identifier="rel-supported-living-payment--temporary-additional-support--association" xsi:type="Association" source="supported-living-payment" target="temporary-additional-support"/>
+    <relationship identifier="rel-supported-living-payment--special-needs-grant--association" xsi:type="Association" source="supported-living-payment" target="special-needs-grant"/>
+    <relationship identifier="rel-supported-living-payment--recoverable-assistance-payment--association" xsi:type="Association" source="supported-living-payment" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-supported-living-payment--advance-payment-of-benefit--association" xsi:type="Association" source="supported-living-payment" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-supported-living-payment--winter-energy-payment--association" xsi:type="Association" source="supported-living-payment" target="winter-energy-payment"/>
+    <relationship identifier="rel-supported-living-payment--family-tax-credit--association" xsi:type="Association" source="supported-living-payment" target="family-tax-credit"/>
+    <relationship identifier="rel-supported-living-payment--best-start-tax-credit--association" xsi:type="Association" source="supported-living-payment" target="best-start-tax-credit"/>
+    <relationship identifier="rel-supported-living-payment--community-services-card--association" xsi:type="Association" source="supported-living-payment" target="community-services-card"/>
+    <relationship identifier="rel-supported-living-payment--social-rehabilitation-assistance--association" xsi:type="Association" source="supported-living-payment" target="social-rehabilitation-assistance"/>
+    <relationship identifier="rel-supported-living-payment--mana-in-mahi--association" xsi:type="Association" source="supported-living-payment" target="mana-in-mahi"/>
+    <relationship identifier="rel-supported-living-payment--training-incentive-allowance--association" xsi:type="Association" source="supported-living-payment" target="training-incentive-allowance"/>
+    <relationship identifier="rel-supported-living-payment--employment-transition-assistance--association" xsi:type="Association" source="supported-living-payment" target="employment-transition-assistance"/>
+    <relationship identifier="rel-supported-living-payment--relationship-status-for-benefit--influence" xsi:type="Influence" source="supported-living-payment" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-supported-living-payment--pre-benefit-requirements--influence" xsi:type="Influence" source="supported-living-payment" target="pre-benefit-requirements"/>
+    <relationship identifier="rel-supported-living-payment--child-support--influence" xsi:type="Influence" source="supported-living-payment" target="child-support"/>
+    <relationship identifier="rel-supported-living-payment--care-and-protection-concerns-for-a-child-or-young-person--influence" xsi:type="Influence" source="supported-living-payment" target="care-and-protection-concerns-for-a-child-or-young-person"/>
+    <relationship identifier="rel-supported-living-payment--reviews-and-appeals--serving" xsi:type="Serving" source="supported-living-payment" target="reviews-and-appeals"/>
+    <relationship identifier="rel-supported-living-payment--application-for-benefit--serving" xsi:type="Serving" source="supported-living-payment" target="application-for-benefit"/>
+    <relationship identifier="rel-supported-living-payment--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="supported-living-payment" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-supported-living-payment--redirection-of-benefit-payment--serving" xsi:type="Serving" source="supported-living-payment" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-supported-living-payment--general-portability--serving" xsi:type="Serving" source="supported-living-payment" target="general-portability"/>
+    <relationship identifier="rel-supported-living-payment--special-portability--serving" xsi:type="Serving" source="supported-living-payment" target="special-portability"/>
+    <relationship identifier="rel-supported-living-payment--residence--association" xsi:type="Association" source="supported-living-payment" target="residence"/>
+    <relationship identifier="rel-supported-living-payment--reciprocal-agreements--association" xsi:type="Association" source="supported-living-payment" target="reciprocal-agreements"/>
+    <relationship identifier="rel-supported-living-payment--income--association" xsi:type="Association" source="supported-living-payment" target="income"/>
+    <relationship identifier="rel-supported-living-payment--definition-of-income--association" xsi:type="Association" source="supported-living-payment" target="definition-of-income"/>
+    <relationship identifier="rel-supported-living-payment--portability--association" xsi:type="Association" source="supported-living-payment" target="portability"/>
+    <relationship identifier="rel-temporary-accommodation-assistance-niwe--accommodation-supplement--association" xsi:type="Association" source="temporary-accommodation-assistance-niwe" target="accommodation-supplement"/>
+    <relationship identifier="rel-temporary-accommodation-assistance-niwe--housing-support-products--association" xsi:type="Association" source="temporary-accommodation-assistance-niwe" target="housing-support-products"/>
+    <relationship identifier="rel-temporary-accommodation-assistance-niwe--reviews-and-appeals--serving" xsi:type="Serving" source="temporary-accommodation-assistance-niwe" target="reviews-and-appeals"/>
+    <relationship identifier="rel-temporary-accommodation-assistance-niwe--residence--association" xsi:type="Association" source="temporary-accommodation-assistance-niwe" target="residence"/>
+    <relationship identifier="rel-temporary-additional-support--disability-allowance--association" xsi:type="Association" source="temporary-additional-support" target="disability-allowance"/>
+    <relationship identifier="rel-temporary-additional-support--accommodation-supplement--association" xsi:type="Association" source="temporary-additional-support" target="accommodation-supplement"/>
+    <relationship identifier="rel-temporary-additional-support--special-benefit--association" xsi:type="Association" source="temporary-additional-support" target="special-benefit"/>
+    <relationship identifier="rel-temporary-additional-support--jobseeker-support--association" xsi:type="Association" source="temporary-additional-support" target="jobseeker-support"/>
+    <relationship identifier="rel-temporary-additional-support--sole-parent-support--association" xsi:type="Association" source="temporary-additional-support" target="sole-parent-support"/>
+    <relationship identifier="rel-temporary-additional-support--supported-living-payment--association" xsi:type="Association" source="temporary-additional-support" target="supported-living-payment"/>
+    <relationship identifier="rel-temporary-additional-support--emergency-benefit--association" xsi:type="Association" source="temporary-additional-support" target="emergency-benefit"/>
+    <relationship identifier="rel-temporary-additional-support--young-parent-payment--association" xsi:type="Association" source="temporary-additional-support" target="young-parent-payment"/>
+    <relationship identifier="rel-temporary-additional-support--youth-payment--association" xsi:type="Association" source="temporary-additional-support" target="youth-payment"/>
+    <relationship identifier="rel-temporary-additional-support--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="temporary-additional-support" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-temporary-additional-support--best-start-tax-credit--association" xsi:type="Association" source="temporary-additional-support" target="best-start-tax-credit"/>
+    <relationship identifier="rel-temporary-additional-support--family-tax-credit--association" xsi:type="Association" source="temporary-additional-support" target="family-tax-credit"/>
+    <relationship identifier="rel-temporary-additional-support--child-disability-allowance--association" xsi:type="Association" source="temporary-additional-support" target="child-disability-allowance"/>
+    <relationship identifier="rel-temporary-additional-support--recoverable-assistance-payment--association" xsi:type="Association" source="temporary-additional-support" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-temporary-additional-support--special-needs-grant--association" xsi:type="Association" source="temporary-additional-support" target="special-needs-grant"/>
+    <relationship identifier="rel-temporary-additional-support--income-related-rent--association" xsi:type="Association" source="temporary-additional-support" target="income-related-rent"/>
+    <relationship identifier="rel-temporary-additional-support--emergency-housing--association" xsi:type="Association" source="temporary-additional-support" target="emergency-housing"/>
+    <relationship identifier="rel-temporary-additional-support--application-for-assistance--serving" xsi:type="Serving" source="temporary-additional-support" target="application-for-assistance"/>
+    <relationship identifier="rel-temporary-additional-support--reviews-and-appeals--serving" xsi:type="Serving" source="temporary-additional-support" target="reviews-and-appeals"/>
+    <relationship identifier="rel-temporary-additional-support--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="temporary-additional-support" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-temporary-additional-support--residence--association" xsi:type="Association" source="temporary-additional-support" target="residence"/>
+    <relationship identifier="rel-temporary-additional-support--income--association" xsi:type="Association" source="temporary-additional-support" target="income"/>
+    <relationship identifier="rel-temporary-additional-support--definition-of-income--association" xsi:type="Association" source="temporary-additional-support" target="definition-of-income"/>
+    <relationship identifier="rel-temporary-additional-support--child-support-income--association" xsi:type="Association" source="temporary-additional-support" target="child-support-income"/>
+    <relationship identifier="rel-tenancy-costs-cover--housing-support-products--association" xsi:type="Association" source="tenancy-costs-cover" target="housing-support-products"/>
+    <relationship identifier="rel-tenancy-costs-cover--accommodation-supplement--association" xsi:type="Association" source="tenancy-costs-cover" target="accommodation-supplement"/>
+    <relationship identifier="rel-tenancy-costs-cover--reviews-and-appeals--serving" xsi:type="Serving" source="tenancy-costs-cover" target="reviews-and-appeals"/>
+    <relationship identifier="rel-tenancy-costs-cover--residence--association" xsi:type="Association" source="tenancy-costs-cover" target="residence"/>
+    <relationship identifier="rel-training-incentive-allowance--supported-living-payment--association" xsi:type="Association" source="training-incentive-allowance" target="supported-living-payment"/>
+    <relationship identifier="rel-training-incentive-allowance--sole-parent-support--association" xsi:type="Association" source="training-incentive-allowance" target="sole-parent-support"/>
+    <relationship identifier="rel-training-incentive-allowance--young-parent-payment--association" xsi:type="Association" source="training-incentive-allowance" target="young-parent-payment"/>
+    <relationship identifier="rel-training-incentive-allowance--emergency-benefit--association" xsi:type="Association" source="training-incentive-allowance" target="emergency-benefit"/>
+    <relationship identifier="rel-training-incentive-allowance--emergency-maintenance-allowance--association" xsi:type="Association" source="training-incentive-allowance" target="emergency-maintenance-allowance"/>
+    <relationship identifier="rel-training-incentive-allowance--jobseeker-support--association" xsi:type="Association" source="training-incentive-allowance" target="jobseeker-support"/>
+    <relationship identifier="rel-training-incentive-allowance--student-loan--association" xsi:type="Association" source="training-incentive-allowance" target="student-loan"/>
+    <relationship identifier="rel-training-incentive-allowance--specific-employment-related-assistance--association" xsi:type="Association" source="training-incentive-allowance" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-training-incentive-allowance--reviews-and-appeals--serving" xsi:type="Serving" source="training-incentive-allowance" target="reviews-and-appeals"/>
+    <relationship identifier="rel-transition-to-alternative-housing-grant--housing-support-products--association" xsi:type="Association" source="transition-to-alternative-housing-grant" target="housing-support-products"/>
+    <relationship identifier="rel-transition-to-alternative-housing-grant--reviews-and-appeals--serving" xsi:type="Serving" source="transition-to-alternative-housing-grant" target="reviews-and-appeals"/>
+    <relationship identifier="rel-transition-to-alternative-housing-grant--residence--association" xsi:type="Association" source="transition-to-alternative-housing-grant" target="residence"/>
+    <relationship identifier="rel-vehicle-modification-funding--reviews-and-appeals--serving" xsi:type="Serving" source="vehicle-modification-funding" target="reviews-and-appeals"/>
+    <relationship identifier="rel-veterans-pension--family-tax-credit--association" xsi:type="Association" source="veterans-pension" target="family-tax-credit"/>
+    <relationship identifier="rel-veterans-pension--best-start-tax-credit--association" xsi:type="Association" source="veterans-pension" target="best-start-tax-credit"/>
+    <relationship identifier="rel-veterans-pension--disability-allowance--association" xsi:type="Association" source="veterans-pension" target="disability-allowance"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-agreements--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-agreements"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-australia--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-australia"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-canada--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-canada"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-denmark--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-denmark"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-hellenic-republic--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-hellenic-republic"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-ireland--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-ireland"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-jersey-guernsey--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-jersey-guernsey"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-republic-of-korea--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-republic-of-korea"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-malta--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-malta"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-netherlands--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-netherlands"/>
+    <relationship identifier="rel-veterans-pension--reciprocal-united-kingdom--influence" xsi:type="Influence" source="veterans-pension" target="reciprocal-united-kingdom"/>
+    <relationship identifier="rel-veterans-pension--portability--influence" xsi:type="Influence" source="veterans-pension" target="portability"/>
+    <relationship identifier="rel-veterans-pension--general-portability--influence" xsi:type="Influence" source="veterans-pension" target="general-portability"/>
+    <relationship identifier="rel-veterans-pension--special-portability--influence" xsi:type="Influence" source="veterans-pension" target="special-portability"/>
+    <relationship identifier="rel-veterans-pension--student-loan--influence" xsi:type="Influence" source="veterans-pension" target="student-loan"/>
+    <relationship identifier="rel-veterans-pension--residence--association" xsi:type="Association" source="veterans-pension" target="residence"/>
+    <relationship identifier="rel-veterans-pension--income--association" xsi:type="Association" source="veterans-pension" target="income"/>
+    <relationship identifier="rel-winter-energy-payment--temporary-additional-support--association" xsi:type="Association" source="winter-energy-payment" target="temporary-additional-support"/>
+    <relationship identifier="rel-winter-energy-payment--social-rehabilitation-assistance--association" xsi:type="Association" source="winter-energy-payment" target="social-rehabilitation-assistance"/>
+    <relationship identifier="rel-winter-energy-payment--emergency-housing--association" xsi:type="Association" source="winter-energy-payment" target="emergency-housing"/>
+    <relationship identifier="rel-winter-energy-payment--new-zealand-superannuation--association" xsi:type="Association" source="winter-energy-payment" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-winter-energy-payment--veterans-pension--association" xsi:type="Association" source="winter-energy-payment" target="veterans-pension"/>
+    <relationship identifier="rel-winter-energy-payment--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="winter-energy-payment" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-winter-energy-payment--income-related-rent--association" xsi:type="Association" source="winter-energy-payment" target="income-related-rent"/>
+    <relationship identifier="rel-winter-energy-payment--portability--influence" xsi:type="Influence" source="winter-energy-payment" target="portability"/>
+    <relationship identifier="rel-winter-energy-payment--general-portability--influence" xsi:type="Influence" source="winter-energy-payment" target="general-portability"/>
+    <relationship identifier="rel-winter-energy-payment--special-portability--influence" xsi:type="Influence" source="winter-energy-payment" target="special-portability"/>
+    <relationship identifier="rel-winter-energy-payment--reciprocal-agreements--influence" xsi:type="Influence" source="winter-energy-payment" target="reciprocal-agreements"/>
+    <relationship identifier="rel-work-bonus--specific-employment-related-assistance--association" xsi:type="Association" source="work-bonus" target="specific-employment-related-assistance"/>
+    <relationship identifier="rel-work-bonus--employment-and-work-readiness-assistance--association" xsi:type="Association" source="work-bonus" target="employment-and-work-readiness-assistance"/>
+    <relationship identifier="rel-young-parent-payment--youth-payment--association" xsi:type="Association" source="young-parent-payment" target="youth-payment"/>
+    <relationship identifier="rel-young-parent-payment--family-tax-credit--association" xsi:type="Association" source="young-parent-payment" target="family-tax-credit"/>
+    <relationship identifier="rel-young-parent-payment--jobseeker-support--association" xsi:type="Association" source="young-parent-payment" target="jobseeker-support"/>
+    <relationship identifier="rel-young-parent-payment--supported-living-payment--association" xsi:type="Association" source="young-parent-payment" target="supported-living-payment"/>
+    <relationship identifier="rel-young-parent-payment--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="young-parent-payment" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-young-parent-payment--accommodation-supplement--association" xsi:type="Association" source="young-parent-payment" target="accommodation-supplement"/>
+    <relationship identifier="rel-young-parent-payment--temporary-additional-support--association" xsi:type="Association" source="young-parent-payment" target="temporary-additional-support"/>
+    <relationship identifier="rel-young-parent-payment--advance-payment-of-benefit--association" xsi:type="Association" source="young-parent-payment" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-young-parent-payment--special-needs-grant--association" xsi:type="Association" source="young-parent-payment" target="special-needs-grant"/>
+    <relationship identifier="rel-young-parent-payment--recoverable-assistance-payment--association" xsi:type="Association" source="young-parent-payment" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-young-parent-payment--child-support--influence" xsi:type="Influence" source="young-parent-payment" target="child-support"/>
+    <relationship identifier="rel-young-parent-payment--relationship-status-for-benefit--influence" xsi:type="Influence" source="young-parent-payment" target="relationship-status-for-benefit"/>
+    <relationship identifier="rel-young-parent-payment--redirection-of-benefit-payment--serving" xsi:type="Serving" source="young-parent-payment" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-young-parent-payment--reviews-and-appeals--serving" xsi:type="Serving" source="young-parent-payment" target="reviews-and-appeals"/>
+    <relationship identifier="rel-young-parent-payment--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="young-parent-payment" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-young-parent-payment--youth-service-information-sharing--serving" xsi:type="Serving" source="young-parent-payment" target="youth-service-information-sharing"/>
+    <relationship identifier="rel-young-parent-payment--residence--association" xsi:type="Association" source="young-parent-payment" target="residence"/>
+    <relationship identifier="rel-young-parent-payment--income--association" xsi:type="Association" source="young-parent-payment" target="income"/>
+    <relationship identifier="rel-youth-payment--young-parent-payment--association" xsi:type="Association" source="youth-payment" target="young-parent-payment"/>
+    <relationship identifier="rel-youth-payment--jobseeker-support--association" xsi:type="Association" source="youth-payment" target="jobseeker-support"/>
+    <relationship identifier="rel-youth-payment--supported-living-payment--association" xsi:type="Association" source="youth-payment" target="supported-living-payment"/>
+    <relationship identifier="rel-youth-payment--special-disability-allowance--association" xsi:type="Association" source="youth-payment" target="special-disability-allowance"/>
+    <relationship identifier="rel-youth-payment--advance-payment-of-benefit--association" xsi:type="Association" source="youth-payment" target="advance-payment-of-benefit"/>
+    <relationship identifier="rel-youth-payment--special-needs-grant--association" xsi:type="Association" source="youth-payment" target="special-needs-grant"/>
+    <relationship identifier="rel-youth-payment--recoverable-assistance-payment--association" xsi:type="Association" source="youth-payment" target="recoverable-assistance-payment"/>
+    <relationship identifier="rel-youth-payment--temporary-additional-support--association" xsi:type="Association" source="youth-payment" target="temporary-additional-support"/>
+    <relationship identifier="rel-youth-payment--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="youth-payment" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-youth-payment--youth-service-information-sharing--association" xsi:type="Association" source="youth-payment" target="youth-service-information-sharing"/>
+    <relationship identifier="rel-youth-payment--redirection-of-benefit-payment--serving" xsi:type="Serving" source="youth-payment" target="redirection-of-benefit-payment"/>
+    <relationship identifier="rel-youth-payment--reviews-and-appeals--serving" xsi:type="Serving" source="youth-payment" target="reviews-and-appeals"/>
+    <relationship identifier="rel-youth-payment--residence--association" xsi:type="Association" source="youth-payment" target="residence"/>
+    <relationship identifier="rel-youth-payment--income--association" xsi:type="Association" source="youth-payment" target="income"/>
+    <relationship identifier="rel-youth-payment--community-services-card--association" xsi:type="Association" source="youth-payment" target="community-services-card"/>
+    <relationship identifier="rel-childcare-assistance-programme--child-disability-allowance--association" xsi:type="Association" source="childcare-assistance-programme" target="child-disability-allowance"/>
+    <relationship identifier="rel-childcare-assistance-programme--early-learning-payment--association" xsi:type="Association" source="childcare-assistance-programme" target="early-learning-payment"/>
+    <relationship identifier="rel-childcare-assistance-programme--flexible-childcare-assistance--association" xsi:type="Association" source="childcare-assistance-programme" target="flexible-childcare-assistance"/>
+    <relationship identifier="rel-childcare-assistance-programme--guaranteed-childcare-assistance-payment--association" xsi:type="Association" source="childcare-assistance-programme" target="guaranteed-childcare-assistance-payment"/>
+    <relationship identifier="rel-income-related-rent-subsidy--assessment-of-eligibility--serving" xsi:type="Serving" source="income-related-rent-subsidy" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-income-related-rent-subsidy--income-related-rent-debt--association" xsi:type="Association" source="income-related-rent-subsidy" target="income-related-rent-debt"/>
+    <relationship identifier="rel-income-related-rent-subsidy--income-related-rent--association" xsi:type="Association" source="income-related-rent-subsidy" target="income-related-rent"/>
+    <relationship identifier="rel-income-related-rent--accommodation-supplement--association" xsi:type="Association" source="income-related-rent" target="accommodation-supplement"/>
+    <relationship identifier="rel-income-related-rent--jobseeker-support--association" xsi:type="Association" source="income-related-rent" target="jobseeker-support"/>
+    <relationship identifier="rel-income-related-rent--supported-living-payment--association" xsi:type="Association" source="income-related-rent" target="supported-living-payment"/>
+    <relationship identifier="rel-income-related-rent--new-zealand-superannuation--association" xsi:type="Association" source="income-related-rent" target="new-zealand-superannuation"/>
+    <relationship identifier="rel-income-related-rent--veterans-pension--association" xsi:type="Association" source="income-related-rent" target="veterans-pension"/>
+    <relationship identifier="rel-income-related-rent--family-tax-credit--association" xsi:type="Association" source="income-related-rent" target="family-tax-credit"/>
+    <relationship identifier="rel-income-related-rent--orphans-benefit-and-unsupported-childs-benefit--association" xsi:type="Association" source="income-related-rent" target="orphans-benefit-and-unsupported-childs-benefit"/>
+    <relationship identifier="rel-income-related-rent--child-support--influence" xsi:type="Influence" source="income-related-rent" target="child-support"/>
+    <relationship identifier="rel-income-related-rent--reviews-and-appeals--serving" xsi:type="Serving" source="income-related-rent" target="reviews-and-appeals"/>
+    <relationship identifier="rel-income-related-rent--assessment-of-eligibility--serving" xsi:type="Serving" source="income-related-rent" target="assessment-of-eligibility"/>
+    <relationship identifier="rel-income-related-rent--duty-to-advise-of-changes-in-circumstances--serving" xsi:type="Serving" source="income-related-rent" target="duty-to-advise-of-changes-in-circumstances"/>
+    <relationship identifier="rel-income-related-rent--types-of-income--association" xsi:type="Association" source="income-related-rent" target="types-of-income"/>
+    <relationship identifier="rel-income-related-rent--income-related-rent-subsidy--association" xsi:type="Association" source="income-related-rent" target="income-related-rent-subsidy"/>
+    <relationship identifier="rel-income-related-rent--income-related-rent-debt--association" xsi:type="Association" source="income-related-rent" target="income-related-rent-debt"/>
+    <relationship identifier="rel-income-related-rent--tenancy-reviews--association" xsi:type="Association" source="income-related-rent" target="tenancy-reviews"/>
+  </relationships>
+</model>

--- a/docs/reference/ArchiMate/sample-with-view.xml
+++ b/docs/reference/ArchiMate/sample-with-view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Hand-authored ArchiMate Open Exchange (3.0) sample. Used by the test
+  suite to exercise the view-parsing path: 3 elements, 2 relationships,
+  1 view containing all three nodes + both connections.
+-->
+<model xmlns="http://www.opengroup.org/xsd/archimate/3.0/"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       identifier="model-sample-with-view">
+  <name xml:lang="en">Iris Sample (with view)</name>
+  <documentation>Hand-authored fixture for the iris OEX importer.</documentation>
+
+  <elements>
+    <element identifier="el-customer" xsi:type="BusinessActor">
+      <name xml:lang="en">Customer</name>
+      <documentation>External buyer.</documentation>
+    </element>
+    <element identifier="el-place-order" xsi:type="BusinessProcess">
+      <name xml:lang="en">Place Order</name>
+    </element>
+    <element identifier="el-order-svc" xsi:type="ApplicationService">
+      <name xml:lang="en">Order Service</name>
+    </element>
+  </elements>
+
+  <relationships>
+    <relationship identifier="rel-serves" source="el-place-order" target="el-customer" xsi:type="Serving"/>
+    <relationship identifier="rel-realises" source="el-order-svc" target="el-place-order" xsi:type="Realization"/>
+  </relationships>
+
+  <views>
+    <diagrams>
+      <view identifier="view-overview" xsi:type="Diagram">
+        <name xml:lang="en">Overview</name>
+        <node identifier="n-customer" elementRef="el-customer" x="40" y="40" w="120" h="60"/>
+        <node identifier="n-place-order" elementRef="el-place-order" x="220" y="40" w="120" h="60"/>
+        <node identifier="n-order-svc" elementRef="el-order-svc" x="220" y="160" w="120" h="60"/>
+        <connection identifier="c-serves" relationshipRef="rel-serves" source="n-place-order" target="n-customer"/>
+        <connection identifier="c-realises" relationshipRef="rel-realises" source="n-order-svc" target="n-place-order"/>
+      </view>
+    </diagrams>
+  </views>
+</model>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.4.0",
+	"version": "5.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.5.10",
+			"version": "5.6.0",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.5.10",
+	"version": "5.6.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/import/+page.svelte
+++ b/frontend/src/routes/import/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	/** Import page — upload .qea/.eap (SparxEA) or .pptx (DoView) files. */
+	/** Import page — upload .qea/.eap (SparxEA), .pptx (DoView), or .xml/.archimate/.oex (ArchiMate Open Exchange) files. */
 	import { goto } from '$app/navigation';
 	import { getAccessToken } from '$lib/stores/auth.svelte.js';
 	import { API_BASE_URL } from '$lib/config.js';
@@ -63,8 +63,12 @@
 	let showCreateSetDialog = $state(false);
 	let selectorRef: { reload: () => Promise<void> } | undefined = $state();
 
+	const ARCHIMATE_EXT = /\.(xml|archimate|oex)$/i;
 	const isBatch = $derived(selectedFiles.length > 1 && selectedFiles.every((f) => f.name.endsWith('.pptx')));
 	const isPptx = $derived(selectedFiles.length === 1 && (selectedFiles[0]?.name.endsWith('.pptx') ?? false));
+	const isArchimate = $derived(
+		selectedFiles.length === 1 && (selectedFiles[0] ? ARCHIMATE_EXT.test(selectedFiles[0].name) : false),
+	);
 	const hasResults = $derived(summary !== null || batchSummary !== null);
 
 	function handleDragOver(event: DragEvent) {
@@ -94,10 +98,14 @@
 
 	function selectFiles(files: File[]) {
 		const valid = files.filter(
-			(f) => f.name.endsWith('.qea') || f.name.endsWith('.eap') || f.name.endsWith('.pptx'),
+			(f) =>
+				f.name.endsWith('.qea') ||
+				f.name.endsWith('.eap') ||
+				f.name.endsWith('.pptx') ||
+				ARCHIMATE_EXT.test(f.name),
 		);
 		if (valid.length === 0) {
-			error = 'Supported formats: .qea, .eap (SparxEA) or .pptx (DoView).';
+			error = 'Supported formats: .qea, .eap (SparxEA); .pptx (DoView); .xml, .archimate, .oex (ArchiMate Open Exchange).';
 			return;
 		}
 		// Multi-file only for .pptx
@@ -160,7 +168,11 @@
 
 				progress = 20;
 
-				const endpoint = isPptx ? '/api/import/pptx' : '/api/import/sparx';
+				const endpoint = isPptx
+					? '/api/import/pptx'
+					: isArchimate
+						? '/api/import/archimate'
+						: '/api/import/sparx';
 				const response = await fetch(`${API_BASE_URL}${endpoint}`, {
 					method: 'POST',
 					headers,
@@ -223,7 +235,7 @@
 <div>
 	<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Import</h1>
 	<p class="mt-1 text-sm" style="color: var(--color-muted)">
-		Import diagrams from SparxEA (.qea, .eap) or DoView (.pptx) files. Select multiple .pptx files for batch import.
+		Import diagrams from SparxEA (.qea, .eap), DoView (.pptx), or ArchiMate Open Exchange (.xml, .archimate, .oex) files. Select multiple .pptx files for batch import.
 	</p>
 </div>
 
@@ -383,7 +395,7 @@
 		<input
 			bind:this={fileInputEl}
 			type="file"
-			accept=".qea,.eap,.pptx"
+			accept=".qea,.eap,.pptx,.xml,.archimate,.oex"
 			multiple
 			class="hidden"
 			onchange={handleFileInput}
@@ -400,7 +412,7 @@
 			{/if}
 		</p>
 		<p class="mt-1 text-xs" style="color: var(--color-muted)">
-			SparxEA (.qea, .eap) or DoView (.pptx) — select multiple .pptx for batch import
+			SparxEA (.qea, .eap), DoView (.pptx), or ArchiMate Open Exchange (.xml, .archimate, .oex) — select multiple .pptx for batch import
 		</p>
 	</div>
 

--- a/frontend/tests/e2e/uat/ensure-archimate-test-set.setup.ts
+++ b/frontend/tests/e2e/uat/ensure-archimate-test-set.setup.ts
@@ -1,0 +1,70 @@
+/**
+ * v5.6.0 (issue #52): ensure an "ArchiMate Test" set exists on UAT for
+ * the OEX import spec to drop the imported model into. Idempotent —
+ * reuses the existing set if found, creates one under the "test"
+ * collection otherwise. Writes the resolved set id to a JSON sidecar so
+ * the import spec can read it without a second round-trip.
+ */
+
+import { test as setup } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+const API = 'https://iris-api-gtb3.onrender.com';
+const SIDECAR = 'tests/e2e/uat/.auth/archimate-set.json';
+
+async function getToken(page: import('@playwright/test').Page): Promise<string | null> {
+	return await page.evaluate(() => {
+		for (let i = 0; i < localStorage.length; i++) {
+			const k = localStorage.key(i);
+			if (k && k.includes('auth-token')) {
+				const raw = localStorage.getItem(k);
+				if (raw) {
+					try {
+						const parsed = JSON.parse(raw);
+						return parsed.access_token ?? null;
+					} catch { /* ignore */ }
+				}
+			}
+		}
+		return null;
+	});
+}
+
+setup('ensure ArchiMate test set exists', async ({ page }) => {
+	await page.goto('/');
+	await page.getByRole('heading', { name: 'Dashboard' }).waitFor({ timeout: 15_000 });
+	const token = await getToken(page);
+	if (!token) throw new Error('No auth token in localStorage after login');
+	const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+	// Find the "test" collection.
+	const collectionsResp = await page.request.get(`${API}/api/collections?page_size=50`, { headers });
+	if (!collectionsResp.ok()) throw new Error(`GET /api/collections failed: ${collectionsResp.status()}`);
+	const collections = (await collectionsResp.json()).items ?? [];
+	const testCollection = collections.find((c: { name: string }) => /test/i.test(c.name));
+	if (!testCollection) throw new Error('No "test" collection found on UAT — manual setup required.');
+
+	// Find or create the "ArchiMate Test" set under it.
+	const setsResp = await page.request.get(
+		`${API}/api/sets?collection_id=${testCollection.id}&page_size=50`,
+		{ headers },
+	);
+	if (!setsResp.ok()) throw new Error(`GET /api/sets failed: ${setsResp.status()}`);
+	const sets = (await setsResp.json()).items ?? [];
+	let archimateSet = sets.find((s: { name: string }) => s.name === 'ArchiMate Test');
+	if (!archimateSet) {
+		const create = await page.request.post(`${API}/api/sets`, {
+			headers,
+			data: { name: 'ArchiMate Test', collection_id: testCollection.id },
+		});
+		if (!create.ok()) {
+			throw new Error(`POST /api/sets failed: ${create.status()} ${await create.text()}`);
+		}
+		archimateSet = await create.json();
+	}
+
+	mkdirSync(dirname(SIDECAR), { recursive: true });
+	writeFileSync(SIDECAR, JSON.stringify({ set_id: archimateSet.id, set_name: archimateSet.name }, null, 2));
+	console.log(`[ensure-archimate] set ready: ${archimateSet.id}`);
+});

--- a/frontend/tests/e2e/uat/issue-52-archimate-import.spec.ts
+++ b/frontend/tests/e2e/uat/issue-52-archimate-import.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * v5.6.0 (issue #52): Playwright UAT spec for ArchiMate Open Exchange XML
+ * import. Drives the live UAT site:
+ *  1. Uploads the real-world MSD fixture via /import — asserts the summary
+ *     reports ~127 elements / ~977 relationships / 1 auto-generated diagram.
+ *  2. Opens the auto-generated Overview diagram and confirms the canvas
+ *     renders ≥100 nodes without throwing.
+ *  3. Opens /elements filtered to the test set and confirms a known
+ *     imported element ("Reciprocal Australia") is listed.
+ *
+ * Pre-req: feature is deployed to UAT (run after promotion). Until then
+ * the suite will fail with a 404 on /api/import/archimate, which is the
+ * expected red state.
+ */
+
+import { test, expect } from '@playwright/test';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SHOTS = 'tests/e2e/uat/screenshots';
+const FIXTURE = resolve(__dirname, '../../../../docs/reference/ArchiMate/msd-map.xml');
+const SIDECAR = resolve(__dirname, '.auth/archimate-set.json');
+
+test.beforeAll(() => {
+	if (!existsSync(SHOTS)) mkdirSync(SHOTS, { recursive: true });
+});
+
+function trackErrors(page: import('@playwright/test').Page): string[] {
+	const errors: string[] = [];
+	page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+	page.on('console', (msg) => {
+		if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+	});
+	return errors;
+}
+
+function readSidecar(): { set_id: string; set_name: string } {
+	const raw = readFileSync(SIDECAR, 'utf-8');
+	return JSON.parse(raw);
+}
+
+test('issue #52: imports MSD ArchiMate OEX file and reports summary', async ({ page }) => {
+	const errors = trackErrors(page);
+	const { set_id, set_name } = readSidecar();
+
+	await page.goto('/import');
+	await expect(page.getByRole('heading', { name: 'Import' })).toBeVisible();
+
+	// Pick the fixture via the hidden file input.
+	const input = page.locator('input[type="file"]');
+	await input.setInputFiles(FIXTURE);
+
+	// SetSelector should be visible now; choose the ArchiMate Test set by
+	// matching its name in the visible options.
+	const setSelector = page.locator('select, [role="combobox"]').first();
+	if (await setSelector.count()) {
+		// Best-effort: try a select first, fall back to typing in a combobox.
+		try {
+			await setSelector.selectOption({ label: set_name });
+		} catch {
+			await setSelector.fill(set_name);
+		}
+	}
+
+	await page.screenshot({ path: `${SHOTS}/52-01-pre-import.png`, fullPage: true });
+
+	// Confirm dialog ("Are you sure you want to import to existing set ...")
+	page.once('dialog', (d) => d.accept());
+
+	// Hit Import — wait for either the summary panel or an error banner.
+	await page.getByRole('button', { name: /^Import(?:\s|$)/i }).click();
+
+	// The import has to ingest 977 relationships → comfortably under 90s on Render.
+	await expect(page.getByRole('heading', { name: 'Import Complete' })).toBeVisible({
+		timeout: 90_000,
+	});
+
+	const summaryText = await page
+		.locator('div:has(> h2:has-text("Import Complete"))')
+		.first()
+		.textContent();
+	expect(summaryText).toBeTruthy();
+	const elementsCreated = Number(summaryText!.match(/(\d+)\s*Elements/)?.[1] ?? '0');
+	const relsCreated = Number(summaryText!.match(/(\d+)\s*Relationships/)?.[1] ?? '0');
+	const diagramsCreated = Number(summaryText!.match(/(\d+)\s*Diagrams/)?.[1] ?? '0');
+	expect(elementsCreated).toBeGreaterThanOrEqual(120);
+	expect(relsCreated).toBeGreaterThanOrEqual(900);
+	expect(diagramsCreated).toBe(1);
+
+	await page.screenshot({ path: `${SHOTS}/52-02-import-summary.png`, fullPage: true });
+
+	// No page-level errors during the import.
+	const fatal = errors.filter((e) => !/keep-alive|favicon|404 .* image/i.test(e));
+	expect(fatal, `pageerrors: ${fatal.join('\n')}`).toHaveLength(0);
+
+	// Stash the set id for follow-on tests.
+	expect(set_id).toBeTruthy();
+});
+
+test('issue #52: opens the auto-generated Overview diagram', async ({ page }) => {
+	const errors = trackErrors(page);
+	const { set_id } = readSidecar();
+
+	await page.goto(`/views?set_id=${set_id}`);
+
+	// Find a diagram whose title contains "Overview" — the auto-generated one.
+	const overviewLink = page
+		.locator('a[href*="/views/"]')
+		.filter({ hasText: /Overview/i })
+		.first();
+	await expect(overviewLink).toBeVisible({ timeout: 15_000 });
+	await overviewLink.click();
+	await page.waitForURL(/\/views\/[a-f0-9-]+/);
+
+	// Wait for the canvas to mount with a population of nodes.
+	await page.locator('.svelte-flow__node').first().waitFor({ timeout: 30_000 });
+	const count = await page.locator('.svelte-flow__node').count();
+	expect(count).toBeGreaterThanOrEqual(100);
+
+	await page.screenshot({ path: `${SHOTS}/52-03-overview-canvas.png`, fullPage: true });
+
+	const fatal = errors.filter((e) => !/keep-alive|favicon|404 .* image/i.test(e));
+	expect(fatal, `pageerrors: ${fatal.join('\n')}`).toHaveLength(0);
+});
+
+test('issue #52: imported elements appear in /elements list', async ({ page }) => {
+	const { set_id } = readSidecar();
+	await page.goto(`/elements?set_id=${set_id}`);
+	// Look for a known constraint from the MSD fixture.
+	await expect(page.getByText(/Reciprocal Australia/i).first()).toBeVisible({
+		timeout: 15_000,
+	});
+	await page.screenshot({ path: `${SHOTS}/52-04-elements-list.png`, fullPage: true });
+});

--- a/frontend/tests/unit/importPageAcceptsArchimate.test.ts
+++ b/frontend/tests/unit/importPageAcceptsArchimate.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Static-parser tests for the import page — confirms the v5.6.0 ArchiMate
+ * Open Exchange wiring is in place: file picker advertises the new
+ * extensions, the help text mentions ArchiMate, and the upload routes to
+ * the new /api/import/archimate endpoint.
+ */
+describe('import page accepts ArchiMate OEX files', () => {
+	const src = readFileSync(
+		resolve(__dirname, '../../src/routes/import/+page.svelte'),
+		'utf-8',
+	);
+
+	it('file input accept attribute includes archimate extensions', () => {
+		expect(src).toMatch(/accept="[^"]*\.archimate[^"]*"/);
+		expect(src).toMatch(/accept="[^"]*\.oex[^"]*"/);
+		expect(src).toMatch(/accept="[^"]*\.xml[^"]*"/);
+	});
+
+	it('help text mentions ArchiMate Open Exchange', () => {
+		expect(src).toContain('ArchiMate Open Exchange');
+	});
+
+	it('uploads route to /api/import/archimate when file is archimate', () => {
+		expect(src).toContain('/api/import/archimate');
+		expect(src).toContain('isArchimate');
+	});
+
+	it('selectFiles error message lists ArchiMate as a supported format', () => {
+		expect(src).toMatch(/Supported formats:[^.]*ArchiMate/);
+	});
+});


### PR DESCRIPTION
## Summary

Promote v5.6.0 to UAT — adds ArchiMate Open Exchange XML import (issue #52).

Closes #52 once verified on UAT.

## Verification (post-deploy)

- [ ] `npm run test:uat -- issue-52-archimate-import` — three specs green, screenshots in `frontend/tests/e2e/uat/screenshots/52-*.png`.
- [ ] Manual smoke: drag `docs/reference/ArchiMate/msd-map.xml` onto `/import` on UAT → 127/977/1 import → "MSD MAP Business Architecture — Overview" diagram renders 127 nodes in a grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)