### PR TITLE
Promote v5.8.0 to UAT — scope-level system prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.0] - 2026-05-11
+
+### Added
+
+- **Scope-level system prompts for Collections and Sets** (ADR-150,
+  SPEC-150-A). Each Collection and each Set can now carry a
+  free-text `system_prompt` that is prepended to every Ask Iris
+  question (discuss and creation) and every MCP `ask` call that
+  touches the scope. A Set inherits its parent Collection's
+  prompt — composition is additive, never overriding. Multi-set
+  asks dedup collection prompts by id and preserve `set_ids`
+  order. Edit screens (`/collections/[id]`, `/sets/[id]`) gain a
+  "System prompt" textarea. Anonymous AI asks (ADR-123) get scope
+  prompts applied the same way as signed-in asks. A soft warning
+  fires in `[AI_DEBUG]` when the composed system content exceeds
+  16 000 characters; no hard truncation. First phase of a larger
+  Skills feature; full Skills (DB-resident, progressive disclosure
+  via MCP `list_skills` / `get_skill`) land in a follow-up release.
+
 ## [5.7.3] - 2026-05-11
 
 ### Fixed

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -418,6 +418,12 @@ async def _ask_streaming(
             retrieval = await get_retrieval_strategy(db)
             context = await retrieval.retrieve_context(db, body.question, [set_id])
 
+            # ADR-150: scope-level prepend (collection then set prompts).
+            from app.ai.scope_prompts import build_scope_prompts
+            scope_prepend = await build_scope_prompts(
+                db, set_ids=[set_id], collection_id=None,
+            )
+
             if body.mode == "creation":
                 from app.ai.creation import build_creation_system_prompt
                 creation_notation = body.notation or "doview"
@@ -441,6 +447,14 @@ async def _ask_streaming(
                         "You are an AI assistant helping users understand their architecture models. "
                         "Answer questions based on the provided Set context.\n\nContext:\n" + context
                     )
+
+            if scope_prepend:
+                system_content = f"{scope_prepend}\n\n{system_content}"
+            if len(system_content) > 16_000:
+                log.warning(
+                    "[AI_DEBUG] composed system_content is %d chars (>16000)",
+                    len(system_content),
+                )
 
             if body.mode == "creation":
                 # Preserve the shipped DoView opener verbatim; for other
@@ -658,6 +672,12 @@ async def _ask_multi_set_streaming(
 
             primary_set_id = set_ids[0] if set_ids else None
 
+            # ADR-150: scope-level prepend (collection + set prompts).
+            from app.ai.scope_prompts import build_scope_prompts
+            scope_prepend = await build_scope_prompts(
+                db, set_ids=set_ids, collection_id=collection_id,
+            )
+
             if body.mode == "creation":
                 from app.ai.creation import build_creation_system_prompt
                 creation_notation = body.notation or "doview"
@@ -698,6 +718,14 @@ async def _ask_multi_set_streaming(
                         "You are an AI assistant helping users understand their architecture models. "
                         "Answer questions based on the provided context from multiple Sets.\n\nContext:\n" + context
                     )
+
+            if scope_prepend:
+                system_content = f"{scope_prepend}\n\n{system_content}"
+            if len(system_content) > 16_000:
+                log.warning(
+                    "[AI_DEBUG] composed system_content is %d chars (>16000)",
+                    len(system_content),
+                )
 
             if body.mode == "creation":
                 # Preserve the shipped DoView opener verbatim; for other

--- a/backend/app/ai/scope_prompts.py
+++ b/backend/app/ai/scope_prompts.py
@@ -1,0 +1,84 @@
+"""Scope-level system prompt composition (ADR-150, SPEC-150-A).
+
+Builds the additive prepend that lives at the front of the system
+message for every Ask Iris and MCP `ask` request. Composition order:
+
+    [collection prompt 1]
+    [collection prompt 2]   # multi-collection multi-set ask
+    [set prompt 1]
+    [set prompt 2]
+
+Each block is separated by a blank line. Collection prompts are
+deduplicated by id. When the caller supplies `collection_id` (e.g.,
+multi-set Q&A where the UI tracks an active collection), that
+collection is placed first; any additional collections derived from
+the sets follow in `set_ids` order.
+
+Empty / whitespace-only prompts are skipped. If nothing applies, an
+empty string is returned and the caller composes its existing
+system content untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    pass
+
+
+async def build_scope_prompts(
+    db: Any,
+    *,
+    set_ids: list[str],
+    collection_id: str | None,
+) -> str:
+    """Return the scope prepend text (or "" when nothing applies)."""
+    # Per-set lookup: their prompt and parent collection.
+    set_prompts: list[str] = []
+    derived_collection_ids: list[str] = []
+    seen_collections: set[str] = set()
+
+    # If caller supplied an explicit collection_id, reserve its slot at
+    # the front of the ordered collection list.
+    ordered_collection_ids: list[str] = []
+    if collection_id:
+        ordered_collection_ids.append(collection_id)
+        seen_collections.add(collection_id)
+
+    for set_id in set_ids:
+        cursor = await db.execute(
+            "SELECT system_prompt, collection_id FROM sets "
+            "WHERE id = ? AND is_deleted = 0",
+            (set_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            continue
+        sp = row[0]
+        if sp and sp.strip():
+            set_prompts.append(sp.strip())
+        cid = row[1]
+        if cid and cid not in seen_collections:
+            ordered_collection_ids.append(cid)
+            seen_collections.add(cid)
+            derived_collection_ids.append(cid)
+
+    # Fetch collection prompts in order. Orphan collection ids are
+    # silently dropped (the SELECT just returns no row).
+    collection_prompts: list[str] = []
+    for cid in ordered_collection_ids:
+        cursor = await db.execute(
+            "SELECT system_prompt FROM collections "
+            "WHERE id = ? AND is_deleted = 0",
+            (cid,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            continue
+        cp = row[0]
+        if cp and cp.strip():
+            collection_prompts.append(cp.strip())
+
+    parts = collection_prompts + set_prompts
+    return "\n\n".join(parts)

--- a/backend/app/ai/service.py
+++ b/backend/app/ai/service.py
@@ -304,6 +304,12 @@ async def ask_question(
     retrieval = await get_retrieval_strategy(db)
     context = await retrieval.retrieve_context(db, question, [set_id])
 
+    # ADR-150: scope-level prepend (collection + set prompts).
+    from app.ai.scope_prompts import build_scope_prompts
+    scope_prepend = await build_scope_prompts(
+        db, set_ids=[set_id], collection_id=None,
+    )
+
     # 3. Build messages
     system_prompt = str(provider.get("system_prompt") or "")
     if system_prompt:
@@ -312,6 +318,15 @@ async def ask_question(
         system_content = (
             "You are an AI assistant helping users understand their architecture models. "
             "Answer questions based on the provided Set context.\n\nContext:\n" + context
+        )
+
+    if scope_prepend:
+        system_content = f"{scope_prepend}\n\n{system_content}"
+    if len(system_content) > 16_000:
+        import logging  # noqa: PLC0415
+        logging.getLogger("app.ai").warning(
+            "[AI_DEBUG] composed system_content is %d chars (>16000)",
+            len(system_content),
         )
 
     messages = [
@@ -490,6 +505,12 @@ async def ask_multi_set_question(
 
     primary_set_id = set_ids[0] if set_ids else None
 
+    # ADR-150: scope-level prepend (collection + set prompts).
+    from app.ai.scope_prompts import build_scope_prompts  # noqa: PLC0415
+    scope_prepend = await build_scope_prompts(
+        db, set_ids=set_ids, collection_id=collection_id,
+    )
+
     has_sets = bool(set_ids)
     has_docref = bool(docref_doc_ids)
     has_files = bool(file_contexts)
@@ -516,6 +537,15 @@ async def ask_multi_set_question(
         system_content = (
             "You are an AI assistant helping users understand their architecture models. "
             "Answer questions based on the provided context from multiple Sets.\n\nContext:\n" + context
+        )
+
+    if scope_prepend:
+        system_content = f"{scope_prepend}\n\n{system_content}"
+    if len(system_content) > 16_000:
+        import logging  # noqa: PLC0415
+        logging.getLogger("app.ai").warning(
+            "[AI_DEBUG] composed system_content is %d chars (>16000)",
+            len(system_content),
         )
 
     messages = [

--- a/backend/app/collections/models.py
+++ b/backend/app/collections/models.py
@@ -19,6 +19,7 @@ class CollectionUpdate(BaseModel):
     description: str | None = None
     thumbnail_source: str | None = None
     thumbnail_diagram_id: str | None = None
+    system_prompt: str | None = None
 
 
 class CollectionResponse(BaseModel):
@@ -39,6 +40,7 @@ class CollectionResponse(BaseModel):
     has_thumbnail_image: bool = False
     thumbnail_diagram_data: dict | None = None
     thumbnail_diagram_type: str | None = None
+    system_prompt: str | None = None
 
 
 class CollectionListResponse(BaseModel):

--- a/backend/app/collections/router.py
+++ b/backend/app/collections/router.py
@@ -97,6 +97,7 @@ async def update(
             description=body.description,
             thumbnail_source=body.thumbnail_source,
             thumbnail_diagram_id=body.thumbnail_diagram_id,
+            system_prompt=body.system_prompt,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/collections/service.py
+++ b/backend/app/collections/service.py
@@ -28,13 +28,14 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
         "thumbnail_source": row[7],
         "thumbnail_diagram_id": row[8],
         "has_thumbnail_image": has_thumbnail_image,
+        "system_prompt": row[10] if len(row) > 10 else None,
     }
 
 
 _COLLECTION_COLUMNS = (
     "c.id, c.name, c.description, c.created_at, c.created_by, "
     "c.updated_at, c.is_deleted, c.thumbnail_source, c.thumbnail_diagram_id, "
-    "c.thumbnail_image IS NOT NULL"
+    "c.thumbnail_image IS NOT NULL, c.system_prompt"
 )
 
 
@@ -74,6 +75,7 @@ async def create_collection(
         "thumbnail_source": None,
         "thumbnail_diagram_id": None,
         "has_thumbnail_image": False,
+        "system_prompt": None,
     }
 
 
@@ -186,8 +188,9 @@ async def update_collection(
     description: str | None,
     thumbnail_source: str | None = None,
     thumbnail_diagram_id: str | None = None,
+    system_prompt: str | None = None,
 ) -> dict[str, object] | None:
-    """Update a collection's name, description, and thumbnail settings.
+    """Update a collection's name, description, thumbnail and system_prompt.
 
     Returns None if not found.
     """
@@ -215,16 +218,18 @@ async def update_collection(
     if thumbnail_source != "image":
         await db.execute(
             "UPDATE collections SET name = ?, description = ?, updated_at = ?, "
-            "thumbnail_source = ?, thumbnail_diagram_id = ?, thumbnail_image = NULL "
+            "thumbnail_source = ?, thumbnail_diagram_id = ?, thumbnail_image = NULL, "
+            "system_prompt = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, collection_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, collection_id),
         )
     else:
         await db.execute(
             "UPDATE collections SET name = ?, description = ?, updated_at = ?, "
-            "thumbnail_source = ?, thumbnail_diagram_id = ? "
+            "thumbnail_source = ?, thumbnail_diagram_id = ?, "
+            "system_prompt = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, collection_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, collection_id),
         )
     await db.commit()
 

--- a/backend/app/migrations/m047_scope_system_prompts.py
+++ b/backend/app/migrations/m047_scope_system_prompts.py
@@ -1,0 +1,35 @@
+"""Migration 047: Scope-level system prompts (ADR-150, SPEC-150-A).
+
+Adds a nullable `system_prompt TEXT` column to `collections` and `sets`
+so the owner of a scope can attach domain-specific instructions that
+travel with every AI question (Ask Iris discuss / creation; Iris MCP
+`ask` tool) that touches the scope.
+
+Inheritance is additive — a Set inherits its parent Collection's
+prompt rather than overriding it. Composition is performed at runtime
+in `app/ai/scope_prompts.py`; this migration only adds the storage.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m047_scope_system_prompts"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up — additive ALTER COLUMNs, idempotent."""
+    cursor = await db.execute("PRAGMA table_info(collections)")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "system_prompt" not in columns:
+        await db.execute("ALTER TABLE collections ADD COLUMN system_prompt TEXT")
+
+    cursor = await db.execute("PRAGMA table_info(sets)")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "system_prompt" not in columns:
+        await db.execute("ALTER TABLE sets ADD COLUMN system_prompt TEXT")
+
+    await db.commit()

--- a/backend/app/migrations/supabase/m051_scope_system_prompts.sql
+++ b/backend/app/migrations/supabase/m051_scope_system_prompts.sql
@@ -1,0 +1,14 @@
+-- Migration 051: Scope-level system prompts (ADR-150, SPEC-150-A).
+--
+-- Mirrors SQLite migration m047_scope_system_prompts.py. Adds a
+-- nullable `system_prompt TEXT` column to `collections` and `sets`.
+-- Composition is runtime; this migration only adds storage.
+--
+-- Idempotent — uses IF NOT EXISTS so re-running on a partially-applied
+-- DB is safe.
+
+ALTER TABLE collections
+    ADD COLUMN IF NOT EXISTS system_prompt TEXT;
+
+ALTER TABLE sets
+    ADD COLUMN IF NOT EXISTS system_prompt TEXT;

--- a/backend/app/sets/models.py
+++ b/backend/app/sets/models.py
@@ -21,6 +21,7 @@ class SetUpdate(BaseModel):
     thumbnail_source: str | None = None
     thumbnail_diagram_id: str | None = None
     collection_id: str | None = None
+    system_prompt: str | None = None
 
 
 class SetResponse(BaseModel):
@@ -42,6 +43,7 @@ class SetResponse(BaseModel):
     has_thumbnail_image: bool = False
     thumbnail_diagram_data: dict | None = None
     thumbnail_diagram_type: str | None = None
+    system_prompt: str | None = None
 
 
 class SetListResponse(BaseModel):

--- a/backend/app/sets/router.py
+++ b/backend/app/sets/router.py
@@ -101,6 +101,7 @@ async def update(
             thumbnail_source=body.thumbnail_source,
             thumbnail_diagram_id=body.thumbnail_diagram_id,
             collection_id=body.collection_id,
+            system_prompt=body.system_prompt,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -32,13 +32,14 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
         "has_thumbnail_image": has_thumbnail_image,
         "collection_id": row[10] if len(row) > 10 else None,
         "collection_name": row[11] if len(row) > 11 else None,
+        "system_prompt": row[12] if len(row) > 12 else None,
     }
 
 
 _SET_COLUMNS = (
     "s.id, s.name, s.description, s.created_at, s.created_by, "
     "s.updated_at, s.is_deleted, s.thumbnail_source, s.thumbnail_diagram_id, "
-    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name"
+    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt"
 )
 
 
@@ -78,6 +79,7 @@ async def create_set(
         "thumbnail_source": None,
         "thumbnail_diagram_id": None,
         "has_thumbnail_image": False,
+        "system_prompt": None,
     }
 
 
@@ -186,8 +188,9 @@ async def update_set(
     thumbnail_source: str | None = None,
     thumbnail_diagram_id: str | None = None,
     collection_id: str | None = None,
+    system_prompt: str | None = None,
 ) -> dict[str, object] | None:
-    """Update a set's name, description, thumbnail settings, and collection.
+    """Update a set's name, description, thumbnail, collection, system_prompt.
 
     Returns None if not found.
     """
@@ -215,17 +218,19 @@ async def update_set(
         await db.execute(
             "UPDATE sets SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, thumbnail_image = NULL, "
-            "collection_id = ? "
+            "collection_id = ?, system_prompt = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, collection_id, set_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id,
+             collection_id, system_prompt, set_id),
         )
     else:
         await db.execute(
             "UPDATE sets SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, "
-            "collection_id = ? "
+            "collection_id = ?, system_prompt = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, collection_id, set_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id,
+             collection_id, system_prompt, set_id),
         )
     await db.commit()
 

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -51,6 +51,7 @@ from app.migrations.m043_bpmn_notation import up as m043_up
 from app.migrations.m044_text_diagram_class import up as m044_up
 from app.migrations.m045_images import up as m045_up
 from app.migrations.m046_extensions_source import up as m046_up
+from app.migrations.m047_scope_system_prompts import up as m047_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -128,6 +129,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m044_up(main)
     await m045_up(main)
     await m046_up(main)
+    await m047_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -73,3 +73,8 @@ packages = ["app"]
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=1.3.0",
+]

--- a/backend/tests/test_ai/test_ask_with_scope_prompts.py
+++ b/backend/tests/test_ai/test_ask_with_scope_prompts.py
@@ -1,0 +1,268 @@
+"""Integration tests: scope prompts flow into composed system_content.
+
+ADR-150 / SPEC-150-A. Asks the question through the real service path
+with a stub AI client so we can assert the exact `system_content` the
+model receives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.ai import service as ai_service
+from app.ai.client import AIClient
+from app.ai.models import ProviderTestResult
+
+
+_USER_ID = "test-user"
+
+
+class RecordingClient(AIClient):
+    """Captures the messages the service composes for the LLM."""
+
+    last_messages: list[dict[str, str]] | None = None
+
+    def __init__(self, provider_row: dict[str, object]) -> None:  # noqa: ARG002
+        self.stream_usage: tuple[int | None, int | None] = (1, 2)
+
+    async def chat(
+        self, messages: list[dict[str, str]],
+    ) -> tuple[str, int | None, int | None]:
+        RecordingClient.last_messages = messages
+        return ("stub answer", 1, 2)
+
+    async def chat_stream(
+        self, messages: list[dict[str, str]],
+    ) -> AsyncIterator[str]:
+        RecordingClient.last_messages = messages
+        yield "stub answer"
+
+    async def test_connection(self) -> ProviderTestResult:
+        return ProviderTestResult(ok=True)
+
+
+@pytest_asyncio.fixture
+async def db():
+    """Minimal direct schema (we bypass the full migration chain so the test
+    doesn't depend on every upstream table)."""
+    async with aiosqlite.connect(":memory:") as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                system_prompt TEXT
+            );
+            CREATE TABLE sets (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                created_at TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                collection_id TEXT,
+                system_prompt TEXT
+            );
+            CREATE TABLE ai_providers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                provider_type TEXT NOT NULL,
+                base_url TEXT,
+                api_key TEXT,
+                model TEXT NOT NULL,
+                system_prompt TEXT,
+                parameters TEXT,
+                timeout_ms INTEGER NOT NULL DEFAULT 30000,
+                retries INTEGER NOT NULL DEFAULT 3,
+                is_default INTEGER NOT NULL DEFAULT 0,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                created_by TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            CREATE TABLE ai_conversations (
+                id TEXT PRIMARY KEY,
+                set_id TEXT,
+                user_id TEXT NOT NULL,
+                question TEXT NOT NULL,
+                answer TEXT NOT NULL,
+                context_summary TEXT,
+                model_used TEXT NOT NULL,
+                provider_id TEXT NOT NULL,
+                tokens_in INTEGER,
+                tokens_out INTEGER,
+                duration_ms INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                mode TEXT,
+                thread_id TEXT,
+                collection_id TEXT
+            );
+            CREATE TABLE ai_usage_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                provider_id TEXT NOT NULL,
+                user_id TEXT,
+                endpoint TEXT NOT NULL,
+                model TEXT NOT NULL,
+                tokens_in INTEGER,
+                tokens_out INTEGER,
+                duration_ms INTEGER NOT NULL,
+                status TEXT NOT NULL,
+                error TEXT,
+                created_at TEXT NOT NULL
+            );
+            -- minimal tables retrieval.py touches; we leave them empty so
+            -- retrieve_context returns "".
+            CREATE TABLE elements (
+                id TEXT PRIMARY KEY,
+                element_type TEXT NOT NULL,
+                current_version INTEGER NOT NULL DEFAULT 1,
+                set_id TEXT,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                created_by TEXT, created_at TEXT, updated_at TEXT
+            );
+            CREATE TABLE element_versions (
+                element_id TEXT NOT NULL, version INTEGER NOT NULL,
+                name TEXT NOT NULL, description TEXT,
+                data TEXT NOT NULL DEFAULT '{}',
+                created_by TEXT, created_at TEXT,
+                PRIMARY KEY (element_id, version)
+            );
+            CREATE TABLE relationships (
+                id TEXT PRIMARY KEY,
+                source_element_id TEXT NOT NULL,
+                target_element_id TEXT NOT NULL,
+                relationship_type TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE diagrams (
+                id TEXT PRIMARY KEY,
+                diagram_type TEXT NOT NULL,
+                current_version INTEGER NOT NULL DEFAULT 1,
+                set_id TEXT,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                created_by TEXT, created_at TEXT, updated_at TEXT
+            );
+            CREATE TABLE diagram_versions (
+                diagram_id TEXT NOT NULL, version INTEGER NOT NULL,
+                name TEXT NOT NULL, description TEXT,
+                data TEXT NOT NULL DEFAULT '{}',
+                created_by TEXT, created_at TEXT,
+                PRIMARY KEY (diagram_id, version)
+            );
+            CREATE TABLE settings (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+            """
+        )
+        await conn.commit()
+        yield conn
+
+
+async def _make_provider(db: Any) -> str:
+    p = await ai_service.create_provider(
+        db, name="stub", provider_type="openai", model="stub-model",
+        is_default=True, created_by=_USER_ID,
+    )
+    return str(p["id"])
+
+
+async def _make_set(
+    db: Any, *, set_id: str, name: str,
+    collection_id: str | None = None, system_prompt: str | None = None,
+) -> None:
+    await db.execute(
+        "INSERT INTO sets (id, name, description, created_at, created_by, "
+        "updated_at, collection_id, system_prompt) "
+        "VALUES (?, ?, NULL, '2026-01-01', ?, '2026-01-01', ?, ?)",
+        (set_id, name, _USER_ID, collection_id, system_prompt),
+    )
+    await db.commit()
+
+
+async def _make_collection(
+    db: Any, *, collection_id: str, name: str, system_prompt: str | None = None,
+) -> None:
+    await db.execute(
+        "INSERT INTO collections (id, name, description, created_at, created_by, "
+        "updated_at, system_prompt) "
+        "VALUES (?, ?, NULL, '2026-01-01', ?, '2026-01-01', ?)",
+        (collection_id, name, _USER_ID, system_prompt),
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def stub_client(monkeypatch):
+    monkeypatch.setattr(ai_service, "create_ai_client", RecordingClient)
+    RecordingClient.last_messages = None
+
+
+async def test_set_prompt_is_prepended(db):
+    await _make_provider(db)
+    await _make_set(db, set_id="s1", name="S1", system_prompt="USE FOO")
+    await ai_service.ask_question(
+        db, set_id="s1", question="hi", user_id=_USER_ID,
+    )
+    sys = RecordingClient.last_messages[0]["content"]
+    assert sys.startswith("USE FOO\n\n")
+
+
+async def test_collection_then_set_order(db):
+    await _make_provider(db)
+    await _make_collection(db, collection_id="c1", name="C1", system_prompt="COLL")
+    await _make_set(
+        db, set_id="s1", name="S1", collection_id="c1", system_prompt="SET",
+    )
+    await ai_service.ask_question(
+        db, set_id="s1", question="hi", user_id=_USER_ID,
+    )
+    sys = RecordingClient.last_messages[0]["content"]
+    assert sys.startswith("COLL\n\nSET\n\n")
+    # Collection prompt must come strictly before set prompt.
+    assert sys.index("COLL") < sys.index("SET")
+
+
+async def test_no_prompts_leaves_legacy_system_content(db):
+    await _make_provider(db)
+    await _make_set(db, set_id="s1", name="S1")
+    await ai_service.ask_question(
+        db, set_id="s1", question="hi", user_id=_USER_ID,
+    )
+    sys = RecordingClient.last_messages[0]["content"]
+    # Should fall through to the existing default boilerplate.
+    assert sys.startswith("You are an AI assistant")
+
+
+async def test_multi_set_dedups_collection_prompt(db):
+    await _make_provider(db)
+    await _make_collection(db, collection_id="c1", name="C1", system_prompt="COLL")
+    await _make_set(
+        db, set_id="s1", name="S1", collection_id="c1", system_prompt="SETA",
+    )
+    await _make_set(
+        db, set_id="s2", name="S2", collection_id="c1", system_prompt="SETB",
+    )
+    await ai_service.ask_multi_set_question(
+        db, set_ids=["s1", "s2"], question="hi", user_id=_USER_ID,
+    )
+    sys = RecordingClient.last_messages[0]["content"]
+    # COLL exactly once; SETA before SETB.
+    assert sys.count("COLL") == 1
+    assert sys.index("SETA") < sys.index("SETB")

--- a/backend/tests/test_ai/test_scope_prompts.py
+++ b/backend/tests/test_ai/test_scope_prompts.py
@@ -1,0 +1,180 @@
+"""Tests for the scope-level system prompt builder (ADR-150)."""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest_asyncio
+
+from app.ai.scope_prompts import build_scope_prompts
+
+
+@pytest_asyncio.fixture
+async def db():
+    """Minimal schema with collections + sets columns we need."""
+    async with aiosqlite.connect(":memory:") as conn:
+        await conn.executescript(
+            """
+            CREATE TABLE collections (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                system_prompt TEXT
+            );
+            CREATE TABLE sets (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                is_deleted INTEGER NOT NULL DEFAULT 0,
+                collection_id TEXT,
+                system_prompt TEXT
+            );
+            """
+        )
+        await conn.commit()
+        yield conn
+
+
+async def _insert_collection(db, *, id_: str, name: str, prompt: str | None) -> None:
+    await db.execute(
+        "INSERT INTO collections (id, name, system_prompt) VALUES (?, ?, ?)",
+        (id_, name, prompt),
+    )
+    await db.commit()
+
+
+async def _insert_set(
+    db,
+    *,
+    id_: str,
+    name: str,
+    collection_id: str | None,
+    prompt: str | None,
+) -> None:
+    await db.execute(
+        "INSERT INTO sets (id, name, collection_id, system_prompt) VALUES (?, ?, ?, ?)",
+        (id_, name, collection_id, prompt),
+    )
+    await db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Empty / trivial cases
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_set_ids_returns_empty(db):
+    assert await build_scope_prompts(db, set_ids=[], collection_id=None) == ""
+
+
+async def test_set_without_prompt_or_collection_returns_empty(db):
+    await _insert_set(db, id_="s1", name="S1", collection_id=None, prompt=None)
+    assert (
+        await build_scope_prompts(db, set_ids=["s1"], collection_id=None) == ""
+    )
+
+
+async def test_explicit_collection_id_with_no_prompt_returns_empty(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt=None)
+    assert (
+        await build_scope_prompts(db, set_ids=[], collection_id="c1") == ""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composition order
+# ---------------------------------------------------------------------------
+
+
+async def test_set_prompt_only(db):
+    await _insert_set(db, id_="s1", name="S1", collection_id=None, prompt="SET PROMPT")
+    result = await build_scope_prompts(db, set_ids=["s1"], collection_id=None)
+    assert result == "SET PROMPT"
+
+
+async def test_collection_prompt_only(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="COLL PROMPT")
+    result = await build_scope_prompts(db, set_ids=[], collection_id="c1")
+    assert result == "COLL PROMPT"
+
+
+async def test_collection_then_set_order(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="COLL")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt="SET")
+    result = await build_scope_prompts(db, set_ids=["s1"], collection_id=None)
+    assert result == "COLL\n\nSET"
+
+
+async def test_collection_derived_from_set_when_no_explicit_id(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="DERIVED")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt=None)
+    result = await build_scope_prompts(db, set_ids=["s1"], collection_id=None)
+    assert result == "DERIVED"
+
+
+# ---------------------------------------------------------------------------
+# Dedup + ordering
+# ---------------------------------------------------------------------------
+
+
+async def test_multi_set_same_collection_dedups_collection_prompt(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="COLL")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt="SET1")
+    await _insert_set(db, id_="s2", name="S2", collection_id="c1", prompt="SET2")
+    result = await build_scope_prompts(
+        db, set_ids=["s1", "s2"], collection_id=None,
+    )
+    # Collection prompt appears once, then both set prompts in order.
+    assert result == "COLL\n\nSET1\n\nSET2"
+
+
+async def test_multi_set_multi_collection_concatenates_in_set_order(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="COLL1")
+    await _insert_collection(db, id_="c2", name="C2", prompt="COLL2")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt="SET1")
+    await _insert_set(db, id_="s2", name="S2", collection_id="c2", prompt="SET2")
+    result = await build_scope_prompts(
+        db, set_ids=["s1", "s2"], collection_id=None,
+    )
+    assert result == "COLL1\n\nCOLL2\n\nSET1\n\nSET2"
+
+
+async def test_explicit_collection_id_placed_first_then_derived(db):
+    # Caller supplied collection_id explicitly. It should appear first,
+    # then any other collections derived from the sets.
+    await _insert_collection(db, id_="c1", name="C1", prompt="EXPLICIT")
+    await _insert_collection(db, id_="c2", name="C2", prompt="DERIVED")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c2", prompt=None)
+    result = await build_scope_prompts(
+        db, set_ids=["s1"], collection_id="c1",
+    )
+    assert result == "EXPLICIT\n\nDERIVED"
+
+
+async def test_explicit_collection_id_dedups_against_derived(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="ONLY")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt=None)
+    result = await build_scope_prompts(
+        db, set_ids=["s1"], collection_id="c1",
+    )
+    assert result == "ONLY"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_collection_in_db_is_silently_skipped(db):
+    # A set points at a collection id that doesn't exist (orphan).
+    # Should not error; behave as if there is no collection prompt.
+    await _insert_set(
+        db, id_="s1", name="S1", collection_id="ghost", prompt="SET",
+    )
+    result = await build_scope_prompts(db, set_ids=["s1"], collection_id=None)
+    assert result == "SET"
+
+
+async def test_whitespace_only_prompt_treated_as_empty(db):
+    await _insert_collection(db, id_="c1", name="C1", prompt="   ")
+    await _insert_set(db, id_="s1", name="S1", collection_id="c1", prompt="SET")
+    result = await build_scope_prompts(db, set_ids=["s1"], collection_id=None)
+    assert result == "SET"

--- a/backend/tests/test_collections/test_crud.py
+++ b/backend/tests/test_collections/test_crud.py
@@ -136,6 +136,65 @@ class TestUpdateCollection:
         assert resp.json()["description"] == "Updated"
 
 
+class TestSystemPrompt:
+    """ADR-150: collections can carry a free-text system_prompt."""
+
+    async def test_create_defaults_to_null_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/collections", json={"name": "No Prompt Coll"}, headers=headers,
+        )
+        assert resp.status_code == 201
+        assert resp.json()["system_prompt"] is None
+
+    async def test_put_persists_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/collections", json={"name": "Prompted Coll"}, headers=headers,
+        )
+        collection_id = create_resp.json()["id"]
+        resp = await client.put(
+            f"/api/collections/{collection_id}",
+            json={"name": "Prompted Coll", "system_prompt": "Always cite the control."},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["system_prompt"] == "Always cite the control."
+
+    async def test_get_returns_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/collections", json={"name": "Get Prompt Coll"}, headers=headers,
+        )
+        collection_id = create_resp.json()["id"]
+        await client.put(
+            f"/api/collections/{collection_id}",
+            json={"name": "Get Prompt Coll", "system_prompt": "House rules apply."},
+            headers=headers,
+        )
+        resp = await client.get(f"/api/collections/{collection_id}", headers=headers)
+        assert resp.json()["system_prompt"] == "House rules apply."
+
+    async def test_put_can_clear_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/collections", json={"name": "Clearable Coll"}, headers=headers,
+        )
+        collection_id = create_resp.json()["id"]
+        await client.put(
+            f"/api/collections/{collection_id}",
+            json={"name": "Clearable Coll", "system_prompt": "Temporary."},
+            headers=headers,
+        )
+        resp = await client.put(
+            f"/api/collections/{collection_id}",
+            json={"name": "Clearable Coll", "system_prompt": None},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["system_prompt"] is None
+
+
 class TestDeleteCollection:
     async def test_soft_delete(self, client: httpx.AsyncClient) -> None:
         headers = await _auth_headers(client)

--- a/backend/tests/test_migrations/test_scope_system_prompts_schema.py
+++ b/backend/tests/test_migrations/test_scope_system_prompts_schema.py
@@ -1,0 +1,49 @@
+"""v5.8.0 (ADR-150, SPEC-150-A): static-parser test asserting the
+Supabase migration `m051_scope_system_prompts.sql` mirrors the SQLite
+migration `m047_scope_system_prompts.py`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_sqlite_m047_adds_collections_system_prompt() -> None:
+    py = _read("app/migrations/m047_scope_system_prompts.py")
+    assert "ALTER TABLE collections ADD COLUMN system_prompt" in py
+
+
+def test_sqlite_m047_adds_sets_system_prompt() -> None:
+    py = _read("app/migrations/m047_scope_system_prompts.py")
+    assert "ALTER TABLE sets ADD COLUMN system_prompt" in py
+
+
+def test_sqlite_m047_is_idempotent_on_collections() -> None:
+    py = _read("app/migrations/m047_scope_system_prompts.py")
+    # Idempotency guard: PRAGMA table_info inspection before ALTER.
+    assert "PRAGMA table_info(collections)" in py
+
+
+def test_sqlite_m047_is_idempotent_on_sets() -> None:
+    py = _read("app/migrations/m047_scope_system_prompts.py")
+    assert "PRAGMA table_info(sets)" in py
+
+
+def test_supabase_m051_adds_collections_system_prompt() -> None:
+    sql = _read("app/migrations/supabase/m051_scope_system_prompts.sql")
+    assert "ALTER TABLE collections" in sql
+    assert "ADD COLUMN IF NOT EXISTS system_prompt" in sql
+
+
+def test_supabase_m051_adds_sets_system_prompt() -> None:
+    sql = _read("app/migrations/supabase/m051_scope_system_prompts.sql")
+    assert "ALTER TABLE sets" in sql
+    # Both ALTERs add system_prompt; verify the column appears at least twice
+    # (once per table). Substring count is sufficient — the SQL file has
+    # no other reason to mention system_prompt.
+    assert sql.count("system_prompt") >= 2

--- a/backend/tests/test_sets/test_crud.py
+++ b/backend/tests/test_sets/test_crud.py
@@ -138,6 +138,46 @@ class TestUpdateSet:
         assert resp.json()["description"] == "Updated"
 
 
+class TestSetSystemPrompt:
+    """ADR-150: sets can carry a free-text system_prompt."""
+
+    async def test_create_defaults_to_null_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/sets", json={"name": "No Prompt Set"}, headers=headers,
+        )
+        assert resp.status_code == 201
+        assert resp.json()["system_prompt"] is None
+
+    async def test_put_persists_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/sets", json={"name": "Prompted Set"}, headers=headers,
+        )
+        set_id = create_resp.json()["id"]
+        resp = await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "Prompted Set", "system_prompt": "Use the SREv2 vocabulary."},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["system_prompt"] == "Use the SREv2 vocabulary."
+
+    async def test_get_returns_system_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/sets", json={"name": "Get Prompt Set"}, headers=headers,
+        )
+        set_id = create_resp.json()["id"]
+        await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "Get Prompt Set", "system_prompt": "Strict ISO 27001 framing."},
+            headers=headers,
+        )
+        resp = await client.get(f"/api/sets/{set_id}", headers=headers)
+        assert resp.json()["system_prompt"] == "Strict ISO 27001 framing."
+
+
 class TestDeleteSet:
     async def test_delete_empty_set(self, client: httpx.AsyncClient) -> None:
         headers = await _auth_headers(client)

--- a/docs/adrs/ADR-150-Scope-Level-System-Prompts.md
+++ b/docs/adrs/ADR-150-Scope-Level-System-Prompts.md
@@ -1,0 +1,138 @@
+# ADR-150: Scope-level system prompts (Collection and Set)
+
+Status: Accepted (2026-05-11)
+
+## Context
+
+Iris's AI features (Ask Iris in discuss and creation modes; the Iris
+MCP `ask` tool consumed by Claude Desktop / web) compose a system
+prompt from one place only: the active provider's `system_prompt` row
+plus retrieved Set context. There is no way for the owner of a
+Collection or Set to attach domain-specific instructions that travel
+with the scope.
+
+A user editing a Collection or Set wants to be able to say things
+like "this collection is about NZISM controls — always cite the
+control number" or "this set is the Auckland Transport reference
+model — preserve element naming conventions in any creation output".
+Today that intent has to be repeated in every prompt by every user.
+
+This ADR also sets up the surface that ADR-151 plugs into for Skills.
+
+## Decision
+
+**Add a nullable `system_prompt TEXT` column to both the `collections`
+and `sets` tables.** When an AI request is dispatched for a scope
+(set, multi-set, or set within a collection), compose system content
+in this order:
+
+1. **Scope prepend** — collection prompt(s) first, then set prompt(s),
+   each separated by a blank line.
+2. **Provider system prompt** (existing, unchanged).
+3. **Creation prompt** (if creation mode; ADR-132 layered prompts).
+4. **Retrieved context** (existing, unchanged).
+
+The scope prepend is additive — a set inherits its parent collection's
+prompt, never overrides it. This matches the way the user picked it
+during planning and mirrors how nested settings compose elsewhere in
+the stack (e.g., Claude Code's project-then-user settings cascade).
+
+**Multi-set requests** that span multiple collections concatenate each
+distinct collection prompt once, in `set_ids` order, then each set
+prompt in `set_ids` order. Duplicate collection prompts are
+deduplicated by collection id.
+
+**Anonymous AI asks** (ADR-123) get scope prompts applied the same way
+as signed-in asks. The scope prompt is metadata the asker can already
+see (it appears in the edit screen of any collection/set they can
+view); no new privilege boundary.
+
+**Soft warning at 16 000 chars**: when the composed `system_content`
+exceeds 16 000 characters, log a warning under the `[AI_DEBUG]`
+channel. No hard truncation in v1 — model context windows are
+generally large enough that the warning is an authoring signal, not
+a correctness boundary.
+
+## Why a column on the existing tables, not a separate `scope_prompts` table
+
+- **No multiplicity to model.** A collection has at most one prompt;
+  same for a set. A side table would force an extra LEFT JOIN on
+  every list/read for no expressive gain.
+- **Matches the `ai_providers.system_prompt` precedent.** That column
+  is also free-text on the parent row, and the symmetry keeps the
+  Pydantic models, the migration shape, and the test patterns
+  uniform.
+- **Migration is two ALTER TABLE statements.** Smallest possible
+  schema delta; idempotent without joining any new tables into the
+  existing soft-delete / search-indexing flows.
+
+## Why additive inheritance, not override
+
+- **Composability.** Authors can put "house rules" on the collection
+  ("we use a hexagonal architecture lens") and reserve the set
+  prompt for narrower context ("this set is the SREv2 platform").
+  Override semantics would push authors to copy the collection
+  prompt into every set.
+- **Discoverability.** A reader of a set's prompt doesn't have to
+  guess whether the parent collection's prompt is also in effect —
+  it always is.
+- **Aligns with how skills will compose** (ADR-151). Skills are
+  additive across the hierarchy. Keeping prompts the same avoids two
+  different mental models for the two adjacent features.
+
+## Why dedup collection prompts in multi-set asks
+
+A user asking about three sets in the same collection should not
+have the collection prompt prepended three times. Dedup is by
+collection id; the prompt itself is included once even if two
+collections happen to have the same text.
+
+## Consequences
+
+- One new migration (`m047_scope_system_prompts.py`) and its Supabase
+  mirror (`m051_scope_system_prompts.sql`).
+- Pydantic `CollectionUpdate` / `CollectionResponse` and `SetUpdate` /
+  `SetResponse` gain a `system_prompt: str | None` field.
+- `update_collection` and `update_set` service functions accept
+  `system_prompt` and persist it. Existing callers continue to work
+  (parameter is keyword-only with a default).
+- A new small module `app/ai/scope_prompts.py` exposes
+  `build_scope_prompts(db, set_ids, collection_id)` returning the
+  composed prepend text. Returns `""` when no scope has a prompt.
+- Composition wiring lands in four places that all read the same
+  helper: `router._ask_streaming`, `router._ask_multi_set_streaming`,
+  `service.ask_question`, `service.ask_multi_set_question`.
+- The MCP `ask` tool benefits automatically — it already forwards
+  `collection_id` and `set_ids` to `/api/ai/ask`.
+- New ADR-150-related fields surface in the Collection and Set edit
+  pages as a textarea below the description field.
+- Token-budget warning is observability only; no behaviour change
+  beyond the log line in v1.
+
+## Out of scope (deferred)
+
+- **Per-user overrides.** Could be useful ("never use markdown
+  tables") but introduces a fourth composition layer and a privacy
+  question. Revisit when there's a concrete request.
+- **Per-conversation overrides.** A user might want to temporarily
+  suppress the scope prompt for a single thread. Solvable with a
+  `?ignore_scope_prompt=true` query param later; not needed v1.
+- **Prompt templating / variables.** Plain text only for v1. Variable
+  substitution (`{{collection.name}}`) is a power-user feature that
+  can be added without a schema change.
+- **Per-mode prompts.** A future "creation-only" or "discuss-only"
+  field could let authors split intent. For v1 the same prompt
+  applies in both modes; the model can be told which mode it's in
+  via the prompt text.
+
+## See also
+
+- [ADR-093](ADR-093-AI-Q-And-A.md) — original Ask Iris architecture.
+- [ADR-102](ADR-102-Collections.md) — collections data model.
+- [ADR-123](ADR-123-Anonymous-AI-Asks.md) — anonymous asker rules.
+- [ADR-132](ADR-132-Layered-Creation-Prompts.md) — the prompt-layering
+  precedent we extend with scope prepend.
+- [ADR-151](ADR-151-DB-Resident-Skills-Progressive-Disclosure.md) —
+  Skills, the companion feature that uses the same scope hierarchy.
+- [SPEC-150-A](specs/SPEC-150-A-Scope-System-Prompts.md) — schema,
+  composition rules, endpoint diffs, edit-page wiring, test plan.

--- a/docs/adrs/specs/SPEC-150-A-Scope-System-Prompts.md
+++ b/docs/adrs/specs/SPEC-150-A-Scope-System-Prompts.md
@@ -1,0 +1,180 @@
+# SPEC-150-A: Scope-level system prompts
+
+ADR: [ADR-150](../ADR-150-Scope-Level-System-Prompts.md)
+
+## Database schema
+
+### Columns added
+
+| Table | Column | SQLite type | Postgres type | Notes |
+|---|---|---|---|---|
+| `collections` | `system_prompt` | `TEXT` | `TEXT` | Nullable. Free-text. No length cap in DB; service layer warns above 16 000 chars. |
+| `sets` | `system_prompt` | `TEXT` | `TEXT` | Same. |
+
+### Migrations
+
+- `backend/app/migrations/m047_scope_system_prompts.py` (SQLite —
+  idempotent `ALTER TABLE` guarded by `PRAGMA table_info`).
+- `backend/app/migrations/supabase/m051_scope_system_prompts.sql`
+  (Postgres — `ALTER TABLE … ADD COLUMN IF NOT EXISTS`).
+
+Numbering note: SQLite migrations are at m046; Supabase migrations
+are at m050. The next SQLite slot is m047; the next Supabase slot is
+m051. This skew is pre-existing (see m046_extensions_source.py vs
+m048_extensions_source.sql).
+
+## Composition logic
+
+### `backend/app/ai/scope_prompts.py`
+
+```python
+async def build_scope_prompts(
+    db: DatabasePort,
+    *,
+    set_ids: list[str],
+    collection_id: str | None,
+) -> str:
+    """Return the scope prepend text, or "" when no prompts apply.
+
+    Composition order:
+      [collection prompt 1]
+      [collection prompt 2]   # multi-collection multi-set ask
+      [set prompt 1]
+      [set prompt 2]
+
+    Each non-empty prompt is followed by a blank line.
+
+    Collection prompts are deduplicated by collection id. If
+    `collection_id` is supplied explicitly, it's used; otherwise the
+    parent collection is derived per set from `sets.collection_id`.
+    """
+```
+
+Behavioural rules:
+
+1. If `set_ids` is empty (multi-set with only docref / file context),
+   and `collection_id` is None, return `""`.
+2. Otherwise, look up the set rows in `set_ids` order and gather
+   `system_prompt` and `collection_id` per set.
+3. Build a unique-by-id, order-preserving list of collection ids.
+   When `collection_id` arg is non-None, place it first.
+4. Fetch each collection's `system_prompt`. Skip empties.
+5. Append each set's `system_prompt`. Skip empties.
+6. Join with `\n\n`. If empty, return `""`.
+
+### Wiring points
+
+All four sites concatenate the prepend ahead of the existing
+`system_content`:
+
+- `backend/app/ai/router.py::_ask_streaming` (single-set discuss /
+  creation). Derive collection from the set row.
+- `backend/app/ai/router.py::_ask_multi_set_streaming` (multi-set;
+  `body.collection_id` may be supplied).
+- `backend/app/ai/service.py::ask_question` (non-streaming single).
+- `backend/app/ai/service.py::ask_multi_set_question` (non-streaming
+  multi).
+
+Pseudocode for the wiring (identical at each site):
+
+```python
+scope_prepend = await build_scope_prompts(
+    db, set_ids=[set_id], collection_id=None,
+)
+# … existing composition that produces `system_content` …
+if scope_prepend:
+    system_content = f"{scope_prepend}\n\n{system_content}"
+if len(system_content) > 16_000:
+    log.warning(
+        "[AI_DEBUG] composed system_content is %d chars (>16000)",
+        len(system_content),
+    )
+```
+
+## API
+
+### `PUT /api/collections/{id}`
+
+`CollectionUpdate` adds a `system_prompt: str | None = None` field.
+The `update_collection` service writes it to the `system_prompt`
+column. `CollectionResponse` includes it on read.
+
+### `PUT /api/sets/{id}`
+
+Same shape on `SetUpdate` and `SetResponse`. `update_set` persists
+the value. The `collection_id` parameter and validation are
+unchanged.
+
+### No new endpoints
+
+Phase 1 reuses the existing CRUD endpoints; the system prompt rides
+in the same PUT body the frontend already sends.
+
+## Frontend
+
+### `frontend/src/routes/collections/[id]/+page.svelte`
+
+Add a System prompt section below the Description field:
+
+```svelte
+<label class="block">
+  <span class="text-sm font-medium">System prompt</span>
+  <textarea
+    bind:value={systemPrompt}
+    rows="6"
+    maxlength="20000"
+    placeholder="Optional. Prepended to every AI question about Sets in this Collection."
+    class="…"
+  ></textarea>
+  <span class="text-xs text-muted">
+    Inherited by every Set in this Collection.
+  </span>
+</label>
+```
+
+`handleSave` includes `system_prompt: DOMPurify.sanitize(systemPrompt)`
+in the PUT body alongside `name` / `description`.
+
+### `frontend/src/routes/sets/[id]/+page.svelte`
+
+Same control. Helper text: "Optional. Applied in addition to the
+parent Collection's system prompt."
+
+### Sanitisation
+
+`DOMPurify.sanitize` is applied for parity with how description is
+handled today, even though the textarea content goes to the model
+as plain text. Defence in depth: prevents `<script>`-shaped junk
+from being persisted if a user pastes HTML.
+
+## Tests
+
+| File | Coverage |
+|---|---|
+| `backend/tests/test_migrations/test_scope_system_prompts_schema.py` | Static-parser test: SQLite m047 adds `system_prompt` to both `collections` and `sets`; Supabase m051 uses `ADD COLUMN IF NOT EXISTS system_prompt`. |
+| `backend/tests/test_ai/test_scope_prompts.py` | `build_scope_prompts` unit tests: empty scope returns ""; single-set with collection prompt; single-set without collection; multi-set same collection (dedup); multi-set multi-collection (preserves order); explicit `collection_id` arg overrides derived order. |
+| `backend/tests/test_collections/test_router.py` | New cases: PUT with `system_prompt` persists; GET returns it; legacy PUT without the field is non-destructive (preserves the existing value). |
+| `backend/tests/test_sets/test_router.py` | Same as collections. |
+| `backend/tests/test_ai/test_ask_with_scope_prompts.py` | Integration: with a mocked provider, asking about a set whose collection has a prompt yields a `system_content` that contains the collection prompt then the set prompt then the existing provider/context body. |
+
+## Observability
+
+`[AI_DEBUG]` log lines on each ask path already record system content
+length. Add a `WARNING` when length > 16 000 chars (separate line so
+it stays visible in production logs even if `AI_DEBUG` is off).
+
+## Migration safety
+
+The migrations are additive `ALTER TABLE ADD COLUMN` only. No data
+backfill, no constraint changes, no index changes. Rollback path is
+not provided (consistent with every other migration in the project)
+but is trivially `DROP COLUMN` should it ever be needed.
+
+## Out of scope (deferred per ADR-150)
+
+- Per-user / per-conversation prompt overrides.
+- Prompt templating / variable substitution.
+- Per-mode (discuss vs creation) split prompts.
+- Versioning / change history of the prompt text. (Service-layer
+  audit log captures who changed it via the existing `updated_at`
+  bump.)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.7.3",
+	"version": "5.8.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -285,6 +285,7 @@ export interface IrisSet {
 	thumbnail_diagram_type?: string;
 	collection_id: string | null;
 	collection_name: string | null;
+	system_prompt?: string | null;
 }
 
 export interface IrisCollection {
@@ -303,6 +304,7 @@ export interface IrisCollection {
 	has_thumbnail_image: boolean;
 	thumbnail_diagram_data?: Record<string, unknown>;
 	thumbnail_diagram_type?: string;
+	system_prompt?: string | null;
 }
 
 export interface BatchResult {

--- a/frontend/src/routes/collections/[id]/+page.svelte
+++ b/frontend/src/routes/collections/[id]/+page.svelte
@@ -15,6 +15,7 @@
 
 	let name = $state('');
 	let description = $state('');
+	let systemPrompt = $state('');
 
 	let showDeleteDialog = $state(false);
 	let deleting = $state(false);
@@ -39,6 +40,7 @@
 			// Initialize form state
 			name = collectionData.name;
 			description = collectionData.description ?? '';
+			systemPrompt = collectionData.system_prompt ?? '';
 		} catch {
 			error = 'Failed to load collection';
 		}
@@ -54,12 +56,16 @@
 			const sanitizedDesc = description.trim()
 				? DOMPurify.sanitize(description.trim())
 				: null;
+			const sanitizedPrompt = systemPrompt.trim()
+				? DOMPurify.sanitize(systemPrompt.trim())
+				: null;
 
 			await apiFetch<IrisCollection>(`/api/collections/${collectionId}`, {
 				method: 'PUT',
 				body: JSON.stringify({
 					name: sanitizedName,
 					description: sanitizedDesc,
+					system_prompt: sanitizedPrompt,
 				}),
 			});
 
@@ -140,6 +146,25 @@
 				class="mt-1 w-full rounded border px-3 py-2 text-sm"
 				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 			></textarea>
+		</div>
+
+		<!-- System prompt (ADR-150) -->
+		<div class="mt-4">
+			<label for="collection-edit-system-prompt" class="text-sm font-medium" style="color: var(--color-fg)">
+				System prompt
+			</label>
+			<textarea
+				id="collection-edit-system-prompt"
+				bind:value={systemPrompt}
+				rows="6"
+				maxlength="20000"
+				placeholder="Optional. Prepended to every AI question about Sets in this Collection."
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
+			></textarea>
+			<p class="mt-1 text-xs" style="color: var(--color-muted)">
+				Inherited by every Set in this Collection. Applied alongside any Set-level prompt.
+			</p>
 		</div>
 
 		<!-- Save button -->

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -22,6 +22,7 @@
 	let thumbnailDiagramId = $state<string | null>(null);
 	let thumbnailFile = $state<File | null>(null);
 	let collectionId = $state<string | null>(null);
+	let systemPrompt = $state('');
 
 	let showDeleteDialog = $state(false);
 	let deleting = $state(false);
@@ -49,6 +50,7 @@
 			thumbnailSource = setData.thumbnail_source;
 			thumbnailDiagramId = setData.thumbnail_diagram_id;
 			collectionId = setData.collection_id ?? null;
+			systemPrompt = setData.system_prompt ?? '';
 		} catch {
 			error = 'Failed to load set';
 		}
@@ -64,6 +66,9 @@
 			const sanitizedDesc = description.trim()
 				? DOMPurify.sanitize(description.trim())
 				: null;
+			const sanitizedPrompt = systemPrompt.trim()
+				? DOMPurify.sanitize(systemPrompt.trim())
+				: null;
 
 			await apiFetch<IrisSet>(`/api/sets/${setId}`, {
 				method: 'PUT',
@@ -73,6 +78,7 @@
 					thumbnail_source: thumbnailSource,
 					thumbnail_diagram_id: thumbnailSource === 'model' ? thumbnailDiagramId : null,
 					collection_id: collectionId,
+					system_prompt: sanitizedPrompt,
 				}),
 			});
 
@@ -200,6 +206,25 @@
 				showAll={true}
 				label="Collection"
 			/>
+		</div>
+
+		<!-- System prompt (ADR-150) -->
+		<div class="mt-4">
+			<label for="set-edit-system-prompt" class="text-sm font-medium" style="color: var(--color-fg)">
+				System prompt
+			</label>
+			<textarea
+				id="set-edit-system-prompt"
+				bind:value={systemPrompt}
+				rows="6"
+				maxlength="20000"
+				placeholder="Optional. Prepended to every AI question about this Set."
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
+			></textarea>
+			<p class="mt-1 text-xs" style="color: var(--color-muted)">
+				Applied in addition to the parent Collection's system prompt.
+			</p>
 		</div>
 
 		<!-- Thumbnail -->


### PR DESCRIPTION
Promotes **main → render-supabase-uat** with v5.8.0:

- Scope-level system prompts for Collections and Sets (ADR-150 / SPEC-150-A)
- New SQLite + Supabase migrations (m047 / m051) — additive `ALTER TABLE` adding `system_prompt TEXT`, idempotent
- Frontend edit-screen textareas
- 30 new tests, all green

Migrations are additive only and idempotent — safe to apply on the existing UAT Supabase instance with no manual steps.

Release notes: https://github.com/cgbarlow/iris/releases/tag/v5.8.0
Origin PR: #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)