### PR TITLE
v5.6.1: hierarchy DRY, warmer keep-alive, dashboard scope colours, MCP web_url

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -28,8 +28,15 @@ jobs:
           # plus the frontend so Render's free-tier doesn't spin it down
           # mid-flow. /favicon.ico is retained as a cheap secondary so
           # we still see the static-asset edge come up too.
+          # v5.6.1: also ping /api/extensions/public-status — the only
+          # public DB-touching endpoint we have. /health doesn't query
+          # the database, so the asyncpg pool to Supabase still went
+          # cold between user sessions and the first real page load
+          # paid the reconnect cost. public-status is a tiny SELECT
+          # that keeps the pool warm.
           URLS=(
             'https://iris-api-gtb3.onrender.com/health'
+            'https://iris-api-gtb3.onrender.com/api/extensions/public-status'
             'https://iris-api-gtb3.onrender.com/favicon.ico'
             'https://iris-mcp-gtb3.onrender.com/info'  # ADR-134; update suffix when Render assigns it
             'https://iris-uat.chrisbarlow.nz/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Show menu offered "Only with children" instead of the dashboard's
   Diagrams / Text type-filter checkboxes. Both screens now render
   the same `HierarchyControls` component.
+- **Dashboard Collections/Sets cards: selected-name colour matches
+  the count colour** — when no scope was selected, the count used
+  the knowledge-graph node colour (`getNodeTypeColor('collection')`
+  / `'set'`); when selected, the name dropped back to plain
+  foreground. Both states now use the type-coloured value so the
+  card's visual identity carries through.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.6.1] - 2026-05-07
+
+### Changed
+
+- **Hierarchy controls on `/views/[id]` now reuse the shared
+  `HierarchyControls` component (DRY)** — the diagram-detail page's
+  hierarchy sidebar had its own inline copy of the +New / Show
+  dropdown buttons that drifted from the dashboard's version: the
+  Show menu offered "Only with children" instead of the dashboard's
+  Diagrams / Text type-filter checkboxes. Both screens now render
+  the same `HierarchyControls` component.
+
+### Fixed
+
+- **First page load latency after idle on UAT** — the keep-alive
+  workflow now also pings `/api/extensions/public-status`, the
+  one public DB-touching endpoint we have. `/health` keeps the
+  FastAPI dyno warm but doesn't query the database, so the asyncpg
+  pool to Supabase still went cold between sessions and the first
+  real page paid the reconnect cost. `public-status` is a tiny
+  SELECT that keeps the pool hot.
+
 ## [5.6.0] - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.6.1] - 2026-05-07
 
+### Added
+
+- **iris-mcp returns a `web_url` per entity** — every tool response that
+  carries an entity id now also carries a resolved front-end URL
+  (`https://<IRIS_WEB_URL>/views/<id>`, `/elements/<id>`,
+  `/packages/<id>`, `/sets/<id>`, `/collections/<id>`). Search results
+  decorate per-result via the `result_type` discriminator. Reads from
+  the new `IRIS_WEB_URL` env var; when unset the field is omitted and
+  responses are identical to v5.6.0. Stops MCP-using LLMs from guessing
+  the iris host and producing broken links. Render UAT defaults to
+  `https://iris-uat.chrisbarlow.nz`. Surfaced in `/info` for diagnosis.
+
 ### Changed
 
 - **Hierarchy controls on `/views/[id]` now reuse the shared

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.6.0",
+			"version": "5.6.1",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.6.0",
+	"version": "5.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -523,7 +523,10 @@
 			style="border-color: var(--color-border); color: var(--color-fg); background: var(--color-surface)"
 		>
 			{#if activeCollection}
-				<div class="text-xl font-bold" style="color: var(--color-fg)">{activeCollection.name}</div>
+				<!-- v5.6.1: name uses the same knowledge-graph node colour as the
+					 count, so the card's visual identity carries through both
+					 unselected (count) and selected (name) states. -->
+				<div class="text-xl font-bold" style="color: {getNodeTypeColor('collection')}">{activeCollection.name}</div>
 				<button
 					onclick={() => { clearActiveCollection(); clearActiveSet(); setId = ''; collectionId = ''; loadDashboard(); }}
 					class="mt-1 inline-block text-sm"
@@ -546,7 +549,7 @@
 			style="border-color: var(--color-border); color: var(--color-fg); background: var(--color-surface)"
 		>
 			{#if activeSet}
-				<div class="text-xl font-bold" style="color: var(--color-fg)">{activeSet.name}</div>
+				<div class="text-xl font-bold" style="color: {getNodeTypeColor('set')}">{activeSet.name}</div>
 				<button
 					onclick={() => { clearActiveSet(); setId = ''; loadDashboard(); }}
 					class="mt-1 inline-block text-sm"

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -35,6 +35,7 @@
 	import PackagePicker from '$lib/components/PackagePicker.svelte';
 	import NodeDeleteDialog from '$lib/components/NodeDeleteDialog.svelte';
 	import TreeNode from '$lib/components/TreeNode.svelte';
+	import HierarchyControls from '$lib/components/HierarchyControls.svelte';
 	import VersionHistory from '$lib/components/VersionHistory.svelte';
 	import TagInput from '$lib/components/TagInput.svelte';
 	import ThemeSelector from '$lib/components/ThemeSelector.svelte';
@@ -221,13 +222,15 @@
 	let treeSearchQuery = $state('');
 	let showCreateChildDialog = $state(false);
 	let showCreateChildPackageDialog = $state(false);
-	let showChildMenu = $state(false);
-	// v5.5.4 (#46 hierarchy-button-match): controls the new Show ▾ dropdown
-	// in the view-detail hierarchy sidebar.
-	let showHierarchyShowMenu = $state(false);
 	let childPackageName = $state('');
 	let childPackageDescription = $state('');
 	let showParentPicker = $state(false);
+	// v5.6.1: align with dashboard's HierarchyControls — Diagrams / Text type
+	// filters (Packages always shown). The legacy `treeDiagramsOnly` toggle on
+	// the focus/full-screen sidebar variants below uses a separate, narrower
+	// "only items with child diagrams" filter.
+	let showDiagrams = $state(true);
+	let showText = $state(true);
 	let treeDiagramsOnly = $state(false);
 	let treeExpandedIds = $state(new Set<string>());
 	let sidebarScrollTop = $state(0);
@@ -2019,100 +2022,19 @@
 		>
 			<div class="flex items-center justify-between p-3" style="border-bottom: 1px solid var(--color-border); flex-shrink: 0">
 				<span class="text-sm font-semibold" style="color: var(--color-fg)">Hierarchy</span>
-				<div class="flex items-center gap-2" style="position: relative">
-					<!-- v5.5.4 (#46 hierarchy-button-match): match the dashboard's
-						 "+ New ▾" / "Show ▾" pattern from HierarchyControls. The
-						 semantics here are child-create (Package / Diagram) rather
-						 than top-level, but visually they line up with the
-						 dashboard's hierarchy panel. -->
-					<div style="position: relative">
-						<button
-							type="button"
-							onclick={() => { showChildMenu = !showChildMenu; showHierarchyShowMenu = false; }}
-							class="rounded px-3 py-1 text-xs text-white"
-							style="background-color: var(--color-primary)"
-							aria-haspopup="menu"
-							aria-expanded={showChildMenu}
-						>
-							+ New ▾
-						</button>
-						{#if showChildMenu}
-							<!-- svelte-ignore a11y_no_static_element_interactions -->
-							<div
-								style="position: fixed; inset: 0; z-index: 9"
-								onclick={() => (showChildMenu = false)}
-								onkeydown={(e) => { if (e.key === 'Escape') showChildMenu = false; }}
-							></div>
-							<div
-								role="menu"
-								class="absolute right-0 z-50 mt-1 min-w-[160px] rounded border py-1 shadow-lg"
-								style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
-							>
-								<button
-									role="menuitem"
-									onclick={() => { showCreateChildPackageDialog = true; showChildMenu = false; }}
-									class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
-									style="color: var(--color-fg)"
-								>
-									Package
-								</button>
-								<button
-									role="menuitem"
-									onclick={() => { showCreateChildDialog = true; showChildMenu = false; }}
-									class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
-									style="color: var(--color-fg); padding-left: 2rem"
-								>
-									View
-								</button>
-							</div>
-						{/if}
-					</div>
-					<div style="position: relative">
-						<button
-							type="button"
-							onclick={() => { showHierarchyShowMenu = !showHierarchyShowMenu; showChildMenu = false; }}
-							class="rounded border px-3 py-1 text-xs"
-							style="border-color: var(--color-border); color: var(--color-fg)"
-							aria-haspopup="menu"
-							aria-expanded={showHierarchyShowMenu}
-						>
-							Show ▾
-						</button>
-						{#if showHierarchyShowMenu}
-							<!-- svelte-ignore a11y_no_static_element_interactions -->
-							<div
-								style="position: fixed; inset: 0; z-index: 9"
-								onclick={() => (showHierarchyShowMenu = false)}
-								onkeydown={(e) => { if (e.key === 'Escape') showHierarchyShowMenu = false; }}
-							></div>
-							<div
-								role="menu"
-								class="absolute right-0 z-50 mt-1 min-w-[180px] rounded border py-1 shadow-lg"
-								style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
-							>
-								<div
-									class="px-4 pb-0.5 pt-1 text-xs uppercase tracking-wide"
-									style="color: var(--color-muted); pointer-events: none"
-								>
-									Views
-								</div>
-								<label
-									class="flex cursor-pointer items-center gap-2 px-4 py-1.5 text-sm hover:opacity-80"
-									style="color: var(--color-fg)"
-								>
-									<input
-										type="checkbox"
-										checked={treeDiagramsOnly}
-										onchange={(e) => (treeDiagramsOnly = (e.target as HTMLInputElement).checked)}
-									/>
-									Only with children
-								</label>
-								<p class="mt-1 px-4 py-1 text-xs" style="color: var(--color-muted)">
-									Packages are always shown.
-								</p>
-							</div>
-						{/if}
-					</div>
+				<div class="flex items-center gap-2">
+					<!-- v5.6.1: reuse the shared HierarchyControls component (DRY).
+						 Same +New / Show menus as the dashboard so the toolbar reads
+						 the same everywhere. The +New here creates a *child* under
+						 the current diagram's package, hence the dialog handlers. -->
+					<HierarchyControls
+						{showDiagrams}
+						{showText}
+						onShowDiagrams={(v) => (showDiagrams = v)}
+						onShowText={(v) => (showText = v)}
+						oncreatepackage={() => (showCreateChildPackageDialog = true)}
+						oncreateview={() => (showCreateChildDialog = true)}
+					/>
 					<button
 						onclick={() => { sidebarOpen = false; localStorage.setItem('iris-hierarchy-sidebar-open', 'false'); }}
 						class="rounded p-1 text-xs"
@@ -2141,7 +2063,7 @@
 				{:else}
 					<ul role="tree">
 						{#each hierarchyTree as node (node.id)}
-							<TreeNode {node} currentDiagramId={diagram.id} searchQuery={treeSearchQuery} showDiagramsOnly={treeDiagramsOnly} expandedIds={treeExpandedIds} />
+							<TreeNode {node} currentDiagramId={diagram.id} searchQuery={treeSearchQuery} {showDiagrams} {showText} expandedIds={treeExpandedIds} />
 						{/each}
 					</ul>
 				{/if}

--- a/mcp/src/iris_mcp/config.py
+++ b/mcp/src/iris_mcp/config.py
@@ -12,10 +12,15 @@ DEFAULT_URL = "http://localhost:8000"
 class McpConfig:
     url: str
     token: str | None
+    web_url: str | None  # v5.6.1: base URL of the iris web UI; emitted
+                         # alongside item ids so the LLM can produce real
+                         # links instead of guessing the host.
 
 
 def load() -> McpConfig:
+    raw_web = os.environ.get("IRIS_WEB_URL")
     return McpConfig(
         url=os.environ.get("IRIS_URL", DEFAULT_URL),
         token=os.environ.get("IRIS_TOKEN"),
+        web_url=raw_web.rstrip("/") if raw_web else None,
     )

--- a/mcp/src/iris_mcp/http_main.py
+++ b/mcp/src/iris_mcp/http_main.py
@@ -78,6 +78,10 @@ def create_app() -> FastAPI:
             "service": "iris-mcp",
             "endpoint": "/",
             "backend": iris_url,
+            # v5.6.1: surface IRIS_WEB_URL in the info payload so an
+            # operator can verify the deployment knows the front-end
+            # URL it'll inject into tool responses.
+            "web_url": os.environ.get("IRIS_WEB_URL"),
         }
 
     async def mcp_asgi(

--- a/mcp/src/iris_mcp/links.py
+++ b/mcp/src/iris_mcp/links.py
@@ -1,0 +1,152 @@
+"""v5.6.1: web-UI link decoration for tool responses.
+
+The MCP host's LLM otherwise has to *guess* the iris web URL when asked
+to cite a diagram or element — e.g. "https://iris-uat.chrisbarlow.nz/views/<id>"
+— which has produced broken links when the guess was wrong.
+
+We solve this by decorating every entity dict the tools return with a
+`web_url` field. The LLM sees the resolved URL in the response and can
+quote it verbatim. When `IRIS_WEB_URL` isn't configured (local dev),
+decoration is a no-op and responses are identical to before.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+# Map an entity "kind" → the frontend path segment that displays it.
+# The keys cover both singular and plural so search results
+# (`result_type: "diagram"`) and list endpoints (kind="diagrams") all
+# resolve through the same table.
+_KIND_TO_PATH: dict[str, str] = {
+    "diagram": "views",
+    "diagrams": "views",
+    "element": "elements",
+    "elements": "elements",
+    "package": "packages",
+    "packages": "packages",
+    "set": "sets",
+    "sets": "sets",
+    "collection": "collections",
+    "collections": "collections",
+}
+
+
+def web_base() -> str | None:
+    """Read IRIS_WEB_URL fresh each call so tests can monkeypatch the env."""
+    raw = os.environ.get("IRIS_WEB_URL")
+    return raw.rstrip("/") if raw else None
+
+
+def web_url_for(kind: str, entity_id: str, base: str | None = None) -> str | None:
+    """Build a `<base>/<path>/<id>` URL for the given entity, or None if
+    the web base or kind is unknown."""
+    resolved_base = base if base is not None else web_base()
+    if not resolved_base or not entity_id:
+        return None
+    path = _KIND_TO_PATH.get(kind)
+    if not path:
+        return None
+    return f"{resolved_base}/{path}/{entity_id}"
+
+
+def decorate_item(item: dict[str, Any], kind: str, base: str | None = None) -> None:
+    """In-place: attach `web_url` to a single entity dict if we can."""
+    if not isinstance(item, dict):
+        return
+    entity_id = item.get("id")
+    if not isinstance(entity_id, str):
+        return
+    url = web_url_for(kind, entity_id, base)
+    if url:
+        item.setdefault("web_url", url)
+
+
+def decorate_list(items: list[Any], kind: str, base: str | None = None) -> None:
+    """In-place: attach web_urls to every dict-shaped item in a homogeneous list."""
+    if not isinstance(items, list):
+        return
+    resolved_base = base if base is not None else web_base()
+    if not resolved_base:
+        return
+    for item in items:
+        decorate_item(item, kind, resolved_base)
+
+
+def decorate_search(payload: dict[str, Any], base: str | None = None) -> None:
+    """In-place: attach web_urls to a SearchResponse dict — each result
+    carries a `result_type` discriminator (diagram | element | …)."""
+    if not isinstance(payload, dict):
+        return
+    resolved_base = base if base is not None else web_base()
+    if not resolved_base:
+        return
+    results = payload.get("results")
+    if not isinstance(results, list):
+        return
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        kind = r.get("result_type")
+        if isinstance(kind, str):
+            decorate_item(r, kind, resolved_base)
+
+
+# ----- public helpers used by tool handlers -----------------------------------
+
+
+def with_web_url(payload: str, kind: str) -> str:
+    """Decorate a JSON-serialised single-entity tool response.
+
+    `kind` is the kind we expect (e.g. "diagram" for `get_diagram`).
+    No-ops when IRIS_WEB_URL is unset or the payload isn't valid JSON.
+    """
+    base = web_base()
+    if not base:
+        return payload
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    decorate_item(data, kind, base)
+    return json.dumps(data)
+
+
+def with_web_urls_list(payload: str, kind: str) -> str:
+    """Decorate a JSON-serialised list-of-entities tool response."""
+    base = web_base()
+    if not base:
+        return payload
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    decorate_list(data, kind, base)
+    return json.dumps(data)
+
+
+def with_web_urls_search(payload: str) -> str:
+    """Decorate a JSON-serialised SearchResponse."""
+    base = web_base()
+    if not base:
+        return payload
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    decorate_search(data, base)
+    return json.dumps(data)
+
+
+__all__ = [
+    "decorate_item",
+    "decorate_list",
+    "decorate_search",
+    "web_base",
+    "web_url_for",
+    "with_web_url",
+    "with_web_urls_list",
+    "with_web_urls_search",
+]

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -16,6 +16,11 @@ from iris_client import IrisClient
 from mcp import types
 
 from iris_mcp.errors import format_error
+from iris_mcp.links import (
+    with_web_url,
+    with_web_urls_list,
+    with_web_urls_search,
+)
 
 
 @dataclass(frozen=True)
@@ -45,52 +50,62 @@ async def _search(c: IrisClient, args: dict[str, Any]) -> str:
         collection_id=args.get("collection_id"),
         limit=int(args.get("limit", 25)),
     )
-    return result.model_dump_json()
+    return with_web_urls_search(result.model_dump_json())
 
 
 async def _get_diagram(c: IrisClient, args: dict[str, Any]) -> str:
-    return (await c.get_diagram(args["diagram_id"])).model_dump_json()
+    return with_web_url(
+        (await c.get_diagram(args["diagram_id"])).model_dump_json(), "diagram",
+    )
 
 
 async def _list_diagrams(c: IrisClient, args: dict[str, Any]) -> str:
     rows = await c.list_diagrams(set_id=args.get("set_id"))
-    return json.dumps([r.model_dump() for r in rows])
+    return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "diagram")
 
 
 async def _get_element(c: IrisClient, args: dict[str, Any]) -> str:
-    return (await c.get_element(args["element_id"])).model_dump_json()
+    return with_web_url(
+        (await c.get_element(args["element_id"])).model_dump_json(), "element",
+    )
 
 
 async def _list_elements(c: IrisClient, args: dict[str, Any]) -> str:
     rows = await c.list_elements(set_id=args.get("set_id"))
-    return json.dumps([r.model_dump() for r in rows])
+    return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "element")
 
 
 async def _get_package(c: IrisClient, args: dict[str, Any]) -> str:
-    return (await c.get_package(args["package_id"])).model_dump_json()
+    return with_web_url(
+        (await c.get_package(args["package_id"])).model_dump_json(), "package",
+    )
 
 
 async def _list_packages(c: IrisClient, args: dict[str, Any]) -> str:
     rows = await c.list_packages(set_id=args.get("set_id"))
-    return json.dumps([r.model_dump() for r in rows])
+    return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "package")
 
 
 async def _list_sets(c: IrisClient, args: dict[str, Any]) -> str:
     rows = await c.list_sets(collection_id=args.get("collection_id"))
-    return json.dumps([r.model_dump() for r in rows])
+    return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "set")
 
 
 async def _get_set(c: IrisClient, args: dict[str, Any]) -> str:
-    return (await c.get_set(args["set_id"])).model_dump_json()
+    return with_web_url(
+        (await c.get_set(args["set_id"])).model_dump_json(), "set",
+    )
 
 
 async def _list_collections(c: IrisClient, _args: dict[str, Any]) -> str:
     rows = await c.list_collections()
-    return json.dumps([r.model_dump() for r in rows])
+    return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "collection")
 
 
 async def _get_collection(c: IrisClient, args: dict[str, Any]) -> str:
-    return (await c.get_collection(args["collection_id"])).model_dump_json()
+    return with_web_url(
+        (await c.get_collection(args["collection_id"])).model_dump_json(), "collection",
+    )
 
 
 async def _export(

--- a/mcp/tests/test_links.py
+++ b/mcp/tests/test_links.py
@@ -1,0 +1,203 @@
+"""v5.6.1: tests for the web-URL link decorator (links.py).
+
+The decorator is what stops MCP-using LLMs from guessing the iris web
+URL when they cite an entity. Without IRIS_WEB_URL configured the
+decoration is a no-op and tool output is unchanged from prior versions.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+from iris_mcp.links import (
+    decorate_item,
+    decorate_search,
+    web_base,
+    web_url_for,
+    with_web_url,
+    with_web_urls_list,
+    with_web_urls_search,
+)
+
+BASE = "http://iris.test"
+WEB = "https://iris-uat.chrisbarlow.nz"
+
+
+class TestWebUrlFor:
+    def test_returns_none_when_base_unset(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        assert web_url_for("diagram", "abc") is None
+
+    def test_returns_none_for_unknown_kind(self) -> None:
+        assert web_url_for("nope", "abc", base=WEB) is None
+
+    def test_returns_none_for_empty_id(self) -> None:
+        assert web_url_for("diagram", "", base=WEB) is None
+
+    @pytest.mark.parametrize(
+        ("kind", "path"),
+        [
+            ("diagram", "views"),
+            ("diagrams", "views"),
+            ("element", "elements"),
+            ("package", "packages"),
+            ("set", "sets"),
+            ("collection", "collections"),
+        ],
+    )
+    def test_routes_each_kind_to_frontend_path(self, kind: str, path: str) -> None:
+        assert web_url_for(kind, "x-1", base=WEB) == f"{WEB}/{path}/x-1"
+
+    def test_strips_trailing_slash_via_web_base(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", "https://iris.example.com/")
+        assert web_base() == "https://iris.example.com"
+        assert web_url_for("diagram", "x") == "https://iris.example.com/views/x"
+
+
+class TestDecorateItem:
+    def test_attaches_web_url_to_dict(self) -> None:
+        item = {"id": "abc", "name": "thing"}
+        decorate_item(item, "diagram", WEB)
+        assert item["web_url"] == f"{WEB}/views/abc"
+
+    def test_does_not_overwrite_existing_web_url(self) -> None:
+        item = {"id": "abc", "web_url": "https://kept"}
+        decorate_item(item, "diagram", WEB)
+        assert item["web_url"] == "https://kept"
+
+    def test_skips_when_id_missing(self) -> None:
+        item = {"name": "no id"}
+        decorate_item(item, "diagram", WEB)
+        assert "web_url" not in item
+
+
+class TestDecorateSearch:
+    def test_decorates_each_result_by_result_type(self) -> None:
+        payload = {
+            "query": "x",
+            "results": [
+                {"id": "d1", "result_type": "diagram", "name": "Diag"},
+                {"id": "e1", "result_type": "element", "name": "Elem"},
+                {"id": "s1", "result_type": "set", "name": "Set"},
+            ],
+            "total": 3,
+        }
+        decorate_search(payload, WEB)
+        urls = [r["web_url"] for r in payload["results"]]
+        assert urls == [
+            f"{WEB}/views/d1",
+            f"{WEB}/elements/e1",
+            f"{WEB}/sets/s1",
+        ]
+
+
+class TestWrappers:
+    def test_with_web_url_noop_when_unset(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        original = '{"id": "abc"}'
+        assert with_web_url(original, "diagram") == original
+
+    def test_with_web_url_decorates_when_set(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        decorated = with_web_url('{"id": "abc"}', "diagram")
+        body = json.loads(decorated)
+        assert body["web_url"] == f"{WEB}/views/abc"
+
+    def test_with_web_urls_list_decorates_each(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        decorated = with_web_urls_list(
+            '[{"id": "a"}, {"id": "b"}]', "set",
+        )
+        body = json.loads(decorated)
+        assert body[0]["web_url"] == f"{WEB}/sets/a"
+        assert body[1]["web_url"] == f"{WEB}/sets/b"
+
+    def test_with_web_urls_search_decorates_results(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        decorated = with_web_urls_search(
+            json.dumps({
+                "query": "q",
+                "results": [{"id": "d1", "result_type": "diagram"}],
+                "total": 1,
+            }),
+        )
+        body = json.loads(decorated)
+        assert body["results"][0]["web_url"] == f"{WEB}/views/d1"
+
+    def test_invalid_json_passes_through(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        assert with_web_url("not json", "diagram") == "not json"
+
+
+# ----- end-to-end through the dispatch layer ---------------------------------
+
+
+class TestToolsDispatchWithWebUrl:
+    @pytest.mark.asyncio
+    async def test_get_diagram_includes_web_url(
+        self,
+        client: IrisClient,
+        respx_mock: respx.Router,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        respx_mock.get(f"{BASE}/api/diagrams/d-42").mock(
+            return_value=httpx.Response(200, json={
+                "id": "d-42", "name": "Demo",
+                "diagram_type": "process", "current_version": 1,
+                "created_at": "2026-05-07T00:00:00Z",
+                "updated_at": "2026-05-07T00:00:00Z",
+            }),
+        )
+        result = await tools.dispatch("get_diagram", client, {"diagram_id": "d-42"})
+        body = json.loads(result[0].text)
+        assert body["web_url"] == f"{WEB}/views/d-42"
+
+    @pytest.mark.asyncio
+    async def test_search_includes_per_result_web_urls(
+        self,
+        client: IrisClient,
+        respx_mock: respx.Router,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        respx_mock.get(f"{BASE}/api/search").mock(
+            return_value=httpx.Response(200, json={
+                "query": "demo",
+                "results": [
+                    {"id": "d-1", "result_type": "diagram", "name": "D"},
+                    {"id": "e-1", "result_type": "element", "name": "E"},
+                ],
+                "total": 2,
+            }),
+        )
+        result = await tools.dispatch("search", client, {"query": "demo"})
+        body = json.loads(result[0].text)
+        urls = [r["web_url"] for r in body["results"]]
+        assert urls == [f"{WEB}/views/d-1", f"{WEB}/elements/e-1"]
+
+    @pytest.mark.asyncio
+    async def test_no_web_url_when_env_unset(
+        self,
+        client: IrisClient,
+        respx_mock: respx.Router,
+        monkeypatch,  # type: ignore[no-untyped-def]
+    ) -> None:
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        respx_mock.get(f"{BASE}/api/diagrams/d-42").mock(
+            return_value=httpx.Response(200, json={
+                "id": "d-42", "name": "Demo",
+                "diagram_type": "process", "current_version": 1,
+                "created_at": "2026-05-07T00:00:00Z",
+                "updated_at": "2026-05-07T00:00:00Z",
+            }),
+        )
+        result = await tools.dispatch("get_diagram", client, {"diagram_id": "d-42"})
+        body = json.loads(result[0].text)
+        assert "web_url" not in body

--- a/render.yaml
+++ b/render.yaml
@@ -98,3 +98,9 @@ services:
         # Render-assigned URL of the iris-api service above. Update if
         # iris-api ever moves to a custom domain.
         value: https://iris-api-gtb3.onrender.com
+      - key: IRIS_WEB_URL
+        # v5.6.1: front-end URL the MCP returns alongside entity ids
+        # so the AI host can produce real "https://iris-uat..." links
+        # instead of guessing the host. Optional — when unset the MCP
+        # omits `web_url` from tool responses.
+        value: https://iris-uat.chrisbarlow.nz


### PR DESCRIPTION
## Summary

Four small, related polish items.

- **DRY hierarchy controls**: replace the inline `+New ▾` / `Show ▾` copy on `/views/[id]` with the shared `HierarchyControls` component used on the dashboard. The Show menu on the diagram-detail sidebar was offering "Only with children" instead of the dashboard's Diagrams / Text type-filter checkboxes — they're now identical. Net diff is **-100 lines** of UI code.
- **Warmer keep-alive**: add `/api/extensions/public-status` to the keep-alive workflow's ping list. `/health` keeps the FastAPI dyno warm but doesn't query the database, so the asyncpg pool to Supabase went cold between user sessions and the first real page after idle paid the reconnect cost. `public-status` is a tiny public SELECT — the cheapest DB-touching endpoint we have.
- **Dashboard scope cards**: when a Collection or Set is active, the card showed the name in plain foreground colour while the count (when unselected) used the knowledge-graph node colour. Both states now use the type-coloured value.
- **iris-mcp emits `web_url` per entity**: every tool response with an entity id also carries a resolved front-end URL (`https://<IRIS_WEB_URL>/views/<id>`, `/elements/<id>`, etc.). Search decorates per-result via the `result_type` discriminator. Stops MCP-using LLMs from guessing the iris host and producing broken links. Reads `IRIS_WEB_URL` (UAT default `https://iris-uat.chrisbarlow.nz`); unset → field omitted → responses identical to v5.6.0.

## Test plan

- [x] **MCP link tests**: 22 new tests in `mcp/tests/test_links.py`, all green. Cover the helpers, dispatch end-to-end (`get_diagram` and `search`), and the no-op-when-unset path.
- [x] `/views/[id]` Hierarchy sidebar Show menu now shows "Diagrams" + "Text" checkboxes — identical to dashboard.
- [x] `+ New ▾` still creates a child Package or View under the current diagram (callbacks wire to existing `showCreateChildPackageDialog` / `showCreateChildDialog`).
- [x] Dashboard Collection card: pick a collection → its name renders in the same colour as the unselected `Collections` count. Same for Set card.
- [ ] After deploy: come back to UAT after a 30+ minute idle window — first page load no longer pays a noticeable reconnect cost.
- [ ] After deploy: query iris-mcp `get_diagram` (or `search`) and confirm response includes `web_url` pointing at UAT host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)