### PR TITLE
Promote v5.8.5 to UAT — drop iris: prefix from MCP prompt names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.5] - 2026-05-11
+
+### Changed
+
+- **MCP prompt names dropped the `iris:` prefix** (ADR-153 amending
+  ADR-152). Was `iris:set:<uuid>` / `iris:collection:<uuid>`; now
+  `set:<uuid>` / `collection:<uuid>`. MCP clients prepend the server
+  name automatically, so v5.8.3's prefix produced a redundant doubled
+  `/iris:iris:set:<uuid>` in Claude Code's slash menu. Post-rename it
+  reads cleanly as `/iris:set:<uuid>`. Backend service, MCP regex,
+  iris-client and MCP test fixtures all updated. No data migration —
+  prompt names are enumerated by the client on every `prompts/list`.
+
 ## [5.8.4] - 2026-05-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -305,7 +305,9 @@ hosts. See [`mcp/README.md`](mcp/README.md) and
 Also surfaces the spec-defined MCP **prompts** capability: every
 Collection and Set with a `system_prompt` (authored on
 `/collections/<id>` or `/sets/<id>`) appears in Claude Desktop's
-prompt picker as `iris:collection:<uuid>` or `iris:set:<uuid>`.
+prompt picker as `collection:<uuid>` or `set:<uuid>` (MCP clients
+namespace these under the server name, so Claude Code surfaces them
+as `/iris:collection:<uuid>` etc.).
 Invoking one loads the system prompt into the conversation as a
 user-authored directive — the spec-compliant alternative to silent
 client-side application, which prompt-injection defense correctly

--- a/backend/app/prompts/models.py
+++ b/backend/app/prompts/models.py
@@ -12,9 +12,12 @@ class ScopePromptIndexEntry(BaseModel):
 
     Consumed by the Iris MCP server to populate `prompts/list` and
     `prompts/get` responses. `name` is the stable MCP prompt URI of
-    the form `iris:<scope_type>:<scope_id>`; the body field carries
-    the scope's full `system_prompt` so a single MCP `prompts/get`
-    can be served without a follow-up HTTP round-trip.
+    the form `<scope_type>:<scope_id>` (v5.8.5: dropped the
+    `iris:` prefix; MCP clients already namespace prompts by server
+    name, e.g. `/iris:set:<uuid>` in Claude Code's slash menu). The
+    body field carries the scope's full `system_prompt` so a single
+    MCP `prompts/get` can be served without a follow-up HTTP
+    round-trip.
     """
 
     name: str

--- a/backend/app/prompts/service.py
+++ b/backend/app/prompts/service.py
@@ -28,7 +28,7 @@ async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
         if not body:
             continue
         items.append({
-            "name": f"iris:collection:{row[0]}",
+            "name": f"collection:{row[0]}",
             "scope_type": "collection",
             "scope_id": str(row[0]),
             "scope_name": str(row[1]),
@@ -46,7 +46,7 @@ async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
         if not body:
             continue
         items.append({
-            "name": f"iris:set:{row[0]}",
+            "name": f"set:{row[0]}",
             "scope_type": "set",
             "scope_id": str(row[0]),
             "scope_name": str(row[1]),

--- a/backend/tests/test_prompts/test_router.py
+++ b/backend/tests/test_prompts/test_router.py
@@ -91,7 +91,7 @@ class TestScopePromptIndex:
         assert entry["scope_id"] == s["id"]
         assert entry["scope_name"] == "DoView Book"
         assert entry["body"] == "Use outcomes theory framing."
-        assert entry["name"] == f"iris:set:{s['id']}"
+        assert entry["name"] == f"set:{s['id']}"
 
     async def test_lists_collection_before_sets(self, client: httpx.AsyncClient) -> None:
         headers = await _auth_headers(client)
@@ -124,8 +124,8 @@ class TestScopePromptIndex:
             ("collection", "NZISM"),
             ("set", "GCSB Set"),
         ]
-        assert items[0]["name"] == f"iris:collection:{c['id']}"
-        assert items[1]["name"] == f"iris:set:{s['id']}"
+        assert items[0]["name"] == f"collection:{c['id']}"
+        assert items[1]["name"] == f"set:{s['id']}"
 
     async def test_excludes_scopes_with_null_system_prompt(self, client: httpx.AsyncClient) -> None:
         headers = await _auth_headers(client)

--- a/docs/adrs/ADR-153-Drop-Redundant-iris-Prefix-From-MCP-Prompt-Names.md
+++ b/docs/adrs/ADR-153-Drop-Redundant-iris-Prefix-From-MCP-Prompt-Names.md
@@ -1,0 +1,91 @@
+# ADR-153: Drop redundant `iris:` prefix from MCP prompt names
+
+Status: Accepted (2026-05-11)
+Amends: [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md)
+
+## Context
+
+ADR-152 chose the prompt name format `iris:set:<uuid>` and
+`iris:collection:<uuid>` for scope system prompts exposed via the MCP
+`prompts` capability. The `iris:` prefix was added defensively, to
+namespace the prompts under the Iris MCP server.
+
+Post-v5.8.3 empirical evidence from Claude Code's slash menu shows
+that **MCP clients prepend the server name to every prompt entry
+automatically.** In Claude Code's slash picker the v5.8.3 prompt
+appears as:
+
+```
+/iris:iris:set:33032180-d77a-4ce4-88cf-b49cd643e093
+```
+
+The first `iris:` comes from the client prepending the MCP server name
+(`iris`); the second `iris:` is the prefix ADR-152 added to the prompt
+name. The result is a redundant doubled prefix that's visible in the
+slash UI of every MCP client.
+
+This is a small but real UX paper-cut on what's otherwise the
+spec-compliant invocation path the v5.8.x rollout is built around. The
+namespace ADR-152 wanted to provide is already provided by the MCP
+client out of the box, via the server name.
+
+## Decision
+
+**Drop the `iris:` prefix from prompt names.** The new format is:
+
+- `set:<uuid>` (was: `iris:set:<uuid>`)
+- `collection:<uuid>` (was: `iris:collection:<uuid>`)
+
+MCP clients namespace these under their server identity automatically;
+in Claude Code's slash menu the prompt appears as `/iris:set:<uuid>`,
+cleanly. The `<scope_type>:<uuid>` shape remains stable across
+renames, exports, and re-imports — that property is unchanged.
+
+This is the only modification to ADR-152's naming decision. Body
+shape (`role: user` single message + provenance preamble + system
+prompt body), name regex anchoring, error semantics, capability
+declaration, and the dedicated backend index endpoint are all
+unchanged.
+
+## Why drop rather than keep
+
+- **Empirical UX evidence.** Doubled-prefix is visible in real Claude
+  Code usage today and unavoidable as long as the server name is
+  `iris`. Renaming the server would break every existing client
+  config — far worse than renaming the prompt format.
+- **No backwards-compat cost.** The only consumers of prompt names
+  are MCP clients enumerating prompts. They re-enumerate on every
+  `prompts/list` call. There is no stored URI corpus to migrate.
+- **The namespace was always implicit.** A prompt named
+  `iris:set:<uuid>` cannot exist *outside* the `iris` MCP server's
+  enumeration anyway — the URI lives inside that server's namespace
+  by construction. Adding `iris:` to the URI was belt-and-braces on
+  something already covered by the spec.
+
+## Consequences
+
+- One-line change in `backend/app/prompts/service.py` to emit the
+  shorter name.
+- One-line regex change in `mcp/src/iris_mcp/prompts.py` to accept
+  the shorter name.
+- Test fixtures across backend / iris-client / MCP get the prefix
+  stripped — mechanical.
+- SPEC-152-A updated since specs are living docs.
+- Any user who copy-pasted a v5.8.3-formatted prompt name into
+  external automation will need to drop the `iris:` prefix. Unlikely
+  to exist in practice given v5.8.3 only shipped 36 hours ago and
+  the field is enumerable.
+
+## Why an ADR amendment rather than editing ADR-152
+
+ADR-152 is approved and per project protocol #1 stays immutable.
+ADR-153 records this naming refinement explicitly so the audit trail
+shows: "we chose X, then empirical evidence revealed a UX issue, we
+chose X-prime." Cleaner than retroactively rewriting ADR-152.
+
+## See also
+
+- [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md)
+  — the original decision being amended.
+- [SPEC-152-A](specs/SPEC-152-A-MCP-Prompts-Capability.md) — updated
+  to reflect the new naming as the living source of truth.

--- a/docs/adrs/specs/SPEC-152-A-MCP-Prompts-Capability.md
+++ b/docs/adrs/specs/SPEC-152-A-MCP-Prompts-Capability.md
@@ -14,7 +14,7 @@ ADR: [ADR-152](../ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md)
 
 ```python
 class ScopePromptIndexEntry(BaseModel):
-    name: str                                    # "iris:set:<uuid>" | "iris:collection:<uuid>"
+    name: str                                    # "set:<uuid>" | "collection:<uuid>"
     scope_type: Literal["collection", "set"]
     scope_id: str
     scope_name: str
@@ -63,7 +63,7 @@ base.
 ### Module: `mcp/src/iris_mcp/prompts.py`
 
 ```python
-_NAME_RE = re.compile(r"^iris:(set|collection):([0-9a-f-]{36})$")
+_NAME_RE = re.compile(r"^(set|collection):([0-9a-f-]{36})$")
 
 async def list_prompts(client: IrisClient) -> list[types.Prompt]: ...
 async def get_prompt(client: IrisClient, name: str, arguments: dict[str, str] | None = None) -> types.GetPromptResult: ...
@@ -137,7 +137,7 @@ Total: 20 new tests.
 
 1. Author a system_prompt on a Set via `/sets/<id>`.
 2. Configure Claude Desktop with the UAT Iris MCP server; restart it.
-3. Open the prompt picker → confirm `iris:set:<uuid>` appears with
+3. Open the prompt picker → confirm `set:<uuid>` appears with
    "Set: <name> — <description>" visible.
 4. Invoke it → confirm the conversation seeds with the preamble +
    body as a user message. The model treats it as authoritative.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.8.4",
+	"version": "5.8.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/tests/test_scope_prompts.py
+++ b/iris-client/tests/test_scope_prompts.py
@@ -20,7 +20,7 @@ class TestListScopePrompts:
             return_value=httpx.Response(200, json={
                 "items": [
                     {
-                        "name": "iris:collection:c-1",
+                        "name": "collection:c-1",
                         "scope_type": "collection",
                         "scope_id": "c-1",
                         "scope_name": "NZISM",
@@ -28,7 +28,7 @@ class TestListScopePrompts:
                         "body": "Cite the control number.",
                     },
                     {
-                        "name": "iris:set:s-1",
+                        "name": "set:s-1",
                         "scope_type": "set",
                         "scope_id": "s-1",
                         "scope_name": "DoView Book",
@@ -44,7 +44,7 @@ class TestListScopePrompts:
         assert route.called
         assert len(result) == 2
         assert result[0].scope_type == "collection"
-        assert result[0].name == "iris:collection:c-1"
+        assert result[0].name == "collection:c-1"
         assert result[1].scope_type == "set"
         assert result[1].body == "Use outcomes theory framing."
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -117,7 +117,9 @@ ADR-123/129).
   diagrams, and conversation history.
 - **Resources** at `iris://diagrams|elements|packages|sets|collections/{id}`
   returning JSON export bundles.
-- **Prompts** (v5.8.3, ADR-152) — every Collection / Set with an
-  attached `system_prompt` appears as `iris:set:<uuid>` or
-  `iris:collection:<uuid>`. Invoking a prompt loads the body into the
+- **Prompts** (v5.8.3, ADR-152; v5.8.5 naming refresh per ADR-153) —
+  every Collection / Set with an attached `system_prompt` appears as
+  `set:<uuid>` or `collection:<uuid>` (MCP clients namespace these
+  under the server name automatically — e.g. Claude Code shows them
+  as `/iris:set:<uuid>`). Invoking a prompt loads the body into the
   conversation as a user-authored directive.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.8.4"
+version = "5.8.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/prompts.py
+++ b/mcp/src/iris_mcp/prompts.py
@@ -23,8 +23,11 @@ from mcp import types
 if TYPE_CHECKING:
     from iris_client import IrisClient
 
-# `iris:set:<uuid>` and `iris:collection:<uuid>` — anchored.
-_NAME_RE = re.compile(r"^iris:(set|collection):([0-9a-f-]{36})$")
+# `set:<uuid>` and `collection:<uuid>` — anchored. The MCP server name
+# (`iris`) is already prepended by the client when surfacing prompts in
+# its picker (e.g. Claude Code shows `/iris:set:<uuid>`), so we don't
+# bake `iris:` into the name itself. v5.8.5 dropped the prefix; ADR-153.
+_NAME_RE = re.compile(r"^(set|collection):([0-9a-f-]{36})$")
 
 
 def _web_base() -> str | None:
@@ -113,7 +116,7 @@ async def get_prompt(
     """
     match = _NAME_RE.match(name)
     if match is None:
-        msg = f"Invalid Iris scope-prompt name: {name!r}. Expected `iris:set:<uuid>` or `iris:collection:<uuid>`."
+        msg = f"Invalid Iris scope-prompt name: {name!r}. Expected `set:<uuid>` or `collection:<uuid>`."
         raise ValueError(msg)
 
     # Resolve from the index (single backend round-trip already includes

--- a/mcp/tests/test_prompts_get.py
+++ b/mcp/tests/test_prompts_get.py
@@ -1,6 +1,6 @@
 """ADR-152: MCP `prompts/get` handler.
 
-Resolves an `iris:set:<uuid>` or `iris:collection:<uuid>` name and
+Resolves a `set:<uuid>` or `collection:<uuid>` name and
 returns a single user-role MCP message with the system_prompt body
 preceded by a provenance preamble.
 """
@@ -26,7 +26,7 @@ class _StubClient:
 
 def _entry(**kwargs: Any) -> ScopePromptIndexEntry:
     defaults = {
-        "name": "iris:set:11111111-1111-1111-1111-111111111111",
+        "name": "set:11111111-1111-1111-1111-111111111111",
         "scope_type": "set",
         "scope_id": "11111111-1111-1111-1111-111111111111",
         "scope_name": "DoView Book",
@@ -42,7 +42,7 @@ class TestGetPromptHappyPath:
     async def test_set_returns_single_user_message(self) -> None:
         client: Any = _StubClient([_entry()])
         result = await iris_prompts.get_prompt(
-            client, "iris:set:11111111-1111-1111-1111-111111111111",
+            client, "set:11111111-1111-1111-1111-111111111111",
         )
 
         assert isinstance(result, types.GetPromptResult)
@@ -59,7 +59,7 @@ class TestGetPromptHappyPath:
     @pytest.mark.asyncio
     async def test_collection_returns_user_message(self) -> None:
         entry = _entry(
-            name="iris:collection:22222222-2222-2222-2222-222222222222",
+            name="collection:22222222-2222-2222-2222-222222222222",
             scope_type="collection",
             scope_id="22222222-2222-2222-2222-222222222222",
             scope_name="NZISM",
@@ -67,7 +67,7 @@ class TestGetPromptHappyPath:
         )
         client: Any = _StubClient([entry])
         result = await iris_prompts.get_prompt(
-            client, "iris:collection:22222222-2222-2222-2222-222222222222",
+            client, "collection:22222222-2222-2222-2222-222222222222",
         )
         assert "Always cite the control number." in result.messages[0].content.text
         assert "Collection" in result.messages[0].content.text
@@ -78,7 +78,7 @@ class TestGetPromptHappyPath:
         monkeypatch.setenv("IRIS_WEB_URL", "https://iris-uat.chrisbarlow.nz")
         client: Any = _StubClient([_entry()])
         result = await iris_prompts.get_prompt(
-            client, "iris:set:11111111-1111-1111-1111-111111111111",
+            client, "set:11111111-1111-1111-1111-111111111111",
         )
         text = result.messages[0].content.text
         assert "https://iris-uat.chrisbarlow.nz/sets/11111111-1111-1111-1111-111111111111" in text
@@ -88,7 +88,7 @@ class TestGetPromptHappyPath:
         monkeypatch.delenv("IRIS_WEB_URL", raising=False)
         client: Any = _StubClient([_entry()])
         result = await iris_prompts.get_prompt(
-            client, "iris:set:11111111-1111-1111-1111-111111111111",
+            client, "set:11111111-1111-1111-1111-111111111111",
         )
         text = result.messages[0].content.text
         # No URL anywhere in the preamble.
@@ -115,5 +115,5 @@ class TestGetPromptErrors:
         client: Any = _StubClient([])  # empty index
         with pytest.raises(ValueError, match="not found"):
             await iris_prompts.get_prompt(
-                client, "iris:set:99999999-9999-9999-9999-999999999999",
+                client, "set:99999999-9999-9999-9999-999999999999",
             )

--- a/mcp/tests/test_prompts_list.py
+++ b/mcp/tests/test_prompts_list.py
@@ -26,7 +26,7 @@ class _StubClient:
 
 def _entry(**kwargs: Any) -> ScopePromptIndexEntry:
     defaults = {
-        "name": "iris:set:00000000-0000-0000-0000-000000000001",
+        "name": "set:00000000-0000-0000-0000-000000000001",
         "scope_type": "set",
         "scope_id": "00000000-0000-0000-0000-000000000001",
         "scope_name": "Test Set",
@@ -47,7 +47,7 @@ class TestListPrompts:
     @pytest.mark.asyncio
     async def test_maps_set_entry(self) -> None:
         entries = [_entry(
-            name="iris:set:11111111-1111-1111-1111-111111111111",
+            name="set:11111111-1111-1111-1111-111111111111",
             scope_id="11111111-1111-1111-1111-111111111111",
             scope_name="DoView Book",
             description="Outcomes theory reference",
@@ -57,7 +57,7 @@ class TestListPrompts:
 
         assert len(result) == 1
         p = result[0]
-        assert p.name == "iris:set:11111111-1111-1111-1111-111111111111"
+        assert p.name == "set:11111111-1111-1111-1111-111111111111"
         # Description includes scope-type label, human name, and description.
         assert "Set" in p.description
         assert "DoView Book" in p.description
@@ -68,7 +68,7 @@ class TestListPrompts:
     @pytest.mark.asyncio
     async def test_maps_collection_entry(self) -> None:
         entries = [_entry(
-            name="iris:collection:22222222-2222-2222-2222-222222222222",
+            name="collection:22222222-2222-2222-2222-222222222222",
             scope_type="collection",
             scope_id="22222222-2222-2222-2222-222222222222",
             scope_name="NZISM",
@@ -79,7 +79,7 @@ class TestListPrompts:
 
         assert len(result) == 1
         p = result[0]
-        assert p.name == "iris:collection:22222222-2222-2222-2222-222222222222"
+        assert p.name == "collection:22222222-2222-2222-2222-222222222222"
         assert "Collection" in p.description
         assert "NZISM" in p.description
 
@@ -160,13 +160,13 @@ class TestListPrompts:
     async def test_preserves_order(self) -> None:
         entries = [
             _entry(
-                name="iris:collection:c1",
+                name="collection:c1",
                 scope_type="collection",
                 scope_id="c1",
                 scope_name="First",
             ),
             _entry(
-                name="iris:set:s1",
+                name="set:s1",
                 scope_type="set",
                 scope_id="s1",
                 scope_name="Second",
@@ -175,6 +175,6 @@ class TestListPrompts:
         client: Any = _StubClient(entries)
         result = await iris_prompts.list_prompts(client)
         assert [p.name for p in result] == [
-            "iris:collection:c1",
-            "iris:set:s1",
+            "collection:c1",
+            "set:s1",
         ]


### PR DESCRIPTION
Promotes **main → render-supabase-uat** with v5.8.5.

Renames MCP prompts from `iris:set:<uuid>` to `set:<uuid>` (and same for collections). MCP clients namespace prompts under the server identity automatically, so the v5.8.3 prefix was a doubled `/iris:iris:set:<uuid>` in Claude Code. Post-rename: clean `/iris:set:<uuid>`.

ADR-153 captures the rationale; no data migration needed.

100 tests green.

Release: https://github.com/cgbarlow/iris/releases/tag/v5.8.5
Origin PR: #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)