### PR TITLE
Promote v5.8.2 to UAT — strip system_prompt at MCP boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.2] - 2026-05-11
+
+### Fixed
+
+- **MCP boundary now strips `system_prompt` from tool responses**
+  (ADR-151, SPEC-151-A). v5.8.0 added `system_prompt` to the
+  Set/Collection response models. The four MCP tools that return
+  Set or Collection data (`get_set`, `list_sets`, `get_collection`,
+  `list_collections`) were forwarding it to Claude Desktop as
+  untrusted tool data, where it triggered prompt-injection
+  defenses ("this set has a system prompt attached … I'm flagging
+  it"). The MCP egress helpers (`with_web_url` /
+  `with_web_urls_list` / `with_web_urls_search` in
+  `mcp/src/iris_mcp/links.py`) now redact the field on every tool
+  response. Authoring (REST endpoints + web GUI) and the MCP `ask`
+  tool (which composes the prompt server-side) are unchanged. The
+  spec-compliant channel for invoking a scope's system prompt
+  inside a Claude Desktop conversation arrives in v5.8.3 via the
+  MCP `prompts` capability.
+
 ## [5.8.1] - 2026-05-11
 
 ### Fixed

--- a/docs/adrs/ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md
+++ b/docs/adrs/ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md
@@ -1,0 +1,105 @@
+# ADR-151: MCP boundary strips scope `system_prompt`
+
+Status: Accepted (2026-05-11)
+
+## Context
+
+v5.8.0 (ADR-150) added a free-text `system_prompt` field to Collections
+and Sets. The field is consumed correctly in three places:
+
+- **Web GUI** edit screens (`/collections/[id]`, `/sets/[id]`) — authors
+  read and write it via the existing REST endpoints.
+- **Iris backend ask path** (`/api/ai/ask`) — the field is composed
+  into the LLM's system message in `build_scope_prompts`. The model
+  sees it as part of its own system context, not as tool data.
+- **Iris MCP `ask` tool** — same backend code path, same result.
+
+What broke: the *four other* MCP tools that return Set or Collection
+data — `list_sets`, `get_set`, `list_collections`, `get_collection` —
+serialise the full response model and pass `system_prompt` straight
+through to the MCP client as a JSON field. UAT testing surfaced this
+within hours: Claude Desktop, presented with a `system_prompt` field
+inside a tool's JSON response, correctly treats it as untrusted data
+and announces "this set has a system prompt attached … I'm flagging
+it rather than silently obeying."
+
+This is **Claude's prompt-injection defense working as designed.**
+Tool outputs are data, not instructions. If a malicious actor attached
+a `system_prompt` to a resource, the model must not silently obey it.
+The defense applies even when the author is legitimate (Iris has no
+way to convey "this came from a trusted scope owner" through the
+tool-response channel; any such marker would itself be untrusted data).
+
+## Decision
+
+**The Iris MCP server must redact `system_prompt` from every tool
+response that crosses the MCP boundary.** Authoring still flows
+through the REST endpoints unchanged. Scope prompts continue to apply
+silently via the `ask` MCP tool (the backend injects them
+server-side). The spec-compliant channel for delivering scope-attached
+directives to a Claude Desktop conversation is the MCP `prompts`
+capability, which ADR-152 introduces.
+
+Implementation: the strip lives in the three serialisation helpers in
+`mcp/src/iris_mcp/links.py` — `with_web_url`, `with_web_urls_list`,
+`with_web_urls_search`. Every Set- or Collection-returning tool
+already routes through these helpers for web-URL decoration; the
+strip is added inside the existing JSON parse/serialise round-trip,
+adding one `dict.pop("system_prompt", None)` call per item. The
+strip runs *unconditionally* — independent of whether `IRIS_WEB_URL`
+is configured.
+
+The list of stripped keys lives in a module-level constant
+`_STRIPPED_KEYS = ("system_prompt",)`. Future redactions (e.g.,
+forthcoming MCP-sensitive fields on other entities) extend the tuple
+rather than copy-pasting strip logic into every handler.
+
+## Why strip at the helper layer
+
+Three options were considered:
+
+1. **Backend response models exclude `system_prompt`.** Rejected — the
+   web GUI authoring flow needs the field on the same endpoints.
+2. **iris-client filters the field.** Rejected — iris-client is a
+   shared library used by surfaces that legitimately need the field
+   (e.g., a hypothetical Python admin CLI).
+3. **MCP server strips at the egress boundary.** Accepted — the only
+   layer where "MCP" is the meaningful constraint and where the rest
+   of the system stays untouched. Single edit, durable across future
+   handlers that follow the same pattern.
+
+Within option 3, the strip could live in each MCP handler (`_list_sets`,
+`_get_set`, etc.) or in the shared `with_web_url*` helpers. The
+helpers were chosen for durability: every Set- or Collection-returning
+tool today already calls them, and any new tool following the same
+pattern will inherit the strip automatically. Catches future leaks
+without future code review having to flag them.
+
+## Consequences
+
+- Single small diff in `mcp/src/iris_mcp/links.py` (adds one private
+  helper, three calls).
+- No changes to handlers, iris-client, or the backend.
+- Future tools returning Set or Collection data inherit the strip for
+  free as long as they route through `with_web_url*`. A handler that
+  bypasses the helpers would re-introduce the leak; the pattern is
+  consistent enough that the chance is low, but worth flagging in code
+  review.
+- The MCP `ask` tool continues to apply prompts server-side
+  (unchanged) — it doesn't return Set/Collection JSON; it returns a
+  text answer.
+- "Silent automatic application of scope prompts inside a Claude
+  Desktop conversation outside of `ask`" is explicitly **not** achievable
+  through this fix. ADR-152 introduces the MCP `prompts` channel for
+  that use case.
+
+## See also
+
+- [ADR-095](ADR-095-RLS-Posture.md) — analogous "defence-at-the-boundary"
+  principle for Supabase RLS.
+- [ADR-150](ADR-150-Scope-Level-System-Prompts.md) — original feature
+  that introduced the leaking field.
+- ADR-152 — the spec-compliant alternative channel for delivering
+  scope prompts to MCP clients.
+- [SPEC-151-A](specs/SPEC-151-A-MCP-System-Prompt-Strip.md) — the
+  helpers, the test plan, and the future-redaction extension point.

--- a/docs/adrs/specs/SPEC-151-A-MCP-System-Prompt-Strip.md
+++ b/docs/adrs/specs/SPEC-151-A-MCP-System-Prompt-Strip.md
@@ -1,0 +1,87 @@
+# SPEC-151-A: MCP `system_prompt` strip
+
+ADR: [ADR-151](../ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md)
+
+## What to strip
+
+A module-level tuple in `mcp/src/iris_mcp/links.py`:
+
+```python
+_STRIPPED_KEYS: tuple[str, ...] = ("system_prompt",)
+```
+
+v5.8.2 ships with one key. Future additions extend the tuple. No
+per-handler strip logic.
+
+## Where the strip runs
+
+Inside three existing serialisation helpers in `links.py`:
+
+| Helper | Strip target |
+|---|---|
+| `with_web_url(payload, kind)` | the top-level dict |
+| `with_web_urls_list(payload, kind)` | each dict in the parsed list |
+| `with_web_urls_search(payload)` | each dict in `data["results"]` |
+
+The strip runs **unconditionally** — independent of whether
+`IRIS_WEB_URL` is set. (Prior to v5.8.2 the helpers were full no-ops
+when `IRIS_WEB_URL` was unset; the strip half of the helper now
+always runs, the web-URL decoration half still skips.)
+
+Two private helpers are added:
+
+```python
+def _strip_sensitive_keys(item: Any) -> None: ...
+def _strip_sensitive_keys_list(items: Any) -> None: ...
+```
+
+The first mutates a single dict in place; the second mutates each
+element of a list in place. Non-dict inputs are silently ignored.
+
+## Coverage
+
+All four Set/Collection-returning MCP tools already route through
+the affected helpers — no handler changes needed:
+
+| Handler | Helper called |
+|---|---|
+| `_get_set` | `with_web_url(..., "set")` |
+| `_list_sets` | `with_web_urls_list(..., "set")` |
+| `_get_collection` | `with_web_url(..., "collection")` |
+| `_list_collections` | `with_web_urls_list(..., "collection")` |
+
+`with_web_urls_search` is included in the strip for defence in depth
+— the FTS index does not currently surface `system_prompt`, but
+keeping the boundary consistent across all three helpers means a
+future change to search wouldn't accidentally reintroduce the leak.
+
+## Tests
+
+`mcp/tests/test_links_strip_system_prompt.py` — pins the new
+behaviour. Nine cases:
+
+| Helper | Case | Assertion |
+|---|---|---|
+| `with_web_url` | set payload | `system_prompt` absent; other fields + `web_url` preserved |
+| `with_web_url` | collection payload | same |
+| `with_web_url` | env unset | `system_prompt` still absent |
+| `with_web_url` | field absent | no-op for that key; other fields intact |
+| `with_web_url` | bad JSON | passthrough |
+| `with_web_urls_list` | each set item | `system_prompt` absent from every item |
+| `with_web_urls_list` | each collection item | same |
+| `with_web_urls_list` | env unset | still strips |
+| `with_web_urls_search` | each result | `system_prompt` absent |
+
+Existing 22 tests in `tests/test_links.py` continue to pass — the
+strip is additive and doesn't change any prior assertions.
+
+## Out of scope (deferred)
+
+- Stripping additional fields — none currently identified. The
+  `_STRIPPED_KEYS` tuple is the extension point.
+- Stripping nested fields (e.g., `set.collection.system_prompt`) —
+  none currently exist; the top-level strip covers all known leak
+  shapes.
+- Logging / metrics on every strip — adds noise without value. If
+  Iris ever wants to audit the boundary, the existing MCP request
+  log is the right place.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.8.1",
+	"version": "5.8.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/src/iris_mcp/links.py
+++ b/mcp/src/iris_mcp/links.py
@@ -40,6 +40,28 @@ def web_base() -> str | None:
     return raw.rstrip("/") if raw else None
 
 
+# v5.8.2 (ADR-151): keys that must never leave the MCP boundary as tool
+# data. Currently just `system_prompt` — scope prompts get surfaced to
+# clients via the MCP `prompts` capability instead (ADR-152, v5.8.3).
+_STRIPPED_KEYS: tuple[str, ...] = ("system_prompt",)
+
+
+def _strip_sensitive_keys(item: Any) -> None:
+    """In-place: remove any sensitive keys from a single entity dict."""
+    if not isinstance(item, dict):
+        return
+    for key in _STRIPPED_KEYS:
+        item.pop(key, None)
+
+
+def _strip_sensitive_keys_list(items: Any) -> None:
+    """In-place: apply `_strip_sensitive_keys` to every dict in a list."""
+    if not isinstance(items, list):
+        return
+    for item in items:
+        _strip_sensitive_keys(item)
+
+
 def web_url_for(kind: str, entity_id: str, base: str | None = None) -> str | None:
     """Build a `<base>/<path>/<id>` URL for the given entity, or None if
     the web base or kind is unknown."""
@@ -101,42 +123,54 @@ def with_web_url(payload: str, kind: str) -> str:
     """Decorate a JSON-serialised single-entity tool response.
 
     `kind` is the kind we expect (e.g. "diagram" for `get_diagram`).
-    No-ops when IRIS_WEB_URL is unset or the payload isn't valid JSON.
+    Also strips MCP-sensitive keys (v5.8.2, ADR-151) regardless of
+    whether IRIS_WEB_URL is configured. No-ops on invalid JSON.
     """
-    base = web_base()
-    if not base:
-        return payload
     try:
         data = json.loads(payload)
     except (json.JSONDecodeError, TypeError):
         return payload
-    decorate_item(data, kind, base)
+    _strip_sensitive_keys(data)
+    base = web_base()
+    if base:
+        decorate_item(data, kind, base)
     return json.dumps(data)
 
 
 def with_web_urls_list(payload: str, kind: str) -> str:
-    """Decorate a JSON-serialised list-of-entities tool response."""
-    base = web_base()
-    if not base:
-        return payload
+    """Decorate a JSON-serialised list-of-entities tool response.
+
+    Also strips MCP-sensitive keys from each item (v5.8.2, ADR-151)
+    regardless of whether IRIS_WEB_URL is configured.
+    """
     try:
         data = json.loads(payload)
     except (json.JSONDecodeError, TypeError):
         return payload
-    decorate_list(data, kind, base)
+    _strip_sensitive_keys_list(data)
+    base = web_base()
+    if base:
+        decorate_list(data, kind, base)
     return json.dumps(data)
 
 
 def with_web_urls_search(payload: str) -> str:
-    """Decorate a JSON-serialised SearchResponse."""
-    base = web_base()
-    if not base:
-        return payload
+    """Decorate a JSON-serialised SearchResponse.
+
+    Also strips MCP-sensitive keys from each result (v5.8.2, ADR-151)
+    regardless of whether IRIS_WEB_URL is configured.
+    """
     try:
         data = json.loads(payload)
     except (json.JSONDecodeError, TypeError):
         return payload
-    decorate_search(data, base)
+    if isinstance(data, dict):
+        results = data.get("results")
+        if isinstance(results, list):
+            _strip_sensitive_keys_list(results)
+    base = web_base()
+    if base:
+        decorate_search(data, base)
     return json.dumps(data)
 
 

--- a/mcp/tests/test_links_strip_system_prompt.py
+++ b/mcp/tests/test_links_strip_system_prompt.py
@@ -1,0 +1,135 @@
+"""v5.8.2 (ADR-151): MCP boundary must strip scope `system_prompt`.
+
+The Iris backend exposes a `system_prompt` field on Sets and Collections
+(v5.8.0, ADR-150). When that field travels through MCP tool responses
+to Claude Desktop, it gets treated as untrusted data — and rightly
+flagged as suspected prompt injection. The fix is to redact the field
+at the MCP egress boundary, inside the `with_web_url` / `with_web_urls_list`
+/ `with_web_urls_search` helpers that every Set/Collection-returning
+tool already routes through.
+
+These tests pin the behaviour: when `system_prompt` is present in any
+payload the helpers handle, it must be absent from the returned JSON.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from iris_mcp.links import with_web_url, with_web_urls_list, with_web_urls_search
+
+WEB = "https://iris-uat.chrisbarlow.nz"
+
+
+# ---------------------------------------------------------------------------
+# with_web_url (single-entity payload)
+# ---------------------------------------------------------------------------
+
+
+class TestWithWebUrlStripsSystemPrompt:
+    def test_strips_system_prompt_from_set(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "id": "set-1", "name": "DoView Book",
+            "system_prompt": "Always cite the chapter.",
+            "description": "Visual companion.",
+        })
+        out = json.loads(with_web_url(payload, "set"))
+        assert "system_prompt" not in out
+        # Other fields preserved.
+        assert out["id"] == "set-1"
+        assert out["name"] == "DoView Book"
+        assert out["description"] == "Visual companion."
+        # web_url still decorated.
+        assert out["web_url"] == f"{WEB}/sets/set-1"
+
+    def test_strips_system_prompt_from_collection(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "id": "coll-1", "name": "NZISM",
+            "system_prompt": "Cite the control number.",
+        })
+        out = json.loads(with_web_url(payload, "collection"))
+        assert "system_prompt" not in out
+        assert out["web_url"] == f"{WEB}/collections/coll-1"
+
+    def test_strips_even_when_iris_web_url_is_unset(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        """The leak must not depend on IRIS_WEB_URL being configured — local
+        dev and self-hosted deployments without it should still strip."""
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        payload = json.dumps({
+            "id": "set-1", "name": "X", "system_prompt": "secret",
+        })
+        out = json.loads(with_web_url(payload, "set"))
+        assert "system_prompt" not in out
+
+    def test_no_op_when_system_prompt_absent(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({"id": "set-1", "name": "X"})
+        out = json.loads(with_web_url(payload, "set"))
+        assert "system_prompt" not in out
+        assert out["id"] == "set-1"
+        assert out["web_url"] == f"{WEB}/sets/set-1"
+
+    def test_invalid_json_passes_through_unchanged(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        # Bad JSON: helper degrades safely to passthrough.
+        assert with_web_url("not json", "set") == "not json"
+
+
+# ---------------------------------------------------------------------------
+# with_web_urls_list (homogeneous-list payload)
+# ---------------------------------------------------------------------------
+
+
+class TestWithWebUrlsListStripsSystemPrompt:
+    def test_strips_from_each_set_item(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps([
+            {"id": "s1", "name": "A", "system_prompt": "p1"},
+            {"id": "s2", "name": "B", "system_prompt": "p2"},
+            {"id": "s3", "name": "C"},  # no prompt — still fine
+        ])
+        out = json.loads(with_web_urls_list(payload, "set"))
+        assert all("system_prompt" not in item for item in out)
+        assert [item["id"] for item in out] == ["s1", "s2", "s3"]
+        assert all(item["web_url"].startswith(f"{WEB}/sets/") for item in out)
+
+    def test_strips_from_each_collection_item(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps([
+            {"id": "c1", "name": "A", "system_prompt": "p1"},
+            {"id": "c2", "name": "B"},
+        ])
+        out = json.loads(with_web_urls_list(payload, "collection"))
+        assert all("system_prompt" not in item for item in out)
+
+    def test_strips_even_when_iris_web_url_is_unset(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        payload = json.dumps([{"id": "s1", "name": "A", "system_prompt": "secret"}])
+        out = json.loads(with_web_urls_list(payload, "set"))
+        assert "system_prompt" not in out[0]
+
+
+# ---------------------------------------------------------------------------
+# with_web_urls_search (search response — defence in depth)
+# ---------------------------------------------------------------------------
+
+
+class TestWithWebUrlsSearchStripsSystemPrompt:
+    def test_strips_from_each_search_result(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "query": "x",
+            "results": [
+                {"result_type": "set", "id": "s1", "name": "S1",
+                 "system_prompt": "p1"},
+                {"result_type": "collection", "id": "c1", "name": "C1",
+                 "system_prompt": "p2"},
+            ],
+        })
+        out = json.loads(with_web_urls_search(payload))
+        for r in out["results"]:
+            assert "system_prompt" not in r


### PR DESCRIPTION
Promotes **main → render-supabase-uat** with v5.8.2.

Stops the system_prompt leak through MCP tool responses. The four Set/Collection-returning MCP tools now return payloads with `system_prompt` redacted. Authoring (REST + web GUI) and MCP `ask` are unchanged.

Release notes: https://github.com/cgbarlow/iris/releases/tag/v5.8.2
Origin PR: #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)