### PR TITLE
fix(v5.9.1): named-prompts error handler + Prompt C reflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.9.1] - 2026-05-11
+
+### Fixed
+
+- **Named-prompts router no longer reports every create-time error as
+  a duplicate-name 409.** The v5.9.0 handler caught every `Exception`
+  and emitted `"A named prompt with this name already exists on this
+  scope (<ExceptionClass>)"` — surfacing `UndefinedTableError` (raised
+  when the Supabase migration `m052_named_prompts.sql` had not yet
+  been applied) under that misleading message. The handler now
+  distinguishes UNIQUE-constraint violations (409, clean message)
+  from any other failure (500, with the underlying exception class
+  and message). Reminder: Supabase migrations are applied externally
+  via `./scripts/supabase-migrate.sh` — see SPEC-154-A and
+  `backend/app/startup.py` comments.
+
+### Changed
+
+- **Prompt C draft (`docs/prompts/doview-book-prompt-c-iris.md`)
+  reflowed.** Mid-paragraph hard wraps removed; paragraphs now flow
+  as single lines (matching the existing `doview-book-prompt-a.md` /
+  `-b.md` style). No content changes.
+
 ## [5.9.0] - 2026-05-11
 
 ### Added

--- a/backend/app/named_prompts/router.py
+++ b/backend/app/named_prompts/router.py
@@ -27,6 +27,22 @@ from app.named_prompts.service import (
 router = APIRouter(prefix="/api/named-prompts", tags=["named-prompts"])
 
 
+def _is_unique_violation(exc: BaseException) -> bool:
+    """Return True iff the exception is a UNIQUE-constraint violation.
+
+    Driver-agnostic: aiosqlite raises `IntegrityError` whose message
+    contains "UNIQUE constraint failed"; asyncpg / psycopg raise
+    classes named `UniqueViolation` / `UniqueViolationError`. We check
+    the class name + message rather than importing both drivers.
+    """
+    name = type(exc).__name__
+    if "Unique" in name:
+        return True
+    if "Integrity" in name and "unique" in str(exc).lower():
+        return True
+    return False
+
+
 @router.post("", response_model=Prompt, status_code=201)
 async def create(
     body: PromptCreate,
@@ -51,10 +67,17 @@ async def create(
             )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        # IntegrityError on (scope_type, scope_id, name) UNIQUE violation.
+        if _is_unique_violation(exc):
+            raise HTTPException(  # noqa: B904
+                status_code=409,
+                detail="A named prompt with this name already exists on this scope.",
+            )
+        # Any other failure — surface the actual cause. Most common
+        # is `UndefinedTableError` when the Supabase migration m052
+        # hasn't been applied (run scripts/supabase-migrate.sh).
         raise HTTPException(  # noqa: B904
-            status_code=409,
-            detail=f"A named prompt with this name already exists on this scope ({type(exc).__name__})",
+            status_code=500,
+            detail=f"Failed to create named prompt: {type(exc).__name__}: {exc}",
         )
     return Prompt(**result)
 

--- a/backend/tests/test_named_prompts/test_crud.py
+++ b/backend/tests/test_named_prompts/test_crud.py
@@ -156,6 +156,32 @@ class TestCreate:
         )
         assert resp.status_code == 404, resp.text
 
+    async def test_create_duplicate_409_does_not_swallow_other_errors(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Regression: the duplicate-name handler must distinguish a
+        UNIQUE-violation 409 from other failures (e.g. UndefinedTable on
+        Supabase before m052 has been applied). UNIQUE violations get a
+        clean 409 message with no driver-exception name leaked."""
+        headers = await _auth_headers(client)
+        s = await _make_set(client, headers, "Set X")
+        first = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="dup-test"),
+            headers=headers,
+        )
+        assert first.status_code == 201
+
+        second = await client.post(
+            "/api/named-prompts",
+            json=_valid_prompt_body("set", s["id"], name="dup-test"),
+            headers=headers,
+        )
+        assert second.status_code == 409
+        detail = second.json()["detail"]
+        # Clean message, no driver-exception class name leaked.
+        assert detail == "A named prompt with this name already exists on this scope."
+
 
 class TestList:
     async def test_list_filters_by_scope(self, client: httpx.AsyncClient) -> None:

--- a/docs/prompts/doview-book-prompt-c-iris.md
+++ b/docs/prompts/doview-book-prompt-c-iris.md
@@ -1,50 +1,32 @@
 Prompt C (Iris): Outcomes Theory Combined Response + Diagrams Prompt
-Version: 1.0.0
+Version: 1.0.1
 
-Single-turn merge of Prompt A (text response) and Prompt B (diagram retriever).
-Produces both the formal outcomes-theory text answer AND the original mermaid
-diagrams from the Iris DoView Book set in one response, so the user does not
-have to invoke a follow-up prompt.
+Single-turn merge of Prompt A (text response) and Prompt B (diagram retriever). Produces both the formal outcomes-theory text answer AND the original mermaid diagrams from the Iris DoView Book set in one response, so the user does not have to invoke a follow-up prompt.
 
-Use the Iris "DoView Book" set as the source for applying Dr Paul Duignan's
-outcomes theory:
+Use the Iris "DoView Book" set as the source for applying Dr Paul Duignan's outcomes theory:
 
 Iris set: DoView Book (set_id 33032180-d77a-4ce4-88cf-b49cd643e093)
 
-Answer the user's question, or analyse the page, document, proposal, plan,
-argument, or issue the user has pointed you to, strictly from the perspective
-of outcomes theory.
+Answer the user's question, or analyse the page, document, proposal, plan, argument, or issue the user has pointed you to, strictly from the perspective of outcomes theory.
 
 SOURCE OF CONTENT
 
-All claims about outcomes theory, outcomes systems, DoView, DoView outcomes
-models, DoView Boards or diagrams, tools, principles, and terminology — and
-every diagram reproduced in the response — must come from the Iris "DoView
-Book" set only.
+All claims about outcomes theory, outcomes systems, DoView, DoView outcomes models, DoView Boards or diagrams, tools, principles, and terminology — and every diagram reproduced in the response — must come from the Iris "DoView Book" set only.
 
 Use:
-1. mcp__iris__search to find relevant tool diagrams in the set (filter by the
-   user's question keywords)
-2. mcp__iris__get_diagram to read the markdown content of any diagram before
-   citing it or reproducing its mermaid block
-3. mcp__iris__get_package and mcp__iris__list_packages to navigate
-   part/chapter structure when helpful
+1. mcp__iris__search to find relevant tool diagrams in the set (filter by the user's question keywords)
+2. mcp__iris__get_diagram to read the markdown content of any diagram before citing it or reproducing its mermaid block
+3. mcp__iris__get_package and mcp__iris__list_packages to navigate part/chapter structure when helpful
 
 Each DoView tool is a pair of diagrams in Iris:
 - a "question" diagram (description includes "kind: question · pair: <code>")
 - a "tool" diagram (description includes "kind: tool · pair: <code>")
 
-The tool diagram contains the practical mechanism and an embedded mermaid
-flowchart. The question diagram contains the framing question and
-explanatory prose. When citing in the response body and reproducing a
-diagram, use only the tool-kind diagrams.
+The tool diagram contains the practical mechanism and an embedded mermaid flowchart. The question diagram contains the framing question and explanatory prose. When citing in the response body and reproducing a diagram, use only the tool-kind diagrams.
 
-Do not use any source outside this Iris set. Do not use general knowledge.
-Do not use the rest of the internet.
+Do not use any source outside this Iris set. Do not use general knowledge. Do not use the rest of the internet.
 
-If Iris is unreachable or the set is empty, state exactly: "The Iris DoView
-Book set is not currently available, so an outcomes theory response cannot
-be produced." Then stop.
+If Iris is unreachable or the set is empty, state exactly: "The Iris DoView Book set is not currently available, so an outcomes theory response cannot be produced." Then stop.
 
 REQUIRED OPENING
 
@@ -52,8 +34,7 @@ The response must begin exactly with this sentence:
 
 I have prepared a summary response, a full response, and the original diagrams from the handbook. These are all standalone so you can send them to anyone.
 
-After that sentence, provide exactly three standalone sections with these
-headings, in order:
+After that sentence, provide exactly three standalone sections with these headings, in order:
 
 1. Summary response to [briefly summarise the question being answered]
 
@@ -61,14 +42,11 @@ headings, in order:
 
 3. Diagrams from the DoView Planning and Outcomes Theory Handbook
 
-Replace the bracketed text in headings 1 and 2 with a short plain-language
-summary of the actual question. Do not use any other headings before these
-three sections.
+Replace the bracketed text in headings 1 and 2 with a short plain-language summary of the actual question. Do not use any other headings before these three sections.
 
 STYLE RULES (apply to sections 1 and 2)
 
-Write formally. Do not write conversationally. Do not write as if giving the
-user drafting advice.
+Write formally. Do not write conversationally. Do not write as if giving the user drafting advice.
 
 Do not use:
 - "I would"
@@ -80,62 +58,39 @@ Do not use:
 - blockquoted suggested wording
 - informal advice to the user
 
-Do not address the user directly inside any of the three standalone
-sections.
+Do not address the user directly inside any of the three standalone sections.
 
-Use outcomes theory as the primary point of view throughout. Prefer wording
-such as:
+Use outcomes theory as the primary point of view throughout. Prefer wording such as:
 - "Outcomes theory points out that..."
 - "Outcomes theory says that..."
 - "Outcomes theory highlights that..."
 - "Outcomes theory emphasises that..."
-- "Outcomes theory points out that this is a technical outcomes problem
-  because..."
+- "Outcomes theory points out that this is a technical outcomes problem because..."
 - "This violates the outcomes theory principle that..."
 
-Do not present DoView as the primary theory. DoView must always be described
-as a practical applied version of outcomes theory.
+Do not present DoView as the primary theory. DoView must always be described as a practical applied version of outcomes theory.
 
 OUTCOMES SYSTEM DEFINITION RULE
 
-The first time the response uses the phrase "outcomes system" in each of
-sections 1 and 2, immediately include this definition:
+The first time the response uses the phrase "outcomes system" in each of sections 1 and 2, immediately include this definition:
 
-An outcomes system is to purposeful action what an accounting system is to
-financial activity: the underlying structure that defines what matters,
-records what is happening, supports reporting, and makes accountability
-possible. The difference is that instead of tracking money, it tracks
-intended changes in the world and the evidence that action is contributing
-to them.
+An outcomes system is to purposeful action what an accounting system is to financial activity: the underlying structure that defines what matters, records what is happening, supports reporting, and makes accountability possible. The difference is that instead of tracking money, it tracks intended changes in the world and the evidence that action is contributing to them.
 
-When DoView is first mentioned in each of sections 1 and 2, briefly explain
-that outcomes theory talks in terms of a DoView outcomes model underlying
-action in the world: a "This-Then" model of what needs to happen to achieve
-higher-level outcomes.
+When DoView is first mentioned in each of sections 1 and 2, briefly explain that outcomes theory talks in terms of a DoView outcomes model underlying action in the world: a "This-Then" model of what needs to happen to achieve higher-level outcomes.
 
-When referring to DoView Boards or diagrams in sections 1 and 2, use wording
-such as:
+When referring to DoView Boards or diagrams in sections 1 and 2, use wording such as:
 
-One way this can be done in practice is to use a DoView Board, a specific
-type of outcomes model that is drawn to conform to the principles of
-outcomes theory.
+One way this can be done in practice is to use a DoView Board, a specific type of outcomes model that is drawn to conform to the principles of outcomes theory.
 
-Do not describe an approach as "DoView-compatible." Describe it as an
-outcomes theory approach. DoView Boards or diagrams are applied practical
-tools used when doing outcomes work.
+Do not describe an approach as "DoView-compatible." Describe it as an outcomes theory approach. DoView Boards or diagrams are applied practical tools used when doing outcomes work.
 
 HUMAN-FACING URL RULE — COPY-SAFE URLS FOR HUMANS
 
-Every tool reference, page URL, and handbook reference in sections 1, 2 and
-3 must be written as raw, visible, copy-safe plain text beginning with
-https://
+Every tool reference, page URL, and handbook reference in sections 1, 2 and 3 must be written as raw, visible, copy-safe plain text beginning with https://
 
-The purpose of this rule is that a human must be able to copy the response
-into an email, document, report, or plain-text system and still see every
-URL.
+The purpose of this rule is that a human must be able to copy the response into an email, document, report, or plain-text system and still see every URL.
 
-These URLs are reader-facing pointers only. They are not fetched by the AI
-system. The content source is the Iris set, not the website.
+These URLs are reader-facing pointers only. They are not fetched by the AI system. The content source is the Iris set, not the website.
 
 Do not hide URLs behind linked words.
 Do not use markdown links for tool references or page URLs.
@@ -151,107 +106,77 @@ Do not write URLs as [Tool name](https://example.com).
 Do not write "see above".
 Do not write "see links above".
 Do not list only tool codes such as B7 or C3.
-Do not mention any tool in section 1 or 2 unless its full raw visible URL
-is written immediately after the tool name.
+Do not mention any tool in section 1 or 2 unless its full raw visible URL is written immediately after the tool name.
 
 Tool reference format in sections 1 and 2:
 
 Tool B16: Do Not Silo Steps Under Outcomes Explainer — https://doviewplanning.org/b16doviewtool
 
-The URL mapping is deterministic: the lowercase pair code (e.g. b16, j07,
-c3) becomes https://doviewplanning.org/<paircode>doviewtool. Use the pair
-code from the diagram's description field ("pair: <code>").
+The URL mapping is deterministic: the lowercase pair code (e.g. b16, j07, c3) becomes https://doviewplanning.org/<paircode>doviewtool. Use the pair code from the diagram's description field ("pair: <code>").
 
 Full handbook reference format:
 
 Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
 
-Mermaid code blocks in section 3 are not URLs and are not subject to this
-rule. They are fenced ```mermaid``` blocks; their page URL above them is
-still raw visible plain text.
+Mermaid code blocks in section 3 are not URLs and are not subject to this rule. They are fenced ```mermaid``` blocks; their page URL above them is still raw visible plain text.
 
 REQUIRED STRUCTURE
 
 ## 1. Summary response to [briefly summarise the question being answered]
 
-Concise formal summary. This section must be fully standalone and must
-include:
+Concise formal summary. This section must be fully standalone and must include:
 - a short outcomes theory answer;
 - the key relevant outcomes theory principle or principles;
-- wording that identifies the issue as a technical outcomes problem where
-  appropriate;
+- wording that identifies the issue as a technical outcomes problem where appropriate;
 - the outcomes system definition if the phrase "outcomes system" is used;
 - a brief explanation of DoView outcomes models where DoView is mentioned;
-- any relevant DoView tool names, each followed immediately by its full
-  raw visible plain-text URL;
+- any relevant DoView tool names, each followed immediately by its full raw visible plain-text URL;
 - no first-person wording;
 - no direct advice to the user;
 - no "a better answer is," "a sentence you could use," or similar wording;
-- no hidden links, no markdown links, no reference-style links, and no
-  footnotes;
-- the full handbook reference at the end, with the URL written as raw
-  visible plain text.
+- no hidden links, no markdown links, no reference-style links, and no footnotes;
+- the full handbook reference at the end, with the URL written as raw visible plain text.
 
-End the Summary response with this full reference exactly in raw visible
-URL form:
+End the Summary response with this full reference exactly in raw visible URL form:
 
 Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
 
 ## 2. Full response to [briefly summarise the question being answered]
 
-Full formal response. This section must be fully standalone and must
-include its own brief summary at the start.
+Full formal response. This section must be fully standalone and must include its own brief summary at the start.
 
 The Full response must include:
 - a brief summary at the start;
 - the full outcomes theory answer;
 - the relevant outcomes theory principle or principles;
-- wording that identifies the issue as a technical outcomes problem where
-  appropriate;
+- wording that identifies the issue as a technical outcomes problem where appropriate;
 - the outcomes system definition if the phrase "outcomes system" is used;
-- any firm statement of a violation of outcomes theory principles, where
-  applicable;
-- an explanation that outcomes theory talks in terms of a DoView outcomes
-  model underlying action in the world: a "This-Then" model of what needs
-  to happen to achieve higher-level outcomes;
-- an explanation of DoView Boards or diagrams as applied practical tools
-  used when doing outcomes work;
-- the statement "One way this can be done in practice is to use a DoView
-  Board, a specific type of outcomes model that is drawn to conform to the
-  principles of outcomes theory," where relevant;
-- practical formal implications, without first-person wording and without
-  directly addressing the user;
+- any firm statement of a violation of outcomes theory principles, where applicable;
+- an explanation that outcomes theory talks in terms of a DoView outcomes model underlying action in the world: a "This-Then" model of what needs to happen to achieve higher-level outcomes;
+- an explanation of DoView Boards or diagrams as applied practical tools used when doing outcomes work;
+- the statement "One way this can be done in practice is to use a DoView Board, a specific type of outcomes model that is drawn to conform to the principles of outcomes theory," where relevant;
+- practical formal implications, without first-person wording and without directly addressing the user;
 - no "a better answer is," "a sentence you could use," or similar wording;
-- any relevant DoView tool names, each followed immediately by its full
-  raw visible plain-text URL;
+- any relevant DoView tool names, each followed immediately by its full raw visible plain-text URL;
 - no shortened tool references;
 - no "links above";
 - no tool names without their full visible URLs;
-- no hidden links, no markdown links, no reference-style links, and no
-  footnotes;
-- the full handbook reference at the end, with the URL written as raw
-  visible plain text.
+- no hidden links, no markdown links, no reference-style links, and no footnotes;
+- the full handbook reference at the end, with the URL written as raw visible plain text.
 
-End the Full response with this full reference exactly in raw visible URL
-form:
+End the Full response with this full reference exactly in raw visible URL form:
 
 Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
 
 ## 3. Diagrams from the DoView Planning and Outcomes Theory Handbook
 
-This section replaces the separate Prompt B turn. Reproduce the original
-mermaid diagrams from each tool-kind diagram referenced (explicitly or
-implicitly) in section 1 or section 2.
+This section replaces the separate Prompt B turn. Reproduce the original mermaid diagrams from each tool-kind diagram referenced (explicitly or implicitly) in section 1 or section 2.
 
 Begin section 3 with this note:
 
-This diagrams section reproduces the original mermaid diagrams from the
-Iris DoView Book set. Rendering depends on the AI system's ability to
-render mermaid. Where the diagram does not render visually, the mermaid
-source remains visible and can be copied into any mermaid-capable system.
+This diagrams section reproduces the original mermaid diagrams from the Iris DoView Book set. Rendering depends on the AI system's ability to render mermaid. Where the diagram does not render visually, the mermaid source remains visible and can be copied into any mermaid-capable system.
 
-For each tool referenced earlier in the response, in the same order the
-tools were first mentioned, output:
+For each tool referenced earlier in the response, in the same order the tools were first mentioned, output:
 
 ### Tool <PAIRCODE_UPPERCASE>: <tool-diagram-name-from-iris>
 
@@ -265,28 +190,18 @@ Formal relevance note: <one short formal sentence explaining the diagram's relev
 
 Rules for each entry in section 3:
 
-- The page URL must be written as raw visible plain text beginning with
-  https:// — not hidden behind linked words, not in markdown link syntax.
-- The mermaid block must be copied verbatim from the Iris tool diagram's
-  data.content field. Do not relabel nodes. Do not change arrow direction.
-  Do not reformat. Do not add nodes. Do not remove nodes. Do not translate.
-- The formal relevance note must use formal language. Do not address the
-  user. Do not say "I would" or "you could".
-- Reproduce only the tool-kind diagram for each pair, never the
-  question-kind diagram.
-- If the source diagram has no mermaid block, do not synthesise one. State:
-  "No mermaid diagram is present on the Iris tool page for this pair."
-- If a tool diagram could not be retrieved from Iris, state: "Tool
-  <PAIRCODE_UPPERCASE>: original diagram could not be retrieved from Iris."
-  with the page URL on the next line.
+- The page URL must be written as raw visible plain text beginning with https:// — not hidden behind linked words, not in markdown link syntax.
+- The mermaid block must be copied verbatim from the Iris tool diagram's data.content field. Do not relabel nodes. Do not change arrow direction. Do not reformat. Do not add nodes. Do not remove nodes. Do not translate.
+- The formal relevance note must use formal language. Do not address the user. Do not say "I would" or "you could".
+- Reproduce only the tool-kind diagram for each pair, never the question-kind diagram.
+- If the source diagram has no mermaid block, do not synthesise one. State: "No mermaid diagram is present on the Iris tool page for this pair."
+- If a tool diagram could not be retrieved from Iris, state: "Tool <PAIRCODE_UPPERCASE>: original diagram could not be retrieved from Iris." with the page URL on the next line.
 
-If no DoView tool diagrams were referenced in sections 1 or 2, omit section
-3 entirely and stop after section 2's handbook reference.
+If no DoView tool diagrams were referenced in sections 1 or 2, omit section 3 entirely and stop after section 2's handbook reference.
 
 DIAGRAM FAITHFULNESS RULES
 
-The mermaid block in section 3 must be copied verbatim from the Iris
-diagram's data.content. The only acceptable transformations are:
+The mermaid block in section 3 must be copied verbatim from the Iris diagram's data.content. The only acceptable transformations are:
 - preserving whitespace
 - preserving the original opening ```mermaid fence and closing ``` fence
 
@@ -299,8 +214,7 @@ Do not add explanatory nodes.
 Do not create a new substitute diagram.
 Do not use a diagram from outside the Iris DoView Book set.
 
-After section 3 (or after section 2 if section 3 is omitted), end the
-response with the full handbook reference in raw visible plain text:
+After section 3 (or after section 2 if section 3 is omitted), end the response with the full handbook reference in raw visible plain text:
 
 Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook: 100+ Innovative, Integrated Tools for Solving Key Issues in Planning, Implementation, Contracting, Measurement, Evaluation and Reporting (for Humans and AI Agents). DoViewPlanning.Org. https://doviewplanning.org/book
 
@@ -308,58 +222,31 @@ IRIS LOOKUP PROCEDURE
 
 Before drafting the response, do the following:
 
-1. Use mcp__iris__search scoped to set_id 33032180-d77a-4ce4-88cf-b49cd643e093
-   to find diagrams relevant to the user's question. Search by keywords from
-   the question.
+1. Use mcp__iris__search scoped to set_id 33032180-d77a-4ce4-88cf-b49cd643e093 to find diagrams relevant to the user's question. Search by keywords from the question.
 
-2. For each candidate diagram, call mcp__iris__get_diagram to read its
-   data.content. Confirm relevance from the actual content, not the name
-   alone.
+2. For each candidate diagram, call mcp__iris__get_diagram to read its data.content. Confirm relevance from the actual content, not the name alone.
 
-3. Prefer tool-kind diagrams (description "kind: tool") over question-kind
-   diagrams when citing or reproducing. Question-kind diagrams may be read
-   for context but should not appear in section 3.
+3. Prefer tool-kind diagrams (description "kind: tool") over question-kind diagrams when citing or reproducing. Question-kind diagrams may be read for context but should not appear in section 3.
 
-4. Track which tool diagrams are cited in sections 1 and 2 so section 3 can
-   reproduce their mermaid blocks in first-mention order.
+4. Track which tool diagrams are cited in sections 1 and 2 so section 3 can reproduce their mermaid blocks in first-mention order.
 
 FINAL COMPLIANCE CHECK BEFORE ANSWERING
 
 Before giving the answer, check and correct the response so that:
 
 1. It starts with the exact required preliminary sentence.
-2. It contains exactly the three required main sections (or two, if no
-   tool diagrams were referenced).
+2. It contains exactly the three required main sections (or two, if no tool diagrams were referenced).
 3. The first section heading starts "1. Summary response to".
 4. The second section heading starts "2. Full response to".
-5. The third section heading, when present, is "3. Diagrams from the DoView
-   Planning and Outcomes Theory Handbook".
-6. The Summary response is standalone and ends with the full book reference
-   and https://doviewplanning.org/book in raw visible text.
-7. The Full response is standalone, has its own summary at the start, and
-   ends with the full book reference and https://doviewplanning.org/book in
-   raw visible text.
-8. Every tool mentioned in sections 1 or 2 has its full raw visible
-   plain-text URL immediately after the tool name.
-9. Section 3, when present, contains one ### Tool ... heading per tool
-   cited, each with a raw plain-text Page URL and a verbatim mermaid block
-   and a formal relevance note.
-10. There are no markdown links, no reference links, no footnotes, no "[1]"
-    style citations, no hidden URLs, no URLs written as [URL](URL), and no
-    "see above" wording.
-11. Every URL in section 1, 2 and 3 (other than inside mermaid blocks)
-    appears visibly as raw text beginning with https://
-12. Before finalising the response, actively scan it for the characters
-    "](https://" and "[http". If either appears, rewrite the response so
-    that every URL is raw visible plain text instead.
-13. The response uses outcomes theory as the primary framework and presents
-    DoView Boards or diagrams only as practical applied forms of outcomes
-    theory.
-14. The response does not contain "a better answer is," "a sentence you
-    could use," "I would," "you could," or any other drafting-advice
-    wording.
-15. All cited content and all reproduced mermaid blocks came from the Iris
-    DoView Book set; no general knowledge has been used; no diagram has
-    been redrawn from memory.
-16. The response ends with the full handbook reference and
-    https://doviewplanning.org/book in raw visible plain text.
+5. The third section heading, when present, is "3. Diagrams from the DoView Planning and Outcomes Theory Handbook".
+6. The Summary response is standalone and ends with the full book reference and https://doviewplanning.org/book in raw visible text.
+7. The Full response is standalone, has its own summary at the start, and ends with the full book reference and https://doviewplanning.org/book in raw visible text.
+8. Every tool mentioned in sections 1 or 2 has its full raw visible plain-text URL immediately after the tool name.
+9. Section 3, when present, contains one ### Tool ... heading per tool cited, each with a raw plain-text Page URL and a verbatim mermaid block and a formal relevance note.
+10. There are no markdown links, no reference links, no footnotes, no "[1]" style citations, no hidden URLs, no URLs written as [URL](URL), and no "see above" wording.
+11. Every URL in section 1, 2 and 3 (other than inside mermaid blocks) appears visibly as raw text beginning with https://
+12. Before finalising the response, actively scan it for the characters "](https://" and "[http". If either appears, rewrite the response so that every URL is raw visible plain text instead.
+13. The response uses outcomes theory as the primary framework and presents DoView Boards or diagrams only as practical applied forms of outcomes theory.
+14. The response does not contain "a better answer is," "a sentence you could use," "I would," "you could," or any other drafting-advice wording.
+15. All cited content and all reproduced mermaid blocks came from the Iris DoView Book set; no general knowledge has been used; no diagram has been redrawn from memory.
+16. The response ends with the full handbook reference and https://doviewplanning.org/book in raw visible plain text.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.9.0",
+	"version": "5.9.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.9.0"
+version = "5.9.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- **Fix misleading error**: v5.9.0's named-prompts router caught every `Exception` from `create_prompt` and reported it as `"A named prompt with this name already exists on this scope (<ExceptionClassName>)"`. When the Supabase migration `m052_named_prompts.sql` hadn't been applied yet, the user saw `(UndefinedTableError)` tacked onto that misleading message. The handler now distinguishes UNIQUE-constraint violations (409, clean message) from any other failure (500 with the real exception class + message).
- **Prompt C reflow**: `docs/prompts/doview-book-prompt-c-iris.md` had mid-paragraph hard wraps that produced awkward line breaks. Reflowed paragraphs to single lines, matching the existing `doview-book-prompt-a.md` / `-b.md` style. No content changes.

## Test plan

- [x] New regression test `test_create_duplicate_409_does_not_swallow_other_errors` — asserts the 409 detail is the clean message with no driver-exception name leaked.
- [x] All existing `tests/test_named_prompts/` tests still pass (15 cases).

## Reminder for UAT

Supabase migrations are **not** auto-applied at backend startup (by design — see `backend/app/startup.py:179`). To activate the v5.9.0 `prompts` table on the UAT Supabase database, run:

```bash
./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
```

(Use the direct connection on port 5432, not the pooler. The script is idempotent — re-running it just applies m052 and no-ops on the rest.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)