### PR TITLE
release(v5.7.0): mermaid diagram rendering in shared markdown view (ADR-149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.0] - 2026-05-10
+
+Mermaid diagram rendering in the shared markdown view (ADR-149,
+SPEC-149-A) — un-defers the "markdown extensions" item from ADR-137's
+out-of-scope list.
+
+### Added
+
+- **Mermaid diagrams in Markdown views** (ADR-149, SPEC-149-A).
+  ` ```mermaid ` fenced blocks now render as SVG diagrams in any
+  surface that uses the shared `MarkdownView` component — Text
+  diagram views (`/views/[id]`) and User Guide pages. Supports the
+  full mermaid syntax: flowcharts, sequence, class, state, ER,
+  gantt, etc.
+
+  Implementation highlights:
+  - Custom `marked` extension emits a `<pre class="mermaid-block"
+    data-mermaid-source="<base64>">` placeholder so the markdown
+    pipeline stays synchronous and SSR-safe (`markdownHelpers.ts:23`,
+    `markdownMermaidExtension.ts`).
+  - Lazy-loaded mermaid bundle via dynamic `import('mermaid')` —
+    only fetched when a document actually contains a mermaid block.
+    Vite produces a separate ~525KB chunk that zero-block documents
+    do not pay for (`markdownMermaidRender.ts`).
+  - Two-stage DOMPurify sanitisation (protocol #7): stage 1 on the
+    markdown HTML, stage 2 on mermaid's output SVG (`USE_PROFILES:
+    { svg: true, svgFilters: true }`, plus an explicit
+    `ADD_TAGS: ['foreignObject']` for HTML labels). Mermaid runs in
+    `securityLevel: 'strict'` so user-authored labels cannot inject
+    HTML.
+  - Theme follows Iris's class-based dark mode automatically via a
+    `MutationObserver` on `<html>`.
+  - Per-block error fallback: an invalid mermaid block renders as
+    `<div class="mermaid-error">` with the parser message; the rest
+    of the document still renders.
+
+  Note: AI Q&A panel answers do **not** yet render mermaid — that
+  consolidation is tracked in
+  [issue #71](https://github.com/cgbarlow/iris/issues/71).
+
+### Changed
+
+- **DOMPurify bumped to 3.4.2** (from 3.3.1) — picks up CVE fixes
+  including `ADD_TAGS` short-circuit-evaluation bypass
+  ([GHSA-39q2-94rc-95cp](https://github.com/advisories/GHSA-39q2-94rc-95cp))
+  and other XSS hardening. Iris's existing `markdownHelpers.ts`
+  pipeline and the new SVG sanitiser both inherit the fixes.
+
+### Verification
+
+- 18 new unit tests across `markdownMermaidExtension.test.ts` (7),
+  `markdownMermaidRender.test.ts` (6), and
+  `markdownMermaidSvgSanitise.test.ts` (5) cover placeholder shape,
+  base64 round-trip, lazy-load contract, error fallback, and stage-2
+  sanitisation against `<script>` / event handlers / inside
+  `<foreignObject>`.
+- 4 new Playwright e2e tests in `text-view-mermaid.spec.ts` exercise
+  a Text view with valid + invalid + non-mermaid fences and confirm
+  SVG renders, error fallback works, and the document survives.
+- Frontend full unit suite: 939 pass, 3 unchanged pre-existing
+  baseline failures (extension manager / import idempotency /
+  archimate-format error string — same as v5.6.2).
+- `vite build` confirms mermaid is in a separate chunk (~525KB) that
+  is only fetched on first sight of a mermaid block.
+
 ## [5.6.2] - 2026-05-08
 
 BPMN polish (issue #69) — closes the user-reported drag-connect bug

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The default self-hosted mode requires no external services. The optional Render 
 | **ArchiMate** | 11 types across Business, Application, Technology layers | Serving, Composition, Aggregation, Assignment, Realization, Access, Influence, Triggering |
 | **C4** | Person, Software System, Container, Component, Code Element, Deployment Node, Infrastructure Node | Uses, Depends On, Contains |
 | **DoView** | Outcome Box, Final Outcome, Overview Tile, Source Reference | Causal Link |
-| **Markdown (Text)** | Markdown source rendered as a document; cross-links via the `iris://diagram/<id>` and `iris://element/<id>` URL scheme | TOC drawer with depth-indented headings; in-editor toolbar (B / I / H1–H3 / lists / quote / code / link / image / hr) and Ctrl+B / Ctrl+I / Ctrl+K shortcuts; clipboard image paste |
+| **Markdown (Text)** | Markdown source rendered as a document; cross-links via the `iris://diagram/<id>` and `iris://element/<id>` URL scheme; ` ```mermaid ` fenced blocks render as SVG diagrams (flowchart, sequence, class, state, ER, gantt) | TOC drawer with depth-indented headings; in-editor toolbar (B / I / H1–H3 / lists / quote / code / link / image / hr) and Ctrl+B / Ctrl+I / Ctrl+K shortcuts; clipboard image paste |
 | **BPMN 2.0** *(preview, WIP)* | 14 base types across Activities, Events, Gateways, Swimlanes, Data, Artifacts via discriminator fields | Sequence Flow (default + conditional), Message Flow, Association, Data Association |
 | **Sequence** *(UML diagram type)* | Participants with lifelines | Sync, Async, Reply messages with activation boxes |
 

--- a/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
+++ b/docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md
@@ -533,3 +533,29 @@ rendering for Text. The Text-branch render was a duplicate. The
 amendment removes the duplicate; v5.4.0 §D's intent is preserved
 (the trio still renders for Text views in edit mode) by virtue of
 the parent toolbar.
+
+## Amendment 2026-05-10 — v5.7.0: mermaid extension implemented (ADR-149)
+
+The "markdown extensions (mermaid blocks, callouts, footnotes)" line
+in [Out of scope (deferred)](#out-of-scope-deferred) above is **partially
+fulfilled**: ` ```mermaid ` fenced blocks now render as SVG diagrams in
+the shared `MarkdownView` component per
+[ADR-149](ADR-149-Mermaid-In-Markdown-Renderer.md) and
+[SPEC-149-A](specs/SPEC-149-A-Mermaid-Rendering.md). Callouts and
+footnotes remain deferred.
+
+The integration is non-invasive — the existing pipeline at
+`markdownHelpers.ts:82-95` is unchanged. ADR-149 adds:
+
+- A `marked` extension that emits a `<pre class="mermaid-block">`
+  placeholder (registered at module scope in `markdownHelpers.ts`).
+- A separate lazy-loaded runner (`markdownMermaidRender.ts`) that runs
+  inside `MarkdownView.svelte`'s `$effect` after `{@html}` injects the
+  placeholder.
+- A second `DOMPurify` pass on mermaid's output SVG with an explicit
+  `foreignObject` add — necessary for mermaid HTML labels.
+
+The AI Q&A panel (`SetQA.svelte`) keeps its divergent local renderer
+in v5.7.0; its consolidation onto the shared pipeline is tracked as
+[issue #71](https://github.com/cgbarlow/iris/issues/71) and will land
+in a follow-up release.

--- a/docs/adrs/ADR-149-Mermaid-In-Markdown-Renderer.md
+++ b/docs/adrs/ADR-149-Mermaid-In-Markdown-Renderer.md
@@ -1,0 +1,166 @@
+# ADR-149: Mermaid diagram rendering in the shared Markdown view
+
+Status: Accepted (2026-05-10) — supersedes the "Markdown extensions" deferral in [ADR-137](ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md) §"Out of scope (deferred)" for the mermaid clause only (callouts and footnotes remain deferred).
+
+## Context
+
+ADR-137 shipped a shared markdown rendering pipeline used by the User
+Guide and Text diagram views, and explicitly deferred markdown
+extensions: *"Markdown extensions (mermaid blocks, callouts,
+footnotes) — start with stock markdown; extend if users ask."* The
+user is now asking — Mermaid diagrams as code (` ```mermaid ` fenced
+blocks) are commonly the most natural way to embed flowcharts,
+sequence diagrams and ER diagrams inside an architectural document,
+and Iris's existing Diagram canvases don't cover the lightweight
+"sketch a flow inline with prose" use case that markdown-based docs
+target.
+
+The AI Q&A panel (`SetQA.svelte`) maintains a divergent local
+`renderMarkdown` independent of the shared pipeline. Bringing AI
+answers onto the shared renderer (so they also render mermaid,
+`iris://` links and images) is recognised but **out of scope for
+v5.7.0** — it is tracked in [issue
+#71](https://github.com/cgbarlow/iris/issues/71). Scoping it out keeps
+this release focused on the Markdown view surface and avoids bundling
+an AI-answer behavioural change with the mermaid feature.
+
+## Decision
+
+Three concrete decisions:
+
+### 1. Mermaid is integrated via a custom `marked` extension that emits a placeholder, plus a post-render Svelte effect that calls `mermaid.run()` on the live DOM
+
+The pipeline at `frontend/src/lib/components/markdownHelpers.ts:82` is
+intentionally synchronous (`marked.parse(source, { async: false })`)
+and SSR-safe (early-returns when `document` is undefined). Pre-rendering
+mermaid SVG inside the helper would force the pipeline async and pull
+the ~500KB mermaid bundle into every render — defeats lazy loading and
+breaks SSR.
+
+Instead, the `marked` extension matches ` ```mermaid ` fenced blocks
+and emits:
+
+```html
+<pre class="mermaid-block" data-mermaid-source="<base64-encoded-source>"><code>...escaped source...</code></pre>
+```
+
+This placeholder survives stage-1 DOMPurify with default config (no
+allowlist widening at the markdown stage). After `{@html}` injects the
+sanitised HTML, a Svelte `$effect` in `MarkdownView.svelte` calls
+`runMermaidIn(rootEl, theme)` which lazy-imports `mermaid`, walks the
+placeholders, decodes the source, calls `mermaid.render()` per block,
+sanitises the resulting SVG (stage 2 — see decision 2), and replaces
+the placeholder.
+
+Per-block errors are caught and shown as a small
+`<div class="mermaid-error">…</div>`; the rest of the document still
+renders.
+
+### 2. Two-stage DOMPurify sanitisation
+
+Protocol #7 mandates DOMPurify on every `{@html}`. The pipeline now
+has two stages:
+
+1. **Stage 1 (existing)**: markdown → marked → DOMPurify (default tags
+   + Iris's URL allowlist). The placeholder `<pre>` survives unchanged.
+2. **Stage 2 (new)**: mermaid output SVG → `DOMPurify.sanitize(svg, {
+   USE_PROFILES: { svg: true, svgFilters: true }, ADD_TAGS:
+   ['foreignObject'] })` → the placeholder's `innerHTML` is replaced
+   with the sanitised SVG.
+
+`foreignObject` is **not** in DOMPurify's default SVG profile (it is
+the typical XSS vector for SVG sanitisers) but mermaid uses it for
+HTML labels in flowcharts. Because mermaid runs in
+`securityLevel: 'strict'` (decision 3), the HTML inside any
+`foreignObject` is mermaid-controlled and bounded — we accept the
+narrow widening as the cost of HTML-label rendering.
+
+### 3. Mermaid runs in `securityLevel: 'strict'`
+
+`mermaid.initialize({ securityLevel: 'strict', ... })` disables HTML
+in user-authored labels and disables click-bindings emitted into the
+SVG. This aligns with protocol #7's "treat user content as hostile"
+posture and constrains mermaid's own input parser. Stage-2 DOMPurify
+remains as defence-in-depth.
+
+If a future use case warrants HTML labels, a one-line ADR amendment
+documents the trade-off and relaxes the level.
+
+## Why a `marked` extension + post-render effect, not pre-rendering inside the helper
+
+- The helper is sync and SSR-safe today. Going async cascades to every
+  consumer (the User Guide route, `TextCanvas`, and every test that
+  imports `renderMarkdown`).
+- Mermaid intrinsically mutates a live DOM (it appends measurement
+  nodes to `document.body`). The cleanest place for that is a Svelte
+  `$effect` where mount/unmount lifecycle is already handled.
+- The placeholder approach keeps the helper a pure function of its
+  input. Tests that exercise `renderMarkdown` continue to need only
+  jsdom — they never need the mermaid bundle to assert on rendered
+  HTML shape.
+
+## Why lazy-load mermaid via dynamic `import('mermaid')`
+
+The mermaid bundle is ~500KB gzipped — the largest dependency in the
+frontend. Loading it eagerly would inflate the initial JS chunk for
+every user, including those who never view a markdown document
+containing a mermaid block. Dynamic import keeps mermaid in a separate
+Vite chunk that is only fetched when the renderer detects at least one
+`.mermaid-block` placeholder. Zero-block documents pay zero bundle
+cost.
+
+## Why `securityLevel: 'strict'` not `'loose'`
+
+`'strict'` disables HTML labels and click bindings in user-authored
+mermaid source. Mermaid is itself a parser running on user input —
+the strict level reduces the surface that the parser can inject. The
+stage-2 DOMPurify pass is the second layer; running mermaid loose
+would force DOMPurify to do the only line of defence on richer HTML,
+inverting protocol #7's "be conservative at every stage" approach.
+
+## Compatibility
+
+- Existing markdown documents are unaffected — non-mermaid fenced code
+  blocks render exactly as before.
+- The TOC heading extractor already skips fenced blocks
+  (`markdownHelpers.ts:59`); mermaid blocks are still fenced, so TOC
+  behaviour is unchanged.
+- The `iris://` link allowlist, image-src allowlist, and URL scheme
+  allowlist are unchanged.
+- The existing `<pre>` styles in `MarkdownView.svelte` lines 125-132
+  apply to ordinary fenced code blocks; the new
+  `:global(.mermaid-block)` rule overrides them with a transparent
+  background and no padding so the placeholder reads cleanly during
+  the brief moment before the SVG replaces it.
+- SSR is preserved: the `marked.parse` step runs server-side and
+  emits the placeholder; the `$effect` only runs client-side.
+
+## Out of scope (deferred)
+
+- **AI Q&A panel mermaid + DRY consolidation** — `SetQA.svelte`'s
+  divergent local `renderMarkdown` is left untouched. Tracked in
+  [issue #71](https://github.com/cgbarlow/iris/issues/71).
+- **Mermaid editor toolbar buttons** (insert flowchart / sequence
+  templates) — typing a fence is straightforward enough; defer toolbar
+  ergonomics until usage warrants.
+- **Live-preview mermaid while typing** in `TextCanvas` — the current
+  browse-vs-edit toggle is sufficient; split-pane preview is its own
+  workstream.
+- **Mermaid in non-markdown views** (Sequence canvas, BPMN canvas) —
+  those have their own native renderers; mermaid here is a markdown
+  feature, not a general diagram backend.
+- **Export-to-PNG/SVG of rendered mermaid** — browser print or
+  right-click-save-image is the workaround.
+- **Markdown callouts and footnotes** — still deferred from ADR-137.
+- **Relaxing `securityLevel`** to allow HTML labels and click
+  bindings — defer to a future ADR amendment if user requests it.
+
+## See also
+
+- [ADR-137](ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md) —
+  shared MarkdownView pipeline that this ADR extends.
+- [SPEC-149-A](specs/SPEC-149-A-Mermaid-Rendering.md) — extension
+  shape, placeholder contract, lazy-load flow, theme integration,
+  error UX, file map, test coverage.
+- [Issue #71](https://github.com/cgbarlow/iris/issues/71) — follow-up
+  to consolidate `SetQA` onto the shared renderer.

--- a/docs/adrs/specs/SPEC-149-A-Mermaid-Rendering.md
+++ b/docs/adrs/specs/SPEC-149-A-Mermaid-Rendering.md
@@ -1,0 +1,246 @@
+# SPEC-149-A: Mermaid rendering in MarkdownView
+
+ADR: [ADR-149](../ADR-149-Mermaid-In-Markdown-Renderer.md)
+
+## Frontend file map
+
+| Surface                          | File |
+|---|---|
+| `marked` mermaid extension       | `frontend/src/lib/components/markdownMermaidExtension.ts` |
+| Lazy-load mermaid runner         | `frontend/src/lib/components/markdownMermaidRender.ts`    |
+| Pipeline registration            | `frontend/src/lib/components/markdownHelpers.ts`          |
+| Component wiring + styling       | `frontend/src/lib/components/MarkdownView.svelte`         |
+| Mermaid library (lazy chunk)     | `frontend/node_modules/mermaid/` (dynamic `import('mermaid')`) |
+
+## Rendering pipeline (post-v5.7.0)
+
+```
+markdown source
+  → marked.parse({ async: false })       ← mermaid extension intercepts ```mermaid fences,
+                                            emits <pre class="mermaid-block" data-mermaid-source="b64">
+  → DOMPurify.sanitize({ ALLOWED_URI_REGEXP: /^(?:https?|mailto|iris):|… })
+  → walk anchors → enforce URL-scheme allowlist + tag iris:// targets
+  → walk imgs → enforce src allowlist
+  → {@html}                              ← stage-1 done, placeholder is now in the DOM
+  → MarkdownView.svelte $effect
+     → runMermaidIn(rootEl, theme)
+        → if no .mermaid-block: return
+        → dynamic import('mermaid') (cached after first call)
+        → mermaid.initialize({ securityLevel: 'strict', theme })
+        → for each placeholder:
+            → decode data-mermaid-source (base64)
+            → mermaid.render(uniqueId, source) → svg
+            → DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true }, ADD_TAGS: ['foreignObject'] })   ← stage 2
+            → placeholder.innerHTML = sanitisedSvg
+            → on error: replace placeholder with <div class="mermaid-error">…</div>
+```
+
+## Placeholder contract
+
+The marked extension emits exactly:
+
+```html
+<pre class="mermaid-block" data-mermaid-source="<base64>"><code>...escaped source...</code></pre>
+```
+
+| Attribute / class | Purpose |
+|---|---|
+| `class="mermaid-block"` | Selector used by the runner to find blocks. |
+| `data-mermaid-source` | Base64-encoded original source. Base64 sidesteps quote/newline escaping pitfalls in HTML attributes and survives DOMPurify with default config. |
+| Inner `<code>...</code>` | Holds the human-readable source so search/select-copy still works on the placeholder if for some reason mermaid never runs (e.g. no JS, lazy-load fails, SSR snapshot). |
+
+The runner reads `data-mermaid-source`, base64-decodes, and renders.
+The inner `<code>` is replaced when the SVG injects.
+
+## Stage-1 DOMPurify (unchanged)
+
+```ts
+DOMPurify.sanitize(raw, {
+  ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|iris):|\/|\.{1,2}\/)/i,
+});
+```
+
+The placeholder uses `<pre>` + `class` + `data-*` attribute — all
+covered by DOMPurify's default tag/attribute allowlist. No
+configuration change at this stage.
+
+## Stage-2 DOMPurify (new)
+
+```ts
+DOMPurify.sanitize(svg, {
+  USE_PROFILES: { svg: true, svgFilters: true },
+  ADD_TAGS: ['foreignObject'],
+});
+```
+
+| Tag/attr | Why it's allowed |
+|---|---|
+| `<svg>`, `<g>`, `<path>`, `<rect>`, `<line>`, `<polygon>`, `<text>`, `<tspan>`, `<marker>`, `<defs>`, `<use>`, `<symbol>` | Default svg profile — needed for any mermaid SVG. |
+| svg filter primitives | `svgFilters` profile — mermaid uses `<filter>` for drop-shadow effects. |
+| `<foreignObject>` | Explicit add. Mermaid uses it for HTML labels in flowcharts. The HTML inside is mermaid-controlled because `securityLevel: 'strict'` disables user-authored HTML in labels. Stage-2 sanitisation still strips `<script>` / `onload` / `onerror` etc. inside foreignObject — verified by `markdownMermaidSvgSanitise.test.ts`. |
+
+Tags **not** added: `<iframe>`, `<object>`, `<embed>`, `<script>`,
+`<form>`. Inline event handlers (`onload`, `onerror`, `onclick`)
+remain stripped by DOMPurify defaults.
+
+## Mermaid configuration
+
+```ts
+mermaid.initialize({
+  startOnLoad: false,           // we drive rendering ourselves
+  securityLevel: 'strict',      // protocol #7 alignment
+  theme: themeFor(rootEl),      // see "Theme integration" below
+  suppressErrorRendering: true, // we render our own error placeholder
+});
+```
+
+`startOnLoad: false` is critical — mermaid's default is to scan the
+document for `.mermaid` selectors at load and render automatically.
+We want our runner to be the only entry point so error handling and
+sanitisation are centralised.
+
+## Lazy-load contract
+
+The mermaid bundle lives behind a dynamic `import('mermaid')` in
+`markdownMermaidRender.ts`. The first call awaits the import; the
+result is cached in module scope. Subsequent calls reuse the resolved
+promise.
+
+Vite produces a separate chunk for `mermaid` because it's a dynamic
+import. The `vite build` output should show a chunk named like
+`mermaid.<hash>.js` distinct from the main app chunk. This is verified
+manually during release.
+
+If a document contains zero `.mermaid-block` placeholders, the
+dynamic import is **not** triggered. `markdownMermaidExtension.test.ts`
+asserts this contract via `vi.mock('mermaid')` configured to fail if
+called.
+
+## Theme integration
+
+Iris uses class-based theming (`frontend/src/app.css:15,27`):
+
+| Theme | Class on `<html>` | Mermaid theme |
+|---|---|---|
+| Light (default) | (none) | `'default'` |
+| Dark | `dark` | `'dark'` |
+| High-contrast | `high-contrast` | `'dark'` (no high-contrast preset; closest match is dark with explicit overrides via `themeVariables` if needed) |
+
+The runner reads `document.documentElement.classList` at render time
+to derive the mermaid theme. A `MutationObserver` on
+`document.documentElement.attributes` (filter to `class`) re-invokes
+`runMermaidIn` when the theme class changes. The observer is created
+once per `MarkdownView` mount and disposed on unmount.
+
+## Error UX
+
+When `mermaid.render(...)` throws (invalid syntax, unsupported diagram
+type, etc.), the runner replaces the placeholder with:
+
+```html
+<div class="mermaid-error" role="alert">
+  <strong>Mermaid render error:</strong>
+  <code>{{ message }}</code>
+</div>
+```
+
+Styling (in `MarkdownView.svelte` `<style>`):
+
+```css
+.md-view :global(.mermaid-error) {
+  border: 1px solid var(--color-danger, #dc2626);
+  background: var(--color-surface-hover, #f3f4f6);
+  border-radius: 6px;
+  padding: 8px 12px;
+  color: var(--color-danger, #dc2626);
+  font-family: ui-monospace, monospace;
+  font-size: 0.92em;
+}
+```
+
+The rest of the document continues to render — one bad mermaid block
+does not break the whole view.
+
+## Re-render hygiene
+
+`MarkdownView` already runs `renderMarkdown` inside a `$derived`,
+which re-runs whenever `source` changes. The new `$effect` watches
+`html` and `theme` and re-invokes `runMermaidIn` on each change. To
+avoid mermaid's "duplicate id" error, the runner uses a per-block
+unique id derived from a monotonically incrementing module counter
+plus a per-render salt.
+
+Mermaid injects a small `<style>` tag into `<head>` on first render.
+Subsequent renders reuse the same tag (mermaid de-dups). On
+`MarkdownView` unmount we leave the style tag in place — removing it
+would force a flash on the next mount.
+
+## Component wiring
+
+`MarkdownView.svelte` changes:
+
+```svelte
+<script lang="ts">
+  // ... existing imports ...
+  import { runMermaidIn } from './markdownMermaidRender';
+
+  let rootEl: HTMLDivElement;
+
+  // ... existing $derived blocks ...
+
+  $effect(() => {
+    // Re-run on html change (new content) or theme change
+    if (!rootEl) return;
+    void html;            // depend on html
+    void currentTheme;    // depend on theme signal
+    runMermaidIn(rootEl, currentTheme);
+  });
+</script>
+
+<div bind:this={rootEl} class="md-view" onclick={onClick} role="presentation">
+  {@html html}
+</div>
+```
+
+CSS additions:
+
+```css
+.md-view :global(.mermaid-block) {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  overflow: visible;
+}
+.md-view :global(.mermaid-block svg) {
+  max-width: 100%;
+  height: auto;
+}
+```
+
+The `.mermaid-block` rule overrides the existing `:global(pre)` rule
+at lines 125-132 because the placeholder is itself a `<pre>`.
+
+## Tests
+
+| Test file | Coverage |
+|---|---|
+| `frontend/tests/unit/markdownMermaidExtension.test.ts` | Placeholder shape; base64 round-trip; non-mermaid fences untouched; mixed-content document; lazy-load contract (`vi.mock('mermaid')` asserts no import). |
+| `frontend/tests/unit/markdownMermaidSvgSanitise.test.ts` | Stage-2 DOMPurify config preserves `<svg>/<g>/<path>/<marker>/<defs>/<foreignObject>`; strips `<script>` / `onload="..."` / `onerror="..."` even inside `foreignObject`. |
+| `frontend/tests/unit/markdownViewMermaidComponent.test.ts` | Mounts `MarkdownView` with `vi.mock('mermaid')`; asserts placeholder swapped for SVG; invalid syntax produces `.mermaid-error`; rest of document renders; zero blocks → zero `mermaid` imports. |
+| `frontend/tests/e2e/text-view-mermaid.spec.ts` | Playwright: create Text view with flowchart, browse-mode shows SVG, edit-mode shows source, theme switch re-renders. |
+| `frontend/tests/e2e/user-guide-mermaid.spec.ts` | Playwright: User Guide page containing a mermaid block renders SVG (cross-consumer parity). |
+
+Existing tests must continue to pass:
+
+- `frontend/tests/unit/markdownView.test.ts` — sanitisation, iris://
+  link rewriting, heading extraction.
+- `frontend/tests/unit/markdownImageAllowlist.test.ts` — image-src
+  allowlist defence-in-depth.
+
+## Out of scope
+
+Tracked verbatim in the [ADR-149 "Out of scope (deferred)"](../ADR-149-Mermaid-In-Markdown-Renderer.md) section. Headlines:
+
+- `SetQA` consolidation — issue #71.
+- Mermaid toolbar buttons / live-preview / export — future ADRs.
+- Callouts and footnotes — still deferred from ADR-137.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "frontend",
-	"version": "5.6.1",
+	"version": "5.6.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "frontend",
-			"version": "5.6.1",
+			"version": "5.6.2",
 			"dependencies": {
 				"@supabase/supabase-js": "^2.99.3",
 				"@tailwindcss/vite": "^4.2.1",
@@ -14,12 +14,13 @@
 				"@types/react-dom": "^19.2.3",
 				"@xyflow/svelte": "^1.5.1",
 				"bits-ui": "^2.16.2",
-				"dompurify": "^3.3.1",
+				"dompurify": "^3.4.2",
 				"force-graph": "^1.51.2",
 				"html-to-image": "^1.11.13",
 				"jspdf": "^4.2.0",
 				"lucide-svelte": "^0.577.0",
 				"marked": "^17.0.4",
+				"mermaid": "^11.14.0",
 				"mode-watcher": "^1.1.0",
 				"react": "^19.2.4",
 				"react-dom": "^19.2.4",
@@ -51,6 +52,19 @@
 			"integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@antfu/install-pkg": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+			"integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+			"license": "MIT",
+			"dependencies": {
+				"package-manager-detector": "^1.3.0",
+				"tinyexec": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "5.0.1",
@@ -124,6 +138,12 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@braintree/sanitize-url": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+			"license": "MIT"
+		},
 		"node_modules/@bramus/specificity": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
@@ -136,6 +156,43 @@
 			"bin": {
 				"specificity": "bin/cli.js"
 			}
+		},
+		"node_modules/@chevrotain/cst-dts-gen": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/types": "12.0.0"
+			}
+		},
+		"node_modules/@chevrotain/gast": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/types": "12.0.0"
+			}
+		},
+		"node_modules/@chevrotain/regexp-to-ast": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@chevrotain/types": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/@chevrotain/utils": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@colors/colors": {
 			"version": "1.5.0",
@@ -873,6 +930,23 @@
 			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
 			"license": "MIT"
 		},
+		"node_modules/@iconify/types": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+			"integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+			"license": "MIT"
+		},
+		"node_modules/@iconify/utils": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+			"integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+			"license": "MIT",
+			"dependencies": {
+				"@antfu/install-pkg": "^1.1.0",
+				"@iconify/types": "^2.0.0",
+				"import-meta-resolve": "^4.2.0"
+			}
+		},
 		"node_modules/@internationalized/date": {
 			"version": "3.11.0",
 			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.11.0.tgz",
@@ -926,6 +1000,15 @@
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@mermaid-js/parser": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+			"integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+			"license": "MIT",
+			"dependencies": {
+				"langium": "^4.0.0"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -1956,10 +2039,100 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/d3": {
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+			"integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/d3-axis": "*",
+				"@types/d3-brush": "*",
+				"@types/d3-chord": "*",
+				"@types/d3-color": "*",
+				"@types/d3-contour": "*",
+				"@types/d3-delaunay": "*",
+				"@types/d3-dispatch": "*",
+				"@types/d3-drag": "*",
+				"@types/d3-dsv": "*",
+				"@types/d3-ease": "*",
+				"@types/d3-fetch": "*",
+				"@types/d3-force": "*",
+				"@types/d3-format": "*",
+				"@types/d3-geo": "*",
+				"@types/d3-hierarchy": "*",
+				"@types/d3-interpolate": "*",
+				"@types/d3-path": "*",
+				"@types/d3-polygon": "*",
+				"@types/d3-quadtree": "*",
+				"@types/d3-random": "*",
+				"@types/d3-scale": "*",
+				"@types/d3-scale-chromatic": "*",
+				"@types/d3-selection": "*",
+				"@types/d3-shape": "*",
+				"@types/d3-time": "*",
+				"@types/d3-time-format": "*",
+				"@types/d3-timer": "*",
+				"@types/d3-transition": "*",
+				"@types/d3-zoom": "*"
+			}
+		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-axis": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+			"integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-brush": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+			"integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-selection": "*"
+			}
+		},
+		"node_modules/@types/d3-chord": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+			"integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+			"license": "MIT"
+		},
 		"node_modules/@types/d3-color": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
 			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-contour": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+			"integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-array": "*",
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-dispatch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+			"integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-drag": {
@@ -1971,6 +2144,54 @@
 				"@types/d3-selection": "*"
 			}
 		},
+		"node_modules/@types/d3-dsv": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+			"integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-fetch": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+			"integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-dsv": "*"
+			}
+		},
+		"node_modules/@types/d3-force": {
+			"version": "3.0.10",
+			"resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+			"integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-format": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+			"integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-geo": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+			"integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/geojson": "*"
+			}
+		},
+		"node_modules/@types/d3-hierarchy": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+			"integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+			"license": "MIT"
+		},
 		"node_modules/@types/d3-interpolate": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -1980,10 +2201,76 @@
 				"@types/d3-color": "*"
 			}
 		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-polygon": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+			"integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-quadtree": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+			"integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-random": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+			"integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-scale-chromatic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+			"integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+			"license": "MIT"
+		},
 		"node_modules/@types/d3-selection": {
 			"version": "3.0.11",
 			"resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
 			"integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-time-format": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+			"integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/d3-transition": {
@@ -2045,6 +2332,12 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
+		},
+		"node_modules/@types/geojson": {
+			"version": "7946.0.16",
+			"resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+			"integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/hast": {
 			"version": "3.0.4",
@@ -2149,6 +2442,16 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"license": "ISC"
+		},
+		"node_modules/@upsetjs/venn.js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+			"integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+			"license": "MIT",
+			"optionalDependencies": {
+				"d3-selection": "^3.0.0",
+				"d3-transition": "^3.0.1"
+			}
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.18",
@@ -2549,6 +2852,34 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/chevrotain": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@chevrotain/cst-dts-gen": "12.0.0",
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/regexp-to-ast": "12.0.0",
+				"@chevrotain/types": "12.0.0",
+				"@chevrotain/utils": "12.0.0"
+			},
+			"engines": {
+				"node": ">=22.0.0"
+			}
+		},
+		"node_modules/chevrotain-allstar": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+			"integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash-es": "^4.18.1"
+			},
+			"peerDependencies": {
+				"chevrotain": "^12.0.0"
+			}
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2639,6 +2970,15 @@
 				"url": "https://opencollective.com/core-js"
 			}
 		},
+		"node_modules/cose-base": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+			"integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^1.0.0"
+			}
+		},
 		"node_modules/css-line-break": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
@@ -2685,6 +3025,95 @@
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
 			"license": "MIT"
 		},
+		"node_modules/cytoscape": {
+			"version": "3.33.3",
+			"resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+			"integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/cytoscape-cose-bilkent": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+			"integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^1.0.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+			"integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"cose-base": "^2.2.0"
+			},
+			"peerDependencies": {
+				"cytoscape": "^3.2.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/cose-base": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+			"integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+			"license": "MIT",
+			"dependencies": {
+				"layout-base": "^2.0.0"
+			}
+		},
+		"node_modules/cytoscape-fcose/node_modules/layout-base": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+			"integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+			"license": "MIT"
+		},
+		"node_modules/d3": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+			"integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "3",
+				"d3-axis": "3",
+				"d3-brush": "3",
+				"d3-chord": "3",
+				"d3-color": "3",
+				"d3-contour": "4",
+				"d3-delaunay": "6",
+				"d3-dispatch": "3",
+				"d3-drag": "3",
+				"d3-dsv": "3",
+				"d3-ease": "3",
+				"d3-fetch": "3",
+				"d3-force": "3",
+				"d3-format": "3",
+				"d3-geo": "3",
+				"d3-hierarchy": "3",
+				"d3-interpolate": "3",
+				"d3-path": "3",
+				"d3-polygon": "3",
+				"d3-quadtree": "3",
+				"d3-random": "3",
+				"d3-scale": "4",
+				"d3-scale-chromatic": "3",
+				"d3-selection": "3",
+				"d3-shape": "3",
+				"d3-time": "3",
+				"d3-time-format": "4",
+				"d3-timer": "3",
+				"d3-transition": "3",
+				"d3-zoom": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-array": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -2697,17 +3126,78 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-axis": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+			"integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-binarytree": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
 			"integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
 			"license": "MIT"
 		},
+		"node_modules/d3-brush": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+			"integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-drag": "2 - 3",
+				"d3-interpolate": "1 - 3",
+				"d3-selection": "3",
+				"d3-transition": "3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-chord": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+			"integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-color": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
 			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
 			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-contour": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+			"integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "^3.2.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-delaunay": {
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+			"integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+			"license": "ISC",
+			"dependencies": {
+				"delaunator": "5"
+			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -2734,11 +3224,71 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-dsv": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+			"integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+			"license": "ISC",
+			"dependencies": {
+				"commander": "7",
+				"iconv-lite": "0.6",
+				"rw": "1"
+			},
+			"bin": {
+				"csv2json": "bin/dsv2json.js",
+				"csv2tsv": "bin/dsv2dsv.js",
+				"dsv2dsv": "bin/dsv2dsv.js",
+				"dsv2json": "bin/dsv2json.js",
+				"json2csv": "bin/json2dsv.js",
+				"json2dsv": "bin/json2dsv.js",
+				"json2tsv": "bin/json2dsv.js",
+				"tsv2csv": "bin/dsv2dsv.js",
+				"tsv2json": "bin/dsv2json.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-dsv/node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/d3-ease": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
 			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
 			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-fetch": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+			"integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dsv": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-force": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+			"integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-dispatch": "1 - 3",
+				"d3-quadtree": "1 - 3",
+				"d3-timer": "1 - 3"
+			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -2768,6 +3318,27 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/d3-geo": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+			"integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.5.0 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-hierarchy": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+			"integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-interpolate": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -2786,6 +3357,24 @@
 			"integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
 			"license": "MIT"
 		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-polygon": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+			"integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/d3-quadtree": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
@@ -2794,6 +3383,55 @@
 			"engines": {
 				"node": ">=12"
 			}
+		},
+		"node_modules/d3-random": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+			"integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-sankey": {
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+			"integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-array": "1 - 2",
+				"d3-shape": "^1.2.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-array": {
+			"version": "2.12.1",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+			"integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"internmap": "^1.0.0"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/d3-path": {
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+			"integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/d3-sankey/node_modules/d3-shape": {
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+			"integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"d3-path": "1"
+			}
+		},
+		"node_modules/d3-sankey/node_modules/internmap": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+			"integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+			"license": "ISC"
 		},
 		"node_modules/d3-scale": {
 			"version": "4.0.2",
@@ -2829,6 +3467,18 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
 			"engines": {
 				"node": ">=12"
 			}
@@ -2901,6 +3551,16 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/dagre-d3-es": {
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+			"integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+			"license": "MIT",
+			"dependencies": {
+				"d3": "^7.9.0",
+				"lodash-es": "^4.17.21"
+			}
+		},
 		"node_modules/data-urls": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2924,6 +3584,12 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/kossnocorp"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -2972,6 +3638,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/delaunator": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+			"integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+			"license": "ISC",
+			"dependencies": {
+				"robust-predicates": "^3.0.2"
+			}
+		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3017,9 +3692,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-			"integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+			"integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -3356,6 +4031,12 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
 		},
+		"node_modules/hachure-fill": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+			"integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+			"license": "MIT"
+		},
 		"node_modules/hast-util-to-jsx-runtime": {
 			"version": "2.3.6",
 			"resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3476,11 +4157,33 @@
 				"node": ">=20.0.0"
 			}
 		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/idb": {
 			"version": "8.0.3",
 			"resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
 			"integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
 			"license": "ISC"
+		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+			"integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
 		},
 		"node_modules/index-array-by": {
 			"version": "1.4.2",
@@ -3713,6 +4416,36 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/katex": {
+			"version": "0.16.45",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+			"integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/khroma": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+			"integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3722,6 +4455,30 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/langium": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+			"integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+			"license": "MIT",
+			"dependencies": {
+				"@chevrotain/regexp-to-ast": "~12.0.0",
+				"chevrotain": "~12.0.0",
+				"chevrotain-allstar": "~0.4.3",
+				"vscode-languageserver": "~9.0.1",
+				"vscode-languageserver-textdocument": "~1.0.11",
+				"vscode-uri": "~3.1.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/layout-base": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+			"integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+			"license": "MIT"
 		},
 		"node_modules/lightningcss": {
 			"version": "1.31.1",
@@ -4364,6 +5121,60 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/mermaid": {
+			"version": "11.14.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+			"integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+			"license": "MIT",
+			"dependencies": {
+				"@braintree/sanitize-url": "^7.1.1",
+				"@iconify/utils": "^3.0.2",
+				"@mermaid-js/parser": "^1.1.0",
+				"@types/d3": "^7.4.3",
+				"@upsetjs/venn.js": "^2.0.0",
+				"cytoscape": "^3.33.1",
+				"cytoscape-cose-bilkent": "^4.1.0",
+				"cytoscape-fcose": "^2.2.0",
+				"d3": "^7.9.0",
+				"d3-sankey": "^0.12.3",
+				"dagre-d3-es": "7.0.14",
+				"dayjs": "^1.11.19",
+				"dompurify": "^3.3.1",
+				"katex": "^0.16.25",
+				"khroma": "^2.1.0",
+				"lodash-es": "^4.17.23",
+				"marked": "^16.3.0",
+				"roughjs": "^4.6.6",
+				"stylis": "^4.3.6",
+				"ts-dedent": "^2.2.0",
+				"uuid": "^11.1.0"
+			}
+		},
+		"node_modules/mermaid/node_modules/marked": {
+			"version": "16.4.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/mermaid/node_modules/uuid": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/micromark": {
@@ -5142,6 +5953,12 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/package-manager-detector": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+			"integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+			"license": "MIT"
+		},
 		"node_modules/pako": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -5185,6 +6002,12 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
+		},
+		"node_modules/path-data-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+			"license": "MIT"
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -5296,6 +6119,22 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/points-on-curve": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+			"integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+			"license": "MIT"
+		},
+		"node_modules/points-on-path": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+			"integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+			"license": "MIT",
+			"dependencies": {
+				"path-data-parser": "0.1.0",
+				"points-on-curve": "0.2.0"
 			}
 		},
 		"node_modules/postcss": {
@@ -5612,6 +6451,12 @@
 				"node": ">= 0.8.15"
 			}
 		},
+		"node_modules/robust-predicates": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+			"integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+			"license": "Unlicense"
+		},
 		"node_modules/rollup": {
 			"version": "4.59.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -5654,6 +6499,18 @@
 				"@rollup/rollup-win32-x64-gnu": "4.59.0",
 				"@rollup/rollup-win32-x64-msvc": "4.59.0",
 				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/roughjs": {
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+			"integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+			"license": "MIT",
+			"dependencies": {
+				"hachure-fill": "^0.5.2",
+				"path-data-parser": "^0.1.0",
+				"points-on-curve": "^0.2.0",
+				"points-on-path": "^0.2.1"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -5704,6 +6561,12 @@
 				}
 			}
 		},
+		"node_modules/rw": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+			"integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -5716,6 +6579,12 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
 		},
 		"node_modules/saxes": {
 			"version": "6.0.0",
@@ -5911,6 +6780,12 @@
 				"inline-style-parser": "0.2.7"
 			}
 		},
+		"node_modules/stylis": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+			"integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
+			"license": "MIT"
+		},
 		"node_modules/svelte": {
 			"version": "5.53.5",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.5.tgz",
@@ -6061,7 +6936,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
 			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -6182,6 +7056,15 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/ts-dedent": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+			"integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.10"
+			}
+		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6212,7 +7095,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -6548,6 +7431,55 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/vscode-jsonrpc": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/vscode-languageserver": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-languageserver-protocol": "3.17.5"
+			},
+			"bin": {
+				"installServerIntoExtension": "bin/installServerIntoExtension"
+			}
+		},
+		"node_modules/vscode-languageserver-protocol": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+			"license": "MIT",
+			"dependencies": {
+				"vscode-jsonrpc": "8.2.0",
+				"vscode-languageserver-types": "3.17.5"
+			}
+		},
+		"node_modules/vscode-languageserver-textdocument": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-languageserver-types": {
+			"version": "3.17.5",
+			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+			"license": "MIT"
+		},
+		"node_modules/vscode-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+			"license": "MIT"
 		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.6.2",
+	"version": "5.7.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
@@ -47,12 +47,13 @@
 		"@types/react-dom": "^19.2.3",
 		"@xyflow/svelte": "^1.5.1",
 		"bits-ui": "^2.16.2",
-		"dompurify": "^3.3.1",
+		"dompurify": "^3.4.2",
 		"force-graph": "^1.51.2",
 		"html-to-image": "^1.11.13",
 		"jspdf": "^4.2.0",
 		"lucide-svelte": "^0.577.0",
 		"marked": "^17.0.4",
+		"mermaid": "^11.14.0",
 		"mode-watcher": "^1.1.0",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",

--- a/frontend/src/lib/components/MarkdownView.svelte
+++ b/frontend/src/lib/components/MarkdownView.svelte
@@ -28,6 +28,7 @@
 		type ExtractedLink,
 		type TocHeading,
 	} from './markdownHelpers';
+	import { runMermaidIn, type MermaidTheme } from './markdownMermaidRender';
 	export type { ExtractedLink, TocHeading } from './markdownHelpers';
 
 	interface Props {
@@ -60,14 +61,37 @@
 		goto(path);
 	}
 
+	// ADR-149: mermaid runs after {@html} injects placeholders.
+	let rootEl: HTMLDivElement | undefined = $state();
+	let theme: MermaidTheme = $state('default');
+
+	function readTheme(): MermaidTheme {
+		return document.documentElement.classList.contains('dark') ? 'dark' : 'default';
+	}
+
+	$effect(() => {
+		// Re-run when html changes (new content) or theme flips.
+		void html;
+		void theme;
+		if (!rootEl) return;
+		void runMermaidIn(rootEl, theme);
+	});
+
 	onMount(() => {
 		// Headings/links are emitted via queueMicrotask after the first $derived run.
 		void headings;
 		void html;
+		theme = readTheme();
+		const observer = new MutationObserver(() => {
+			const next = readTheme();
+			if (next !== theme) theme = next;
+		});
+		observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+		return () => observer.disconnect();
 	});
 </script>
 
-<div class="md-view" onclick={onClick} role="presentation">
+<div bind:this={rootEl} class="md-view" onclick={onClick} role="presentation">
 	<!-- Sanitised markdown — pipeline above enforces protocol #7. -->
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html html}
@@ -152,5 +176,34 @@
 	/* Issue #26: text-document refs render in muted colour vs. black diagram refs. */
 	.md-view :global(.md-iris-link--text) {
 		color: var(--color-muted, #6b7280) !important;
+	}
+	/* ADR-149: mermaid placeholder + rendered SVG override the
+	   :global(pre) code-block styling above so the diagram reads
+	   cleanly. */
+	.md-view :global(.mermaid-block) {
+		background: transparent;
+		padding: 0;
+		border-radius: 0;
+		overflow: visible;
+		margin: 1rem 0;
+	}
+	.md-view :global(.mermaid-block svg) {
+		max-width: 100%;
+		height: auto;
+		display: block;
+	}
+	.md-view :global(.mermaid-error) {
+		border: 1px solid var(--color-danger, #dc2626);
+		background: var(--color-surface-hover, #f3f4f6);
+		border-radius: 6px;
+		padding: 8px 12px;
+		margin: 1rem 0;
+		color: var(--color-danger, #dc2626);
+		font-family: ui-monospace, monospace;
+		font-size: 0.92em;
+	}
+	.md-view :global(.mermaid-error code) {
+		background: transparent;
+		padding: 0;
 	}
 </style>

--- a/frontend/src/lib/components/markdownHelpers.ts
+++ b/frontend/src/lib/components/markdownHelpers.ts
@@ -14,6 +14,13 @@
 
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { markdownMermaidExtension } from './markdownMermaidExtension';
+
+// ADR-149: ```mermaid fenced blocks become <pre class="mermaid-block">
+// placeholders. The mermaid bundle is NOT imported here — it is
+// lazy-loaded by markdownMermaidRender.ts after {@html} injects the
+// placeholders into the DOM.
+marked.use(markdownMermaidExtension());
 
 export interface ExtractedLink {
 	kind: 'diagram' | 'element';

--- a/frontend/src/lib/components/markdownMermaidExtension.ts
+++ b/frontend/src/lib/components/markdownMermaidExtension.ts
@@ -1,0 +1,79 @@
+/**
+ * Marked extension for mermaid fenced blocks (ADR-149 / SPEC-149-A).
+ *
+ * Intercepts ```mermaid fences and emits a placeholder element. The
+ * placeholder survives stage-1 DOMPurify with default config and is
+ * replaced by the live SVG by `runMermaidIn` after `{@html}` injects
+ * the sanitised HTML into the DOM.
+ *
+ * Placeholder shape:
+ *   <pre class="mermaid-block" data-mermaid-source="<base64>">
+ *     <code>...escaped source...</code>
+ *   </pre>
+ *
+ * The base64 encoding sidesteps quote/newline pitfalls in HTML
+ * attributes and survives DOMPurify with default config (no allowlist
+ * widening at the markdown stage). The inner <code> preserves a
+ * human-readable copy so search/select-copy works even before mermaid
+ * runs (or if mermaid never runs — SSR snapshot, JS disabled, etc.).
+ *
+ * This module does NOT import `mermaid` — the bundle is lazy-loaded by
+ * `markdownMermaidRender.ts` only when at least one placeholder is
+ * actually present in the rendered DOM.
+ */
+
+import type { MarkedExtension, Tokens } from 'marked';
+
+interface MermaidToken extends Tokens.Generic {
+	type: 'mermaidBlock';
+	raw: string;
+	source: string;
+}
+
+const FENCE_RE = /^```mermaid[ \t]*\r?\n([\s\S]*?)\r?\n```[ \t]*(?:\r?\n|$)/;
+
+function encodeSource(source: string): string {
+	// Latin-1 → UTF-8 → base64. Symmetric with the runner's decode.
+	return btoa(unescape(encodeURIComponent(source)));
+}
+
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+export function markdownMermaidExtension(): MarkedExtension {
+	return {
+		extensions: [
+			{
+				name: 'mermaidBlock',
+				level: 'block',
+				start(src: string) {
+					const i = src.indexOf('```mermaid');
+					return i === -1 ? undefined : i;
+				},
+				tokenizer(src: string): MermaidToken | undefined {
+					const m = FENCE_RE.exec(src);
+					if (!m) return undefined;
+					return {
+						type: 'mermaidBlock',
+						raw: m[0],
+						source: m[1],
+					};
+				},
+				renderer(token: Tokens.Generic): string {
+					const t = token as MermaidToken;
+					const b64 = encodeSource(t.source);
+					return (
+						`<pre class="mermaid-block" data-mermaid-source="${b64}">` +
+						`<code>${escapeHtml(t.source)}</code>` +
+						`</pre>`
+					);
+				},
+			},
+		],
+	};
+}

--- a/frontend/src/lib/components/markdownMermaidRender.ts
+++ b/frontend/src/lib/components/markdownMermaidRender.ts
@@ -1,0 +1,101 @@
+/**
+ * Lazy-load mermaid runner (ADR-149 / SPEC-149-A).
+ *
+ * Walks `.mermaid-block` placeholders inside a given root element,
+ * lazy-imports `mermaid`, calls `mermaid.render()` per block,
+ * sanitises the output SVG via stage-2 DOMPurify, and replaces the
+ * placeholder. Errors are caught per-block and rendered as a
+ * `.mermaid-error` element so the rest of the document survives one
+ * bad diagram.
+ *
+ * Lazy-load contract: zero placeholders → zero mermaid imports. The
+ * dynamic import promise is cached at module scope after the first
+ * call so subsequent renders reuse the resolved bundle.
+ */
+
+import DOMPurify from 'dompurify';
+
+export type MermaidTheme = 'default' | 'dark';
+
+interface MermaidLib {
+	initialize: (config: Record<string, unknown>) => void;
+	render: (id: string, source: string) => Promise<{ svg: string; bindFunctions?: unknown }>;
+}
+
+let mermaidPromise: Promise<MermaidLib> | null = null;
+let renderCounter = 0;
+
+function loadMermaid(): Promise<MermaidLib> {
+	if (!mermaidPromise) {
+		mermaidPromise = import('mermaid').then((mod) => {
+			const lib = (mod.default ?? mod) as MermaidLib;
+			return lib;
+		});
+	}
+	return mermaidPromise;
+}
+
+// foreignObject is added explicitly because mermaid uses it for HTML
+// labels in flowcharts. Mermaid runs in securityLevel: 'strict' so the
+// HTML inside foreignObject is mermaid-controlled, but we still strip
+// <script>/event-handlers as defence-in-depth.
+const SVG_PURIFY_CONFIG = {
+	USE_PROFILES: { svg: true, svgFilters: true },
+	ADD_TAGS: ['foreignObject'],
+} as const;
+
+export function sanitiseMermaidSvg(svg: string): string {
+	return DOMPurify.sanitize(svg, SVG_PURIFY_CONFIG) as string;
+}
+
+function decodeSource(b64: string): string {
+	return decodeURIComponent(escape(atob(b64)));
+}
+
+function makeError(message: string): HTMLDivElement {
+	const div = document.createElement('div');
+	div.className = 'mermaid-error';
+	div.setAttribute('role', 'alert');
+	const strong = document.createElement('strong');
+	strong.textContent = 'Mermaid render error: ';
+	const code = document.createElement('code');
+	code.textContent = message;
+	div.appendChild(strong);
+	div.appendChild(code);
+	return div;
+}
+
+/**
+ * Walk `.mermaid-block` placeholders inside `rootEl` and render them.
+ * Idempotent: the placeholder is replaced with its rendered SVG (or
+ * an error div) on the first run, so subsequent calls find no
+ * placeholders unless `rootEl.innerHTML` was reset (e.g. new markdown
+ * source).
+ */
+export async function runMermaidIn(rootEl: HTMLElement, theme: MermaidTheme): Promise<void> {
+	const placeholders = rootEl.querySelectorAll<HTMLElement>('pre.mermaid-block[data-mermaid-source]');
+	if (placeholders.length === 0) return;
+
+	const mermaid = await loadMermaid();
+	mermaid.initialize({
+		startOnLoad: false,
+		securityLevel: 'strict',
+		theme,
+		suppressErrorRendering: true,
+	});
+
+	for (const placeholder of placeholders) {
+		const b64 = placeholder.getAttribute('data-mermaid-source') ?? '';
+		const source = decodeSource(b64);
+		const id = `iris-mermaid-${++renderCounter}`;
+
+		try {
+			const { svg } = await mermaid.render(id, source);
+			const safe = sanitiseMermaidSvg(svg);
+			placeholder.innerHTML = safe;
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			placeholder.replaceWith(makeError(message));
+		}
+	}
+}

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -206,6 +206,41 @@ export async function createSet(
 }
 
 /**
+ * Create a diagram via the API and return the response body.
+ */
+export async function createDiagram(
+	baseURL: string | undefined,
+	token: string,
+	data: {
+		diagram_type: string;
+		notation: string;
+		name: string;
+		description?: string;
+		data?: Record<string, unknown>;
+	},
+): Promise<Record<string, unknown>> {
+	const origin = baseURL ?? API_BASE;
+	const res = await fetchWithRetry(`${origin}/api/diagrams`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({
+			diagram_type: data.diagram_type,
+			notation: data.notation,
+			name: data.name,
+			description: data.description ?? '',
+			data: data.data ?? {},
+		}),
+	});
+	if (!res.ok) {
+		throw new Error(`createDiagram failed: ${res.status} ${await res.text()}`);
+	}
+	return (await res.json()) as Record<string, unknown>;
+}
+
+/**
  * Create a package via the API and return the response body.
  */
 export async function createPackage(

--- a/frontend/tests/e2e/text-view-mermaid.spec.ts
+++ b/frontend/tests/e2e/text-view-mermaid.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * E2E: Mermaid rendering in a Text diagram view (ADR-149 / SPEC-149-A).
+ *
+ * Creates a Text diagram via the API with three fenced blocks:
+ *  1. a valid flowchart      → renders as SVG
+ *  2. an invalid mermaid     → renders as .mermaid-error
+ *  3. a plain typescript     → renders as ordinary <pre><code>
+ *
+ * Then visits /views/<id> and asserts the rendered DOM matches.
+ */
+
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin, createDiagram } from './fixtures';
+
+const MERMAID_SOURCE = [
+	'# Mermaid Smoke Test',
+	'',
+	'A valid flowchart:',
+	'',
+	'```mermaid',
+	'flowchart TD',
+	'    A[Client] --> B{Load Balancer}',
+	'    B --> C[Server 1]',
+	'    B --> D[Server 2]',
+	'```',
+	'',
+	'An invalid one to test the error fallback:',
+	'',
+	'```mermaid',
+	'thisIsNotValid ::: nope',
+	'```',
+	'',
+	'A normal code block (must not render as mermaid):',
+	'',
+	'```typescript',
+	'const x: number = 42;',
+	'```',
+	'',
+	'Done.',
+].join('\n');
+
+let diagramId = '';
+
+test.describe('Text view mermaid rendering (ADR-149)', () => {
+	test.beforeAll(async () => {
+		await seedAdmin();
+		const token = await getAuthToken();
+
+		const body = await createDiagram(undefined, token, {
+			diagram_type: 'text',
+			notation: 'markdown',
+			name: 'Mermaid Smoke Test',
+			description: 'Created by text-view-mermaid.spec.ts',
+			data: { content: MERMAID_SOURCE },
+		});
+		diagramId = body.id as string;
+	});
+
+	test('valid mermaid block renders as inline SVG', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+
+		// Wait for the markdown view to mount and mermaid to render.
+		const block = page.locator('.md-view .mermaid-block').first();
+		await expect(block).toBeVisible({ timeout: 15_000 });
+
+		// SVG must replace the placeholder <code>.
+		const svg = block.locator('svg').first();
+		await expect(svg).toBeVisible({ timeout: 15_000 });
+
+		// Diagram content sanity-check: nodes labelled "Client" and
+		// "Load Balancer" appear somewhere in the SVG text content.
+		await expect(block).toContainText('Client');
+		await expect(block).toContainText('Load Balancer');
+	});
+
+	test('invalid mermaid block renders a .mermaid-error fallback', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+
+		const error = page.locator('.md-view .mermaid-error').first();
+		await expect(error).toBeVisible({ timeout: 15_000 });
+		await expect(error).toContainText(/Mermaid render error/i);
+	});
+
+	test('non-mermaid code blocks render as ordinary <pre><code>', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+
+		// The typescript block has class "language-typescript" via marked's
+		// default fenced-code rendering — never gets the mermaid-block class.
+		const tsCode = page.locator('.md-view pre code.language-typescript').first();
+		await expect(tsCode).toBeVisible({ timeout: 15_000 });
+		await expect(tsCode).toContainText('const x: number = 42');
+
+		// And there must be no mermaid-block element wrapping the typescript code.
+		const tsParentClass = await tsCode.evaluate((el) => el.parentElement?.className ?? '');
+		expect(tsParentClass).not.toContain('mermaid-block');
+	});
+
+	test('the rest of the document still renders even if a mermaid block errors', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+
+		// "Done." paragraph appears below all the blocks.
+		await expect(page.locator('.md-view').getByText('Done.')).toBeVisible({ timeout: 15_000 });
+		// And the H1 heading rendered too.
+		await expect(page.locator('.md-view h1', { hasText: 'Mermaid Smoke Test' })).toBeVisible();
+	});
+});

--- a/frontend/tests/unit/markdownMermaidExtension.test.ts
+++ b/frontend/tests/unit/markdownMermaidExtension.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the marked mermaid extension (ADR-149 / SPEC-149-A).
+ *
+ * The extension intercepts ```mermaid fenced blocks and emits a
+ * placeholder <pre class="mermaid-block" data-mermaid-source="<base64>">.
+ * The placeholder must:
+ *   - survive stage-1 DOMPurify with default config,
+ *   - round-trip the source via base64 in the data attribute,
+ *   - leave non-mermaid fenced blocks untouched (regression guard),
+ *   - not pull the mermaid bundle into the synchronous render path
+ *     (lazy-load contract — verified via vi.mock).
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Lazy-load contract: importing `markdownHelpers` (and therefore the
+// mermaid extension at module scope) must NOT pull in the mermaid
+// library. Mock it to throw if anything reaches it during the
+// markdown pipeline.
+vi.mock('mermaid', () => {
+	throw new Error('mermaid bundle imported during markdown render — lazy-load contract violated');
+});
+
+import { renderMarkdown } from '$lib/components/markdownHelpers';
+
+function decodeSource(b64: string): string {
+	// jsdom provides atob
+	return decodeURIComponent(escape(atob(b64)));
+}
+
+describe('markdown mermaid extension — placeholder shape', () => {
+	it('emits a <pre class="mermaid-block"> with the source base64-encoded in data-mermaid-source', () => {
+		const source = '```mermaid\nflowchart TD\nA-->B\n```\n';
+		const { html } = renderMarkdown(source);
+
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+		const block = tpl.content.querySelector('pre.mermaid-block');
+		expect(block).not.toBeNull();
+
+		const b64 = block!.getAttribute('data-mermaid-source');
+		expect(b64).toBeTruthy();
+		expect(decodeSource(b64!)).toBe('flowchart TD\nA-->B');
+	});
+
+	it('preserves a human-readable <code> child so search/select-copy still works before mermaid runs', () => {
+		const { html } = renderMarkdown('```mermaid\ngraph LR\nX-->Y\n```\n');
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+		const code = tpl.content.querySelector('pre.mermaid-block code');
+		expect(code).not.toBeNull();
+		expect(code!.textContent).toContain('graph LR');
+		expect(code!.textContent).toContain('X-->Y');
+	});
+
+	it('round-trips multi-line source with special characters via base64', () => {
+		const source = [
+			'```mermaid',
+			'sequenceDiagram',
+			'  Alice->>Bob: "Hello, & welcome!"',
+			'  Bob-->>Alice: <reply>',
+			'```',
+		].join('\n');
+
+		const { html } = renderMarkdown(source);
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+		const block = tpl.content.querySelector('pre.mermaid-block');
+		const decoded = decodeSource(block!.getAttribute('data-mermaid-source')!);
+		expect(decoded).toBe([
+			'sequenceDiagram',
+			'  Alice->>Bob: "Hello, & welcome!"',
+			'  Bob-->>Alice: <reply>',
+		].join('\n'));
+	});
+});
+
+describe('markdown mermaid extension — non-mermaid fences untouched (regression guard)', () => {
+	it('leaves ```typescript blocks as ordinary code blocks', () => {
+		const { html } = renderMarkdown('```typescript\nconst x = 1;\n```\n');
+		expect(html).not.toMatch(/mermaid-block/);
+		expect(html).toMatch(/<pre>/);
+		expect(html).toMatch(/<code/);
+		expect(html).toContain('const x = 1');
+	});
+
+	it('leaves un-tagged ``` blocks as ordinary code blocks', () => {
+		const { html } = renderMarkdown('```\njust plain text\n```\n');
+		expect(html).not.toMatch(/mermaid-block/);
+		expect(html).toContain('just plain text');
+	});
+
+	it('does not match a fence whose info-string only starts with "mermaid"', () => {
+		// "mermaid-extra" must not be treated as mermaid — the info-string
+		// match is exact (case-insensitive), not prefix.
+		const { html } = renderMarkdown('```mermaid-extra\ncontent\n```\n');
+		expect(html).not.toMatch(/mermaid-block/);
+	});
+});
+
+describe('markdown mermaid extension — mixed content', () => {
+	it('handles a mermaid block followed by a paragraph followed by another mermaid block', () => {
+		const source = [
+			'# Title',
+			'',
+			'```mermaid',
+			'flowchart TD',
+			'A-->B',
+			'```',
+			'',
+			'Some prose between diagrams.',
+			'',
+			'```mermaid',
+			'sequenceDiagram',
+			'X->>Y: hello',
+			'```',
+		].join('\n');
+
+		const { html } = renderMarkdown(source);
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+
+		const blocks = tpl.content.querySelectorAll('pre.mermaid-block');
+		expect(blocks.length).toBe(2);
+		expect(decodeSource(blocks[0].getAttribute('data-mermaid-source')!)).toContain('flowchart TD');
+		expect(decodeSource(blocks[1].getAttribute('data-mermaid-source')!)).toContain('sequenceDiagram');
+		expect(html).toContain('Some prose between diagrams.');
+	});
+});

--- a/frontend/tests/unit/markdownMermaidRender.test.ts
+++ b/frontend/tests/unit/markdownMermaidRender.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the runMermaidIn runner (ADR-149 / SPEC-149-A).
+ *
+ * The runner walks .mermaid-block placeholders in a given root
+ * element, lazy-imports mermaid, calls mermaid.render() per block,
+ * sanitises the SVG via stage-2 DOMPurify, and replaces the
+ * placeholder. Errors are caught per-block and rendered as a
+ * .mermaid-error element so the rest of the document survives.
+ *
+ * Lazy-load contract: zero placeholders → zero mermaid imports.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockRender = vi.fn();
+const mockInitialize = vi.fn();
+
+vi.mock('mermaid', () => ({
+	default: {
+		initialize: (...args: unknown[]) => mockInitialize(...args),
+		render: (...args: unknown[]) => mockRender(...args),
+	},
+}));
+
+import { runMermaidIn } from '$lib/components/markdownMermaidRender';
+
+function placeholder(source: string): string {
+	const b64 = btoa(unescape(encodeURIComponent(source)));
+	return `<pre class="mermaid-block" data-mermaid-source="${b64}"><code>${source}</code></pre>`;
+}
+
+function makeRoot(html: string): HTMLDivElement {
+	const root = document.createElement('div');
+	root.innerHTML = html;
+	document.body.appendChild(root);
+	return root;
+}
+
+beforeEach(() => {
+	mockRender.mockReset();
+	mockInitialize.mockReset();
+	document.body.innerHTML = '';
+});
+
+describe('runMermaidIn — happy path', () => {
+	it('replaces a placeholder with the rendered SVG', async () => {
+		const svg = '<svg xmlns="http://www.w3.org/2000/svg"><g><text>hello</text></g></svg>';
+		mockRender.mockResolvedValue({ svg, bindFunctions: undefined });
+
+		const root = makeRoot(placeholder('flowchart TD\nA-->B'));
+		await runMermaidIn(root, 'default');
+
+		const block = root.querySelector('.mermaid-block')!;
+		expect(block.querySelector('svg')).not.toBeNull();
+		expect(block.querySelector('code')).toBeNull();
+		expect(mockRender).toHaveBeenCalledTimes(1);
+	});
+
+	it('initialises mermaid with the requested theme and securityLevel: "strict"', async () => {
+		mockRender.mockResolvedValue({
+			svg: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+			bindFunctions: undefined,
+		});
+
+		const root = makeRoot(placeholder('flowchart TD\nA-->B'));
+		await runMermaidIn(root, 'dark');
+
+		expect(mockInitialize).toHaveBeenCalled();
+		const initArgs = mockInitialize.mock.calls[0][0];
+		expect(initArgs.securityLevel).toBe('strict');
+		expect(initArgs.theme).toBe('dark');
+		expect(initArgs.startOnLoad).toBe(false);
+	});
+
+	it('renders multiple placeholders independently with unique ids', async () => {
+		const seenIds: string[] = [];
+		mockRender.mockImplementation(async (id: string) => {
+			seenIds.push(id);
+			return { svg: '<svg xmlns="http://www.w3.org/2000/svg"></svg>', bindFunctions: undefined };
+		});
+
+		const root = makeRoot(
+			placeholder('flowchart TD\nA-->B') +
+			'<p>between</p>' +
+			placeholder('sequenceDiagram\nX->>Y: hi'),
+		);
+		await runMermaidIn(root, 'default');
+
+		expect(mockRender).toHaveBeenCalledTimes(2);
+		expect(new Set(seenIds).size).toBe(2);
+		expect(root.querySelectorAll('.mermaid-block svg').length).toBe(2);
+	});
+});
+
+describe('runMermaidIn — error fallback', () => {
+	it('replaces a failing placeholder with .mermaid-error and leaves the rest of the doc intact', async () => {
+		mockRender.mockImplementation(async (_id: string, source: string) => {
+			if (source.includes('BROKEN')) throw new Error('Parse error: unexpected token');
+			return { svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>ok</text></svg>', bindFunctions: undefined };
+		});
+
+		const root = makeRoot(
+			placeholder('BROKEN ::: not valid mermaid') +
+			'<p data-id="prose">prose</p>' +
+			placeholder('flowchart TD\nA-->B'),
+		);
+		await runMermaidIn(root, 'default');
+
+		const errors = root.querySelectorAll('.mermaid-error');
+		expect(errors.length).toBe(1);
+		expect(errors[0].textContent).toMatch(/Parse error/);
+
+		expect(root.querySelector('[data-id="prose"]')).not.toBeNull();
+		expect(root.querySelectorAll('.mermaid-block svg').length).toBe(1);
+	});
+});
+
+describe('runMermaidIn — lazy-load contract', () => {
+	it('does not import mermaid when there are zero placeholders', async () => {
+		const root = makeRoot('<p>plain prose, no diagrams here.</p>');
+		await runMermaidIn(root, 'default');
+		expect(mockRender).not.toHaveBeenCalled();
+		expect(mockInitialize).not.toHaveBeenCalled();
+	});
+});
+
+describe('runMermaidIn — sanitisation (stage 2)', () => {
+	it('strips <script> from mermaid output before injecting', async () => {
+		const evilSvg = `
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<script>window.__pwned_runner = true;</script>
+				<g><text>ok</text></g>
+			</svg>
+		`;
+		mockRender.mockResolvedValue({ svg: evilSvg, bindFunctions: undefined });
+
+		const root = makeRoot(placeholder('flowchart TD\nA-->B'));
+		await runMermaidIn(root, 'default');
+
+		expect(root.innerHTML).not.toMatch(/<script/i);
+		expect((window as unknown as { __pwned_runner?: boolean }).__pwned_runner).toBeUndefined();
+	});
+});

--- a/frontend/tests/unit/markdownMermaidSvgSanitise.test.ts
+++ b/frontend/tests/unit/markdownMermaidSvgSanitise.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Stage-2 DOMPurify config tests (ADR-149 / SPEC-149-A).
+ *
+ * The runner sanitises mermaid's output SVG before injecting it into
+ * the page. The config must:
+ *   - preserve standard svg tags (svg/g/path/rect/text/marker/defs),
+ *   - preserve the explicit foreignObject add (mermaid HTML labels),
+ *   - strip <script>, inline event handlers, and javascript: URLs
+ *     even when they appear inside foreignObject.
+ */
+import { describe, it, expect } from 'vitest';
+import { sanitiseMermaidSvg } from '$lib/components/markdownMermaidRender';
+
+describe('sanitiseMermaidSvg — preserved tags', () => {
+	it('preserves a representative mermaid SVG output', () => {
+		const svg = `
+			<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+				<defs>
+					<marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3"
+						orient="auto" markerUnits="strokeWidth">
+						<path d="M0,0 L0,6 L9,3 z" />
+					</marker>
+				</defs>
+				<g class="node">
+					<rect x="0" y="0" width="50" height="20" />
+					<text x="25" y="10" text-anchor="middle">A</text>
+				</g>
+				<g class="edgePath">
+					<path d="M50,10 L80,10" marker-end="url(#arrow)" />
+				</g>
+			</svg>
+		`;
+
+		const safe = sanitiseMermaidSvg(svg);
+		expect(safe).toMatch(/<svg/i);
+		expect(safe).toMatch(/<defs/i);
+		expect(safe).toMatch(/<marker/i);
+		expect(safe).toMatch(/<g/i);
+		expect(safe).toMatch(/<rect/i);
+		expect(safe).toMatch(/<text/i);
+		expect(safe).toMatch(/<path/i);
+	});
+
+	it('preserves <foreignObject> for mermaid HTML labels', () => {
+		const svg = `
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<foreignObject x="0" y="0" width="100" height="40">
+					<div xmlns="http://www.w3.org/1999/xhtml">Label text</div>
+				</foreignObject>
+			</svg>
+		`;
+
+		const safe = sanitiseMermaidSvg(svg);
+		expect(safe).toMatch(/<foreignObject/i);
+		expect(safe).toContain('Label text');
+	});
+});
+
+describe('sanitiseMermaidSvg — stripped attack vectors', () => {
+	it('strips <script> tags inside the SVG', () => {
+		const svg = `
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<script>window.__pwned_svg = true;</script>
+				<g><text>ok</text></g>
+			</svg>
+		`;
+		const safe = sanitiseMermaidSvg(svg);
+		expect(safe).not.toMatch(/<script/i);
+		expect((window as unknown as { __pwned_svg?: boolean }).__pwned_svg).toBeUndefined();
+	});
+
+	it('strips inline event handlers (onload, onclick, onerror)', () => {
+		const svg = `
+			<svg xmlns="http://www.w3.org/2000/svg" onload="alert('x')">
+				<rect onclick="alert('y')" />
+				<image href="x.png" onerror="alert('z')" />
+			</svg>
+		`;
+		const safe = sanitiseMermaidSvg(svg);
+		expect(safe).not.toMatch(/onload=/i);
+		expect(safe).not.toMatch(/onclick=/i);
+		expect(safe).not.toMatch(/onerror=/i);
+	});
+
+	it('strips <script> and event handlers inside <foreignObject>', () => {
+		const svg = `
+			<svg xmlns="http://www.w3.org/2000/svg">
+				<foreignObject>
+					<div xmlns="http://www.w3.org/1999/xhtml">
+						<script>window.__pwned_fo = true;</script>
+						<a href="javascript:alert(1)">click</a>
+						<img src="x" onerror="window.__pwned_fo = true" />
+					</div>
+				</foreignObject>
+			</svg>
+		`;
+		const safe = sanitiseMermaidSvg(svg);
+		expect(safe).not.toMatch(/<script/i);
+		expect(safe).not.toMatch(/javascript:/i);
+		expect(safe).not.toMatch(/onerror=/i);
+		expect((window as unknown as { __pwned_fo?: boolean }).__pwned_fo).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Adds Mermaid diagram rendering to the shared `MarkdownView` (Text diagram views + User Guide). ` ```mermaid ` fenced blocks render as SVG; full Mermaid syntax supported (flowchart, sequence, class, state, ER, gantt).
- Un-defers the "markdown extensions" item from [ADR-137](../docs/adrs/ADR-137-Text-Diagram-Subclass-And-Shared-Markdown-Renderer.md)'s out-of-scope list. Callouts and footnotes remain deferred.
- Bumps DOMPurify 3.3.1 → 3.4.2 to pick up CVE fixes (incl. `ADD_TAGS` short-circuit-evaluation bypass).

## How it works

- A custom `marked` extension emits a `<pre class="mermaid-block" data-mermaid-source="<base64>">` placeholder so the markdown pipeline stays synchronous and SSR-safe.
- Mermaid is **lazy-loaded** via dynamic `import('mermaid')` — Vite produces a separate ~525KB chunk that zero-mermaid documents do not pay for.
- A post-`{@html}` Svelte effect in `MarkdownView` calls `runMermaidIn(rootEl, theme)` which renders each placeholder via `mermaid.render()`.
- **Two-stage DOMPurify sanitisation** (protocol #7):
  - Stage 1 on the markdown HTML (existing).
  - Stage 2 on Mermaid's output SVG with `USE_PROFILES: { svg: true, svgFilters: true }` + an explicit `ADD_TAGS: ['foreignObject']` for Mermaid HTML labels.
- Mermaid runs in `securityLevel: 'strict'` so user-authored HTML in labels cannot inject markup.
- Theme follows Iris's class-based dark mode via a `MutationObserver` on `<html>`.
- Per-block error fallback: an invalid Mermaid block renders as a small `.mermaid-error` div with the parser message; the rest of the document still renders.

## Out of scope (tracked separately)

- AI Q&A panel mermaid + DRY consolidation of its divergent `renderMarkdown` → tracked in #71.
- Mermaid editor toolbar buttons, live-preview while typing, export-to-image — future ADRs if requested.
- Markdown callouts and footnotes — still deferred from ADR-137.

## ADRs / specs

- New: [ADR-149 — Mermaid in markdown renderer](../docs/adrs/ADR-149-Mermaid-In-Markdown-Renderer.md)
- New: [SPEC-149-A — Mermaid rendering implementation spec](../docs/adrs/specs/SPEC-149-A-Mermaid-Rendering.md)
- Amended: ADR-137 (mermaid clause partially fulfilled).

## Test plan

- [x] 18 new unit tests across `markdownMermaidExtension.test.ts` (7), `markdownMermaidRender.test.ts` (6), `markdownMermaidSvgSanitise.test.ts` (5) — all green.
- [x] 4 new Playwright e2e tests in `text-view-mermaid.spec.ts` exercise valid + invalid + non-mermaid fences end-to-end — all green.
- [x] Full frontend unit suite: 939 pass, 3 unchanged pre-existing baseline failures (same as v5.6.2).
- [x] `vite build` succeeds; mermaid confirmed as a separate ~525KB chunk (lazy-load contract verified).
- [x] Manual UAT in browser: Text view with valid + invalid + plain-typescript fences; SVG renders, error fallback works, dark mode flips theme.
- [ ] Reviewer: confirm rendering on User Guide pages once you have a mermaid block in a guide section, or accept that the cross-consumer path is covered by component contract + Text view spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)