### PR TITLE
release(v5.8.1): enable RLS on graph_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.1] - 2026-05-11
+
+### Fixed
+
+- **Enable Row Level Security on `graph_settings`** (ADR-095
+  alignment). The table — added in m039 and re-created defensively
+  at runtime in `_initialize_supabase` (v5.7.2 fallback) — was the
+  only post-m030 table without RLS, triggering a Supabase advisor
+  warning. Both locations now run `ALTER TABLE graph_settings
+  ENABLE ROW LEVEL SECURITY` (idempotent). FastAPI continues to
+  read/write via asyncpg's `postgres` role, which bypasses RLS, so
+  the app is unaffected; the embedded anon key in the frontend can
+  no longer query the table directly via PostgREST.
+
 ## [5.8.0] - 2026-05-11
 
 ### Added

--- a/backend/app/migrations/supabase/m039_graph_settings.sql
+++ b/backend/app/migrations/supabase/m039_graph_settings.sql
@@ -8,3 +8,7 @@ CREATE TABLE IF NOT EXISTS graph_settings (
     updated_by    TEXT,
     PRIMARY KEY (scope_type, scope_id)
 );
+
+-- v5.8.1: enable RLS to match ADR-095 deny-all posture. PostgreSQL
+-- treats ENABLE ROW LEVEL SECURITY as idempotent so re-running is safe.
+ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -203,6 +203,11 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
         "  PRIMARY KEY (scope_type, scope_id)"
         ")"
     )
+    # v5.8.1: align graph_settings with the ADR-095 deny-all RLS posture.
+    # PostgreSQL's ENABLE ROW LEVEL SECURITY is idempotent — safe on every
+    # startup. Fixes a Supabase advisor warning where graph_settings was the
+    # only post-m030 table without RLS.
+    await port.execute("ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY")
     await port.commit()
     # ADR-117 v5.7.1 amendment: ensure the `__global__` row exists on
     # Supabase startup (the SQLite path already does this on line ~139).

--- a/backend/tests/test_migrations/test_graph_settings_rls_schema.py
+++ b/backend/tests/test_migrations/test_graph_settings_rls_schema.py
@@ -1,0 +1,54 @@
+"""v5.8.1: static-parser test asserting RLS is enabled on graph_settings.
+
+The table was originally added by m039 (and re-created defensively at
+runtime in startup._initialize_supabase as a v5.7.2 fix). Neither
+location enabled RLS, so the Supabase advisor flagged graph_settings
+as a public table without Row Level Security — out of line with the
+deny-all posture ADR-095 set for every other table in the schema.
+
+The fix is one ALTER statement in each place. These tests pin the
+fix so future edits don't regress.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_supabase_m039_enables_rls_on_graph_settings() -> None:
+    sql = _read("app/migrations/supabase/m039_graph_settings.sql")
+    assert "ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY" in sql
+
+
+def test_supabase_m039_alters_after_create_table() -> None:
+    """The ALTER must come after the CREATE TABLE; otherwise Postgres
+    rejects the statement on a fresh DB where the table doesn't exist
+    yet."""
+    sql = _read("app/migrations/supabase/m039_graph_settings.sql")
+    create_idx = sql.find("CREATE TABLE")
+    alter_idx = sql.find("ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY")
+    assert create_idx != -1
+    assert alter_idx != -1
+    assert create_idx < alter_idx
+
+
+def test_startup_enables_rls_on_graph_settings_after_runtime_create() -> None:
+    """startup._initialize_supabase re-creates the table at runtime as
+    a defensive fallback (v5.7.2). It must also enable RLS so that
+    deployments which never ran the SQL migration still get the right
+    posture."""
+    py = _read("app/startup.py")
+    assert "graph_settings ENABLE ROW LEVEL SECURITY" in py
+    # The ALTER must appear after the runtime CREATE TABLE block in the
+    # same function. We anchor on the comment referencing ADR-117 v5.7.2.
+    create_idx = py.find("CREATE TABLE IF NOT EXISTS graph_settings")
+    alter_idx = py.find("ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY")
+    assert create_idx != -1
+    assert alter_idx != -1
+    assert create_idx < alter_idx

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.8.0",
+	"version": "5.8.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Summary
Closes the Supabase advisor warning that `public.graph_settings` had no Row Level Security enabled. Brings the table in line with ADR-095's deny-all posture (every other table already has RLS enabled).

## What changed
- `backend/app/migrations/supabase/m039_graph_settings.sql` — append `ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY;`
- `backend/app/startup.py:_initialize_supabase` — run the same ALTER after the runtime `CREATE TABLE IF NOT EXISTS graph_settings` (v5.7.2 defensive fallback). Idempotent: re-running on every startup is safe.
- New static-parser test `backend/tests/test_migrations/test_graph_settings_rls_schema.py` (3 cases — pin the SQL + the startup code).
- Frontend `package.json` → 5.8.1; CHANGELOG entry.

Defect correction relative to ADR-095, no new ADR.

## Why this is safe
FastAPI connects to Postgres as the `postgres` role via asyncpg, which **bypasses RLS** by design. The app reads and writes `graph_settings` exactly as before. Only direct access via the frontend's embedded anon Supabase key (which there is none of for this table today) would be denied — which is the desired posture.

## Manual hotfix for the live UAT DB
The migration runner on UAT may not pick up the amended m039 automatically. Paste this once in the Supabase SQL editor to clear the advisor warning immediately:

```sql
ALTER TABLE graph_settings ENABLE ROW LEVEL SECURITY;
```

PostgreSQL treats `ENABLE ROW LEVEL SECURITY` as idempotent — safe to run even if it was somehow already enabled.

## Test plan
- [x] `pytest backend/tests/test_migrations/test_graph_settings_rls_schema.py` (3 pass)
- [x] App startup against a Postgres DB still completes (no errors from the ALTER on a fresh deploy or a re-deploy)
- [ ] Apply the SQL hotfix on UAT; advisor warning clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)