### PR TITLE
Promote v5.7.1 to UAT (graph/settings 500 fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.1] - 2026-05-11
+
+Hotfix: `/api/graph/settings` returns 500 on Supabase deployments
+(UAT). Anonymous users observed this as "admin-configured knowledge-
+graph defaults not applied" — the frontend's silent fallback to
+hard-coded defaults masked the underlying 500 from authenticated users
+(whose localStorage carried their own saved settings).
+
+### Fixed
+
+- **`/api/graph/settings` no longer 500s on Supabase deployments**
+  (ADR-117 v5.7.1 amendment). Two-pronged fix:
+  - `get_graph_settings()` and `get_graph_settings_cascaded()` now
+    catch DB-level exceptions (e.g. missing table on a partially
+    migrated deployment) and return hard-coded
+    `GRAPH_SETTINGS_DEFAULTS` so the endpoint stays alive
+    (`backend/app/graph/service.py`).
+  - `_initialize_supabase` now calls
+    `seed_graph_settings_defaults(port)` so the `__global__` row gets
+    inserted on first Supabase start — previously only the SQLite
+    startup path did this (`backend/app/startup.py`).
+  - `seed_graph_settings_defaults()` is itself defensive: a missing
+    table logs-and-skips rather than crashing app startup.
+
+### Verification
+
+- 4 new unit tests in `backend/tests/test_graph/test_settings_resilience.py`
+  cover: read returns None on DB error, cascade returns hard-coded
+  defaults on DB error (both unscoped and scoped), seed no-ops on DB
+  error.
+- Local dev (SQLite path) unchanged: `GET /api/graph/settings` returns
+  200 with the seeded defaults.
+
 ## [5.7.0] - 2026-05-10
 
 Mermaid diagram rendering in the shared markdown view (ADR-149,

--- a/backend/app/graph/service.py
+++ b/backend/app/graph/service.py
@@ -7,9 +7,12 @@ relationship types as edges for a scoped set or collection.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections import Counter
 from typing import TYPE_CHECKING, Any
+
+log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from app.db.adapter import DatabasePort
@@ -453,19 +456,28 @@ GRAPH_SETTINGS_DEFAULTS: dict[str, Any] = {
 
 
 async def seed_graph_settings_defaults(db: "DatabasePort") -> None:
-    """Insert the global defaults row if it doesn't already exist."""
-    cursor = await db.execute(
-        "SELECT 1 FROM graph_settings WHERE scope_type = 'global' AND scope_id = '__global__'",
-    )
-    if await cursor.fetchone():
-        return
-    await db.execute(
-        "INSERT INTO graph_settings (scope_type, scope_id, settings_json, updated_at) "
-        "VALUES (?, ?, ?, ?)",
-        ["global", "__global__", json.dumps(GRAPH_SETTINGS_DEFAULTS),
-         datetime.now(timezone.utc).isoformat()],
-    )
-    await db.commit()
+    """Insert the global defaults row if it doesn't already exist.
+
+    ADR-117 v5.7.1 amendment: must not crash startup if the
+    `graph_settings` table is missing (e.g. partially migrated Supabase
+    deployment). Logs the failure and skips so other startup steps
+    continue.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT 1 FROM graph_settings WHERE scope_type = 'global' AND scope_id = '__global__'",
+        )
+        if await cursor.fetchone():
+            return
+        await db.execute(
+            "INSERT INTO graph_settings (scope_type, scope_id, settings_json, updated_at) "
+            "VALUES (?, ?, ?, ?)",
+            ["global", "__global__", json.dumps(GRAPH_SETTINGS_DEFAULTS),
+             datetime.now(timezone.utc).isoformat()],
+        )
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("seed_graph_settings_defaults skipped: %s", exc)
 
 
 async def get_graph_settings(
@@ -473,13 +485,22 @@ async def get_graph_settings(
     scope_type: str,
     scope_id: str,
 ) -> dict[str, Any] | None:
-    """Return raw settings for a single scope, or None."""
-    cursor = await db.execute(
-        "SELECT settings_json, updated_at, updated_by "
-        "FROM graph_settings WHERE scope_type = ? AND scope_id = ?",
-        [scope_type, scope_id],
-    )
-    row = await cursor.fetchone()
+    """Return raw settings for a single scope, or None on miss or DB error.
+
+    ADR-117 v5.7.1 amendment: DB errors (e.g. missing table on a
+    partially-migrated Supabase deployment) are logged and treated as
+    a miss so callers fall back to defaults rather than 500'ing.
+    """
+    try:
+        cursor = await db.execute(
+            "SELECT settings_json, updated_at, updated_by "
+            "FROM graph_settings WHERE scope_type = ? AND scope_id = ?",
+            [scope_type, scope_id],
+        )
+        row = await cursor.fetchone()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("get_graph_settings(%s, %s) failed: %s", scope_type, scope_id, exc)
+        return None
     if not row:
         return None
     return {

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -185,6 +185,12 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
     await seed_defaults(port)
     await seed_default_themes(port)
     await seed_default_views(port)
+    # ADR-117 v5.7.1 amendment: ensure the `__global__` graph_settings
+    # row exists on Supabase startup (the SQLite path already does this
+    # on line ~139). The seed is idempotent and now also tolerates a
+    # missing graph_settings table.
+    from app.graph.service import seed_graph_settings_defaults  # noqa: PLC0415
+    await seed_graph_settings_defaults(port)
     # Bring AI creation prompts to the latest canonical content (ADR-132).
     # The m041 Supabase migration seeds the initial rows externally via psql;
     # this call keeps prompt_text fresh on each app restart without a new

--- a/backend/tests/test_graph/test_settings_resilience.py
+++ b/backend/tests/test_graph/test_settings_resilience.py
@@ -1,0 +1,85 @@
+"""Unit tests for graph-settings resilience (ADR-117 v5.7.1 amendment).
+
+Background: UAT (Supabase) returned HTTP 500 from
+`GET /api/graph/settings` because the read path raised an unhandled
+exception when the DB query failed (e.g. table missing on a
+partially-migrated deployment, or transient DB error). The frontend
+caught the failure silently and fell back to hard-coded defaults —
+making the bug invisible to admins (their localStorage carries their
+saved settings) but observable to anonymous users.
+
+This module tests the post-fix behaviour:
+- `get_graph_settings` returns None on DB error (logs + swallows).
+- `get_graph_settings_cascaded` returns hard-coded defaults on DB
+  error rather than propagating.
+- `seed_graph_settings_defaults` no-ops on DB error rather than
+  crashing startup.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.graph.service import (
+    GRAPH_SETTINGS_DEFAULTS,
+    get_graph_settings,
+    get_graph_settings_cascaded,
+    seed_graph_settings_defaults,
+)
+
+
+class _FailingDB:
+    """A DatabasePort double whose every read raises."""
+
+    def __init__(self, exc: Exception | None = None) -> None:
+        self._exc = exc or RuntimeError("relation \"graph_settings\" does not exist")
+
+    async def execute(self, *_args: Any, **_kwargs: Any) -> Any:
+        raise self._exc
+
+    async def commit(self) -> None:  # pragma: no cover — never reached
+        pass
+
+
+class TestGetGraphSettingsResilience:
+    @pytest.mark.anyio
+    async def test_returns_none_on_db_error(self) -> None:
+        """A failing SELECT must not propagate — return None so callers can fall back."""
+        db = _FailingDB()
+        result = await get_graph_settings(db, "global", "__global__")
+        assert result is None
+
+
+class TestGetGraphSettingsCascadedResilience:
+    @pytest.mark.anyio
+    async def test_returns_hardcoded_defaults_on_db_error(self) -> None:
+        """The cascade must never raise — return hard-coded defaults so the endpoint stays alive."""
+        db = _FailingDB()
+        result = await get_graph_settings_cascaded(db)
+        assert result["scope_type"] == "global"
+        assert result["scope_id"] == "__global__"
+        # Settings should be the hard-coded defaults verbatim.
+        assert result["settings"]["label_density"] == GRAPH_SETTINGS_DEFAULTS["label_density"]
+        assert result["settings"]["nodes"] == GRAPH_SETTINGS_DEFAULTS["nodes"]
+        assert result["settings"]["edges"] == GRAPH_SETTINGS_DEFAULTS["edges"]
+
+    @pytest.mark.anyio
+    async def test_returns_hardcoded_defaults_on_db_error_with_scopes(self) -> None:
+        """Same resilience when scoped params are present."""
+        db = _FailingDB()
+        result = await get_graph_settings_cascaded(
+            db, set_id="set-id", collection_id="col-id"
+        )
+        assert result["scope_type"] == "global"
+        assert result["settings"]["label_density"] == GRAPH_SETTINGS_DEFAULTS["label_density"]
+
+
+class TestSeedGraphSettingsDefaultsResilience:
+    @pytest.mark.anyio
+    async def test_does_not_crash_when_table_missing(self) -> None:
+        """Seed must log-and-skip on DB error rather than crashing app startup."""
+        db = _FailingDB()
+        # Must not raise.
+        await seed_graph_settings_defaults(db)

--- a/docs/adrs/ADR-117-Graph-Settings-Admin-Defaults.md
+++ b/docs/adrs/ADR-117-Graph-Settings-Admin-Defaults.md
@@ -60,3 +60,41 @@
 |--------|----------|------|
 | Proposed | Engineering | 2026-04-03 |
 | Approved | Engineering | 2026-04-03 |
+
+---
+
+## Amendment 2026-05-11 — v5.7.1 Supabase resilience
+
+UAT (Supabase mode) returned HTTP 500 from `GET /api/graph/settings`
+for both anonymous and authenticated callers, because the
+`_initialize_supabase` startup path did not call
+`seed_graph_settings_defaults()` (only the SQLite path did) and the
+`get_graph_settings_cascaded` read path raised an unhandled exception
+when the underlying SELECT failed. The frontend's
+`fetchAdminDefaults()` silently caught the error and fell back to
+hard-coded defaults — which is invisible to admins (their
+localStorage carries their saved settings) but observable to
+anonymous users, who see "all on" instead of the admin-saved
+visibility.
+
+**Decisions:**
+
+1. **Defensive reads.** `get_graph_settings_cascaded` and
+   `get_graph_settings` now catch DB-layer exceptions and return
+   hard-coded `GRAPH_SETTINGS_DEFAULTS` (with whatever scope rows
+   were already merged in) rather than propagating to a 500. The
+   endpoint stays alive even with a partially-migrated DB.
+2. **Seed parity.** `_initialize_supabase` now calls
+   `seed_graph_settings_defaults(port)` alongside the SQLite path, so
+   the `__global__` row gets inserted on first Supabase start.
+3. **Defensive seed.** `seed_graph_settings_defaults` also wraps the
+   SELECT/INSERT in a try/except so a missing table or transient DB
+   issue logs-and-skips rather than crashing startup.
+
+**Out of scope (deferred):**
+
+- Telemetry on the defensive-fallback path (count how often it fires
+  in prod) — would help spot recurrences of the underlying issue.
+- A migration that re-applies m039 idempotently from Python startup
+  if the table is missing — currently relies on operator running
+  `scripts/supabase-migrate.sh`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.7.0",
+	"version": "5.7.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
Promotes [v5.7.1](https://github.com/cgbarlow/iris/releases/tag/v5.7.1) to UAT (`render-supabase-uat`).

**Hotfix:** `GET /api/graph/settings` was returning HTTP 500 on UAT (`iris-api-gtb3.onrender.com`) for both anonymous and authenticated callers. The frontend's `fetchAdminDefaults()` silently fell back to hard-coded defaults — invisible to admins but observable to anonymous users, who saw "all on" instead of the admin's saved knowledge-graph visibility.

See ADR-117 v5.7.1 amendment for root cause + decisions. Merged via [#74](https://github.com/cgbarlow/iris/pull/74).

## UAT verification (after Render redeploys)

```bash
curl -s https://iris-api-gtb3.onrender.com/api/graph/settings -w "\nHTTP %{http_code}\n"
# Expected: HTTP 200 with the cascaded settings JSON (currently HTTP 500).
```

Once verified, anonymous visitors to https://iris-uat.chrisbarlow.nz should see the admin-configured knowledge-graph defaults applied on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)