### PR TITLE
release(v5.7.3): breadcrumb routes packages to /packages not /views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.7.3] - 2026-05-11
+
+### Fixed
+
+- **Breadcrumb links on `/views/[id]` now route packages to
+  `/packages/<id>`** (previously `/views/<id>`, which 404'd or showed
+  an unrelated view). The breadcrumb's "ancestors" are always packages
+  (a diagram's parent chain walks the packages table — see
+  `backend/app/diagrams/service.py:get_diagram_ancestors`), but the
+  link template hard-coded `/views/<id>`. Extracted a small
+  `viewBreadcrumbHref()` helper that switches on the `type` field
+  returned by `/api/diagrams/{id}/ancestors` so packages route to
+  `/packages/<id>` and any future diagram-typed ancestor would route
+  to `/views/<id>`. Also corrects the local TypeScript shape (the API
+  returns `{id, name, type, parent_package_id}`; the page declared
+  `{id, name, diagram_type}` — wrong field name that happened to type-
+  check because both were `string`). Reported on the live UAT URL
+  `https://iris-uat.chrisbarlow.nz/views/4415adb0-c1db-4627-8952-13f4c911d375`.
+
 ## [5.7.2] - 2026-05-11
 
 Follow-up to v5.7.1: even with the defensive read in place, the

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.7.2",
+	"version": "5.7.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/utils/viewBreadcrumb.ts
+++ b/frontend/src/lib/utils/viewBreadcrumb.ts
@@ -1,0 +1,21 @@
+/**
+ * Helpers for the breadcrumb on /views/[id].
+ *
+ * v5.7.3: the /api/diagrams/{id}/ancestors endpoint returns objects
+ * shaped as { id, name, type, parent_package_id? }. The breadcrumb
+ * previously hard-coded /views/{id} for every ancestor, which broke
+ * navigation because ancestors are packages (a diagram's parent chain
+ * walks the packages table — see backend/app/diagrams/service.py:680).
+ */
+
+export interface BreadcrumbAncestor {
+	id: string;
+	name: string;
+	type: string;
+	parent_package_id?: string | null;
+}
+
+export function viewBreadcrumbHref(ancestor: BreadcrumbAncestor): string {
+	if (ancestor.type === 'package') return `/packages/${ancestor.id}`;
+	return `/views/${ancestor.id}`;
+}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { onDestroy } from 'svelte';
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { viewBreadcrumbHref, type BreadcrumbAncestor } from '$lib/utils/viewBreadcrumb';
 	import { exportToSvg, exportToPng, exportToPdf } from '$lib/utils/export';
 	import type { Diagram, DiagramVersion, Bookmark } from '$lib/types/api';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
@@ -158,8 +159,11 @@
 	let showAddParticipant = $state(false);
 	let showAddMessage = $state(false);
 
-	// Hierarchy breadcrumb state
-	let ancestors = $state<{ id: string; name: string; diagram_type: string }[]>([]);
+	// Hierarchy breadcrumb state. Backend returns objects shaped as
+	// { id, name, type, parent_package_id }; ancestors are packages
+	// because a diagram's parent chain walks through the packages table
+	// (see backend/app/diagrams/service.py:get_diagram_ancestors).
+	let ancestors = $state<BreadcrumbAncestor[]>([]);
 
 	// Focus view state
 	let focusMode = $state(false);
@@ -638,7 +642,7 @@
 
 	async function loadAncestors(id: string) {
 		try {
-			ancestors = await apiFetch<{ id: string; name: string; diagram_type: string }[]>(
+			ancestors = await apiFetch<BreadcrumbAncestor[]>(
 				`/api/diagrams/${id}/ancestors`
 			);
 		} catch {
@@ -1936,7 +1940,7 @@
 			{#each ancestors as ancestor}
 				<li class="flex items-baseline gap-1">
 					<span aria-hidden="true">/</span>
-					<a href="/views/{ancestor.id}" style="color: var(--color-primary)">{ancestor.name}</a>
+					<a href={viewBreadcrumbHref(ancestor)} style="color: var(--color-primary)">{ancestor.name}</a>
 				</li>
 			{/each}
 			<li class="flex items-baseline gap-1">

--- a/frontend/tests/unit/viewBreadcrumbHref.test.ts
+++ b/frontend/tests/unit/viewBreadcrumbHref.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for the breadcrumb href helper used by /views/[id]/+page.svelte.
+ *
+ * Bug v5.7.3: ancestors were rendered as `/views/{id}` regardless of
+ * type. The backend's /api/diagrams/{id}/ancestors returns objects with
+ * `type: "package"` (see backend/app/diagrams/service.py:680), so the
+ * link must route to `/packages/{id}`. A future-proofing branch for
+ * `type === "diagram"` is also tested.
+ */
+import { describe, it, expect } from 'vitest';
+import { viewBreadcrumbHref } from '$lib/utils/viewBreadcrumb';
+
+describe('viewBreadcrumbHref', () => {
+	it('routes package ancestors to /packages/{id}', () => {
+		expect(
+			viewBreadcrumbHref({ id: 'pkg-1', name: 'Part A', type: 'package' })
+		).toBe('/packages/pkg-1');
+	});
+
+	it('routes diagram ancestors to /views/{id}', () => {
+		expect(
+			viewBreadcrumbHref({ id: 'dia-1', name: 'Some diagram', type: 'diagram' })
+		).toBe('/views/dia-1');
+	});
+
+	it('falls back to /views/{id} for unknown types (defensive)', () => {
+		expect(
+			viewBreadcrumbHref({ id: 'x-1', name: '?', type: 'something-new' })
+		).toBe('/views/x-1');
+	});
+});


### PR DESCRIPTION
## Summary

User-reported on https://iris-uat.chrisbarlow.nz/views/4415adb0-c1db-4627-8952-13f4c911d375 — clicking any breadcrumb link sent the user to \`/views/<package-id>\` (404 or unrelated content) instead of the package detail page.

## Root cause

In \`frontend/src/routes/views/[id]/+page.svelte\` the breadcrumb template hard-coded \`/views/{ancestor.id}\` for every entry. The local TS shape declared \`{diagram_type: string}\` whereas \`/api/diagrams/{id}/ancestors\` actually returns \`{type: string}\` — both \`string\` so type-check passed silently. The backend always returns \`type: "package"\` for breadcrumb ancestors because the parent chain walks the packages table (\`backend/app/diagrams/service.py:get_diagram_ancestors\`).

## Fix

- New pure helper \`frontend/src/lib/utils/viewBreadcrumb.ts\` exposing \`viewBreadcrumbHref()\` that switches on \`type\`: package → \`/packages/<id>\`, diagram → \`/views/<id>\`, anything else falls back to \`/views/<id>\` defensively.
- Page imports the helper, uses it in the template, corrects the local TS shape to \`BreadcrumbAncestor\`.
- 3 new unit tests in \`tests/unit/viewBreadcrumbHref.test.ts\` (TDD red → green).

## Test plan

- [x] \`npx vitest run tests/unit/viewBreadcrumbHref.test.ts\` — 3/3 pass.
- [x] svelte-check clean on the touched lines.
- [ ] Post-deploy: revisit the reported URL, click any breadcrumb link, confirm it lands on \`/packages/<id>\` and renders the package detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)