### PR TITLE
release(v5.7.2): graph_settings table on Supabase + visible Save errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.2] - 2026-05-11
+
+Follow-up to v5.7.1: even with the defensive read in place, the
+admin "Save as default" button was silently failing on UAT because
+the `graph_settings` table itself was missing on Supabase (the m039
+SQL migration had never been applied to UAT). The admin saw "Saved"
+on click, but the PUT errored and nothing persisted.
+
+### Fixed
+
+- **`graph_settings` table is now created at Supabase startup**
+  (ADR-117 v5.7.2 amendment). `_initialize_supabase` runs an idempotent
+  `CREATE TABLE IF NOT EXISTS graph_settings (...)` alongside the
+  existing ALTER TABLE patches, then the v5.7.1 seed call inserts the
+  `__global__` row. Subsequent admin PUTs now persist. Mirrors the
+  schema in `backend/app/migrations/supabase/m039_graph_settings.sql`.
+- **`Save as default` button no longer silently swallows errors.** On
+  failure, the button now shows "Save failed" in the danger colour
+  for 4 seconds, sets the error message as the button `title`
+  (tooltip), and logs the full error to the console. Previously the
+  button always showed "Saved" regardless of PUT outcome — masking
+  data-layer failures from admins.
+
 ## [5.7.1] - 2026-05-11
 
 Hotfix: `/api/graph/settings` returns 500 on Supabase deployments

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -185,10 +185,25 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
     await seed_defaults(port)
     await seed_default_themes(port)
     await seed_default_views(port)
-    # ADR-117 v5.7.1 amendment: ensure the `__global__` graph_settings
-    # row exists on Supabase startup (the SQLite path already does this
-    # on line ~139). The seed is idempotent and now also tolerates a
-    # missing graph_settings table.
+    # ADR-117 v5.7.2 amendment: ensure the `graph_settings` table
+    # exists on Supabase deployments that may not have run the m039
+    # SQL migration via supabase-migrate.sh. Idempotent — does nothing
+    # if the table is already there. Without this, the seed below
+    # would log-and-skip (v5.7.1 made it defensive), so no row would
+    # ever be inserted and admin "Save as default" PUTs would fail.
+    await port.execute(
+        "CREATE TABLE IF NOT EXISTS graph_settings ("
+        "  scope_type TEXT NOT NULL CHECK(scope_type IN ('global','collection','set')),"
+        "  scope_id TEXT NOT NULL,"
+        "  settings_json TEXT NOT NULL,"
+        "  updated_at TIMESTAMPTZ,"
+        "  updated_by TEXT,"
+        "  PRIMARY KEY (scope_type, scope_id)"
+        ")"
+    )
+    await port.commit()
+    # ADR-117 v5.7.1 amendment: ensure the `__global__` row exists on
+    # Supabase startup (the SQLite path already does this on line ~139).
     from app.graph.service import seed_graph_settings_defaults  # noqa: PLC0415
     await seed_graph_settings_defaults(port)
     # Bring AI creation prompts to the latest canonical content (ADR-132).

--- a/docs/adrs/ADR-117-Graph-Settings-Admin-Defaults.md
+++ b/docs/adrs/ADR-117-Graph-Settings-Admin-Defaults.md
@@ -97,4 +97,38 @@ visibility.
   in prod) — would help spot recurrences of the underlying issue.
 - A migration that re-applies m039 idempotently from Python startup
   if the table is missing — currently relies on operator running
-  `scripts/supabase-migrate.sh`.
+  `scripts/supabase-migrate.sh`. *(Closed by v5.7.2 amendment below.)*
+
+---
+
+## Amendment 2026-05-11 — v5.7.2 follow-up
+
+UAT verification surfaced a second gap: even with v5.7.1's defensive
+reads in place, the admin "Save as default" button was silently
+failing because the `graph_settings` table itself was missing on
+the Supabase deployment (the m039 SQL migration had never been
+applied to UAT). The v5.7.1 seed correctly caught the underlying
+"relation does not exist" error and skipped — but that meant no row
+ever got inserted and admin PUTs continued to fail.
+
+**Decisions:**
+
+1. **Inline CREATE TABLE in `_initialize_supabase`.** Mirror the
+   existing pattern for inline schema patches (e.g. the ALTER TABLE
+   blocks for `ai_conversations` and `diagrams.sequence_order`).
+   Idempotent — `CREATE TABLE IF NOT EXISTS graph_settings (...)` is
+   a no-op when the table already exists. This makes the Python
+   startup path independent of whether the operator has run
+   `scripts/supabase-migrate.sh` recently.
+2. **Surface save errors in the UI.** `KnowledgeGraphSettings.svelte`
+   previously caught all errors from `onSaveDefault` and showed
+   "Saved" regardless. Now on failure the button briefly shows
+   "Save failed" with the error tooltip, and logs the full error to
+   the console. Closes the "silent button failure" class of bug
+   identified in this UAT cycle.
+
+**Why both fixes in the same release.** They are the data-layer and
+UI-layer of the same bug. Without (1) the admin can never persist
+defaults on Supabase; without (2) the admin cannot tell when their
+save fails. Shipping them separately would leave one half broken in
+between.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.7.1",
+	"version": "5.7.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/KnowledgeGraphSettings.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphSettings.svelte
@@ -159,9 +159,30 @@
 					<button
 						onclick={async (e) => {
 							const btn = e.currentTarget as HTMLButtonElement;
-							try { await onSaveDefault(settings); } catch { /* ignore */ }
-							btn.textContent = 'Saved';
-							setTimeout(() => { btn.textContent = 'Save as default'; }, 1500);
+							const original = 'Save as default';
+							const origBg = btn.style.background;
+							const origBorder = btn.style.borderColor;
+							try {
+								await onSaveDefault(settings);
+								btn.textContent = 'Saved';
+								setTimeout(() => { btn.textContent = original; }, 1500);
+							} catch (err) {
+								// v5.7.2: surface save failures so the admin sees them.
+								// Previously the error was swallowed and the button
+								// always showed "Saved", masking PUT failures.
+								const message = err instanceof Error ? err.message : String(err);
+								btn.textContent = 'Save failed';
+								btn.style.background = 'var(--color-danger, #dc2626)';
+								btn.style.borderColor = 'var(--color-danger, #dc2626)';
+								btn.title = message;
+								console.error('Save as default failed:', err);
+								setTimeout(() => {
+									btn.textContent = original;
+									btn.style.background = origBg;
+									btn.style.borderColor = origBorder;
+									btn.title = '';
+								}, 4000);
+							}
 						}}
 						style="flex: 1; padding: 4px 8px; border-radius: 4px; border: 1px solid var(--color-primary); background: var(--color-primary); color: white; font-size: 0.7rem; cursor: pointer"
 					>Save as default</button>


### PR DESCRIPTION
## Summary

Follow-up to [v5.7.1](https://github.com/cgbarlow/iris/releases/tag/v5.7.1). User verified after the v5.7.1 deploy that admin "Save as default" *still* didn't persist on UAT (`https://iris-uat.chrisbarlow.nz/?set_id=...`). Diagnosis: the `graph_settings` table itself was missing on the Supabase deployment (m039 SQL migration had never been applied to UAT). The v5.7.1 defensive seed caught the underlying "relation does not exist" error and skipped — so no row ever got inserted and admin PUTs continued to fail. Compounding the issue, the Save button **silently swallowed** PUT errors and always showed "Saved" — masking the failure from admins.

## Fix (ADR-117 v5.7.2 amendment)

1. **`graph_settings` table created at Supabase startup.** `_initialize_supabase` now runs an idempotent `CREATE TABLE IF NOT EXISTS graph_settings (...)` alongside the existing inline schema patches. Schema mirrors `backend/app/migrations/supabase/m039_graph_settings.sql`. Makes Python startup independent of whether the operator has re-run `supabase-migrate.sh` since m039 landed.

2. **Save button surfaces errors.** `KnowledgeGraphSettings.svelte` on Save failure now shows "Save failed" in the danger colour for 4 seconds, sets the error message as the button `title` (tooltip), and logs the full error to the console. Previously: silent catch + "Saved" regardless.

## Verification

- [x] v5.7.1 unit tests still green (`backend/tests/test_graph/test_settings_resilience.py`: 4/4 pass).
- [x] CHANGELOG `[5.7.2] - 2026-05-11` entry.
- [x] ADR-117 amended with v5.7.2 §"follow-up".
- [ ] **UAT verification after deploy**: `curl https://iris-api-gtb3.onrender.com/api/graph/settings` should return HTTP 200 with `updated_at: <timestamp>` (proving the seed inserted the row). Admin "Save as default" should then persist (verifiable via subsequent GETs returning the saved settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)