### PR TITLE
feat(v5.9.0): multiple named prompts per scope (ADR-154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.9.0] - 2026-05-11
+
 ### Added
 
 - **Multiple named prompts per scope (Collection / Set)** (ADR-154,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multiple named prompts per scope (Collection / Set)** (ADR-154,
+  SPEC-154-A). New `prompts` table holds zero-or-more named prompts per
+  scope; surfaced via the existing MCP `prompts` channel as
+  `set:<uuid>:<name>` / `collection:<uuid>:<name>` (so Claude clients
+  show them as `/iris:set:<uuid>:<name>` in the prompt picker). Set-
+  scoped names shadow Collection-scoped names per ADR-150 additive
+  inheritance. New `/api/named-prompts*` CRUD endpoints; new
+  `Prompts` section on `/sets/[id]` and `/collections/[id]` edit pages
+  for per-row authoring. Scope-level `system_prompt` (ADR-150) is
+  retained unchanged and continues to auto-apply in Ask Iris and Iris
+  MCP `ask`; named prompts are **picker-invoked only** and never
+  auto-prepend. 43 new tests across migration, backend, iris-client,
+  MCP, and frontend layers; existing v5.8.x tests unchanged. SQLite
+  migration `m048_named_prompts.py`; Supabase mirror
+  `m052_named_prompts.sql` with anonymous-read / authenticated-write
+  RLS posture.
+
+- **DoView Book combined response prompt (Prompt C)** drafted under
+  `docs/prompts/doview-book-prompt-c-iris.md`. Merges Prompt A
+  (outcomes-theory text response) and Prompt B (diagram retrieval)
+  into a single-turn prompt that produces both formal text answer
+  and verbatim mermaid diagrams in one response. Iris-MCP-sourced
+  (set 33032180-d77a-4ce4-88cf-b49cd643e093); intended for upload
+  as a named prompt on the DoView Book Set once v5.9.0 ships.
+
 ## [5.8.5] - 2026-05-11
 
 ### Changed

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,6 +38,7 @@ from app.mnemos.router import router as mnemos_router
 from app.notifications.router import router as notifications_router
 from app.package_relationships.router import router as package_relationships_router
 from app.packages.router import router as packages_router
+from app.named_prompts.router import router as named_prompts_router
 from app.prompts.router import router as prompts_router
 from app.recycle_bin.router import router as recycle_bin_router
 from app.relationships.router import router as relationships_router
@@ -191,6 +192,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(sets_router)
     app.include_router(collections_router)
     app.include_router(prompts_router)
+    app.include_router(named_prompts_router)
     app.include_router(batch_router)
     app.include_router(views_router)
     app.include_router(themes_router)

--- a/backend/app/migrations/m048_named_prompts.py
+++ b/backend/app/migrations/m048_named_prompts.py
@@ -1,0 +1,42 @@
+"""Migration 048: Multiple named prompts per scope (ADR-154, SPEC-154-A).
+
+Creates the `prompts` table holding zero-or-more named prompts per
+Collection or Set. Named prompts are surfaced via the MCP `prompts`
+channel as `set:<uuid>:<name>` / `collection:<uuid>:<name>` (post-ADR-153
+naming, no `iris:` prefix). They are picker-invoked only; the scope
+`system_prompt` column (m047) continues to auto-apply via the Ask
+Iris composition pipeline and is untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m048_named_prompts"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up — additive new table, idempotent."""
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS prompts (
+            id           TEXT PRIMARY KEY,
+            scope_type   TEXT NOT NULL CHECK (scope_type IN ('collection','set')),
+            scope_id     TEXT NOT NULL,
+            name         TEXT NOT NULL,
+            description  TEXT NOT NULL,
+            body         TEXT NOT NULL,
+            created_at   TEXT NOT NULL,
+            updated_at   TEXT NOT NULL,
+            created_by   TEXT,
+            UNIQUE (scope_type, scope_id, name)
+        )
+        """
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_prompts_scope ON prompts(scope_type, scope_id)"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m052_named_prompts.sql
+++ b/backend/app/migrations/supabase/m052_named_prompts.sql
@@ -1,0 +1,70 @@
+-- Migration 052: Multiple named prompts per scope (ADR-154, SPEC-154-A).
+--
+-- Mirrors SQLite migration m048_named_prompts.py. Creates the
+-- `prompts` table holding zero-or-more named prompts per Collection
+-- or Set. Idempotent — every CREATE uses IF NOT EXISTS, every
+-- POLICY is guarded with DO $$ ... $$.
+
+CREATE TABLE IF NOT EXISTS public.prompts (
+    id           text PRIMARY KEY,
+    scope_type   text NOT NULL CHECK (scope_type IN ('collection','set')),
+    scope_id     text NOT NULL,
+    name         text NOT NULL,
+    description  text NOT NULL,
+    body         text NOT NULL,
+    created_at   text NOT NULL,
+    updated_at   text NOT NULL,
+    created_by   text,
+    UNIQUE (scope_type, scope_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompts_scope
+    ON public.prompts(scope_type, scope_id);
+
+ALTER TABLE public.prompts ENABLE ROW LEVEL SECURITY;
+
+-- Anonymous read posture matches collections / sets / scope_system_prompts.
+-- Authenticated writes only.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'prompts' AND policyname = 'prompts_anon_read'
+    ) THEN
+        CREATE POLICY prompts_anon_read ON public.prompts
+            FOR SELECT USING (true);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'prompts' AND policyname = 'prompts_auth_insert'
+    ) THEN
+        CREATE POLICY prompts_auth_insert ON public.prompts
+            FOR INSERT TO authenticated WITH CHECK (true);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'prompts' AND policyname = 'prompts_auth_update'
+    ) THEN
+        CREATE POLICY prompts_auth_update ON public.prompts
+            FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public' AND tablename = 'prompts' AND policyname = 'prompts_auth_delete'
+    ) THEN
+        CREATE POLICY prompts_auth_delete ON public.prompts
+            FOR DELETE TO authenticated USING (true);
+    END IF;
+END $$;

--- a/backend/app/named_prompts/models.py
+++ b/backend/app/named_prompts/models.py
@@ -1,0 +1,53 @@
+"""Pydantic models for named-prompts CRUD (ADR-154, SPEC-154-A)."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+NAME_PATTERN = r"^[a-z][a-z0-9-]{0,63}$"
+NAME_RE = re.compile(NAME_PATTERN)
+
+_DESCRIPTION_MAX = 1024
+_BODY_MAX = 256_000
+
+
+class Prompt(BaseModel):
+    """A named prompt attached to a Collection or Set."""
+
+    id: str
+    scope_type: Literal["collection", "set"]
+    scope_id: str
+    name: str
+    description: str
+    body: str
+    created_at: str
+    updated_at: str
+    created_by: str | None = None
+
+
+class PromptCreate(BaseModel):
+    """Request body for creating a named prompt."""
+
+    scope_type: Literal["collection", "set"]
+    scope_id: str
+    name: str = Field(min_length=1, max_length=64, pattern=NAME_PATTERN)
+    description: str = Field(min_length=1, max_length=_DESCRIPTION_MAX)
+    body: str = Field(min_length=1, max_length=_BODY_MAX)
+
+
+class PromptUpdate(BaseModel):
+    """Request body for updating a named prompt.
+
+    Only description and body are mutable. scope and name are immutable
+    post-create; renaming requires delete-and-recreate.
+    """
+
+    description: str | None = Field(default=None, min_length=1, max_length=_DESCRIPTION_MAX)
+    body: str | None = Field(default=None, min_length=1, max_length=_BODY_MAX)
+
+
+class PromptListResponse(BaseModel):
+    items: list[Prompt]

--- a/backend/app/named_prompts/router.py
+++ b/backend/app/named_prompts/router.py
@@ -1,0 +1,135 @@
+"""Named-prompts API routes (ADR-154, SPEC-154-A)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import Response as FastAPIResponse
+
+from app.auth.dependencies import get_current_user, get_optional_user
+from app.named_prompts.models import (
+    Prompt,
+    PromptCreate,
+    PromptListResponse,
+    PromptUpdate,
+)
+from app.named_prompts.service import (
+    create_prompt,
+    delete_prompt,
+    get_prompt,
+    list_effective_prompts_for_set,
+    list_prompts_for_collection_effective,
+    list_prompts_for_scope,
+    update_prompt,
+)
+
+router = APIRouter(prefix="/api/named-prompts", tags=["named-prompts"])
+
+
+@router.post("", response_model=Prompt, status_code=201)
+async def create(
+    body: PromptCreate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> Prompt:
+    db = request.app.state.db_manager.main_db
+    try:
+        result = await create_prompt(
+            db,
+            scope_type=body.scope_type,
+            scope_id=body.scope_id,
+            name=body.name,
+            description=body.description,
+            body=body.body,
+            created_by=current_user.get("id"),
+        )
+    except ValueError as exc:
+        if str(exc) == "scope_not_found":
+            raise HTTPException(  # noqa: B904
+                status_code=404, detail=f"{body.scope_type.title()} {body.scope_id} not found",
+            )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        # IntegrityError on (scope_type, scope_id, name) UNIQUE violation.
+        raise HTTPException(  # noqa: B904
+            status_code=409,
+            detail=f"A named prompt with this name already exists on this scope ({type(exc).__name__})",
+        )
+    return Prompt(**result)
+
+
+@router.get("", response_model=PromptListResponse)
+async def list_for_scope(
+    request: Request,
+    scope_type: Literal["collection", "set"] = Query(...),
+    scope_id: str = Query(...),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> PromptListResponse:
+    db = request.app.state.db_manager.main_db
+    items = await list_prompts_for_scope(db, scope_type, scope_id)
+    return PromptListResponse(items=[Prompt(**item) for item in items])
+
+
+@router.get("/by-scope", response_model=PromptListResponse)
+async def list_by_scope(
+    request: Request,
+    collection_id: str | None = Query(default=None),
+    set_id: str | None = Query(default=None),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> PromptListResponse:
+    """Effective list including inherited prompts for a Set."""
+    if (collection_id is None) == (set_id is None):
+        raise HTTPException(
+            status_code=400,
+            detail="Exactly one of collection_id or set_id must be supplied.",
+        )
+    db = request.app.state.db_manager.main_db
+    if set_id is not None:
+        items = await list_effective_prompts_for_set(db, set_id)
+    else:
+        assert collection_id is not None  # narrowing for type-checker
+        items = await list_prompts_for_collection_effective(db, collection_id)
+    return PromptListResponse(items=[Prompt(**item) for item in items])
+
+
+@router.get("/{prompt_id}", response_model=Prompt)
+async def get_one(
+    prompt_id: str,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> Prompt:
+    db = request.app.state.db_manager.main_db
+    result = await get_prompt(db, prompt_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Named prompt not found")
+    return Prompt(**result)
+
+
+@router.put("/{prompt_id}", response_model=Prompt)
+async def update(
+    prompt_id: str,
+    body: PromptUpdate,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> Prompt:
+    db = request.app.state.db_manager.main_db
+    result = await update_prompt(
+        db, prompt_id, description=body.description, body=body.body,
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Named prompt not found")
+    return Prompt(**result)
+
+
+@router.delete("/{prompt_id}", response_model=None)
+async def delete(
+    prompt_id: str,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> FastAPIResponse:
+    db = request.app.state.db_manager.main_db
+    deleted = await delete_prompt(db, prompt_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Named prompt not found")
+    return FastAPIResponse(status_code=204)

--- a/backend/app/named_prompts/service.py
+++ b/backend/app/named_prompts/service.py
@@ -1,0 +1,181 @@
+"""Service layer for named prompts (ADR-154, SPEC-154-A).
+
+Each named prompt is attached to a Collection or Set. The MCP `prompts`
+channel surfaces them as `set:<uuid>:<name>` / `collection:<uuid>:<name>`
+alongside the existing scope `system_prompt` entries; they are picker-
+invoked only and never participate in Ask Iris server-side composition.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+ScopeType = Literal["collection", "set"]
+
+
+def _row_to_dict(row: tuple) -> dict[str, object]:
+    return {
+        "id": str(row[0]),
+        "scope_type": str(row[1]),
+        "scope_id": str(row[2]),
+        "name": str(row[3]),
+        "description": str(row[4]),
+        "body": str(row[5]),
+        "created_at": str(row[6]),
+        "updated_at": str(row[7]),
+        "created_by": (str(row[8]) if row[8] is not None else None),
+    }
+
+
+_SELECT_COLS = "id, scope_type, scope_id, name, description, body, created_at, updated_at, created_by"
+
+
+async def list_prompts_for_scope(
+    db: DatabasePort, scope_type: ScopeType, scope_id: str,
+) -> list[dict[str, object]]:
+    """List named prompts for a single scope, alphabetical by name."""
+    cursor = await db.execute(
+        f"SELECT {_SELECT_COLS} FROM prompts "
+        "WHERE scope_type = ? AND scope_id = ? "
+        "ORDER BY name",
+        (scope_type, scope_id),
+    )
+    return [_row_to_dict(row) for row in await cursor.fetchall()]
+
+
+async def list_effective_prompts_for_set(
+    db: DatabasePort, set_id: str,
+) -> list[dict[str, object]]:
+    """List a Set's own named prompts plus its parent collection's.
+
+    Set-scoped names shadow Collection-scoped names with the same string.
+    Order: own first (alphabetical), then inherited (alphabetical),
+    excluding inherited entries whose names collide with own entries.
+    """
+    cursor = await db.execute("SELECT collection_id FROM sets WHERE id = ?", (set_id,))
+    row = await cursor.fetchone()
+    if row is None:
+        return []
+    parent_collection_id = row[0]
+
+    own = await list_prompts_for_scope(db, "set", set_id)
+    own_names = {p["name"] for p in own}
+
+    inherited: list[dict[str, object]] = []
+    if parent_collection_id is not None:
+        for entry in await list_prompts_for_scope(db, "collection", str(parent_collection_id)):
+            if entry["name"] not in own_names:
+                inherited.append(entry)
+
+    return own + inherited
+
+
+async def list_prompts_for_collection_effective(
+    db: DatabasePort, collection_id: str,
+) -> list[dict[str, object]]:
+    """A Collection has no parent — effective list is its own list."""
+    return await list_prompts_for_scope(db, "collection", collection_id)
+
+
+async def get_prompt(db: DatabasePort, prompt_id: str) -> dict[str, object] | None:
+    cursor = await db.execute(
+        f"SELECT {_SELECT_COLS} FROM prompts WHERE id = ?", (prompt_id,),
+    )
+    row = await cursor.fetchone()
+    return _row_to_dict(row) if row is not None else None
+
+
+async def _scope_exists(db: DatabasePort, scope_type: ScopeType, scope_id: str) -> bool:
+    table = "collections" if scope_type == "collection" else "sets"
+    cursor = await db.execute(
+        f"SELECT 1 FROM {table} WHERE id = ? AND is_deleted = 0", (scope_id,),
+    )
+    return (await cursor.fetchone()) is not None
+
+
+async def create_prompt(
+    db: DatabasePort,
+    *,
+    scope_type: ScopeType,
+    scope_id: str,
+    name: str,
+    description: str,
+    body: str,
+    created_by: str | None,
+) -> dict[str, object]:
+    """Insert a new named prompt.
+
+    Raises ValueError("scope_not_found") if the scope does not exist.
+    Raises IntegrityError on (scope_type, scope_id, name) collision —
+    translated to HTTP 409 in the router.
+    """
+    if not await _scope_exists(db, scope_type, scope_id):
+        raise ValueError("scope_not_found")
+
+    prompt_id = str(uuid.uuid4())
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO prompts "
+        "(id, scope_type, scope_id, name, description, body, created_at, updated_at, created_by) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (prompt_id, scope_type, scope_id, name, description, body, now, now, created_by),
+    )
+    await db.commit()
+    return {
+        "id": prompt_id,
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+        "name": name,
+        "description": description,
+        "body": body,
+        "created_at": now,
+        "updated_at": now,
+        "created_by": created_by,
+    }
+
+
+async def update_prompt(
+    db: DatabasePort,
+    prompt_id: str,
+    *,
+    description: str | None = None,
+    body: str | None = None,
+) -> dict[str, object] | None:
+    """Update mutable fields. Returns None if the prompt does not exist."""
+    if description is None and body is None:
+        return await get_prompt(db, prompt_id)
+
+    sets: list[str] = []
+    params: list[object] = []
+    if description is not None:
+        sets.append("description = ?")
+        params.append(description)
+    if body is not None:
+        sets.append("body = ?")
+        params.append(body)
+    now = datetime.now(tz=UTC).isoformat()
+    sets.append("updated_at = ?")
+    params.append(now)
+    params.append(prompt_id)
+
+    cursor = await db.execute(
+        f"UPDATE prompts SET {', '.join(sets)} WHERE id = ?", tuple(params),
+    )
+    if cursor.rowcount == 0:
+        return None
+    await db.commit()
+    return await get_prompt(db, prompt_id)
+
+
+async def delete_prompt(db: DatabasePort, prompt_id: str) -> bool:
+    """Hard-delete a named prompt (no soft-delete column; cheap to recreate)."""
+    cursor = await db.execute("DELETE FROM prompts WHERE id = ?", (prompt_id,))
+    if cursor.rowcount == 0:
+        return False
+    await db.commit()
+    return True

--- a/backend/app/prompts/models.py
+++ b/backend/app/prompts/models.py
@@ -11,21 +11,28 @@ class ScopePromptIndexEntry(BaseModel):
     """One row in the scope-prompt index.
 
     Consumed by the Iris MCP server to populate `prompts/list` and
-    `prompts/get` responses. `name` is the stable MCP prompt URI of
-    the form `<scope_type>:<scope_id>` (v5.8.5: dropped the
-    `iris:` prefix; MCP clients already namespace prompts by server
-    name, e.g. `/iris:set:<uuid>` in Claude Code's slash menu). The
-    body field carries the scope's full `system_prompt` so a single
-    MCP `prompts/get` can be served without a follow-up HTTP
-    round-trip.
+    `prompts/get` responses. `name` is the stable MCP prompt URI:
+
+    - `<scope_type>:<scope_id>` for the scope's `system_prompt`
+      (entry_kind `"system_prompt"`)
+    - `<scope_type>:<scope_id>:<prompt_name>` for a named prompt
+      (entry_kind `"named_prompt"`, ADR-154)
+
+    v5.8.5 (ADR-153) dropped the `iris:` prefix; MCP clients already
+    namespace prompts by server name (e.g. `/iris:set:<uuid>` in
+    Claude Code's slash menu). The body field carries the full prompt
+    body so a single MCP `prompts/get` can be served without a
+    follow-up HTTP round-trip.
     """
 
     name: str
+    entry_kind: Literal["system_prompt", "named_prompt"] = "system_prompt"
     scope_type: Literal["collection", "set"]
     scope_id: str
     scope_name: str
     description: str | None = None
     body: str
+    prompt_name: str | None = None  # set only when entry_kind == "named_prompt"
 
 
 class ScopePromptIndexResponse(BaseModel):

--- a/backend/app/prompts/service.py
+++ b/backend/app/prompts/service.py
@@ -1,9 +1,14 @@
-"""Service layer for the scope-prompt index (ADR-152).
+"""Service layer for the scope-prompt index (ADR-152; extended ADR-154).
 
-Returns one entry per Collection and Set with a non-null, non-empty
-`system_prompt`. Collections first, then Sets — matches the
-priority order users see in the MCP prompt picker (collection-level
-context tends to be the broader framing).
+Returns:
+- one entry per Collection / Set with a non-null, non-empty
+  `system_prompt` (`entry_kind="system_prompt"`)
+- one entry per named prompt on a Collection / Set
+  (`entry_kind="named_prompt"`)
+
+Order: system prompts first (collections then sets, both alphabetical),
+then named prompts (grouped by scope, alphabetical scope name, then
+alphabetical prompt name within each scope).
 """
 
 from __future__ import annotations
@@ -15,7 +20,7 @@ if TYPE_CHECKING:
 
 
 async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
-    """Return scope-prompt index entries (collections then sets)."""
+    """Return scope-prompt index entries (system prompts then named prompts)."""
     items: list[dict[str, object]] = []
 
     cursor = await db.execute(
@@ -29,11 +34,13 @@ async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
             continue
         items.append({
             "name": f"collection:{row[0]}",
+            "entry_kind": "system_prompt",
             "scope_type": "collection",
             "scope_id": str(row[0]),
             "scope_name": str(row[1]),
             "description": row[2],
             "body": body,
+            "prompt_name": None,
         })
 
     cursor = await db.execute(
@@ -47,11 +54,41 @@ async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
             continue
         items.append({
             "name": f"set:{row[0]}",
+            "entry_kind": "system_prompt",
             "scope_type": "set",
             "scope_id": str(row[0]),
             "scope_name": str(row[1]),
             "description": row[2],
             "body": body,
+            "prompt_name": None,
+        })
+
+    # ADR-154 named prompts. Join to fetch scope_name; exclude entries
+    # whose scope has been soft-deleted (LEFT JOIN + WHERE on scope id).
+    cursor = await db.execute(
+        """
+        SELECT p.id, p.scope_type, p.scope_id, p.name, p.description, p.body,
+               COALESCE(c.name, s.name) AS scope_name
+        FROM prompts p
+        LEFT JOIN collections c ON p.scope_type = 'collection' AND p.scope_id = c.id AND c.is_deleted = 0
+        LEFT JOIN sets        s ON p.scope_type = 'set'        AND p.scope_id = s.id AND s.is_deleted = 0
+        WHERE COALESCE(c.id, s.id) IS NOT NULL
+        ORDER BY p.scope_type, scope_name, p.name
+        """,
+    )
+    for row in await cursor.fetchall():
+        scope_type = str(row[1])
+        scope_id = str(row[2])
+        prompt_name = str(row[3])
+        items.append({
+            "name": f"{scope_type}:{scope_id}:{prompt_name}",
+            "entry_kind": "named_prompt",
+            "scope_type": scope_type,
+            "scope_id": scope_id,
+            "scope_name": str(row[6]),
+            "description": row[4],
+            "body": str(row[5]),
+            "prompt_name": prompt_name,
         })
 
     return items

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -52,6 +52,7 @@ from app.migrations.m044_text_diagram_class import up as m044_up
 from app.migrations.m045_images import up as m045_up
 from app.migrations.m046_extensions_source import up as m046_up
 from app.migrations.m047_scope_system_prompts import up as m047_up
+from app.migrations.m048_named_prompts import up as m048_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -130,6 +131,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m045_up(main)
     await m046_up(main)
     await m047_up(main)
+    await m048_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_migrations/test_named_prompts_schema.py
+++ b/backend/tests/test_migrations/test_named_prompts_schema.py
@@ -1,0 +1,85 @@
+"""v5.9.0 (ADR-154, SPEC-154-A): static-parser test asserting the
+SQLite migration m048_named_prompts.py and its Supabase mirror
+m052_named_prompts.sql both create the `prompts` table with the
+expected schema, constraints, indexes, and (Supabase) RLS policies."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_sqlite_m048_creates_prompts_table() -> None:
+    py = _read("app/migrations/m048_named_prompts.py")
+    assert "CREATE TABLE IF NOT EXISTS prompts" in py
+    # All required columns appear in the CREATE TABLE body.
+    for column in (
+        "id",
+        "scope_type",
+        "scope_id",
+        "name",
+        "description",
+        "body",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ):
+        assert column in py, f"column {column!r} missing from m048 CREATE TABLE"
+
+
+def test_sqlite_m048_has_unique_and_check_constraints() -> None:
+    py = _read("app/migrations/m048_named_prompts.py")
+    # Per-scope uniqueness on prompt name.
+    assert "UNIQUE (scope_type, scope_id, name)" in py
+    # scope_type CHECK constraint.
+    assert "scope_type IN ('collection','set')" in py.replace('"', "'")
+
+
+def test_sqlite_m048_creates_scope_index() -> None:
+    py = _read("app/migrations/m048_named_prompts.py")
+    assert "CREATE INDEX IF NOT EXISTS idx_prompts_scope" in py
+    assert "ON prompts(scope_type, scope_id)" in py
+
+
+def test_sqlite_m048_is_idempotent() -> None:
+    py = _read("app/migrations/m048_named_prompts.py")
+    # Idempotency guards: CREATE TABLE IF NOT EXISTS and CREATE INDEX
+    # IF NOT EXISTS mean rerunning on a partially-applied DB is safe.
+    assert "CREATE TABLE IF NOT EXISTS prompts" in py
+    assert "CREATE INDEX IF NOT EXISTS" in py
+
+
+def test_supabase_m052_creates_prompts_table() -> None:
+    sql = _read("app/migrations/supabase/m052_named_prompts.sql")
+    assert "CREATE TABLE IF NOT EXISTS public.prompts" in sql
+    for column in (
+        "id",
+        "scope_type",
+        "scope_id",
+        "name",
+        "description",
+        "body",
+        "created_at",
+        "updated_at",
+        "created_by",
+    ):
+        assert column in sql, f"column {column!r} missing from m052 CREATE TABLE"
+    assert "UNIQUE (scope_type, scope_id, name)" in sql
+    assert "CREATE INDEX IF NOT EXISTS idx_prompts_scope" in sql
+
+
+def test_supabase_m052_has_rls_policies() -> None:
+    sql = _read("app/migrations/supabase/m052_named_prompts.sql")
+    # RLS enabled.
+    assert "ENABLE ROW LEVEL SECURITY" in sql
+    # Anonymous read + authenticated write — same posture as collections/sets.
+    assert "prompts_anon_read" in sql
+    assert "FOR SELECT" in sql
+    assert "prompts_auth_insert" in sql
+    assert "prompts_auth_update" in sql
+    assert "prompts_auth_delete" in sql

--- a/backend/tests/test_named_prompts/test_crud.py
+++ b/backend/tests/test_named_prompts/test_crud.py
@@ -1,0 +1,316 @@
+"""ADR-154 / SPEC-154-A: CRUD + inheritance tests for the named-prompts API.
+
+Each named prompt is attached to a Collection or Set. Set-scoped names
+shadow Collection-scoped names with the same string in the effective
+list. Anonymous read posture matches /api/collections and /api/sets;
+writes require authentication.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _make_set(client: httpx.AsyncClient, headers: dict[str, str], name: str, collection_id: str | None = None) -> dict:
+    body = {"name": name}
+    if collection_id is not None:
+        body["collection_id"] = collection_id
+    resp = await client.post("/api/sets", json=body, headers=headers)
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+async def _make_collection(client: httpx.AsyncClient, headers: dict[str, str], name: str) -> dict:
+    resp = await client.post("/api/collections", json={"name": name}, headers=headers)
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()
+
+
+def _valid_prompt_body(scope_type: str, scope_id: str, name: str = "first-prompt", body: str = "Body content.") -> dict:
+    return {
+        "scope_type": scope_type,
+        "scope_id": scope_id,
+        "name": name,
+        "description": "A short description.",
+        "body": body,
+    }
+
+
+class TestCreate:
+    async def test_create_for_set_happy_path(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "DoView Book")
+
+        resp = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"]),
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        item = resp.json()
+        assert item["scope_type"] == "set"
+        assert item["scope_id"] == s["id"]
+        assert item["name"] == "first-prompt"
+        assert item["description"] == "A short description."
+        assert item["body"] == "Body content."
+        assert "id" in item and item["id"]
+        assert "created_at" in item and "updated_at" in item
+
+    async def test_create_for_collection_happy_path(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        c = await _make_collection(client, headers, "NZISM")
+
+        resp = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("collection", c["id"], name="house-rules"),
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["scope_type"] == "collection"
+
+    async def test_create_rejects_invalid_name(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set A")
+        body = _valid_prompt_body("set", s["id"], name="Has Uppercase")
+
+        resp = await client.post("/api/named-prompts", json=body, headers=headers)
+        assert resp.status_code == 422, resp.text
+
+    async def test_create_rejects_duplicate_name_within_scope(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set A")
+
+        first = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="duplicated"),
+            headers=headers,
+        )
+        assert first.status_code == 201
+
+        second = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="duplicated"),
+            headers=headers,
+        )
+        assert second.status_code == 409, second.text
+
+    async def test_create_404_on_unknown_scope(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", "00000000-0000-0000-0000-000000000000"),
+            headers=headers,
+        )
+        assert resp.status_code == 404, resp.text
+
+
+class TestList:
+    async def test_list_filters_by_scope(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set A")
+        await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="alpha"),
+            headers=headers,
+        )
+        await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="bravo"),
+            headers=headers,
+        )
+
+        resp = await client.get(
+            "/api/named-prompts",
+            params={"scope_type": "set", "scope_id": s["id"]},
+        )
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert [i["name"] for i in items] == ["alpha", "bravo"]
+
+    async def test_anonymous_can_read(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Public Set")
+        await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="public-prompt"),
+            headers=headers,
+        )
+
+        resp = await client.get(
+            "/api/named-prompts",
+            params={"scope_type": "set", "scope_id": s["id"]},
+            # No auth header.
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["items"]) == 1
+
+
+class TestByScopeInheritance:
+    async def test_set_inherits_parent_collection_prompts(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        c = await _make_collection(client, headers, "Parent")
+        s = await _make_set(client, headers, "Child Set", collection_id=c["id"])
+
+        await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("collection", c["id"], name="house-rules"),
+            headers=headers,
+        )
+        await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="set-rules"),
+            headers=headers,
+        )
+
+        resp = await client.get(
+            "/api/named-prompts/by-scope", params={"set_id": s["id"]},
+        )
+        assert resp.status_code == 200
+        names = [i["name"] for i in resp.json()["items"]]
+        # Own first (alphabetical), then inherited (alphabetical).
+        assert names == ["set-rules", "house-rules"]
+
+    async def test_set_scoped_name_shadows_collection_scoped_name(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        c = await _make_collection(client, headers, "Parent")
+        s = await _make_set(client, headers, "Child Set", collection_id=c["id"])
+
+        # Same name on both scopes.
+        await client.post(
+            "/api/named-prompts",
+            json={**_valid_prompt_body("collection", c["id"], name="overridden", body="C-body"),
+                  "description": "from collection"},
+            headers=headers,
+        )
+        await client.post(
+            "/api/named-prompts",
+            json={**_valid_prompt_body("set", s["id"], name="overridden", body="S-body"),
+                  "description": "from set"},
+            headers=headers,
+        )
+
+        resp = await client.get(
+            "/api/named-prompts/by-scope", params={"set_id": s["id"]},
+        )
+        items = resp.json()["items"]
+        assert len(items) == 1, items
+        assert items[0]["scope_type"] == "set"
+        assert items[0]["body"] == "S-body"
+        assert items[0]["description"] == "from set"
+
+    async def test_by_scope_rejects_neither_or_both(self, client: httpx.AsyncClient) -> None:
+        # Neither.
+        resp = await client.get("/api/named-prompts/by-scope")
+        assert resp.status_code == 400
+
+        # Both.
+        resp = await client.get(
+            "/api/named-prompts/by-scope",
+            params={"collection_id": "x", "set_id": "y"},
+        )
+        assert resp.status_code == 400
+
+
+class TestUpdateDelete:
+    async def test_update_changes_description_and_body(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set A")
+        created = (await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="my-prompt"),
+            headers=headers,
+        )).json()
+
+        resp = await client.put(
+            f"/api/named-prompts/{created['id']}",
+            json={"description": "Updated desc.", "body": "Updated body."},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        updated = resp.json()
+        assert updated["description"] == "Updated desc."
+        assert updated["body"] == "Updated body."
+        # Scope and name are immutable — unchanged.
+        assert updated["scope_id"] == s["id"]
+        assert updated["name"] == "my-prompt"
+
+    async def test_update_404_when_missing(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        resp = await client.put(
+            "/api/named-prompts/missing-id",
+            json={"description": "x", "body": "y"},
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_delete_returns_204_then_404(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set A")
+        created = (await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="will-delete"),
+            headers=headers,
+        )).json()
+
+        first = await client.delete(f"/api/named-prompts/{created['id']}", headers=headers)
+        assert first.status_code == 204
+
+        second = await client.delete(f"/api/named-prompts/{created['id']}", headers=headers)
+        assert second.status_code == 404
+
+    async def test_get_by_id_404_for_unknown(self, client: httpx.AsyncClient) -> None:
+        resp = await client.get("/api/named-prompts/unknown-id")
+        assert resp.status_code == 404

--- a/backend/tests/test_prompts/test_router_named_prompts_extension.py
+++ b/backend/tests/test_prompts/test_router_named_prompts_extension.py
@@ -1,0 +1,153 @@
+"""ADR-154 / SPEC-154-A: scope-index extension for named prompts.
+
+`GET /api/prompts/scope-index` now returns BOTH system-prompt entries
+(unchanged shape from ADR-152) AND named-prompt entries with the new
+`entry_kind` discriminator and optional `prompt_name`. Ordering:
+system prompts first, then named prompts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup", json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login", json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+class TestScopeIndexExtension:
+    async def test_includes_named_prompt_entries(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = (await client.post("/api/sets", json={"name": "DoView"}, headers=headers)).json()
+
+        # No system_prompt set — only the named prompt should appear.
+        await client.post(
+            "/api/named-prompts",
+            json={
+                "scope_type": "set",
+                "scope_id": s["id"],
+                "name": "outcomes-theory",
+                "description": "Outcomes theory framing.",
+                "body": "Apply outcomes theory rules.",
+            },
+            headers=headers,
+        )
+
+        resp = await client.get("/api/prompts/scope-index")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        named = [i for i in items if i["entry_kind"] == "named_prompt"]
+        assert len(named) == 1
+        entry = named[0]
+        assert entry["name"] == f"set:{s['id']}:outcomes-theory"
+        assert entry["scope_type"] == "set"
+        assert entry["scope_id"] == s["id"]
+        assert entry["scope_name"] == "DoView"
+        assert entry["prompt_name"] == "outcomes-theory"
+        assert entry["body"] == "Apply outcomes theory rules."
+
+    async def test_entry_kind_discriminator_on_every_entry(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = (await client.post("/api/sets", json={"name": "Mixed"}, headers=headers)).json()
+        await client.put(
+            f"/api/sets/{s['id']}",
+            json={"name": "Mixed", "system_prompt": "House rules."},
+            headers=headers,
+        )
+        await client.post(
+            "/api/named-prompts",
+            json={
+                "scope_type": "set",
+                "scope_id": s["id"],
+                "name": "extra",
+                "description": "An extra directive.",
+                "body": "Do the extra thing.",
+            },
+            headers=headers,
+        )
+
+        items = (await client.get("/api/prompts/scope-index")).json()["items"]
+        assert len(items) == 2
+        kinds = {i["entry_kind"] for i in items}
+        assert kinds == {"system_prompt", "named_prompt"}
+        # prompt_name set only on named entries
+        for entry in items:
+            if entry["entry_kind"] == "named_prompt":
+                assert entry["prompt_name"] is not None
+            else:
+                assert entry["prompt_name"] is None
+
+    async def test_system_prompts_appear_before_named_prompts(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = (await client.post("/api/sets", json={"name": "Z-set"}, headers=headers)).json()
+        # Order matters: named added first, system added second; result
+        # must still place system_prompt first in the index.
+        await client.post(
+            "/api/named-prompts",
+            json={
+                "scope_type": "set", "scope_id": s["id"], "name": "alpha",
+                "description": "A", "body": "B",
+            },
+            headers=headers,
+        )
+        await client.put(
+            f"/api/sets/{s['id']}",
+            json={"name": "Z-set", "system_prompt": "house rules"},
+            headers=headers,
+        )
+
+        items = (await client.get("/api/prompts/scope-index")).json()["items"]
+        kinds_in_order = [i["entry_kind"] for i in items]
+        assert kinds_in_order == ["system_prompt", "named_prompt"]
+
+    async def test_empty_when_neither_prompts_exist(self, client: httpx.AsyncClient) -> None:
+        await _auth_headers(client)
+        resp = await client.get("/api/prompts/scope-index")
+        assert resp.json() == {"items": []}

--- a/docs/adrs/ADR-154-Multiple-Named-Prompts-per-Scope.md
+++ b/docs/adrs/ADR-154-Multiple-Named-Prompts-per-Scope.md
@@ -1,0 +1,236 @@
+# ADR-154: Multiple named prompts per scope (Collection and Set)
+
+Status: Proposed (2026-05-11)
+Extends: [ADR-150](ADR-150-Scope-Level-System-Prompts.md), [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md), [ADR-153](ADR-153-Drop-Redundant-iris-Prefix-From-MCP-Prompt-Names.md)
+
+## Context
+
+ADR-150 added a single `system_prompt` per Collection and per Set. It
+auto-applies via the Ask Iris composition pipeline and is also
+surfaced via the MCP `prompts` capability (ADR-152, ADR-153) so Claude
+clients can see it explicitly. That single slot is exactly right for
+"house rules" content that should always travel with the scope.
+
+What's missing is the ability to author **multiple named directives**
+on the same scope. A real example: the DoView Book Set already has a
+working `system_prompt`, and the user also wants to host two distinct
+authored directives on the same Set — one for outcomes-theory text
+responses and one for diagram retrieval. Each is an entire prompt of
+its own (~250 lines), each is invoked on its own turn, and each must
+appear in the Claude prompt picker as a discrete entry. Squeezing both
+into a single `system_prompt` would force the model to pick which mode
+applies per turn, which is exactly the kind of in-prompt branching
+that user-pickable named prompts exist to avoid.
+
+This ADR also has a non-goal worth naming up front: it is **not** the
+"Skills" feature originally sketched in issue #88. The name "skill"
+in Anthropic's vocabulary now means a model-side auto-trigger
+mechanism backed by local files. The MCP `prompts` capability is
+spec-mandated **user-controlled**, so a server-side directive
+delivered over MCP is a *prompt*, not a skill, no matter what we call
+it. Calling these "skills" would only confuse users who have
+expectations from Claude Code's local skill system.
+
+## Decision
+
+**Add a new `prompts` table holding zero-or-more named prompts per
+scope.** The table is purely additive — the existing
+`collections.system_prompt` and `sets.system_prompt` columns and
+their auto-apply behaviour are unchanged.
+
+```sql
+CREATE TABLE prompts (
+  id           TEXT PRIMARY KEY,
+  scope_type   TEXT NOT NULL CHECK (scope_type IN ('collection','set')),
+  scope_id     TEXT NOT NULL,
+  name         TEXT NOT NULL,        -- ^[a-z][a-z0-9-]{0,63}$
+  description  TEXT NOT NULL,        -- 1..1024 chars (shown in picker)
+  body         TEXT NOT NULL,        -- 1..256000 chars
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  created_by   TEXT,
+  UNIQUE (scope_type, scope_id, name)
+);
+```
+
+Named prompts are surfaced via the **same MCP `prompts` channel** that
+ADR-152 / ADR-153 established for scope `system_prompt`. The
+`/api/prompts/scope-index` endpoint and `mcp/src/iris_mcp/prompts.py`
+both grow to include named-prompt entries alongside the existing
+system_prompt entries. Naming convention (post-v5.8.5, no `iris:`
+prefix per ADR-153):
+
+| Kind | MCP prompt name |
+|---|---|
+| Scope `system_prompt` (existing) | `set:<uuid>` / `collection:<uuid>` |
+| Named prompt (new) | `set:<uuid>:<name>` / `collection:<uuid>:<name>` |
+
+Claude Code clients prepend the server name, so users see them in the
+picker as `/iris:set:<uuid>` and `/iris:set:<uuid>:<name>`.
+
+**Inheritance is additive, mirroring ADR-150.** A Set sees its own
+named prompts plus its parent Collection's named prompts. Same name
+on Set and Collection: the Set entry shadows the Collection entry
+(scoped uniqueness is per `(scope_type, scope_id, name)`, so this
+only matters at MCP-listing time).
+
+**No auto-apply.** Named prompts never participate in the Ask Iris
+server-side composition pipeline. Only `system_prompt` does. This
+preserves the existing Iris discussion / create flow behaviour
+exactly. Auto-apply for one slot per scope is the right ceiling —
+users authoring multiple directives explicitly want the picker, not
+silent prepending.
+
+**Endpoints** (all under `/api/named-prompts`, parallel to
+`/api/prompts` rather than nested):
+
+- `GET    /api/named-prompts?scope_type=&scope_id=` — list scoped
+- `GET    /api/named-prompts/by-scope?collection_id=&set_id=` — effective list (own + inherited)
+- `POST   /api/named-prompts` — create
+- `GET    /api/named-prompts/{id}` — detail
+- `PUT    /api/named-prompts/{id}` — update description and/or body; scope and name immutable
+- `DELETE /api/named-prompts/{id}`
+
+Validation on create / update: `name` must match
+`^[a-z][a-z0-9-]{0,63}$`; `description` 1..1024 chars; `body`
+1..256_000 chars. The 256k body cap is generous — covers the longest
+realistic prompt by a wide margin.
+
+**Anonymous read posture** matches ADR-150: the list endpoint and the
+extended `/api/prompts/scope-index` are anonymous-readable (the prompt
+content is metadata the asker can already see in the scope's edit
+screen). Writes require authentication.
+
+## Why a separate table, not a JSON array on the scope row
+
+- **Real multiplicity now.** Unlike `system_prompt` (always at most
+  one per scope, justifying the column-on-existing-table choice in
+  ADR-150), named prompts have unbounded cardinality. A side table is
+  the right shape.
+- **Per-row CRUD without read-modify-write contention.** The web GUI
+  edits one prompt at a time. A JSON array would force re-serialising
+  the whole array on every edit, racing concurrent edits.
+- **Foreign-key-style scoping with a cheap index.** `(scope_type,
+  scope_id)` is the natural index; uniqueness on `(scope_type,
+  scope_id, name)` enforces the picker's "no duplicate names per
+  scope" requirement at the database layer.
+- **Symmetry with how Skills would have been stored** under issue 88.
+  This is the same shape; only the framing changes.
+
+## Why retain `system_prompt` unchanged
+
+- **The user explicitly asked.** It still applies for Iris's internal
+  AI discussion / create flows, where one always-on directive is
+  exactly the right primitive.
+- **Migration safety.** Existing scopes with non-empty `system_prompt`
+  keep working unchanged. No data move, no behaviour delta for
+  current users.
+- **Different slot, different purpose.** Auto-apply (`system_prompt`)
+  and user-pick (named prompts) are not interchangeable. Conflating
+  them would require a per-prompt `auto_apply` flag, deferred below.
+
+## Why no auto-apply for named prompts
+
+- **Picker-invocation is the whole point.** If the user wanted the
+  prompt to apply silently they'd put the content in `system_prompt`
+  instead.
+- **Context-budget hygiene.** Auto-applying multiple unrelated
+  directives every turn would balloon `system_content` quickly.
+  ADR-150's 16k soft warning would fire constantly.
+- **Avoids prompt-mode-switching.** Two unrelated directives
+  auto-applied together force the model to figure out which one is
+  relevant per turn — exactly the problem named prompts exist to
+  avoid.
+
+A future `auto_apply` boolean is left as a deferred extension below
+if a real use case shows up.
+
+## Why surface via the same MCP `prompts` channel, not a new capability
+
+- **Spec compliance + zero new client work.** Named prompts are
+  user-controlled directives — the exact intent of the MCP `prompts`
+  capability. No new MCP capability is needed.
+- **Consistent UX.** Users see all scope-attached directives —
+  system_prompt and named prompts alike — in the same prompt picker,
+  alongside each other.
+- **No prompt-injection risk above what ADR-152 already analysed.**
+  Same channel, same trust model, same provenance preamble.
+
+## Why no prefix in the name
+
+ADR-153 dropped the `iris:` prefix because clients double-prefix.
+Named prompts inherit the same naming hygiene: no `iris:`, just
+`set:<uuid>:<name>` / `collection:<uuid>:<name>`. The colon between
+UUID and name is the natural separator since UUIDs don't contain
+colons; the regex is unambiguous.
+
+## Consequences
+
+- One new SQLite migration `m048_named_prompts.py` and one Supabase
+  mirror `m052_named_prompts.sql`. Both idempotent (`CREATE TABLE IF
+  NOT EXISTS`, guard the index too).
+- New backend module `app/named_prompts/{models,service,router}.py`.
+  Module is parallel to the existing `app/prompts/` module (which
+  owns the scope-index endpoint), keeping the latter focused.
+- `app/prompts/router.py:list_scope_prompts_endpoint` extends to
+  include named-prompt entries; the response model gains an
+  `entry_kind: Literal["system_prompt", "named_prompt"]` discriminator
+  and a nullable `prompt_name` field on each entry.
+- `mcp/src/iris_mcp/prompts.py:_NAME_RE` extends from
+  `^(set|collection):([0-9a-f-]{36})$` to also match
+  `^(set|collection):([0-9a-f-]{36}):([a-z][a-z0-9-]{0,63})$`.
+  `list_prompts` and `get_prompt` learn to dispatch on whether a
+  third capture group is present. `_preamble` extends to include the
+  prompt name when one is present (`Loaded from Iris {Label}
+  "{scope_name}" — prompt "{prompt_name}" ({url}):\n\n{body}`).
+- `iris-client` gains a `list_named_prompts()` method (or extends the
+  existing `list_scope_prompts()` to return both kinds — TBD in
+  SPEC-154-A).
+- Web GUI: `/sets/[id]` and `/collections/[id]` edit pages each gain
+  a "Prompts" section below the existing "System prompt" textarea,
+  offering per-row CRUD on named prompts.
+- **No changes** to `app/ai/scope_prompts.py` or `app/ai/service.py`.
+  Named prompts are deliberately outside the auto-apply pipeline.
+- **No changes** to the existing `system_prompt` columns, MCP names
+  for scope `system_prompt`, or any other v5.8.x behaviour.
+
+## Out of scope (deferred)
+
+- **Per-prompt `auto_apply` flag.** Tempting unification with
+  `system_prompt` (just promote a named prompt to auto-apply), but
+  introduces composition-order, dedup, and budget questions that
+  aren't worth solving until a real use case appears. The current
+  one-auto-apply-slot-per-scope ceiling is sufficient.
+- **Argument templating** (`{{set.name}}` etc.). A picker prompt that
+  takes named arguments would be useful for parametric workflows.
+  Not needed for the DoView Book use case; can be added without
+  schema change later.
+- **Per-user named prompts.** Personal prompts attached to a user
+  rather than a scope. Different privacy model; revisit on demand.
+- **Skill bundles / multi-file resources.** Issue 88 Phase 3
+  envisaged file attachments to skills. This ADR addresses single-
+  body prompts only.
+- **Local-file delivery** (writing prompts down to `.claude/skills/`
+  or similar). Out of architectural scope for this ADR — would
+  require a CLI / sync mechanism not present today and would
+  conflate server-controlled and client-controlled lifecycles.
+
+## See also
+
+- [ADR-150](ADR-150-Scope-Level-System-Prompts.md) — scope
+  `system_prompt` foundation; the table, composition pipeline, and
+  inheritance pattern this ADR extends.
+- [ADR-151](ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md) —
+  prompt-injection defence at the MCP boundary; same trust model
+  applies to named prompts.
+- [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md)
+  — the MCP `prompts` channel itself; this ADR rides on the same
+  capability.
+- [ADR-153](ADR-153-Drop-Redundant-iris-Prefix-From-MCP-Prompt-Names.md)
+  — current naming convention with no `iris:` prefix.
+- [Issue #88](https://github.com/cgbarlow/iris/issues/88) — original
+  "Skills" roadmap; this ADR fulfils the practical authoring need
+  (multiple named directives per scope) while explicitly rejecting
+  the "Skills" framing for the reasons in Context.
+- [SPEC-154-A](specs/SPEC-154-A-Named-Prompts.md) — schema, endpoint
+  shapes, MCP wiring, edit-page wiring, test plan.

--- a/docs/adrs/specs/SPEC-154-A-Named-Prompts.md
+++ b/docs/adrs/specs/SPEC-154-A-Named-Prompts.md
@@ -1,0 +1,373 @@
+# SPEC-154-A: Multiple named prompts per scope
+
+ADR: [ADR-154](../ADR-154-Multiple-Named-Prompts-per-Scope.md)
+
+## Database
+
+### SQLite migration `backend/app/migrations/m048_named_prompts.py`
+
+Idempotent. Mirrors `m047_scope_system_prompts.py` style: pre-check
+existence, run `CREATE TABLE IF NOT EXISTS`, log a single line.
+
+```sql
+CREATE TABLE IF NOT EXISTS prompts (
+  id           TEXT PRIMARY KEY,
+  scope_type   TEXT NOT NULL CHECK (scope_type IN ('collection','set')),
+  scope_id     TEXT NOT NULL,
+  name         TEXT NOT NULL,
+  description  TEXT NOT NULL,
+  body         TEXT NOT NULL,
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  created_by   TEXT,
+  UNIQUE (scope_type, scope_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_prompts_scope ON prompts(scope_type, scope_id);
+```
+
+No FK constraint to `collections` / `sets` (Iris's existing pattern is
+soft-delete + application-level integrity, e.g. `m047`). Soft-delete
+of a scope leaves orphan named prompts — same posture as today's
+`system_prompt` column.
+
+### Supabase migration `backend/app/migrations/supabase/m052_named_prompts.sql`
+
+Same shape with Supabase idiom (`IF NOT EXISTS` guards), plus RLS
+policies aligned with ADR-095:
+
+```sql
+CREATE TABLE IF NOT EXISTS public.prompts (
+  id           text PRIMARY KEY,
+  scope_type   text NOT NULL CHECK (scope_type IN ('collection','set')),
+  scope_id     text NOT NULL,
+  name         text NOT NULL,
+  description  text NOT NULL,
+  body         text NOT NULL,
+  created_at   text NOT NULL,
+  updated_at   text NOT NULL,
+  created_by   text,
+  UNIQUE (scope_type, scope_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_prompts_scope ON public.prompts(scope_type, scope_id);
+
+ALTER TABLE public.prompts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY prompts_anon_read   ON public.prompts FOR SELECT USING (true);
+CREATE POLICY prompts_auth_insert ON public.prompts FOR INSERT TO authenticated WITH CHECK (true);
+CREATE POLICY prompts_auth_update ON public.prompts FOR UPDATE TO authenticated USING (true) WITH CHECK (true);
+CREATE POLICY prompts_auth_delete ON public.prompts FOR DELETE TO authenticated USING (true);
+```
+
+Read posture matches `/api/collections` / `/api/sets`: anonymous
+read, authenticated write. Every CREATE wrapped in `IF NOT EXISTS` /
+`DO $$ ... $$` guard so the migration is idempotent.
+
+## Backend
+
+### Module layout
+
+`backend/app/named_prompts/{__init__,models,service,router}.py`. Kept
+parallel to `backend/app/prompts/` rather than nested under it: the
+existing `prompts` module owns the scope-index endpoint and its
+service, and conflating them would force a single module to express
+two unrelated CRUD shapes.
+
+### Models — `app/named_prompts/models.py`
+
+```python
+NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+class Prompt(BaseModel):
+    id: str
+    scope_type: Literal["collection", "set"]
+    scope_id: str
+    name: str
+    description: str
+    body: str
+    created_at: str
+    updated_at: str
+    created_by: str | None = None
+
+class PromptCreate(BaseModel):
+    scope_type: Literal["collection", "set"]
+    scope_id: str
+    name: str         = Field(pattern=NAME_RE.pattern, max_length=64)
+    description: str  = Field(min_length=1, max_length=1024)
+    body: str         = Field(min_length=1, max_length=256_000)
+
+class PromptUpdate(BaseModel):
+    description: str | None = Field(default=None, min_length=1, max_length=1024)
+    body: str | None        = Field(default=None, min_length=1, max_length=256_000)
+
+class PromptListResponse(BaseModel):
+    items: list[Prompt]
+```
+
+`scope_id` and `name` are immutable post-create. `PUT` only accepts
+`description` and `body`. Renaming requires delete-and-recreate.
+
+### Service — `app/named_prompts/service.py`
+
+```python
+def list_prompts_for_scope(db, scope_type, scope_id) -> list[Prompt]: ...
+def list_effective_prompts_for_set(db, set_id) -> list[Prompt]:
+    # Own + parent collection's prompts. Set-scoped wins on name conflict.
+    ...
+def get_prompt(db, prompt_id) -> Prompt | None: ...
+def create_prompt(db, body: PromptCreate, created_by: str | None) -> Prompt:
+    # Validate name regex, validate scope exists, insert with new UUID
+    # and `now()` timestamps. Raise `IntegrityError` on UNIQUE violation
+    # → translated to 409 in router.
+    ...
+def update_prompt(db, prompt_id, body: PromptUpdate) -> Prompt | None: ...
+def delete_prompt(db, prompt_id) -> bool: ...
+```
+
+`list_effective_prompts_for_set`: SELECT named prompts where
+`(scope_type='set' AND scope_id=:set_id)` UNION ALL
+`(scope_type='collection' AND scope_id IN (parent collections of the
+set))`. Result ordered: own first (alphabetical), then inherited
+(alphabetical). Set-scoped name shadows Collection-scoped name with
+the same string in the picker — implemented as a Python pass after
+the SQL fetch (smaller blast radius than expressing the conflict
+resolution in SQL).
+
+### Router — `app/named_prompts/router.py`
+
+| Method | Path | Auth | Body | Response |
+|---|---|---|---|---|
+| `GET` | `/api/named-prompts?scope_type=&scope_id=` | Anonymous | — | `200` `PromptListResponse` |
+| `GET` | `/api/named-prompts/by-scope?collection_id=&set_id=` | Anonymous | — | `200` `PromptListResponse` (effective list) |
+| `POST` | `/api/named-prompts` | Authenticated | `PromptCreate` | `201` `Prompt` / `409` on name collision / `400` on validation / `404` on scope not found |
+| `GET` | `/api/named-prompts/{id}` | Anonymous | — | `200` `Prompt` / `404` |
+| `PUT` | `/api/named-prompts/{id}` | Authenticated | `PromptUpdate` | `200` `Prompt` / `404` / `400` |
+| `DELETE` | `/api/named-prompts/{id}` | Authenticated | — | `204` / `404` |
+
+`by-scope` accepts either `collection_id` alone (returns that
+collection's named prompts) or `set_id` alone (returns
+`list_effective_prompts_for_set`). Both supplied → 400. Neither
+supplied → 400.
+
+### Registration — `backend/app/main.py`
+
+```python
+from app.named_prompts.router import router as named_prompts_router
+...
+app.include_router(named_prompts_router)
+```
+
+### `app/ai/scope_prompts.py` and `app/ai/service.py` — UNTOUCHED
+
+Per ADR-154, named prompts do not auto-apply. The composition
+pipeline reads `system_prompt` only.
+
+## Scope-index extension
+
+### Extend `app/prompts/models.py`
+
+```python
+EntryKind = Literal["system_prompt", "named_prompt"]
+
+class ScopePromptIndexEntry(BaseModel):
+    name: str                              # "set:<uuid>" | "set:<uuid>:<prompt-name>" | "collection:..."
+    entry_kind: EntryKind                  # NEW (default "system_prompt" for backwards compat readers)
+    scope_type: Literal["collection", "set"]
+    scope_id: str
+    scope_name: str
+    description: str | None = None
+    body: str
+    prompt_name: str | None = None         # NEW — only set when entry_kind == "named_prompt"
+```
+
+### Extend `app/prompts/service.py:list_scope_prompts`
+
+After the existing two SELECTs, append a third:
+
+```sql
+SELECT p.id, p.scope_type, p.scope_id, p.name, p.description, p.body,
+       COALESCE(c.name, s.name) AS scope_name
+FROM prompts p
+LEFT JOIN collections c ON p.scope_type='collection' AND p.scope_id=c.id AND c.is_deleted=0
+LEFT JOIN sets        s ON p.scope_type='set'        AND p.scope_id=s.id AND s.is_deleted=0
+WHERE COALESCE(c.id, s.id) IS NOT NULL
+ORDER BY p.scope_type, scope_name, p.name;
+```
+
+Map each row into a `ScopePromptIndexEntry` with
+`name=f"{scope_type}:{scope_id}:{name}"`, `entry_kind="named_prompt"`,
+`prompt_name=name`. Append after the existing system_prompt entries
+in the response (so any client that processes them in order sees
+system prompts first, named prompts second, both grouped predictably).
+
+## iris-client
+
+### Extend `IrisClient.list_scope_prompts() -> list[ScopePromptIndexEntry]`
+
+The existing method continues to return all entries (system + named).
+The model gains the two new fields (`entry_kind`, `prompt_name`).
+Existing callers that ignored those fields keep working.
+
+Forward compat: tolerate both `{"items": [...]}` and bare `[...]`,
+unchanged from SPEC-152-A.
+
+No new method needed. (The plan file mentioned `list_named_prompts()`
+as a possibility; keeping the existing method and extending the model
+is cleaner and avoids duplicate code paths in the MCP server.)
+
+## MCP server
+
+### Extend `mcp/src/iris_mcp/prompts.py`
+
+Replace the existing `_NAME_RE` with a single regex that matches
+both kinds:
+
+```python
+_NAME_RE = re.compile(
+    r"^(?P<scope>set|collection):(?P<uuid>[0-9a-f-]{36})(?::(?P<prompt>[a-z][a-z0-9-]{0,63}))?$"
+)
+```
+
+`list_prompts` — unchanged surface, now emits one entry per item from
+`client.list_scope_prompts()` (which already returns both kinds after
+the iris-client extension). For named-prompt entries, the description
+shown in the picker uses the named prompt's own description, formatted
+as `"{Scope}: {scope_name} — {prompt_name} — {prompt_description}"`,
+truncated at 200 chars (existing rule). For system-prompt entries the
+formatting is unchanged from SPEC-152-A.
+
+`get_prompt` — match `_NAME_RE`. If `prompt` group is None, behave
+exactly as today. If `prompt` group is set, look up the corresponding
+named-prompt entry from `client.list_scope_prompts()` (matching on
+`entry.name`) and build the preamble:
+
+```
+Loaded from Iris {Scope} "{scope_name}" — prompt "{prompt_name}" ({url}):
+
+{body}
+```
+
+`{url}` falls back to the no-URL form if `IRIS_WEB_URL` is unset
+(consistent with existing `_preamble`).
+
+### `mcp/src/iris_mcp/server.py`
+
+No changes — the existing `@server.list_prompts()` and
+`@server.get_prompt()` decorators delegate to the (extended)
+`iris_prompts` module functions.
+
+## Web GUI
+
+### `/sets/[id]` and `/collections/[id]` edit pages
+
+Add a "Prompts" `<section>` below the existing "System prompt"
+textarea (which stays for ADR-150 / discussion / create flows).
+
+Layout per row:
+
+```
+[ name (immutable post-create) ]   [ description (single-line) ]
+[ body (textarea, monospace, rows=8) ]
+                                                 [ Save ] [ Delete ]
+```
+
+Plus a "+ Add prompt" button that appends an empty row (with name
+field editable until first save).
+
+Per-row CRUD via the existing `apiFetch<T>` wrapper (no batched form
+submit — partial saves don't drop sibling edits). DOMPurify on every
+input before send, per `{@html}` protocol §7.
+
+Inheritance UI on `/sets/[id]`: below the editable Set-scoped
+prompts, a read-only "Inherited from collection: <name>" group lists
+parent-collection prompts (data from `/api/named-prompts/by-scope`
+filtered to `entry.scope_type=='collection'`). Inheritance is
+display-only; editing a parent prompt happens on the collection edit
+page.
+
+### Frontend types
+
+Extend `frontend/src/lib/types/scope-prompts.ts` (or equivalent) with
+`entry_kind` and `prompt_name`. Add `Prompt`, `PromptCreate`,
+`PromptUpdate` types under `frontend/src/lib/types/named-prompts.ts`.
+
+### Wrappers
+
+`frontend/src/lib/api/named-prompts.ts` — typed wrappers around
+`/api/named-prompts*`, mirroring the existing collections / sets
+client wrappers.
+
+## Tests
+
+| File | Cases | Layer |
+|---|---|---|
+| `backend/tests/test_migrations/test_named_prompts_schema.py` | 6 (SQLite m048: table exists + correct columns + UNIQUE + INDEX; Supabase m052: same + RLS policies present; both: idempotency guard) | migration |
+| `backend/tests/test_named_prompts/test_service.py` | 8 (create happy path; create with duplicate name → IntegrityError; list_prompts_for_scope ordering; list_effective_prompts_for_set inheritance + name shadowing; get_prompt 404; update changes only allowed fields; update non-existent → None; delete idempotent) | backend |
+| `backend/tests/test_named_prompts/test_router.py` | 7 (POST happy path; POST validation error 400; POST duplicate 409; GET list filtered by scope; GET by-scope effective list; PUT update; DELETE 204; anonymous read posture verified) | backend |
+| `backend/tests/test_prompts/test_router_named_prompts_extension.py` | 4 (scope-index includes named prompts; entry_kind discriminator on every entry; prompt_name set only on named entries; ordering: system prompts then named prompts) | backend |
+| `iris-client/tests/test_scope_prompts_named.py` | 3 (model accepts new fields; entry_kind round-trip; prompt_name None for system entries) | iris-client |
+| `mcp/tests/test_prompts_list_named.py` | 4 (named prompt appears in list; description format includes prompt_name; order matches scope-index; collection inheritance reflected via the scope-index level, not MCP-level filtering) | MCP |
+| `mcp/tests/test_prompts_get_named.py` | 4 (named prompt happy path with three-segment name; preamble includes prompt_name; malformed three-segment name 400; unknown prompt_name on existing scope → ValueError) | MCP |
+| `frontend/tests/sets-page-named-prompts.test.ts` | 4 (renders existing prompts; add row + save; edit row body; delete row) | frontend |
+| `frontend/tests/collections-page-named-prompts.test.ts` | 4 (same four cases on collection page) | frontend |
+
+Total: **44 new tests**.
+
+Existing v5.8.x test suites must continue to pass. Key sentinel:
+`backend/tests/test_ai/test_scope_prompts.py` (composition pipeline)
+must show no behaviour change — named prompts are not in the
+composition path.
+
+## End-to-end verification
+
+```bash
+# Branch already created: feature/named-prompts-v5.9.0
+./scripts/dev.sh start
+
+# 1. Web GUI: navigate to /sets/<doview-book-set-id>
+#    Section "System prompt" still shows existing content (unchanged).
+#    Section "Prompts" shows empty list with "+ Add prompt" button.
+#    Add named prompt:
+#      name: "outcomes-theory-text-response"
+#      description: "Apply Dr Paul Duignan's outcomes theory using only the Iris DoView Book set."
+#      body: <Prompt A content drafted earlier in conversation>
+#    Add named prompt:
+#      name: "diagram-retrieval"
+#      description: "Reproduce verbatim mermaid diagrams from the Iris DoView Book set."
+#      body: <Prompt B content drafted earlier in conversation>
+
+# 2. Backend round-trip:
+curl -s "http://localhost:8000/api/named-prompts?scope_type=set&scope_id=33032180-d77a-4ce4-88cf-b49cd643e093" | jq '.items | length'   # → 2
+curl -s "http://localhost:8000/api/prompts/scope-index" | jq '.items | map(select(.entry_kind=="named_prompt")) | length'  # → 2 (or more if other scopes also have named prompts)
+
+# 3. MCP picker (in Claude Code with Iris MCP connected):
+#    /iris:set:33032180-d77a-4ce4-88cf-b49cd643e093                                   → loads existing system_prompt
+#    /iris:set:33032180-d77a-4ce4-88cf-b49cd643e093:outcomes-theory-text-response     → loads Prompt A
+#    /iris:set:33032180-d77a-4ce4-88cf-b49cd643e093:diagram-retrieval                 → loads Prompt B
+
+# 4. Run the test suite for each layer:
+cd backend && pytest tests/test_named_prompts/ tests/test_migrations/test_named_prompts_schema.py tests/test_prompts/test_router_named_prompts_extension.py -v
+cd ../mcp && pytest tests/test_prompts_list_named.py tests/test_prompts_get_named.py -v
+cd ../iris-client && pytest tests/test_scope_prompts_named.py -v
+cd ../frontend && npm test -- sets-page-named-prompts collections-page-named-prompts
+
+# 5. Regression sentinels (must continue to pass):
+cd ../backend && pytest tests/test_ai/test_scope_prompts.py tests/test_prompts/test_router.py -v
+cd ../mcp && pytest tests/test_prompts_list.py tests/test_prompts_get.py -v
+```
+
+All 44 new tests pass; all existing v5.8.x tests still pass; manual
+DoView Book invocation flow works in Claude Code's prompt picker
+across all three names.
+
+## Out of scope (deferred per ADR-154)
+
+- Per-prompt `auto_apply` flag.
+- Argument templating (`{{set.name}}` etc.).
+- Per-user prompts.
+- Skill bundles / multi-file resources.
+- Local-file delivery (`.claude/skills/` sync).
+- Reserved name collision protection (e.g. preventing a user creating
+  a named prompt called `system_prompt` — current uniqueness is per
+  `(scope_type, scope_id, name)`, and the MCP name format
+  `set:<uuid>:<name>` doesn't collide with the system_prompt name
+  `set:<uuid>`, so this isn't a v1 concern).

--- a/docs/prompts/doview-book-prompt-a-iris.md
+++ b/docs/prompts/doview-book-prompt-a-iris.md
@@ -1,0 +1,243 @@
+Prompt A (Iris): Outcomes Theory Text Response Prompt
+Version: 2.0.0
+
+Use the Iris "DoView Book" set as the source for applying Dr Paul Duignan's outcomes theory:
+
+Iris set: DoView Book (set_id 33032180-d77a-4ce4-88cf-b49cd643e093)
+
+Answer the user's question, or analyse the page, document, proposal, plan, argument, or issue the user has pointed you to, strictly from the perspective of outcomes theory.
+
+SOURCE OF CONTENT
+
+All claims about outcomes theory, outcomes systems, DoView, DoView outcomes models, DoView Boards or diagrams, tools, principles, and terminology must come from the Iris "DoView Book" set only.
+
+Use:
+1. mcp__iris__search to find relevant tool diagrams in the set (filter or rank by the user's question)
+2. mcp__iris__get_diagram to read the markdown content of any diagram before citing it
+3. mcp__iris__get_package and mcp__iris__list_packages to navigate part/chapter structure when helpful
+
+Each DoView tool is a pair of diagrams in Iris:
+- a "question" diagram (description includes "kind: question · pair: <code>")
+- a "tool" diagram (description includes "kind: tool · pair: <code>")
+
+The tool diagram contains the practical mechanism and an embedded mermaid flowchart. The question diagram contains the framing question and explanatory prose.
+
+Do not use any source outside this Iris set. Do not use general knowledge. Do not use the rest of the internet.
+
+REQUIRED OPENING
+
+The response must begin exactly with this sentence:
+
+I have prepared a summary response and a full response. These are both standalone so you can send them to anyone.
+
+After that sentence, provide exactly two standalone sections with these headings:
+
+1. Summary response to [briefly summarise the question being answered]
+
+2. Full response to [briefly summarise the question being answered]
+
+Replace the bracketed text with a short plain-language summary of the actual question. Do not use any other headings before these two sections.
+
+The Summary response must be fully standalone. It must include its own formal answer, relevant tool references with their human-facing URLs, and the full book reference.
+
+The Full response must also be fully standalone. It must not rely on the Summary response. It must include its own short summary at the start, its own relevant tool references with their human-facing URLs, the full book reference, and the Image-retrieval seed list for Prompt B.
+
+STYLE RULES
+
+Write formally. Do not write conversationally. Do not write as if giving the user drafting advice.
+
+Do not use:
+- "I would"
+- "you could"
+- "a better answer is"
+- "a sentence you could use"
+- "from a DoView/outcomes theory perspective"
+- "practically, I would"
+- blockquoted suggested wording
+- informal advice to the user
+
+Do not address the user directly inside the Summary response or the Full response.
+
+Use outcomes theory as the primary point of view throughout. Prefer wording such as:
+- "Outcomes theory points out that..."
+- "Outcomes theory says that..."
+- "Outcomes theory highlights that..."
+- "Outcomes theory emphasises that..."
+- "Outcomes theory points out that this is a technical outcomes problem because..."
+- "This violates the outcomes theory principle that..."
+
+Do not present DoView as the primary theory. DoView must always be described as a practical applied version of outcomes theory.
+
+OUTCOMES SYSTEM DEFINITION RULE
+
+The first time the response uses the phrase "outcomes system" in each standalone section, immediately include this definition:
+
+An outcomes system is to purposeful action what an accounting system is to financial activity: the underlying structure that defines what matters, records what is happening, supports reporting, and makes accountability possible. The difference is that instead of tracking money, it tracks intended changes in the world and the evidence that action is contributing to them.
+
+This definition must appear in both the Summary response and the Full response if the phrase "outcomes system" is used in both sections.
+
+When DoView is first mentioned in each standalone section, briefly explain that outcomes theory talks in terms of a DoView outcomes model underlying action in the world: a "This-Then" model of what needs to happen to achieve higher-level outcomes.
+
+When referring to DoView Boards or diagrams, use wording such as:
+
+One way this can be done in practice is to use a DoView Board, a specific type of outcomes model that is drawn to conform to the principles of outcomes theory.
+
+Do not describe an approach as "DoView-compatible." Describe it as an outcomes theory approach. DoView Boards or diagrams are applied practical tools used when doing outcomes work.
+
+HUMAN-FACING URL RULE — COPY-SAFE URLS FOR HUMANS
+
+Every tool reference and the handbook reference in the response body must be written as raw, visible, copy-safe plain text beginning with https://
+
+The purpose of this rule is that a human must be able to copy the response into an email, document, report, or plain-text system and still see every URL.
+
+These URLs are reader-facing pointers only. They are not fetched by the AI system. The content source is the Iris set, not the website.
+
+Do not hide URLs behind linked words.
+Do not use markdown links.
+Do not use reference-style links.
+Do not use footnotes.
+Do not use source icons.
+Do not use citation markers.
+Do not use embedded hyperlinks.
+Do not put URLs inside square brackets.
+Do not put URLs inside markdown link syntax.
+Do not write URLs as [https://example.com](https://example.com).
+Do not write URLs as [Tool name](https://example.com).
+Do not write "see above".
+Do not write "see links above".
+Do not list only tool codes such as B7 or C3.
+Do not mention any tool unless its full raw visible URL is written immediately after the tool name.
+
+Tool reference format in the response body:
+
+Tool B16: Do Not Silo Steps Under Outcomes Explainer — https://doviewplanning.org/b16doviewtool
+
+The URL mapping is deterministic: the lowercase pair code (e.g. b16, j07, c3) becomes https://doviewplanning.org/<paircode>doviewtool. Use the pair code from the diagram's description field ("pair: <code>").
+
+Full handbook reference format:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+Incorrect formats:
+
+Tool B16
+
+B16
+
+Do Not Silo Steps Under Outcomes Explainer
+
+Tool B16: [https://doviewplanning.org/b16doviewtool](https://doviewplanning.org/b16doviewtool)
+
+[Tool B16](https://doviewplanning.org/b16doviewtool)
+
+See links above
+
+This rule applies to the Summary response, the Full response, and every tool reference in either section. If the same tool is mentioned in both sections, the full raw visible URL must be written out in both sections. If the same tool is mentioned more than once, the full raw visible URL must be written out every time.
+
+REQUIRED STRUCTURE
+
+1. Summary response to [briefly summarise the question being answered]
+
+Write a concise formal summary response. This section must be fully standalone and must include:
+- a short outcomes theory answer;
+- the key relevant outcomes theory principle or principles;
+- wording that identifies the issue as a technical outcomes problem where appropriate;
+- the outcomes system definition if the phrase "outcomes system" is used;
+- a brief explanation of DoView outcomes models where DoView is mentioned;
+- any relevant DoView tool names, each followed immediately by its full raw visible plain-text URL;
+- no first-person wording;
+- no direct advice to the user;
+- no "a better answer is," "a sentence you could use," or similar wording;
+- no hidden links, no markdown links, no reference-style links, and no footnotes;
+- the full handbook reference at the end, with the URL written as raw visible plain text.
+
+End the Summary response with this full reference exactly in raw visible URL form:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+2. Full response to [briefly summarise the question being answered]
+
+Write the full formal response. This section must be fully standalone and must include its own brief summary at the start.
+
+The Full response must include:
+- a brief summary at the start;
+- the full outcomes theory answer;
+- the relevant outcomes theory principle or principles;
+- wording that identifies the issue as a technical outcomes problem where appropriate;
+- the outcomes system definition if the phrase "outcomes system" is used;
+- any firm statement of a violation of outcomes theory principles, where applicable;
+- an explanation that outcomes theory talks in terms of a DoView outcomes model underlying action in the world: a "This-Then" model of what needs to happen to achieve higher-level outcomes;
+- an explanation of DoView Boards or diagrams as applied practical tools used when doing outcomes work;
+- the statement "One way this can be done in practice is to use a DoView Board, a specific type of outcomes model that is drawn to conform to the principles of outcomes theory," where relevant;
+- practical formal implications, without first-person wording and without directly addressing the user;
+- no "a better answer is," "a sentence you could use," or similar wording;
+- any relevant DoView tool names, each followed immediately by its full raw visible plain-text URL;
+- no shortened tool references;
+- no "links above";
+- no tool names without their full visible URLs;
+- no hidden links, no markdown links, no reference-style links, and no footnotes;
+- the full handbook reference at the end, with the URL written as raw visible plain text;
+- the Image-retrieval seed list for Prompt B after the full handbook reference.
+
+End the Full response with this full reference exactly in raw visible URL form:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+IMAGE-RETRIEVAL SEED LIST FOR PROMPT B
+
+At the very end of the Full response, after the full handbook reference, include this exact heading:
+
+Image-retrieval seed list for Prompt B
+
+Under that heading, list every tool diagram used in the answer. Each entry must be the Iris diagram UUID of the **tool** diagram (not the question diagram), with the pair code in parentheses for human readability.
+
+Format: one entry per line.
+
+iris-diagram: <uuid> (pair: <paircode>)
+
+Example:
+
+Image-retrieval seed list for Prompt B
+
+iris-diagram: c7148895-d957-4586-8c00-798ed26d518b (pair: j07)
+iris-diagram: 8a3f1e22-9b7d-4c5e-a1f2-3d4e5f6789ab (pair: b16)
+
+Rules for the seed list:
+- Include every tool diagram referenced in either the Summary response or the Full response.
+- Use only tool-kind diagrams (description contains "kind: tool"), never question-kind diagrams.
+- Do not include part-index diagrams or the book front page.
+- Do not include duplicates.
+- Do not include explanations on the seed-list lines.
+- If no tool diagrams were cited, omit the seed-list heading entirely.
+
+The UUID and pair code come from the Iris diagram you read via mcp__iris__get_diagram. The UUID is the diagram's `id` field. The pair code is parsed from the `description` field ("pair: <code>").
+
+IRIS LOOKUP PROCEDURE
+
+Before drafting the response, do the following:
+
+1. Use mcp__iris__search scoped to set_id 33032180-d77a-4ce4-88cf-b49cd643e093 to find diagrams relevant to the user's question. Search by keywords from the question.
+
+2. For each candidate diagram, call mcp__iris__get_diagram to read its `data.content`. Confirm relevance from the actual content, not the name alone.
+
+3. Prefer tool-kind diagrams (description "kind: tool") over question-kind diagrams when citing in the response, because tool diagrams contain the practical mechanism. Question-kind diagrams may be read for context but should not appear in the seed list.
+
+4. If Iris is unreachable or returns no results, state exactly: "The Iris DoView Book set is not currently available, so an outcomes theory response cannot be produced." Do not fall back to general knowledge.
+
+FINAL COMPLIANCE CHECK BEFORE ANSWERING
+
+Before giving the answer, check and correct the response so that:
+1. It starts with the exact required preliminary sentence.
+2. It contains exactly the two required main sections.
+3. The first section heading starts "1. Summary response to".
+4. The second section heading starts "2. Full response to".
+5. The Summary response is standalone and ends with the full book reference and https://doviewplanning.org/book in raw visible text.
+6. The Full response is standalone, has its own summary at the start, ends with the full book reference and https://doviewplanning.org/book in raw visible text, and then includes the Image-retrieval seed list for Prompt B (if any tool diagrams were cited).
+7. Every tool mentioned has its full raw visible plain-text URL immediately after the tool name.
+8. There are no markdown links, no reference links, no footnotes, no "[1]" style citations, no hidden URLs, no URLs written as [URL](URL), and no "see above" wording.
+9. Every URL in the response body appears visibly as raw text beginning with https://
+10. Before finalising the response, actively scan it for the characters "](https://" and "[http". If either appears, rewrite the response so that every URL is raw visible plain text instead.
+11. The response uses outcomes theory as the primary framework and presents DoView Boards or diagrams only as practical applied forms of outcomes theory.
+12. The response does not contain "a better answer is," "a sentence you could use," "I would," "you could," or any other drafting-advice wording.
+13. The Image-retrieval seed list for Prompt B, if present, contains only `iris-diagram:` lines, one per line, with valid UUIDs and pair codes from actual tool-kind diagrams read from Iris.
+14. All cited content came from the Iris DoView Book set; no general knowledge has been used.

--- a/docs/prompts/doview-book-prompt-b-iris.md
+++ b/docs/prompts/doview-book-prompt-b-iris.md
@@ -1,0 +1,123 @@
+Prompt B (Iris): Outcomes Theory Diagram Retriever Prompt
+for use directly after Prompt A response has been generated
+
+Version: 2.0.0
+
+Use the Iris "DoView Book" set as the source for retrieving the original mermaid diagrams associated with the outcomes theory tools cited in the preceding response.
+
+Iris set: DoView Book (set_id 33032180-d77a-4ce4-88cf-b49cd643e093)
+
+Use this prompt after Prompt A: Outcomes Theory Text Response Prompt has produced a response. Look at the response immediately above and locate the heading:
+
+Image-retrieval seed list for Prompt B
+
+Under that heading are one or more lines in this exact format:
+
+iris-diagram: <uuid> (pair: <paircode>)
+
+Use each `<uuid>` to fetch the diagram directly from Iris. The `<paircode>` is for human reference and for constructing the reader-facing page URL.
+
+If the seed-list heading is absent, state exactly: "No image-retrieval seed list was present in the preceding response." Then stop. Do not attempt to recover by guessing or searching.
+
+If Iris is unreachable or any seed UUID cannot be fetched, state exactly: "The Iris DoView Book set is not currently available, so the original diagrams cannot be retrieved." Then stop.
+
+SOURCE RESTRICTION
+
+Use only the Iris "DoView Book" set. Do not use any other source. Do not use general knowledge. Do not invent, redraw, simplify, improve, or approximate a diagram. Do not use the rest of the internet.
+
+TASK
+
+For each `iris-diagram: <uuid>` in the seed list:
+
+1. Call mcp__iris__get_diagram with that UUID.
+
+2. Confirm the diagram is a tool-kind diagram by checking its `description` field for "kind: tool". If it is not, skip it and note "Skipped non-tool diagram <uuid>" in the response.
+
+3. In `data.content`, locate the fenced mermaid code block. It begins with ```` ```mermaid ```` and ends with ```` ``` ````. If no mermaid block is present, note "No mermaid diagram found in <uuid>" and skip that entry.
+
+4. Extract the mermaid block verbatim.
+
+OUTPUT FORMAT
+
+Begin the response with this heading:
+
+Diagrams from the DoView Planning and Outcomes Theory Handbook, Duignan, P. (2025), https://doviewplanning.org/book
+
+Begin with this note:
+
+This diagram-retrieval response reproduces the original mermaid diagrams from the Iris DoView Book set. Rendering depends on the AI system's ability to render mermaid. Where the diagram does not render visually, the mermaid source remains visible and can be copied into any mermaid-capable system.
+
+Then, for each successfully retrieved diagram, in the order they appear in the seed list, output:
+
+### Tool <PAIRCODE_UPPERCASE>: <diagram-name-from-iris>
+
+Page URL: https://doviewplanning.org/<paircode>doviewtool
+
+```mermaid
+<verbatim mermaid block from data.content>
+```
+
+Formal relevance note: <one short formal sentence explaining the diagram's relevance to the preceding outcomes theory answer>
+
+Rules for each entry:
+
+- The page URL must be written as raw visible plain text beginning with https:// — not hidden behind linked words, not in markdown link syntax.
+- The mermaid block must be copied verbatim from `data.content`. Do not relabel nodes. Do not change arrow direction. Do not reformat. Do not add nodes. Do not remove nodes. Do not translate.
+- The formal relevance note must use formal language. Do not address the user. Do not say "I would" or "you could".
+- Do not include the question-kind diagram for any pair, only the tool-kind diagram.
+
+If a seed-list entry could not be retrieved (Iris error, missing mermaid, wrong kind), include a short note in place of the entry:
+
+Tool <PAIRCODE_UPPERCASE>: original diagram could not be retrieved from Iris.
+
+Page URL: https://doviewplanning.org/<paircode>doviewtool
+
+After all entries, end the response with the full handbook reference in raw visible plain text:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+HUMAN-FACING URL RULE — COPY-SAFE URLS FOR HUMANS
+
+Every page URL and the handbook reference must be written as raw, visible, copy-safe plain text beginning with https://
+
+Do not hide page URLs behind words.
+Do not use reference-style links such as "[1]".
+Do not use footnotes.
+Do not use source icons.
+Do not use citation markers.
+Do not use embedded hyperlinks for page URLs.
+Do not write "see above".
+Do not write "see links above".
+Do not use shortened URLs.
+
+The mermaid code block itself is not a URL and is not subject to this rule. It is reproduced as a fenced code block.
+
+DIAGRAM FAITHFULNESS RULES
+
+The mermaid block must be copied verbatim from the Iris diagram's `data.content`. The only acceptable transformations are:
+- preserving whitespace
+- preserving the original opening ```` ```mermaid ```` fence and closing ```` ``` ```` fence
+
+Do not redraw the diagram from memory.
+Do not simplify it.
+Do not improve it.
+Do not rename or translate labels.
+Do not change arrow directions or edge styles.
+Do not add explanatory nodes.
+Do not create a new substitute diagram.
+Do not use a diagram from outside the Iris DoView Book set.
+
+If the source diagram has no mermaid block, do not synthesise one. Note the absence and continue.
+
+FINAL COMPLIANCE CHECK BEFORE ANSWERING
+
+Before giving the response, check and correct it so that:
+
+1. It begins with the required heading and the diagram-retrieval note.
+2. Every retrieved diagram is from the Iris DoView Book set (set_id 33032180-d77a-4ce4-88cf-b49cd643e093).
+3. Every mermaid block has been copied verbatim from the diagram's `data.content`, with no redrawing, simplification, or relabelling.
+4. Every entry pairs the mermaid block with a raw visible plain-text page URL of the form https://doviewplanning.org/<paircode>doviewtool.
+5. Only tool-kind diagrams (description contains "kind: tool") have been reproduced; question-kind diagrams have not been reproduced.
+6. Every URL is raw visible plain text. Scan the response for "](https://" and "[http"; if either appears, rewrite the URL as raw plain text.
+7. The response ends with the full handbook reference and https://doviewplanning.org/book in raw visible plain text.
+8. No content from outside the Iris DoView Book set appears in the response.

--- a/docs/prompts/doview-book-prompt-c-iris.md
+++ b/docs/prompts/doview-book-prompt-c-iris.md
@@ -1,0 +1,365 @@
+Prompt C (Iris): Outcomes Theory Combined Response + Diagrams Prompt
+Version: 1.0.0
+
+Single-turn merge of Prompt A (text response) and Prompt B (diagram retriever).
+Produces both the formal outcomes-theory text answer AND the original mermaid
+diagrams from the Iris DoView Book set in one response, so the user does not
+have to invoke a follow-up prompt.
+
+Use the Iris "DoView Book" set as the source for applying Dr Paul Duignan's
+outcomes theory:
+
+Iris set: DoView Book (set_id 33032180-d77a-4ce4-88cf-b49cd643e093)
+
+Answer the user's question, or analyse the page, document, proposal, plan,
+argument, or issue the user has pointed you to, strictly from the perspective
+of outcomes theory.
+
+SOURCE OF CONTENT
+
+All claims about outcomes theory, outcomes systems, DoView, DoView outcomes
+models, DoView Boards or diagrams, tools, principles, and terminology — and
+every diagram reproduced in the response — must come from the Iris "DoView
+Book" set only.
+
+Use:
+1. mcp__iris__search to find relevant tool diagrams in the set (filter by the
+   user's question keywords)
+2. mcp__iris__get_diagram to read the markdown content of any diagram before
+   citing it or reproducing its mermaid block
+3. mcp__iris__get_package and mcp__iris__list_packages to navigate
+   part/chapter structure when helpful
+
+Each DoView tool is a pair of diagrams in Iris:
+- a "question" diagram (description includes "kind: question · pair: <code>")
+- a "tool" diagram (description includes "kind: tool · pair: <code>")
+
+The tool diagram contains the practical mechanism and an embedded mermaid
+flowchart. The question diagram contains the framing question and
+explanatory prose. When citing in the response body and reproducing a
+diagram, use only the tool-kind diagrams.
+
+Do not use any source outside this Iris set. Do not use general knowledge.
+Do not use the rest of the internet.
+
+If Iris is unreachable or the set is empty, state exactly: "The Iris DoView
+Book set is not currently available, so an outcomes theory response cannot
+be produced." Then stop.
+
+REQUIRED OPENING
+
+The response must begin exactly with this sentence:
+
+I have prepared a summary response, a full response, and the original diagrams from the handbook. These are all standalone so you can send them to anyone.
+
+After that sentence, provide exactly three standalone sections with these
+headings, in order:
+
+1. Summary response to [briefly summarise the question being answered]
+
+2. Full response to [briefly summarise the question being answered]
+
+3. Diagrams from the DoView Planning and Outcomes Theory Handbook
+
+Replace the bracketed text in headings 1 and 2 with a short plain-language
+summary of the actual question. Do not use any other headings before these
+three sections.
+
+STYLE RULES (apply to sections 1 and 2)
+
+Write formally. Do not write conversationally. Do not write as if giving the
+user drafting advice.
+
+Do not use:
+- "I would"
+- "you could"
+- "a better answer is"
+- "a sentence you could use"
+- "from a DoView/outcomes theory perspective"
+- "practically, I would"
+- blockquoted suggested wording
+- informal advice to the user
+
+Do not address the user directly inside any of the three standalone
+sections.
+
+Use outcomes theory as the primary point of view throughout. Prefer wording
+such as:
+- "Outcomes theory points out that..."
+- "Outcomes theory says that..."
+- "Outcomes theory highlights that..."
+- "Outcomes theory emphasises that..."
+- "Outcomes theory points out that this is a technical outcomes problem
+  because..."
+- "This violates the outcomes theory principle that..."
+
+Do not present DoView as the primary theory. DoView must always be described
+as a practical applied version of outcomes theory.
+
+OUTCOMES SYSTEM DEFINITION RULE
+
+The first time the response uses the phrase "outcomes system" in each of
+sections 1 and 2, immediately include this definition:
+
+An outcomes system is to purposeful action what an accounting system is to
+financial activity: the underlying structure that defines what matters,
+records what is happening, supports reporting, and makes accountability
+possible. The difference is that instead of tracking money, it tracks
+intended changes in the world and the evidence that action is contributing
+to them.
+
+When DoView is first mentioned in each of sections 1 and 2, briefly explain
+that outcomes theory talks in terms of a DoView outcomes model underlying
+action in the world: a "This-Then" model of what needs to happen to achieve
+higher-level outcomes.
+
+When referring to DoView Boards or diagrams in sections 1 and 2, use wording
+such as:
+
+One way this can be done in practice is to use a DoView Board, a specific
+type of outcomes model that is drawn to conform to the principles of
+outcomes theory.
+
+Do not describe an approach as "DoView-compatible." Describe it as an
+outcomes theory approach. DoView Boards or diagrams are applied practical
+tools used when doing outcomes work.
+
+HUMAN-FACING URL RULE — COPY-SAFE URLS FOR HUMANS
+
+Every tool reference, page URL, and handbook reference in sections 1, 2 and
+3 must be written as raw, visible, copy-safe plain text beginning with
+https://
+
+The purpose of this rule is that a human must be able to copy the response
+into an email, document, report, or plain-text system and still see every
+URL.
+
+These URLs are reader-facing pointers only. They are not fetched by the AI
+system. The content source is the Iris set, not the website.
+
+Do not hide URLs behind linked words.
+Do not use markdown links for tool references or page URLs.
+Do not use reference-style links.
+Do not use footnotes.
+Do not use source icons.
+Do not use citation markers.
+Do not use embedded hyperlinks.
+Do not put URLs inside square brackets.
+Do not put URLs inside markdown link syntax.
+Do not write URLs as [https://example.com](https://example.com).
+Do not write URLs as [Tool name](https://example.com).
+Do not write "see above".
+Do not write "see links above".
+Do not list only tool codes such as B7 or C3.
+Do not mention any tool in section 1 or 2 unless its full raw visible URL
+is written immediately after the tool name.
+
+Tool reference format in sections 1 and 2:
+
+Tool B16: Do Not Silo Steps Under Outcomes Explainer — https://doviewplanning.org/b16doviewtool
+
+The URL mapping is deterministic: the lowercase pair code (e.g. b16, j07,
+c3) becomes https://doviewplanning.org/<paircode>doviewtool. Use the pair
+code from the diagram's description field ("pair: <code>").
+
+Full handbook reference format:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+Mermaid code blocks in section 3 are not URLs and are not subject to this
+rule. They are fenced ```mermaid``` blocks; their page URL above them is
+still raw visible plain text.
+
+REQUIRED STRUCTURE
+
+## 1. Summary response to [briefly summarise the question being answered]
+
+Concise formal summary. This section must be fully standalone and must
+include:
+- a short outcomes theory answer;
+- the key relevant outcomes theory principle or principles;
+- wording that identifies the issue as a technical outcomes problem where
+  appropriate;
+- the outcomes system definition if the phrase "outcomes system" is used;
+- a brief explanation of DoView outcomes models where DoView is mentioned;
+- any relevant DoView tool names, each followed immediately by its full
+  raw visible plain-text URL;
+- no first-person wording;
+- no direct advice to the user;
+- no "a better answer is," "a sentence you could use," or similar wording;
+- no hidden links, no markdown links, no reference-style links, and no
+  footnotes;
+- the full handbook reference at the end, with the URL written as raw
+  visible plain text.
+
+End the Summary response with this full reference exactly in raw visible
+URL form:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+## 2. Full response to [briefly summarise the question being answered]
+
+Full formal response. This section must be fully standalone and must
+include its own brief summary at the start.
+
+The Full response must include:
+- a brief summary at the start;
+- the full outcomes theory answer;
+- the relevant outcomes theory principle or principles;
+- wording that identifies the issue as a technical outcomes problem where
+  appropriate;
+- the outcomes system definition if the phrase "outcomes system" is used;
+- any firm statement of a violation of outcomes theory principles, where
+  applicable;
+- an explanation that outcomes theory talks in terms of a DoView outcomes
+  model underlying action in the world: a "This-Then" model of what needs
+  to happen to achieve higher-level outcomes;
+- an explanation of DoView Boards or diagrams as applied practical tools
+  used when doing outcomes work;
+- the statement "One way this can be done in practice is to use a DoView
+  Board, a specific type of outcomes model that is drawn to conform to the
+  principles of outcomes theory," where relevant;
+- practical formal implications, without first-person wording and without
+  directly addressing the user;
+- no "a better answer is," "a sentence you could use," or similar wording;
+- any relevant DoView tool names, each followed immediately by its full
+  raw visible plain-text URL;
+- no shortened tool references;
+- no "links above";
+- no tool names without their full visible URLs;
+- no hidden links, no markdown links, no reference-style links, and no
+  footnotes;
+- the full handbook reference at the end, with the URL written as raw
+  visible plain text.
+
+End the Full response with this full reference exactly in raw visible URL
+form:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+## 3. Diagrams from the DoView Planning and Outcomes Theory Handbook
+
+This section replaces the separate Prompt B turn. Reproduce the original
+mermaid diagrams from each tool-kind diagram referenced (explicitly or
+implicitly) in section 1 or section 2.
+
+Begin section 3 with this note:
+
+This diagrams section reproduces the original mermaid diagrams from the
+Iris DoView Book set. Rendering depends on the AI system's ability to
+render mermaid. Where the diagram does not render visually, the mermaid
+source remains visible and can be copied into any mermaid-capable system.
+
+For each tool referenced earlier in the response, in the same order the
+tools were first mentioned, output:
+
+### Tool <PAIRCODE_UPPERCASE>: <tool-diagram-name-from-iris>
+
+Page URL: https://doviewplanning.org/<paircode>doviewtool
+
+```mermaid
+<verbatim mermaid block from data.content of the Iris tool diagram>
+```
+
+Formal relevance note: <one short formal sentence explaining the diagram's relevance to the outcomes theory answer above>
+
+Rules for each entry in section 3:
+
+- The page URL must be written as raw visible plain text beginning with
+  https:// — not hidden behind linked words, not in markdown link syntax.
+- The mermaid block must be copied verbatim from the Iris tool diagram's
+  data.content field. Do not relabel nodes. Do not change arrow direction.
+  Do not reformat. Do not add nodes. Do not remove nodes. Do not translate.
+- The formal relevance note must use formal language. Do not address the
+  user. Do not say "I would" or "you could".
+- Reproduce only the tool-kind diagram for each pair, never the
+  question-kind diagram.
+- If the source diagram has no mermaid block, do not synthesise one. State:
+  "No mermaid diagram is present on the Iris tool page for this pair."
+- If a tool diagram could not be retrieved from Iris, state: "Tool
+  <PAIRCODE_UPPERCASE>: original diagram could not be retrieved from Iris."
+  with the page URL on the next line.
+
+If no DoView tool diagrams were referenced in sections 1 or 2, omit section
+3 entirely and stop after section 2's handbook reference.
+
+DIAGRAM FAITHFULNESS RULES
+
+The mermaid block in section 3 must be copied verbatim from the Iris
+diagram's data.content. The only acceptable transformations are:
+- preserving whitespace
+- preserving the original opening ```mermaid fence and closing ``` fence
+
+Do not redraw the diagram from memory.
+Do not simplify it.
+Do not improve it.
+Do not rename or translate labels.
+Do not change arrow directions or edge styles.
+Do not add explanatory nodes.
+Do not create a new substitute diagram.
+Do not use a diagram from outside the Iris DoView Book set.
+
+After section 3 (or after section 2 if section 3 is omitted), end the
+response with the full handbook reference in raw visible plain text:
+
+Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
+
+IRIS LOOKUP PROCEDURE
+
+Before drafting the response, do the following:
+
+1. Use mcp__iris__search scoped to set_id 33032180-d77a-4ce4-88cf-b49cd643e093
+   to find diagrams relevant to the user's question. Search by keywords from
+   the question.
+
+2. For each candidate diagram, call mcp__iris__get_diagram to read its
+   data.content. Confirm relevance from the actual content, not the name
+   alone.
+
+3. Prefer tool-kind diagrams (description "kind: tool") over question-kind
+   diagrams when citing or reproducing. Question-kind diagrams may be read
+   for context but should not appear in section 3.
+
+4. Track which tool diagrams are cited in sections 1 and 2 so section 3 can
+   reproduce their mermaid blocks in first-mention order.
+
+FINAL COMPLIANCE CHECK BEFORE ANSWERING
+
+Before giving the answer, check and correct the response so that:
+
+1. It starts with the exact required preliminary sentence.
+2. It contains exactly the three required main sections (or two, if no
+   tool diagrams were referenced).
+3. The first section heading starts "1. Summary response to".
+4. The second section heading starts "2. Full response to".
+5. The third section heading, when present, is "3. Diagrams from the DoView
+   Planning and Outcomes Theory Handbook".
+6. The Summary response is standalone and ends with the full book reference
+   and https://doviewplanning.org/book in raw visible text.
+7. The Full response is standalone, has its own summary at the start, and
+   ends with the full book reference and https://doviewplanning.org/book in
+   raw visible text.
+8. Every tool mentioned in sections 1 or 2 has its full raw visible
+   plain-text URL immediately after the tool name.
+9. Section 3, when present, contains one ### Tool ... heading per tool
+   cited, each with a raw plain-text Page URL and a verbatim mermaid block
+   and a formal relevance note.
+10. There are no markdown links, no reference links, no footnotes, no "[1]"
+    style citations, no hidden URLs, no URLs written as [URL](URL), and no
+    "see above" wording.
+11. Every URL in section 1, 2 and 3 (other than inside mermaid blocks)
+    appears visibly as raw text beginning with https://
+12. Before finalising the response, actively scan it for the characters
+    "](https://" and "[http". If either appears, rewrite the response so
+    that every URL is raw visible plain text instead.
+13. The response uses outcomes theory as the primary framework and presents
+    DoView Boards or diagrams only as practical applied forms of outcomes
+    theory.
+14. The response does not contain "a better answer is," "a sentence you
+    could use," "I would," "you could," or any other drafting-advice
+    wording.
+15. All cited content and all reproduced mermaid blocks came from the Iris
+    DoView Book set; no general knowledge has been used; no diagram has
+    been redrawn from memory.
+16. The response ends with the full handbook reference and
+    https://doviewplanning.org/book in raw visible plain text.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.8.5",
+	"version": "5.9.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/api/named-prompts.ts
+++ b/frontend/src/lib/api/named-prompts.ts
@@ -1,0 +1,62 @@
+/**
+ * ADR-154 / SPEC-154-A: typed client for `/api/named-prompts*`.
+ *
+ * Thin wrappers around the shared `apiFetch` helper. Sanitisation
+ * happens at the call site (matching the pattern used for
+ * collections / sets) — keep these wrappers focused on transport.
+ */
+
+import { apiFetch } from '$lib/utils/api';
+import type {
+	NamedPrompt,
+	NamedPromptCreate,
+	NamedPromptListResponse,
+	NamedPromptUpdate,
+	ScopeType,
+} from '$lib/types/named-prompts';
+
+export async function listNamedPromptsForScope(
+	scope_type: ScopeType,
+	scope_id: string,
+): Promise<NamedPrompt[]> {
+	const params = new URLSearchParams({ scope_type, scope_id });
+	const resp = await apiFetch<NamedPromptListResponse>(`/api/named-prompts?${params}`);
+	return resp.items;
+}
+
+export async function listEffectiveNamedPromptsForSet(
+	set_id: string,
+): Promise<NamedPrompt[]> {
+	const params = new URLSearchParams({ set_id });
+	const resp = await apiFetch<NamedPromptListResponse>(`/api/named-prompts/by-scope?${params}`);
+	return resp.items;
+}
+
+export async function listEffectiveNamedPromptsForCollection(
+	collection_id: string,
+): Promise<NamedPrompt[]> {
+	const params = new URLSearchParams({ collection_id });
+	const resp = await apiFetch<NamedPromptListResponse>(`/api/named-prompts/by-scope?${params}`);
+	return resp.items;
+}
+
+export async function createNamedPrompt(body: NamedPromptCreate): Promise<NamedPrompt> {
+	return apiFetch<NamedPrompt>('/api/named-prompts', {
+		method: 'POST',
+		body: JSON.stringify(body),
+	});
+}
+
+export async function updateNamedPrompt(
+	id: string,
+	body: NamedPromptUpdate,
+): Promise<NamedPrompt> {
+	return apiFetch<NamedPrompt>(`/api/named-prompts/${id}`, {
+		method: 'PUT',
+		body: JSON.stringify(body),
+	});
+}
+
+export async function deleteNamedPrompt(id: string): Promise<void> {
+	await apiFetch<void>(`/api/named-prompts/${id}`, { method: 'DELETE' });
+}

--- a/frontend/src/lib/components/NamedPromptsSection.svelte
+++ b/frontend/src/lib/components/NamedPromptsSection.svelte
@@ -1,0 +1,297 @@
+<script lang="ts">
+	import DOMPurify from 'dompurify';
+	import {
+		createNamedPrompt,
+		deleteNamedPrompt,
+		listEffectiveNamedPromptsForCollection,
+		listEffectiveNamedPromptsForSet,
+		listNamedPromptsForScope,
+		updateNamedPrompt,
+	} from '$lib/api/named-prompts';
+	import {
+		NAMED_PROMPT_BODY_MAX,
+		NAMED_PROMPT_DESCRIPTION_MAX,
+		NAMED_PROMPT_NAME_RE,
+		type NamedPrompt,
+		type ScopeType,
+	} from '$lib/types/named-prompts';
+
+	interface Props {
+		scope_type: ScopeType;
+		scope_id: string;
+	}
+
+	const { scope_type, scope_id }: Props = $props();
+
+	let own = $state<NamedPrompt[]>([]);
+	let inherited = $state<NamedPrompt[]>([]);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let savingIds = $state<Set<string>>(new Set());
+
+	// New-prompt form state.
+	let showAddRow = $state(false);
+	let newName = $state('');
+	let newDescription = $state('');
+	let newBody = $state('');
+	let creating = $state(false);
+	let createError = $state<string | null>(null);
+
+	async function load() {
+		loading = true;
+		error = null;
+		try {
+			own = await listNamedPromptsForScope(scope_type, scope_id);
+			if (scope_type === 'set') {
+				const effective = await listEffectiveNamedPromptsForSet(scope_id);
+				const ownNames = new Set(own.map((p) => p.name));
+				inherited = effective.filter((p) => p.scope_type === 'collection' && !ownNames.has(p.name));
+			} else {
+				// Collections have no parent scope.
+				const effective = await listEffectiveNamedPromptsForCollection(scope_id);
+				inherited = effective.filter((p) => p.scope_id !== scope_id);
+			}
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load prompts';
+		}
+		loading = false;
+	}
+
+	$effect(() => {
+		// Reload when scope changes.
+		void scope_id;
+		void scope_type;
+		load();
+	});
+
+	function _sanitize(text: string): string {
+		return DOMPurify.sanitize(text);
+	}
+
+	function _markSaving(id: string, on: boolean) {
+		const next = new Set(savingIds);
+		if (on) next.add(id);
+		else next.delete(id);
+		savingIds = next;
+	}
+
+	async function handleCreate() {
+		createError = null;
+		const name = newName.trim();
+		const description = newDescription.trim();
+		const body = newBody.trim();
+
+		if (!NAMED_PROMPT_NAME_RE.test(name)) {
+			createError = 'Name must start with a lowercase letter and contain only lowercase letters, digits, and hyphens.';
+			return;
+		}
+		if (description.length < 1 || description.length > NAMED_PROMPT_DESCRIPTION_MAX) {
+			createError = `Description must be 1–${NAMED_PROMPT_DESCRIPTION_MAX} characters.`;
+			return;
+		}
+		if (body.length < 1 || body.length > NAMED_PROMPT_BODY_MAX) {
+			createError = `Body must be 1–${NAMED_PROMPT_BODY_MAX} characters.`;
+			return;
+		}
+
+		creating = true;
+		try {
+			const created = await createNamedPrompt({
+				scope_type,
+				scope_id,
+				name,
+				description: _sanitize(description),
+				body: _sanitize(body),
+			});
+			own = [...own, created].sort((a, b) => a.name.localeCompare(b.name));
+			showAddRow = false;
+			newName = '';
+			newDescription = '';
+			newBody = '';
+		} catch (e) {
+			createError = e instanceof Error ? e.message : 'Failed to create prompt';
+		}
+		creating = false;
+	}
+
+	async function handleSave(prompt: NamedPrompt, description: string, body: string) {
+		_markSaving(prompt.id, true);
+		try {
+			const updated = await updateNamedPrompt(prompt.id, {
+				description: _sanitize(description.trim()),
+				body: _sanitize(body.trim()),
+			});
+			own = own.map((p) => (p.id === updated.id ? updated : p));
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to save prompt';
+		}
+		_markSaving(prompt.id, false);
+	}
+
+	async function handleDelete(prompt: NamedPrompt) {
+		if (!confirm(`Delete prompt "${prompt.name}"? This cannot be undone.`)) return;
+		_markSaving(prompt.id, true);
+		try {
+			await deleteNamedPrompt(prompt.id);
+			own = own.filter((p) => p.id !== prompt.id);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to delete prompt';
+		}
+		_markSaving(prompt.id, false);
+	}
+</script>
+
+<section class="mt-6">
+	<div class="flex items-center justify-between">
+		<h2 class="text-base font-semibold" style="color: var(--color-fg)">Prompts</h2>
+		<button
+			type="button"
+			onclick={() => { showAddRow = !showAddRow; createError = null; }}
+			class="rounded px-3 py-1 text-sm"
+			style="background: var(--color-primary); color: var(--color-bg)"
+		>
+			{showAddRow ? 'Cancel' : '+ Add prompt'}
+		</button>
+	</div>
+	<p class="mt-1 text-xs" style="color: var(--color-muted)">
+		User-picked named prompts surfaced via MCP. Unlike the System prompt, named prompts do not auto-apply to Ask Iris.
+	</p>
+
+	{#if loading}
+		<p class="mt-3 text-sm" style="color: var(--color-muted)">Loading prompts…</p>
+	{/if}
+	{#if error}
+		<p class="mt-3 text-sm text-red-600">{error}</p>
+	{/if}
+
+	{#if showAddRow}
+		<div class="mt-3 rounded border p-3" style="border-color: var(--color-border)">
+			<div class="grid grid-cols-1 gap-2 md:grid-cols-2">
+				<input
+					type="text"
+					bind:value={newName}
+					placeholder="prompt-name (lowercase, hyphens)"
+					maxlength="64"
+					class="rounded border px-2 py-1 text-sm"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+				/>
+				<input
+					type="text"
+					bind:value={newDescription}
+					placeholder="Short description shown in the MCP picker"
+					maxlength={NAMED_PROMPT_DESCRIPTION_MAX}
+					class="rounded border px-2 py-1 text-sm"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+				/>
+			</div>
+			<textarea
+				bind:value={newBody}
+				rows="6"
+				maxlength={NAMED_PROMPT_BODY_MAX}
+				placeholder="Prompt body (markdown OK)"
+				class="mt-2 w-full rounded border px-2 py-1 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
+			></textarea>
+			{#if createError}
+				<p class="mt-2 text-xs text-red-600">{createError}</p>
+			{/if}
+			<div class="mt-2 flex justify-end gap-2">
+				<button
+					type="button"
+					onclick={handleCreate}
+					disabled={creating}
+					class="rounded px-3 py-1 text-sm"
+					style="background: var(--color-primary); color: var(--color-bg)"
+				>
+					{creating ? 'Saving…' : 'Save'}
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	{#if own.length > 0}
+		<ul class="mt-3 space-y-3">
+			{#each own as prompt (prompt.id)}
+				<li class="rounded border p-3" style="border-color: var(--color-border)">
+					{@render promptRow(prompt)}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+
+	{#if inherited.length > 0}
+		<h3 class="mt-6 text-sm font-medium" style="color: var(--color-muted)">
+			Inherited from parent
+		</h3>
+		<ul class="mt-2 space-y-3">
+			{#each inherited as prompt (prompt.id)}
+				<li class="rounded border p-3" style="border-color: var(--color-border); opacity: 0.7">
+					<div class="text-sm font-medium" style="color: var(--color-fg)">{prompt.name}</div>
+					<p class="mt-1 text-xs" style="color: var(--color-muted)">{prompt.description}</p>
+					<p class="mt-1 text-xs italic" style="color: var(--color-muted)">
+						Edit on the parent {prompt.scope_type}'s page.
+					</p>
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</section>
+
+{#snippet promptRow(prompt: NamedPrompt)}
+	{@const isSaving = savingIds.has(prompt.id)}
+	{@const initialDescription = prompt.description}
+	{@const initialBody = prompt.body}
+	{@render editor(prompt, initialDescription, initialBody, isSaving)}
+{/snippet}
+
+{#snippet editor(prompt: NamedPrompt, initialDescription: string, initialBody: string, isSaving: boolean)}
+	<div>
+		<div class="flex items-center justify-between">
+			<div class="text-sm font-medium" style="color: var(--color-fg)">{prompt.name}</div>
+			<button
+				type="button"
+				onclick={() => handleDelete(prompt)}
+				disabled={isSaving}
+				class="text-xs"
+				style="color: var(--color-danger, #b00)"
+			>Delete</button>
+		</div>
+		<form
+			class="mt-2"
+			onsubmit={(e) => {
+				e.preventDefault();
+				const form = e.currentTarget as HTMLFormElement;
+				const data = new FormData(form);
+				const desc = String(data.get('description') ?? '');
+				const body = String(data.get('body') ?? '');
+				handleSave(prompt, desc, body);
+			}}
+		>
+			<input
+				type="text"
+				name="description"
+				value={initialDescription}
+				maxlength={NAMED_PROMPT_DESCRIPTION_MAX}
+				class="w-full rounded border px-2 py-1 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			/>
+			<textarea
+				name="body"
+				rows="6"
+				maxlength={NAMED_PROMPT_BODY_MAX}
+				class="mt-2 w-full rounded border px-2 py-1 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
+				>{initialBody}</textarea>
+			<div class="mt-2 flex justify-end">
+				<button
+					type="submit"
+					disabled={isSaving}
+					class="rounded px-3 py-1 text-sm"
+					style="background: var(--color-primary); color: var(--color-bg)"
+				>
+					{isSaving ? 'Saving…' : 'Save'}
+				</button>
+			</div>
+		</form>
+	</div>
+{/snippet}

--- a/frontend/src/lib/types/named-prompts.ts
+++ b/frontend/src/lib/types/named-prompts.ts
@@ -1,0 +1,45 @@
+/**
+ * ADR-154: Multiple named prompts per scope.
+ *
+ * Mirrors the backend `app/named_prompts/models.py` shapes.
+ */
+
+export type ScopeType = 'collection' | 'set';
+
+export interface NamedPrompt {
+	id: string;
+	scope_type: ScopeType;
+	scope_id: string;
+	name: string;
+	description: string;
+	body: string;
+	created_at: string;
+	updated_at: string;
+	created_by: string | null;
+}
+
+export interface NamedPromptCreate {
+	scope_type: ScopeType;
+	scope_id: string;
+	name: string;
+	description: string;
+	body: string;
+}
+
+export interface NamedPromptUpdate {
+	description?: string;
+	body?: string;
+}
+
+export interface NamedPromptListResponse {
+	items: NamedPrompt[];
+}
+
+/**
+ * Name validation regex matches the backend model
+ * (`app/named_prompts/models.py: NAME_PATTERN`).
+ */
+export const NAMED_PROMPT_NAME_RE = /^[a-z][a-z0-9-]{0,63}$/;
+
+export const NAMED_PROMPT_DESCRIPTION_MAX = 1024;
+export const NAMED_PROMPT_BODY_MAX = 256_000;

--- a/frontend/src/routes/collections/[id]/+page.svelte
+++ b/frontend/src/routes/collections/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { apiFetch } from '$lib/utils/api';
 	import type { IrisCollection, IrisSet } from '$lib/types/api';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import NamedPromptsSection from '$lib/components/NamedPromptsSection.svelte';
 	import DOMPurify from 'dompurify';
 
 	let collection = $state<IrisCollection | null>(null);
@@ -166,6 +167,11 @@
 				Inherited by every Set in this Collection. Applied alongside any Set-level prompt.
 			</p>
 		</div>
+
+		<!-- Named prompts (ADR-154) -->
+		{#if collection}
+			<NamedPromptsSection scope_type="collection" scope_id={collection.id} />
+		{/if}
 
 		<!-- Save button -->
 		<div class="mt-6">

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -7,6 +7,7 @@
 	import type { IrisSet, IrisCollection, Diagram, PaginatedResponse } from '$lib/types/api';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import CollectionSelector from '$lib/components/CollectionSelector.svelte';
+	import NamedPromptsSection from '$lib/components/NamedPromptsSection.svelte';
 	import DOMPurify from 'dompurify';
 
 	let set = $state<IrisSet | null>(null);
@@ -226,6 +227,11 @@
 				Applied in addition to the parent Collection's system prompt.
 			</p>
 		</div>
+
+		<!-- Named prompts (ADR-154) -->
+		{#if set}
+			<NamedPromptsSection scope_type="set" scope_id={set.id} />
+		{/if}
 
 		<!-- Thumbnail -->
 		<fieldset class="mt-6">

--- a/frontend/tests/unit/namedPrompts.test.ts
+++ b/frontend/tests/unit/namedPrompts.test.ts
@@ -1,0 +1,123 @@
+/**
+ * ADR-154 / SPEC-154-A: Named-prompts client wrapper, type shapes,
+ * and validation rules. Light-touch unit tests aligned with this
+ * repo's frontend testing posture (data shape + business rules,
+ * not Svelte component rendering).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	NAMED_PROMPT_BODY_MAX,
+	NAMED_PROMPT_DESCRIPTION_MAX,
+	NAMED_PROMPT_NAME_RE,
+	type NamedPrompt,
+	type NamedPromptCreate,
+	type NamedPromptListResponse,
+} from '$lib/types/named-prompts';
+
+describe('NAMED_PROMPT_NAME_RE', () => {
+	it('accepts lowercase-hyphen names', () => {
+		for (const name of [
+			'a',
+			'outcomes-theory',
+			'diagram-retrieval',
+			'a1',
+			'a-1-b-2',
+			'a'.repeat(64),
+		]) {
+			expect(NAMED_PROMPT_NAME_RE.test(name)).toBe(true);
+		}
+	});
+
+	it('rejects invalid names', () => {
+		for (const name of [
+			'',
+			'1leading-digit',
+			'-leading-hyphen',
+			'Has-Uppercase',
+			'has_underscore',
+			'has spaces',
+			'a'.repeat(65), // too long
+		]) {
+			expect(NAMED_PROMPT_NAME_RE.test(name)).toBe(false);
+		}
+	});
+});
+
+describe('Type shape: NamedPrompt', () => {
+	it('matches the backend Prompt model fields', () => {
+		const p: NamedPrompt = {
+			id: 'p-1',
+			scope_type: 'set',
+			scope_id: 's-1',
+			name: 'np',
+			description: 'd',
+			body: 'b',
+			created_at: '2026-05-11T00:00:00Z',
+			updated_at: '2026-05-11T00:00:00Z',
+			created_by: null,
+		};
+		expect(p.scope_type).toBe('set');
+		expect(p.created_by).toBeNull();
+	});
+
+	it('NamedPromptCreate omits server-set fields', () => {
+		const body: NamedPromptCreate = {
+			scope_type: 'collection',
+			scope_id: 'c-1',
+			name: 'house-rules',
+			description: 'd',
+			body: 'b',
+		};
+		expect(Object.keys(body).sort()).toEqual(
+			['body', 'description', 'name', 'scope_id', 'scope_type'],
+		);
+	});
+
+	it('NamedPromptListResponse wraps an items array', () => {
+		const resp: NamedPromptListResponse = { items: [] };
+		expect(resp.items).toEqual([]);
+	});
+});
+
+describe('Validation constants', () => {
+	it('description max matches backend', () => {
+		expect(NAMED_PROMPT_DESCRIPTION_MAX).toBe(1024);
+	});
+
+	it('body max matches backend', () => {
+		expect(NAMED_PROMPT_BODY_MAX).toBe(256_000);
+	});
+});
+
+describe('Effective-prompts inheritance shape', () => {
+	it('set-scoped names shadow collection-scoped names', () => {
+		// Mirrors the backend logic in
+		// app/named_prompts/service.py:list_effective_prompts_for_set
+		const own: NamedPrompt[] = [
+			{
+				id: 'p-set-1', scope_type: 'set', scope_id: 's',
+				name: 'overridden', description: 'set version', body: 'set body',
+				created_at: 't', updated_at: 't', created_by: null,
+			},
+		];
+		const collectionPrompts: NamedPrompt[] = [
+			{
+				id: 'p-coll-1', scope_type: 'collection', scope_id: 'c',
+				name: 'overridden', description: 'coll version', body: 'coll body',
+				created_at: 't', updated_at: 't', created_by: null,
+			},
+			{
+				id: 'p-coll-2', scope_type: 'collection', scope_id: 'c',
+				name: 'unique-to-collection', description: 'd', body: 'b',
+				created_at: 't', updated_at: 't', created_by: null,
+			},
+		];
+
+		const ownNames = new Set(own.map((p) => p.name));
+		const inherited = collectionPrompts.filter((p) => !ownNames.has(p.name));
+
+		expect(inherited.map((p) => p.name)).toEqual(['unique-to-collection']);
+	});
+});

--- a/iris-client/src/iris_client/models/core.py
+++ b/iris-client/src/iris_client/models/core.py
@@ -118,19 +118,28 @@ class Collection(EntityBase):
 
 
 class ScopePromptIndexEntry(_Permissive):
-    """One entry from `GET /api/prompts/scope-index` (ADR-152, v5.8.3).
+    """One entry from `GET /api/prompts/scope-index` (ADR-152, v5.8.3;
+    extended ADR-154, v5.9.0 to include named prompts).
 
-    Surfaces every Collection / Set with a non-empty system_prompt.
+    Surfaces:
+    - every Collection / Set with a non-empty system_prompt (entry_kind
+      "system_prompt"); name format `set:<uuid>` / `collection:<uuid>`
+    - every named prompt on a Collection / Set (entry_kind "named_prompt");
+      name format `set:<uuid>:<prompt_name>` / `collection:<uuid>:<prompt_name>`
+
     The MCP server maps these into MCP `prompts/list` and `prompts/get`
-    responses so Claude Desktop users can invoke them explicitly.
+    responses so Claude Desktop / Claude Code users can invoke them
+    explicitly.
     """
 
     name: str
+    entry_kind: Literal["system_prompt", "named_prompt"] = "system_prompt"
     scope_type: Literal["collection", "set"]
     scope_id: str
     scope_name: str
     description: str | None = None
     body: str
+    prompt_name: str | None = None  # set only when entry_kind == "named_prompt"
 
 
 class Version(_Permissive):

--- a/iris-client/tests/test_scope_prompts_named.py
+++ b/iris-client/tests/test_scope_prompts_named.py
@@ -1,0 +1,111 @@
+"""ADR-154: iris-client model accepts the extended scope-index shape
+that includes named-prompt entries with `entry_kind` and `prompt_name`.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from iris_client import IrisClient
+from iris_client.models.core import ScopePromptIndexEntry
+
+BASE = "http://iris.test"
+
+
+class TestListScopePromptsExtended:
+    @pytest.mark.asyncio
+    async def test_named_prompt_entry_round_trip(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/prompts/scope-index").mock(
+            return_value=httpx.Response(200, json={
+                "items": [
+                    {
+                        "name": "set:s-1",
+                        "entry_kind": "system_prompt",
+                        "scope_type": "set",
+                        "scope_id": "s-1",
+                        "scope_name": "DoView Book",
+                        "description": "Default directive",
+                        "body": "Use outcomes theory framing.",
+                        "prompt_name": None,
+                    },
+                    {
+                        "name": "set:s-1:outcomes-theory",
+                        "entry_kind": "named_prompt",
+                        "scope_type": "set",
+                        "scope_id": "s-1",
+                        "scope_name": "DoView Book",
+                        "description": "Outcomes theory text response.",
+                        "body": "Apply outcomes theory rules.",
+                        "prompt_name": "outcomes-theory",
+                    },
+                ],
+            }),
+        )
+
+        entries = await pat_client.list_scope_prompts()
+        assert len(entries) == 2
+        sys_entry = entries[0]
+        named_entry = entries[1]
+        assert sys_entry.entry_kind == "system_prompt"
+        assert sys_entry.prompt_name is None
+        assert named_entry.entry_kind == "named_prompt"
+        assert named_entry.prompt_name == "outcomes-theory"
+        assert named_entry.name == "set:s-1:outcomes-theory"
+
+    @pytest.mark.asyncio
+    async def test_legacy_payload_without_new_fields_still_validates(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        """Backwards-compat: a v5.8.5-era backend that doesn't yet emit
+        entry_kind or prompt_name must still produce valid entries
+        (defaults: entry_kind='system_prompt', prompt_name=None)."""
+        respx_mock.get(f"{BASE}/api/prompts/scope-index").mock(
+            return_value=httpx.Response(200, json={
+                "items": [
+                    {
+                        "name": "set:s-1",
+                        "scope_type": "set",
+                        "scope_id": "s-1",
+                        "scope_name": "DoView Book",
+                        "description": None,
+                        "body": "Use outcomes theory framing.",
+                    },
+                ],
+            }),
+        )
+
+        entries = await pat_client.list_scope_prompts()
+        assert len(entries) == 1
+        assert entries[0].entry_kind == "system_prompt"
+        assert entries[0].prompt_name is None
+
+    @pytest.mark.asyncio
+    async def test_model_round_trip_independent_of_client(self) -> None:
+        """ScopePromptIndexEntry alone must accept both shapes."""
+        legacy = ScopePromptIndexEntry.model_validate({
+            "name": "set:s-1",
+            "scope_type": "set",
+            "scope_id": "s-1",
+            "scope_name": "X",
+            "description": None,
+            "body": "y",
+        })
+        assert legacy.entry_kind == "system_prompt"
+        assert legacy.prompt_name is None
+
+        extended = ScopePromptIndexEntry.model_validate({
+            "name": "set:s-1:np",
+            "entry_kind": "named_prompt",
+            "scope_type": "set",
+            "scope_id": "s-1",
+            "scope_name": "X",
+            "description": None,
+            "body": "y",
+            "prompt_name": "np",
+        })
+        assert extended.entry_kind == "named_prompt"
+        assert extended.prompt_name == "np"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.8.5"
+version = "5.9.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/prompts.py
+++ b/mcp/src/iris_mcp/prompts.py
@@ -23,11 +23,15 @@ from mcp import types
 if TYPE_CHECKING:
     from iris_client import IrisClient
 
-# `set:<uuid>` and `collection:<uuid>` — anchored. The MCP server name
-# (`iris`) is already prepended by the client when surfacing prompts in
-# its picker (e.g. Claude Code shows `/iris:set:<uuid>`), so we don't
-# bake `iris:` into the name itself. v5.8.5 dropped the prefix; ADR-153.
-_NAME_RE = re.compile(r"^(set|collection):([0-9a-f-]{36})$")
+# `set:<uuid>[:<prompt_name>]` and `collection:<uuid>[:<prompt_name>]`.
+# The MCP server name (`iris`) is already prepended by the client when
+# surfacing prompts in its picker (e.g. Claude Code shows
+# `/iris:set:<uuid>`), so we don't bake `iris:` into the name itself
+# (v5.8.5 dropped the prefix; ADR-153). v5.9.0 (ADR-154) adds an
+# optional third capture group for named-prompt entries.
+_NAME_RE = re.compile(
+    r"^(?P<scope>set|collection):(?P<uuid>[0-9a-f-]{36})(?::(?P<prompt>[a-z][a-z0-9-]{0,63}))?$",
+)
 
 
 def _web_base() -> str | None:
@@ -42,19 +46,39 @@ def _scope_web_url(scope_type: str, scope_id: str) -> str | None:
     return f"{base}/{scope_type}s/{scope_id}"
 
 
-def _preamble(scope_type: str, scope_name: str, scope_id: str) -> str:
-    """Provenance line that prefixes the system_prompt body."""
+def _preamble(
+    scope_type: str,
+    scope_name: str,
+    scope_id: str,
+    prompt_name: str | None = None,
+) -> str:
+    """Provenance line that prefixes the prompt body.
+
+    For a scope `system_prompt`, omits `prompt_name`. For a named
+    prompt (ADR-154), includes `— prompt "<name>"` in the preamble.
+    """
     label = scope_type.title()
     url = _scope_web_url(scope_type, scope_id)
+    suffix = f' — prompt "{prompt_name}"' if prompt_name else ""
     if url:
-        return f'Loaded from Iris {label} "{scope_name}" ({url}):\n\n'
-    return f'Loaded from Iris {label} "{scope_name}":\n\n'
+        return f'Loaded from Iris {label} "{scope_name}"{suffix} ({url}):\n\n'
+    return f'Loaded from Iris {label} "{scope_name}"{suffix}:\n\n'
 
 
-def _short_description(scope_type: str, scope_name: str, scope_description: str | None) -> str:
+def _short_description(
+    scope_type: str,
+    scope_name: str,
+    scope_description: str | None,
+    prompt_name: str | None = None,
+) -> str:
     """Description shown in the MCP prompt picker.
 
-    Format: `{Scope}: {name} — {description}` truncated at 200 chars.
+    Format for scope `system_prompt`:
+        `{Scope}: {scope_name} — {scope_description}`
+    Format for a named prompt (ADR-154):
+        `{Scope}: {scope_name} — {prompt_name} — {prompt_description}`
+
+    Truncated at 200 chars.
 
     v5.8.4: when the scope's description already starts with the scope
     name (common Iris authoring pattern), strip that prefix so the
@@ -67,7 +91,12 @@ def _short_description(scope_type: str, scope_name: str, scope_description: str 
     desc = (scope_description or "").strip()
     if desc:
         desc = _strip_redundant_name_prefix(desc, scope_name)
-    combined = f"{base} — {desc}" if desc else base
+    if prompt_name:
+        # Insert prompt name between scope and description.
+        middle = prompt_name
+        combined = f"{base} — {middle} — {desc}" if desc else f"{base} — {middle}"
+    else:
+        combined = f"{base} — {desc}" if desc else base
     if len(combined) > 200:  # noqa: PLR2004
         combined = combined[:197] + "..."
     return combined
@@ -89,13 +118,14 @@ def _strip_redundant_name_prefix(description: str, scope_name: str) -> str:
 
 
 async def list_prompts(client: IrisClient) -> list[types.Prompt]:
-    """Return MCP `Prompt` objects for every scope with a system_prompt."""
+    """Return MCP `Prompt` objects for every system_prompt and named prompt."""
     entries = await client.list_scope_prompts()
     return [
         types.Prompt(
             name=entry.name,
             description=_short_description(
                 entry.scope_type, entry.scope_name, entry.description,
+                prompt_name=entry.prompt_name,
             ),
             arguments=[],
         )
@@ -108,15 +138,19 @@ async def get_prompt(
     name: str,
     _arguments: dict[str, str] | None = None,
 ) -> types.GetPromptResult:
-    """Return the body of the named scope prompt as a single user message.
+    """Return the body of the named scope or named prompt as a single user message.
 
-    Raises ValueError when `name` is malformed or the named scope has no
-    system_prompt. The MCP server framework converts ValueErrors into the
+    Raises ValueError when `name` is malformed or the prompt does not
+    exist. The MCP server framework converts ValueErrors into the
     spec-defined error responses.
     """
     match = _NAME_RE.match(name)
     if match is None:
-        msg = f"Invalid Iris scope-prompt name: {name!r}. Expected `set:<uuid>` or `collection:<uuid>`."
+        msg = (
+            f"Invalid Iris prompt name: {name!r}. Expected "
+            "`set:<uuid>`, `collection:<uuid>`, `set:<uuid>:<prompt>`, "
+            "or `collection:<uuid>:<prompt>`."
+        )
         raise ValueError(msg)
 
     # Resolve from the index (single backend round-trip already includes
@@ -125,17 +159,21 @@ async def get_prompt(
     entry = next((e for e in entries if e.name == name), None)
     if entry is None:
         msg = (
-            f"Iris scope-prompt {name!r} not found. The scope may have been "
-            "deleted, or its system_prompt was cleared."
+            f"Iris prompt {name!r} not found. The scope may have been "
+            "deleted, or its system_prompt / named prompt was cleared."
         )
         raise ValueError(msg)
 
-    preamble = _preamble(entry.scope_type, entry.scope_name, entry.scope_id)
+    preamble = _preamble(
+        entry.scope_type, entry.scope_name, entry.scope_id,
+        prompt_name=entry.prompt_name,
+    )
     text = preamble + entry.body
 
     return types.GetPromptResult(
         description=_short_description(
             entry.scope_type, entry.scope_name, entry.description,
+            prompt_name=entry.prompt_name,
         ),
         messages=[
             types.PromptMessage(

--- a/mcp/tests/test_prompts_get.py
+++ b/mcp/tests/test_prompts_get.py
@@ -99,13 +99,13 @@ class TestGetPromptErrors:
     @pytest.mark.asyncio
     async def test_malformed_name_raises_value_error(self) -> None:
         client: Any = _StubClient([])
-        with pytest.raises(ValueError, match="Invalid Iris scope-prompt name"):
+        with pytest.raises(ValueError, match="Invalid Iris prompt name"):
             await iris_prompts.get_prompt(client, "nope")
 
     @pytest.mark.asyncio
     async def test_wrong_scope_type_in_name_raises(self) -> None:
         client: Any = _StubClient([])
-        with pytest.raises(ValueError, match="Invalid Iris scope-prompt name"):
+        with pytest.raises(ValueError, match="Invalid Iris prompt name"):
             await iris_prompts.get_prompt(
                 client, "iris:diagram:11111111-1111-1111-1111-111111111111",
             )

--- a/mcp/tests/test_prompts_get_named.py
+++ b/mcp/tests/test_prompts_get_named.py
@@ -1,0 +1,75 @@
+"""ADR-154: MCP `prompts/get` handler resolves three-segment named-prompt
+names (set:<uuid>:<name> / collection:<uuid>:<name>) and includes the
+prompt name in the provenance preamble.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from iris_client.models.core import ScopePromptIndexEntry
+
+from iris_mcp import prompts as iris_prompts
+
+
+class _StubClient:
+    def __init__(self, entries: list[ScopePromptIndexEntry]) -> None:
+        self._entries = entries
+
+    async def list_scope_prompts(self) -> list[ScopePromptIndexEntry]:
+        return list(self._entries)
+
+
+SET_UUID = "00000000-0000-0000-0000-000000000001"
+
+
+def _named_entry(**kwargs: Any) -> ScopePromptIndexEntry:
+    defaults = {
+        "name": f"set:{SET_UUID}:outcomes-theory",
+        "entry_kind": "named_prompt",
+        "scope_type": "set",
+        "scope_id": SET_UUID,
+        "scope_name": "DoView Book",
+        "description": "Outcomes-theory text response.",
+        "body": "Apply outcomes theory rules.",
+        "prompt_name": "outcomes-theory",
+    }
+    defaults.update(kwargs)
+    return ScopePromptIndexEntry(**defaults)
+
+
+class TestGetPromptNamed:
+    @pytest.mark.asyncio
+    async def test_named_prompt_happy_path(self) -> None:
+        client: Any = _StubClient([_named_entry()])
+        result = await iris_prompts.get_prompt(client, f"set:{SET_UUID}:outcomes-theory")
+        assert len(result.messages) == 1
+        msg = result.messages[0]
+        assert msg.role == "user"
+        text = msg.content.text
+        # Body present.
+        assert "Apply outcomes theory rules." in text
+        # Preamble includes prompt name.
+        assert 'prompt "outcomes-theory"' in text
+        # Scope name present.
+        assert '"DoView Book"' in text
+
+    @pytest.mark.asyncio
+    async def test_three_segment_name_rejected_when_malformed(self) -> None:
+        client: Any = _StubClient([])
+        # UPPERCASE in prompt segment is not allowed by the regex.
+        with pytest.raises(ValueError, match="Invalid Iris prompt name"):
+            await iris_prompts.get_prompt(client, f"set:{SET_UUID}:Has-Upper")
+
+    @pytest.mark.asyncio
+    async def test_unknown_named_prompt_raises(self) -> None:
+        client: Any = _StubClient([])
+        with pytest.raises(ValueError, match="not found"):
+            await iris_prompts.get_prompt(client, f"set:{SET_UUID}:nope")
+
+    @pytest.mark.asyncio
+    async def test_description_includes_prompt_name(self) -> None:
+        client: Any = _StubClient([_named_entry()])
+        result = await iris_prompts.get_prompt(client, f"set:{SET_UUID}:outcomes-theory")
+        assert result.description == "Set: DoView Book — outcomes-theory — Outcomes-theory text response."

--- a/mcp/tests/test_prompts_list_named.py
+++ b/mcp/tests/test_prompts_list_named.py
@@ -1,0 +1,83 @@
+"""ADR-154: MCP `prompts/list` includes named-prompt entries with
+prompt_name interpolated into the picker description.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from iris_client.models.core import ScopePromptIndexEntry
+
+from iris_mcp import prompts as iris_prompts
+
+
+class _StubClient:
+    def __init__(self, entries: list[ScopePromptIndexEntry]) -> None:
+        self._entries = entries
+
+    async def list_scope_prompts(self) -> list[ScopePromptIndexEntry]:
+        return list(self._entries)
+
+
+def _system_entry(**kwargs: Any) -> ScopePromptIndexEntry:
+    defaults = {
+        "name": "set:00000000-0000-0000-0000-000000000001",
+        "entry_kind": "system_prompt",
+        "scope_type": "set",
+        "scope_id": "00000000-0000-0000-0000-000000000001",
+        "scope_name": "DoView Book",
+        "description": None,
+        "body": "system body",
+        "prompt_name": None,
+    }
+    defaults.update(kwargs)
+    return ScopePromptIndexEntry(**defaults)
+
+
+def _named_entry(**kwargs: Any) -> ScopePromptIndexEntry:
+    defaults = {
+        "name": "set:00000000-0000-0000-0000-000000000001:outcomes-theory",
+        "entry_kind": "named_prompt",
+        "scope_type": "set",
+        "scope_id": "00000000-0000-0000-0000-000000000001",
+        "scope_name": "DoView Book",
+        "description": "Outcomes-theory text response.",
+        "body": "named body",
+        "prompt_name": "outcomes-theory",
+    }
+    defaults.update(kwargs)
+    return ScopePromptIndexEntry(**defaults)
+
+
+class TestListPromptsNamed:
+    @pytest.mark.asyncio
+    async def test_named_prompt_appears_in_list(self) -> None:
+        client: Any = _StubClient([_named_entry()])
+        result = await iris_prompts.list_prompts(client)
+        assert len(result) == 1
+        assert result[0].name == "set:00000000-0000-0000-0000-000000000001:outcomes-theory"
+
+    @pytest.mark.asyncio
+    async def test_description_format_includes_prompt_name(self) -> None:
+        client: Any = _StubClient([_named_entry()])
+        result = await iris_prompts.list_prompts(client)
+        # Format: "Set: {scope_name} — {prompt_name} — {prompt_description}"
+        assert result[0].description == "Set: DoView Book — outcomes-theory — Outcomes-theory text response."
+
+    @pytest.mark.asyncio
+    async def test_system_and_named_coexist_in_order(self) -> None:
+        client: Any = _StubClient([_system_entry(), _named_entry()])
+        result = await iris_prompts.list_prompts(client)
+        assert len(result) == 2
+        # Order preserved from upstream.
+        assert result[0].name == "set:00000000-0000-0000-0000-000000000001"
+        assert result[1].name == "set:00000000-0000-0000-0000-000000000001:outcomes-theory"
+
+    @pytest.mark.asyncio
+    async def test_named_prompt_description_without_body_description(self) -> None:
+        """If a named prompt's own description happens to be empty,
+        picker still shows scope + prompt_name."""
+        client: Any = _StubClient([_named_entry(description="")])
+        result = await iris_prompts.list_prompts(client)
+        assert result[0].description == "Set: DoView Book — outcomes-theory"


### PR DESCRIPTION
## Summary

- Adds a new `prompts` table for zero-or-more named prompts per Collection or Set, additive to the v5.8.0 `system_prompt` column.
- Named prompts are surfaced via the existing v5.8.3 MCP `prompts` channel as `set:<uuid>:<name>` / `collection:<uuid>:<name>` (post-ADR-153 naming) — users see them as `/iris:set:<uuid>:<name>` in the Claude prompt picker.
- Inheritance is additive per ADR-150: a Set sees its own named prompts plus its parent Collection's. Set-scoped names shadow Collection-scoped names with the same string.
- **No auto-apply** for named prompts. Scope `system_prompt` continues to auto-prepend in Ask Iris and Iris MCP `ask` unchanged. Used by Iris's internal AI discussion/create flows.
- New `Prompts` section on `/sets/[id]` and `/collections/[id]` edit pages for per-row authoring.
- DoView Book draft content under `docs/prompts/*-iris.md` (Prompt A split-style text, Prompt B split-style diagrams, **Prompt C** merged single-turn) — intended for upload as named prompts on the DoView Book Set once v5.9.0 ships.

See [ADR-154](docs/adrs/ADR-154-Multiple-Named-Prompts-per-Scope.md) and [SPEC-154-A](docs/adrs/specs/SPEC-154-A-Named-Prompts.md). Note: ADR-153 was already claimed by v5.8.5's `iris:` prefix drop.

## Test plan

- [x] `backend/tests/test_migrations/test_named_prompts_schema.py` — 6 cases (SQLite + Supabase schema + idempotency + RLS)
- [x] `backend/tests/test_named_prompts/test_crud.py` — 14 cases (CRUD + validation + inheritance + anonymous read)
- [x] `backend/tests/test_prompts/test_router_named_prompts_extension.py` — 4 cases (scope-index extension)
- [x] `iris-client/tests/test_scope_prompts_named.py` — 3 cases (extended model accepts legacy + new shape)
- [x] `mcp/tests/test_prompts_list_named.py` — 4 cases (named entries in `prompts/list`)
- [x] `mcp/tests/test_prompts_get_named.py` — 4 cases (three-segment name resolves, preamble includes prompt_name)
- [x] `frontend/tests/unit/namedPrompts.test.ts` — 8 cases (name regex, type shapes, inheritance shadowing)
- [x] **No regressions**: v5.8.x test suites (`test_ai/test_scope_prompts`, `test_prompts/test_router`, `test_collections/test_crud`, MCP `test_prompts_list`/`test_prompts_get`) all still pass. **181 tests total pass across all four layers.**

## End-to-end UAT (post-merge)

1. `git pull` on UAT branch after merge.
2. `./scripts/dev.sh restart`.
3. Navigate to `/sets/<doview-book-set-id>`; verify the System prompt textarea is unchanged AND a new Prompts section appears.
4. Add two named prompts using the Prompt A / Prompt B / Prompt C content from `docs/prompts/*-iris.md`.
5. In Claude Code with Iris MCP connected, verify the prompt picker shows:
   - `/iris:set:<uuid>` (existing system_prompt)
   - `/iris:set:<uuid>:outcomes-theory-text-response`
   - `/iris:set:<uuid>:diagram-retrieval` (or `/iris:set:<uuid>:combined` for the Prompt C variant)
6. Invoke each — confirm the body loads as a user-role directive that Claude follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)