### PR TITLE
feat(v5.11.0): mcp_system_context data passthrough (ADR-156, supersedes ADR-155)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.11.0] - 2026-05-11
+
+### Changed (breaking — supersedes v5.10.0 picker behaviour)
+
+- **Scope `mcp_prompt` column renamed to `mcp_system_context` and
+  repositioned as data passthrough, not a slash-command prompt**
+  (ADR-156, SPEC-156-A). The v5.10.0 design exposed the column via
+  the MCP `prompts` channel as `/iris:set:<uuid>` /
+  `/iris:collection:<uuid>` slash commands. In use that turned out
+  wrong for the intent: the content authors want attached to a
+  scope is **initial context for an MCP client browsing the
+  scope**, not a directive the user picks. v5.11.0 removes the
+  scope-level slash-command exposure entirely and instead passes
+  `mcp_system_context` through `get_set` / `list_sets` /
+  `get_collection` / `list_collections` MCP tool responses as a
+  regular data field. The MCP picker now contains **named prompts
+  only** (ADR-154 entries unchanged).
+- `system_prompt` continues to auto-apply in Iris AI server-side
+  composition (ADR-150) and continues to be stripped from MCP tool
+  responses (ADR-151). Unchanged.
+- Frontend label and helper text updated to reflect the
+  passthrough role.
+
+### Migration
+
+- SQLite `m050_rename_mcp_prompt_to_mcp_system_context.py` —
+  idempotent column rename on `collections` and `sets`.
+- Supabase `m054_rename_mcp_prompt_to_mcp_system_context.sql` —
+  same. Run `./scripts/supabase-migrate.sh` after deploy. Data
+  authored in v5.10.0 is preserved (rename, not drop).
+
 ## [5.10.0] - 2026-05-11
 
 ### Added

--- a/backend/app/collections/models.py
+++ b/backend/app/collections/models.py
@@ -20,7 +20,7 @@ class CollectionUpdate(BaseModel):
     thumbnail_source: str | None = None
     thumbnail_diagram_id: str | None = None
     system_prompt: str | None = None
-    mcp_prompt: str | None = None
+    mcp_system_context: str | None = None
 
 
 class CollectionResponse(BaseModel):
@@ -42,7 +42,7 @@ class CollectionResponse(BaseModel):
     thumbnail_diagram_data: dict | None = None
     thumbnail_diagram_type: str | None = None
     system_prompt: str | None = None
-    mcp_prompt: str | None = None
+    mcp_system_context: str | None = None
 
 
 class CollectionListResponse(BaseModel):

--- a/backend/app/collections/router.py
+++ b/backend/app/collections/router.py
@@ -98,7 +98,7 @@ async def update(
             thumbnail_source=body.thumbnail_source,
             thumbnail_diagram_id=body.thumbnail_diagram_id,
             system_prompt=body.system_prompt,
-            mcp_prompt=body.mcp_prompt,
+            mcp_system_context=body.mcp_system_context,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/collections/service.py
+++ b/backend/app/collections/service.py
@@ -29,14 +29,14 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
         "thumbnail_diagram_id": row[8],
         "has_thumbnail_image": has_thumbnail_image,
         "system_prompt": row[10] if len(row) > 10 else None,
-        "mcp_prompt": row[11] if len(row) > 11 else None,
+        "mcp_system_context": row[11] if len(row) > 11 else None,
     }
 
 
 _COLLECTION_COLUMNS = (
     "c.id, c.name, c.description, c.created_at, c.created_by, "
     "c.updated_at, c.is_deleted, c.thumbnail_source, c.thumbnail_diagram_id, "
-    "c.thumbnail_image IS NOT NULL, c.system_prompt, c.mcp_prompt"
+    "c.thumbnail_image IS NOT NULL, c.system_prompt, c.mcp_system_context"
 )
 
 
@@ -77,7 +77,7 @@ async def create_collection(
         "thumbnail_diagram_id": None,
         "has_thumbnail_image": False,
         "system_prompt": None,
-        "mcp_prompt": None,
+        "mcp_system_context": None,
     }
 
 
@@ -191,9 +191,9 @@ async def update_collection(
     thumbnail_source: str | None = None,
     thumbnail_diagram_id: str | None = None,
     system_prompt: str | None = None,
-    mcp_prompt: str | None = None,
+    mcp_system_context: str | None = None,
 ) -> dict[str, object] | None:
-    """Update a collection's name, description, thumbnail, system_prompt, and mcp_prompt.
+    """Update a collection's name, description, thumbnail, system_prompt, and mcp_system_context.
 
     Returns None if not found.
     """
@@ -222,17 +222,17 @@ async def update_collection(
         await db.execute(
             "UPDATE collections SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, thumbnail_image = NULL, "
-            "system_prompt = ?, mcp_prompt = ? "
+            "system_prompt = ?, mcp_system_context = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, mcp_prompt, collection_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, mcp_system_context, collection_id),
         )
     else:
         await db.execute(
             "UPDATE collections SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, "
-            "system_prompt = ?, mcp_prompt = ? "
+            "system_prompt = ?, mcp_system_context = ? "
             "WHERE id = ?",
-            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, mcp_prompt, collection_id),
+            (name, description, now, thumbnail_source, thumbnail_diagram_id, system_prompt, mcp_system_context, collection_id),
         )
     await db.commit()
 

--- a/backend/app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py
+++ b/backend/app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py
@@ -1,0 +1,38 @@
+"""Migration 050: rename `mcp_prompt` → `mcp_system_context` on
+`collections` and `sets` (ADR-156, SPEC-156-A).
+
+v5.10.0 (ADR-155) shipped the column as `mcp_prompt` and surfaced
+its body via the MCP `prompts` channel (slash-command picker). v5.11.0
+(ADR-156) repositions it as a **data passthrough** field that flows
+through `get_set` / `get_collection` MCP tool responses as scope
+context — no slash command. The rename reflects the new purpose.
+
+Idempotent. PRAGMA-checks column existence on both sides of the
+rename: only renames if the old name is present and the new name is
+absent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m050_rename_mcp_prompt_to_mcp_system_context"
+
+
+async def _rename_if_needed(db: aiosqlite.Connection, table: str) -> None:
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "mcp_prompt" in columns and "mcp_system_context" not in columns:
+        await db.execute(
+            f"ALTER TABLE {table} RENAME COLUMN mcp_prompt TO mcp_system_context",
+        )
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up — idempotent column rename on both tables."""
+    await _rename_if_needed(db, "collections")
+    await _rename_if_needed(db, "sets")
+    await db.commit()

--- a/backend/app/migrations/supabase/m054_rename_mcp_prompt_to_mcp_system_context.sql
+++ b/backend/app/migrations/supabase/m054_rename_mcp_prompt_to_mcp_system_context.sql
@@ -1,0 +1,37 @@
+-- Migration 054: rename `mcp_prompt` → `mcp_system_context` on
+-- `collections` and `sets` (ADR-156, SPEC-156-A).
+--
+-- v5.10.0 (ADR-155) shipped the column as `mcp_prompt` and surfaced
+-- its body via the MCP `prompts` channel (slash-command picker).
+-- v5.11.0 (ADR-156) repositions it as a data passthrough field that
+-- flows through get_set / get_collection MCP tool responses — no
+-- slash command. Rename reflects the new purpose.
+--
+-- Idempotent — only renames if the old column exists and the new one
+-- does not.
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'collections' AND column_name = 'mcp_prompt'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'collections' AND column_name = 'mcp_system_context'
+    ) THEN
+        ALTER TABLE public.collections RENAME COLUMN mcp_prompt TO mcp_system_context;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'sets' AND column_name = 'mcp_prompt'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = 'sets' AND column_name = 'mcp_system_context'
+    ) THEN
+        ALTER TABLE public.sets RENAME COLUMN mcp_prompt TO mcp_system_context;
+    END IF;
+END $$;

--- a/backend/app/prompts/service.py
+++ b/backend/app/prompts/service.py
@@ -1,23 +1,23 @@
-"""Service layer for the scope-prompt index (ADR-152; extended ADR-154; ADR-155 strict split).
+"""Service layer for the scope-prompt index (ADR-152; ADR-154; ADR-156).
+
+v5.11.0 (ADR-156): scope-level prompt entries (`set:<uuid>` /
+`collection:<uuid>`) are no longer emitted. The scope's MCP
+`mcp_system_context` is now passed through as a data field on
+`get_set` / `get_collection` MCP tool responses (ADR-156
+supersedes ADR-155's slash-command approach), so it no longer
+needs a picker entry. The picker now contains **named prompts
+only** (ADR-154).
+
+`system_prompt` continues to auto-apply in Iris AI server-side
+composition (ADR-150) and is stripped from MCP tool responses
+(ADR-151) — unchanged.
 
 Returns:
-- one entry per Collection / Set with a non-null, non-empty
-  `mcp_prompt` (`entry_kind="system_prompt"`, name `set:<uuid>` /
-  `collection:<uuid>`). v5.10.0 / ADR-155: the scope's MCP picker
-  body now comes from the `mcp_prompt` column, NOT `system_prompt`.
-  `system_prompt` continues to auto-apply in Iris AI server-side
-  composition (ADR-150) but is never surfaced via this endpoint.
 - one entry per named prompt on a Collection / Set
-  (`entry_kind="named_prompt"`)
+  (`entry_kind="named_prompt"`, name `set:<uuid>:<name>` /
+  `collection:<uuid>:<name>`)
 
-Order: scope MCP prompts first (collections then sets, both
-alphabetical), then named prompts.
-
-The `entry_kind` literal stays `"system_prompt"` for backwards-compat
-with iris-client / MCP layer code that already discriminates on it.
-The label is now slightly inaccurate — it refers to the scope's
-single MCP-facing prompt, which v5.10.0 routed to its own column —
-but renaming the literal would be a breaking change to every consumer.
+Ordered by scope_type, then scope_name, then prompt_name.
 """
 
 from __future__ import annotations
@@ -29,51 +29,9 @@ if TYPE_CHECKING:
 
 
 async def list_scope_prompts(db: DatabasePort) -> list[dict[str, object]]:
-    """Return scope-prompt index entries (scope MCP prompts then named prompts)."""
+    """Return MCP-picker index entries — named prompts only (ADR-156)."""
     items: list[dict[str, object]] = []
 
-    cursor = await db.execute(
-        "SELECT id, name, description, mcp_prompt FROM collections "
-        "WHERE is_deleted = 0 AND mcp_prompt IS NOT NULL "
-        "ORDER BY name",
-    )
-    for row in await cursor.fetchall():
-        body = (row[3] or "").strip()
-        if not body:
-            continue
-        items.append({
-            "name": f"collection:{row[0]}",
-            "entry_kind": "system_prompt",
-            "scope_type": "collection",
-            "scope_id": str(row[0]),
-            "scope_name": str(row[1]),
-            "description": row[2],
-            "body": body,
-            "prompt_name": None,
-        })
-
-    cursor = await db.execute(
-        "SELECT id, name, description, mcp_prompt FROM sets "
-        "WHERE is_deleted = 0 AND mcp_prompt IS NOT NULL "
-        "ORDER BY name",
-    )
-    for row in await cursor.fetchall():
-        body = (row[3] or "").strip()
-        if not body:
-            continue
-        items.append({
-            "name": f"set:{row[0]}",
-            "entry_kind": "system_prompt",
-            "scope_type": "set",
-            "scope_id": str(row[0]),
-            "scope_name": str(row[1]),
-            "description": row[2],
-            "body": body,
-            "prompt_name": None,
-        })
-
-    # ADR-154 named prompts. Join to fetch scope_name; exclude entries
-    # whose scope has been soft-deleted (LEFT JOIN + WHERE on scope id).
     cursor = await db.execute(
         """
         SELECT p.id, p.scope_type, p.scope_id, p.name, p.description, p.body,

--- a/backend/app/sets/models.py
+++ b/backend/app/sets/models.py
@@ -22,7 +22,7 @@ class SetUpdate(BaseModel):
     thumbnail_diagram_id: str | None = None
     collection_id: str | None = None
     system_prompt: str | None = None
-    mcp_prompt: str | None = None
+    mcp_system_context: str | None = None
 
 
 class SetResponse(BaseModel):
@@ -45,7 +45,7 @@ class SetResponse(BaseModel):
     thumbnail_diagram_data: dict | None = None
     thumbnail_diagram_type: str | None = None
     system_prompt: str | None = None
-    mcp_prompt: str | None = None
+    mcp_system_context: str | None = None
 
 
 class SetListResponse(BaseModel):

--- a/backend/app/sets/router.py
+++ b/backend/app/sets/router.py
@@ -102,7 +102,7 @@ async def update(
             thumbnail_diagram_id=body.thumbnail_diagram_id,
             collection_id=body.collection_id,
             system_prompt=body.system_prompt,
-            mcp_prompt=body.mcp_prompt,
+            mcp_system_context=body.mcp_system_context,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -33,14 +33,14 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
         "collection_id": row[10] if len(row) > 10 else None,
         "collection_name": row[11] if len(row) > 11 else None,
         "system_prompt": row[12] if len(row) > 12 else None,
-        "mcp_prompt": row[13] if len(row) > 13 else None,
+        "mcp_system_context": row[13] if len(row) > 13 else None,
     }
 
 
 _SET_COLUMNS = (
     "s.id, s.name, s.description, s.created_at, s.created_by, "
     "s.updated_at, s.is_deleted, s.thumbnail_source, s.thumbnail_diagram_id, "
-    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt, s.mcp_prompt"
+    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt, s.mcp_system_context"
 )
 
 
@@ -81,7 +81,7 @@ async def create_set(
         "thumbnail_diagram_id": None,
         "has_thumbnail_image": False,
         "system_prompt": None,
-        "mcp_prompt": None,
+        "mcp_system_context": None,
     }
 
 
@@ -191,9 +191,9 @@ async def update_set(
     thumbnail_diagram_id: str | None = None,
     collection_id: str | None = None,
     system_prompt: str | None = None,
-    mcp_prompt: str | None = None,
+    mcp_system_context: str | None = None,
 ) -> dict[str, object] | None:
-    """Update a set's name, description, thumbnail, collection, system_prompt, and mcp_prompt.
+    """Update a set's name, description, thumbnail, collection, system_prompt, and mcp_system_context.
 
     Returns None if not found.
     """
@@ -221,19 +221,19 @@ async def update_set(
         await db.execute(
             "UPDATE sets SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, thumbnail_image = NULL, "
-            "collection_id = ?, system_prompt = ?, mcp_prompt = ? "
+            "collection_id = ?, system_prompt = ?, mcp_system_context = ? "
             "WHERE id = ?",
             (name, description, now, thumbnail_source, thumbnail_diagram_id,
-             collection_id, system_prompt, mcp_prompt, set_id),
+             collection_id, system_prompt, mcp_system_context, set_id),
         )
     else:
         await db.execute(
             "UPDATE sets SET name = ?, description = ?, updated_at = ?, "
             "thumbnail_source = ?, thumbnail_diagram_id = ?, "
-            "collection_id = ?, system_prompt = ?, mcp_prompt = ? "
+            "collection_id = ?, system_prompt = ?, mcp_system_context = ? "
             "WHERE id = ?",
             (name, description, now, thumbnail_source, thumbnail_diagram_id,
-             collection_id, system_prompt, mcp_prompt, set_id),
+             collection_id, system_prompt, mcp_system_context, set_id),
         )
     await db.commit()
 

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -54,6 +54,7 @@ from app.migrations.m046_extensions_source import up as m046_up
 from app.migrations.m047_scope_system_prompts import up as m047_up
 from app.migrations.m048_named_prompts import up as m048_up
 from app.migrations.m049_mcp_prompt_column import up as m049_up
+from app.migrations.m050_rename_mcp_prompt_to_mcp_system_context import up as m050_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -134,6 +135,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m047_up(main)
     await m048_up(main)
     await m049_up(main)
+    await m050_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_migrations/test_mcp_system_context_rename.py
+++ b/backend/tests/test_migrations/test_mcp_system_context_rename.py
@@ -1,0 +1,49 @@
+"""v5.11.0 (ADR-156, SPEC-156-A): static-parser tests asserting that
+m050_rename_mcp_prompt_to_mcp_system_context.py and
+m054_rename_mcp_prompt_to_mcp_system_context.sql rename the column
+on both `collections` and `sets`, with idempotency guards on both
+sides of the rename.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_sqlite_m050_renames_collections_column() -> None:
+    py = _read("app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py")
+    assert "RENAME COLUMN mcp_prompt TO mcp_system_context" in py
+
+
+def test_sqlite_m050_handles_both_tables() -> None:
+    py = _read("app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py")
+    # Helper is invoked for both collections and sets.
+    assert '"collections"' in py
+    assert '"sets"' in py
+
+
+def test_sqlite_m050_is_idempotent() -> None:
+    py = _read("app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py")
+    # Guards on both sides: old column must exist, new must not.
+    assert '"mcp_prompt" in columns' in py
+    assert '"mcp_system_context" not in columns' in py
+
+
+def test_supabase_m054_renames_both_tables() -> None:
+    sql = _read("app/migrations/supabase/m054_rename_mcp_prompt_to_mcp_system_context.sql")
+    assert sql.count("RENAME COLUMN mcp_prompt TO mcp_system_context") == 2
+    assert "ALTER TABLE public.collections" in sql
+    assert "ALTER TABLE public.sets" in sql
+
+
+def test_supabase_m054_is_idempotent() -> None:
+    sql = _read("app/migrations/supabase/m054_rename_mcp_prompt_to_mcp_system_context.sql")
+    # information_schema check on both sides of the rename, per table.
+    assert sql.count("information_schema.columns") >= 4
+    assert "AND NOT EXISTS" in sql

--- a/backend/tests/test_prompts/test_router.py
+++ b/backend/tests/test_prompts/test_router.py
@@ -1,14 +1,17 @@
-"""ADR-152 / SPEC-152-A: scope-prompt index endpoint for MCP prompts.
+"""Scope-prompt index endpoint (ADR-152; ADR-154; ADR-156).
 
-Asserts `GET /api/prompts/scope-index` returns one row per Collection
-and Set that has a non-null, non-empty `system_prompt`. Collections
-come first, then Sets — keeps the ordering predictable for the MCP
-prompt picker.
+v5.11.0 / ADR-156: scope-level prompts no longer appear in the MCP
+picker. The endpoint returns named prompts (ADR-154) only. Scope
+content (`mcp_system_context`) is passed through as data on
+`get_set` / `get_collection` MCP tool responses instead.
+
+`system_prompt` continues to auto-apply in Iris AI (ADR-150) and is
+stripped from MCP tool responses (ADR-151) — unchanged, and not the
+concern of this endpoint.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import httpx
@@ -21,6 +24,7 @@ from app.startup import initialize_databases
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+    from pathlib import Path
 
 
 @pytest.fixture
@@ -65,90 +69,59 @@ async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
 
 
 class TestScopePromptIndex:
-    async def test_empty_when_no_scopes_have_prompts(self, client: httpx.AsyncClient) -> None:
+    async def test_empty_when_no_named_prompts(self, client: httpx.AsyncClient) -> None:
         await _auth_headers(client)
         resp = await client.get("/api/prompts/scope-index")
         assert resp.status_code == 200
         assert resp.json() == {"items": []}
 
-    async def test_lists_one_set_with_prompt(self, client: httpx.AsyncClient) -> None:
+    async def test_scope_mcp_system_context_does_not_appear_in_picker(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """ADR-156: scope-level `mcp_system_context` is data passthrough,
+        NOT a picker entry. The picker shows only named prompts."""
         headers = await _auth_headers(client)
         s = (await client.post(
-            "/api/sets", json={"name": "DoView Book"}, headers=headers,
+            "/api/sets", json={"name": "DoView"}, headers=headers,
         )).json()
         await client.put(
             f"/api/sets/{s['id']}",
-            json={"name": "DoView Book", "mcp_prompt": "Use outcomes theory framing."},
+            json={"name": "DoView", "mcp_system_context": "Use outcomes theory."},
             headers=headers,
         )
 
         resp = await client.get("/api/prompts/scope-index")
         assert resp.status_code == 200
-        items = resp.json()["items"]
-        assert len(items) == 1
-        entry = items[0]
-        assert entry["scope_type"] == "set"
-        assert entry["scope_id"] == s["id"]
-        assert entry["scope_name"] == "DoView Book"
-        assert entry["body"] == "Use outcomes theory framing."
-        assert entry["name"] == f"set:{s['id']}"
+        assert resp.json()["items"] == []
 
-    async def test_lists_collection_before_sets(self, client: httpx.AsyncClient) -> None:
+    async def test_picker_shows_named_prompts_only(
+        self, client: httpx.AsyncClient,
+    ) -> None:
         headers = await _auth_headers(client)
-        c = (await client.post(
-            "/api/collections", json={"name": "NZISM"}, headers=headers,
-        )).json()
-        await client.put(
-            f"/api/collections/{c['id']}",
-            json={"name": "NZISM", "mcp_prompt": "Always cite the control number."},
-            headers=headers,
-        )
         s = (await client.post(
-            "/api/sets",
-            json={"name": "GCSB Set", "collection_id": c["id"]},
-            headers=headers,
+            "/api/sets", json={"name": "DoView"}, headers=headers,
         )).json()
         await client.put(
             f"/api/sets/{s['id']}",
+            json={"name": "DoView", "mcp_system_context": "Scope passthrough."},
+            headers=headers,
+        )
+        await client.post(
+            "/api/named-prompts",
             json={
-                "name": "GCSB Set",
-                "collection_id": c["id"],
-                "mcp_prompt": "Strict GCSB terminology.",
+                "scope_type": "set",
+                "scope_id": s["id"],
+                "name": "outcomes-theory",
+                "description": "Outcomes theory framing.",
+                "body": "Apply outcomes theory.",
             },
             headers=headers,
         )
 
-        resp = await client.get("/api/prompts/scope-index")
-        items = resp.json()["items"]
-        assert [(i["scope_type"], i["scope_name"]) for i in items] == [
-            ("collection", "NZISM"),
-            ("set", "GCSB Set"),
-        ]
-        assert items[0]["name"] == f"collection:{c['id']}"
-        assert items[1]["name"] == f"set:{s['id']}"
-
-    async def test_excludes_scopes_with_null_system_prompt(self, client: httpx.AsyncClient) -> None:
-        headers = await _auth_headers(client)
-        await client.post(
-            "/api/sets", json={"name": "Unprompted Set"}, headers=headers,
-        )
-
-        resp = await client.get("/api/prompts/scope-index")
-        assert resp.json()["items"] == []
-
-    async def test_excludes_scopes_with_whitespace_only_system_prompt(self, client: httpx.AsyncClient) -> None:
-        headers = await _auth_headers(client)
-        s = (await client.post(
-            "/api/sets", json={"name": "Whitespace Set"}, headers=headers,
-        )).json()
-        await client.put(
-            f"/api/sets/{s['id']}",
-            json={"name": "Whitespace Set", "mcp_prompt": "   "},
-            headers=headers,
-        )
-
-        resp = await client.get("/api/prompts/scope-index")
-        assert resp.json()["items"] == []
+        items = (await client.get("/api/prompts/scope-index")).json()["items"]
+        assert len(items) == 1
+        assert items[0]["entry_kind"] == "named_prompt"
+        assert items[0]["name"] == f"set:{s['id']}:outcomes-theory"
 
     async def test_anonymous_can_read_index(self, client: httpx.AsyncClient) -> None:
         """Same posture as list_collections / list_sets — anonymous-readable."""
@@ -156,13 +129,18 @@ class TestScopePromptIndex:
         s = (await client.post(
             "/api/sets", json={"name": "Public Set"}, headers=headers,
         )).json()
-        await client.put(
-            f"/api/sets/{s['id']}",
-            json={"name": "Public Set", "mcp_prompt": "anyone can see this"},
+        await client.post(
+            "/api/named-prompts",
+            json={
+                "scope_type": "set",
+                "scope_id": s["id"],
+                "name": "anyone-can-see-this",
+                "description": "Public",
+                "body": "Body.",
+            },
             headers=headers,
         )
 
-        # No auth header — should still succeed.
         resp = await client.get("/api/prompts/scope-index")
         assert resp.status_code == 200
         assert len(resp.json()["items"]) == 1

--- a/backend/tests/test_prompts/test_router_named_prompts_extension.py
+++ b/backend/tests/test_prompts/test_router_named_prompts_extension.py
@@ -93,12 +93,20 @@ class TestScopeIndexExtension:
         assert entry["prompt_name"] == "outcomes-theory"
         assert entry["body"] == "Apply outcomes theory rules."
 
-    async def test_entry_kind_discriminator_on_every_entry(self, client: httpx.AsyncClient) -> None:
+    async def test_entry_kind_is_named_prompt_only(self, client: httpx.AsyncClient) -> None:
+        """ADR-156: every entry in the scope-index is now a named prompt.
+        Scope-level mcp_system_context never appears here — it flows
+        through MCP tool responses (get_set / get_collection) as data."""
         headers = await _auth_headers(client)
         s = (await client.post("/api/sets", json={"name": "Mixed"}, headers=headers)).json()
+        # Even with scope content populated, no scope entry shows up.
         await client.put(
             f"/api/sets/{s['id']}",
-            json={"name": "Mixed", "mcp_prompt": "House rules."},
+            json={
+                "name": "Mixed",
+                "system_prompt": "Iris-AI directive.",
+                "mcp_system_context": "Scope passthrough.",
+            },
             headers=headers,
         )
         await client.post(
@@ -114,110 +122,62 @@ class TestScopeIndexExtension:
         )
 
         items = (await client.get("/api/prompts/scope-index")).json()["items"]
-        assert len(items) == 2
-        kinds = {i["entry_kind"] for i in items}
-        assert kinds == {"system_prompt", "named_prompt"}
-        # prompt_name set only on named entries
-        for entry in items:
-            if entry["entry_kind"] == "named_prompt":
-                assert entry["prompt_name"] is not None
-            else:
-                assert entry["prompt_name"] is None
+        assert len(items) == 1
+        assert items[0]["entry_kind"] == "named_prompt"
+        assert items[0]["prompt_name"] == "extra"
 
-    async def test_system_prompts_appear_before_named_prompts(self, client: httpx.AsyncClient) -> None:
-        headers = await _auth_headers(client)
-        s = (await client.post("/api/sets", json={"name": "Z-set"}, headers=headers)).json()
-        # Order matters: named added first, system added second; result
-        # must still place system_prompt first in the index.
-        await client.post(
-            "/api/named-prompts",
-            json={
-                "scope_type": "set", "scope_id": s["id"], "name": "alpha",
-                "description": "A", "body": "B",
-            },
-            headers=headers,
-        )
-        await client.put(
-            f"/api/sets/{s['id']}",
-            json={"name": "Z-set", "mcp_prompt": "house rules"},
-            headers=headers,
-        )
-
-        items = (await client.get("/api/prompts/scope-index")).json()["items"]
-        kinds_in_order = [i["entry_kind"] for i in items]
-        assert kinds_in_order == ["system_prompt", "named_prompt"]
-
-    async def test_empty_when_neither_prompts_exist(self, client: httpx.AsyncClient) -> None:
+    async def test_empty_when_no_named_prompts_exist(self, client: httpx.AsyncClient) -> None:
         await _auth_headers(client)
         resp = await client.get("/api/prompts/scope-index")
         assert resp.json() == {"items": []}
 
-    async def test_adr_155_strict_split_system_prompt_alone_does_not_appear(
+    async def test_adr_156_scope_content_is_data_passthrough_not_picker(
         self, client: httpx.AsyncClient,
     ) -> None:
-        """ADR-155: a Set with ONLY `system_prompt` (no mcp_prompt) must
-        NOT appear in the MCP scope-index. system_prompt is Iris-AI-only
-        post-v5.10.0. The MCP picker entry only appears when mcp_prompt
-        is populated.
-        """
+        """ADR-156: `mcp_system_context` content is passed through as
+        data on `get_set` / `get_collection` MCP tool responses, NOT
+        surfaced in the scope-prompt index. The index is named-prompts
+        only."""
         headers = await _auth_headers(client)
         s = (await client.post(
-            "/api/sets", json={"name": "Iris-only set"}, headers=headers,
-        )).json()
-        # Populate system_prompt (auto-apply in Iris AI) but NOT mcp_prompt.
-        await client.put(
-            f"/api/sets/{s['id']}",
-            json={"name": "Iris-only set", "system_prompt": "Iris-only directive."},
-            headers=headers,
-        )
-
-        items = (await client.get("/api/prompts/scope-index")).json()["items"]
-        # Iris-only system_prompt does NOT surface in the MCP picker.
-        assert items == []
-
-    async def test_adr_155_strict_split_mcp_prompt_alone_appears(
-        self, client: httpx.AsyncClient,
-    ) -> None:
-        """ADR-155: a Set with ONLY `mcp_prompt` (no system_prompt) MUST
-        appear in the MCP scope-index. mcp_prompt is the MCP-only
-        channel post-v5.10.0.
-        """
-        headers = await _auth_headers(client)
-        s = (await client.post(
-            "/api/sets", json={"name": "MCP-only set"}, headers=headers,
-        )).json()
-        await client.put(
-            f"/api/sets/{s['id']}",
-            json={"name": "MCP-only set", "mcp_prompt": "MCP-only directive."},
-            headers=headers,
-        )
-
-        items = (await client.get("/api/prompts/scope-index")).json()["items"]
-        assert len(items) == 1
-        assert items[0]["body"] == "MCP-only directive."
-        assert items[0]["name"] == f"set:{s['id']}"
-
-    async def test_adr_155_strict_split_both_populated(
-        self, client: httpx.AsyncClient,
-    ) -> None:
-        """ADR-155: when both columns are populated, MCP picker shows
-        mcp_prompt content (system_prompt continues to auto-apply in
-        Iris AI but is not visible here)."""
-        headers = await _auth_headers(client)
-        s = (await client.post(
-            "/api/sets", json={"name": "Both set"}, headers=headers,
+            "/api/sets", json={"name": "Passthrough set"}, headers=headers,
         )).json()
         await client.put(
             f"/api/sets/{s['id']}",
             json={
-                "name": "Both set",
-                "system_prompt": "Iris-AI directive.",
-                "mcp_prompt": "MCP directive.",
+                "name": "Passthrough set",
+                "mcp_system_context": "Initial context for MCP browsers.",
             },
             headers=headers,
         )
 
+        # Not in the scope-prompt index.
         items = (await client.get("/api/prompts/scope-index")).json()["items"]
-        assert len(items) == 1
-        # MCP picker body is mcp_prompt, NOT system_prompt.
-        assert items[0]["body"] == "MCP directive."
+        assert items == []
+
+        # IS on the Set response (which the MCP get_set tool returns).
+        set_resp = (await client.get(f"/api/sets/{s['id']}")).json()
+        assert set_resp["mcp_system_context"] == "Initial context for MCP browsers."
+
+    async def test_adr_156_system_prompt_stripped_from_set_response_via_mcp(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """ADR-151 (still in force): system_prompt is server-side
+        composition only and is stripped from MCP tool responses. This
+        endpoint is the FastAPI route directly (no MCP boundary), so
+        system_prompt IS visible here. The MCP-boundary strip happens
+        in `iris_mcp/links.py:_strip_sensitive_keys`."""
+        headers = await _auth_headers(client)
+        s = (await client.post(
+            "/api/sets", json={"name": "Iris-AI set"}, headers=headers,
+        )).json()
+        await client.put(
+            f"/api/sets/{s['id']}",
+            json={"name": "Iris-AI set", "system_prompt": "Iris-AI directive."},
+            headers=headers,
+        )
+
+        set_resp = (await client.get(f"/api/sets/{s['id']}")).json()
+        # Backend FastAPI route includes system_prompt — the strip
+        # happens at the MCP layer (links.py) not here.
+        assert set_resp["system_prompt"] == "Iris-AI directive."

--- a/docs/adrs/ADR-156-MCP-System-Context-Data-Passthrough.md
+++ b/docs/adrs/ADR-156-MCP-System-Context-Data-Passthrough.md
@@ -1,0 +1,86 @@
+# ADR-156: Scope `mcp_system_context` is data passthrough, not a slash-command
+
+Status: Accepted (2026-05-11)
+Supersedes: [ADR-155](ADR-155-Strict-Split-Iris-AI-vs-MCP-Scope-Prompts.md) (in part)
+Amends: [ADR-151](ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md), [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md)
+
+## Context
+
+ADR-155 (v5.10.0) split the scope's MCP-facing content out of `system_prompt` into a new column `mcp_prompt`, and surfaced it through the MCP `prompts` channel as a slash-command (`/iris:set:<uuid>` / `/iris:collection:<uuid>`). Released to UAT immediately.
+
+In use, the slash-command exposure turned out wrong for the intended job. The content the user wants attached to a scope is **initial context for an MCP client browsing the scope** — not a directive the user picks. It should accompany `get_set` / `get_collection` MCP tool responses as scope-level data the model can read while exploring, not appear as a separate command the user has to invoke.
+
+We had this flow pre-v5.8.2. In v5.8.0 (ADR-150) `system_prompt` was simply a field on Collections and Sets, and MCP `get_set` returned the full record including it as data. ADR-151 then redacted the field at the MCP boundary because `system_prompt` had become an Iris-AI-only directive whose contents were never intended for the external model and posed a prompt-injection vector when surfaced as untrusted tool data.
+
+ADR-156 reintroduces the data-passthrough mechanism but on a column **explicitly authored for that purpose**, so the security analysis of ADR-151 doesn't apply: the content is not internal Iris-AI behaviour leaking out, it's deliberate scope context the author intends external models to see.
+
+## Decision
+
+Three changes, all in v5.11.0.
+
+### 1. Rename the column
+
+Rename `mcp_prompt` (introduced v5.10.0, ADR-155) → `mcp_system_context`. The new name reflects its purpose: scope context for MCP clients, not a pickable prompt. SQLite m050 and Supabase m054 perform the rename idempotently.
+
+### 2. Remove scope-level entries from the MCP `prompts` channel
+
+`backend/app/prompts/service.py:list_scope_prompts` no longer emits `set:<uuid>` / `collection:<uuid>` entries. The endpoint now returns **named prompts only** (ADR-154 entries, names of the form `set:<uuid>:<name>` / `collection:<uuid>:<name>`). This is a partial revert of ADR-152's scope-system-prompt exposure: scope `system_prompt` is no longer in MCP (ADR-151 strip still applies), and scope `mcp_system_context` was never wired in (ADR-155's wiring is undone before any prod use).
+
+ADR-152's MCP `prompts` capability stays. ADR-154 named prompts still flow through it. Only the per-scope single entry goes away.
+
+### 3. Let `mcp_system_context` flow through MCP tool responses
+
+`mcp_system_context` is **not** in `iris_mcp/links.py:_STRIPPED_KEYS`, so the field passes through `get_set`, `list_sets`, `get_collection`, `list_collections`, and the search endpoint untouched. An MCP client browsing the scope sees the column as part of the entity payload — exactly the pre-ADR-151 flow but on a column built for the role.
+
+`system_prompt` continues to be stripped (ADR-151 unchanged) because it remains a server-side-only directive for Iris's internal AI flows.
+
+## Why undo ADR-155's slash-command exposure rather than keep both
+
+- **One concept, one mechanism.** Keeping the same column as both a tool-data passthrough AND a slash-command entry doubles the consumer's mental model with no benefit. Authors picking which behaviour they want when they only want one is friction.
+- **The slash-command path duplicates named prompts** (ADR-154). If an author wants a discrete pickable directive, that's already what named prompts are for — and they support many per scope. The scope-level single slash command was a redundant slot.
+- **The passthrough path is genuinely new** and is the actual unmet need.
+
+Removing the slash-command exposure now is cheap because v5.10.0 was released minutes before this ADR — no authored content depends on it yet on the UAT instance.
+
+## Why not strip `mcp_system_context` symmetrically with `system_prompt`
+
+- **ADR-151's strip targets server-side-only directive content.** That category fits `system_prompt` (Iris-AI internal). It does not fit `mcp_system_context`, which exists *because* the author wants the external model to see it.
+- **Prompt-injection posture.** Tool data is still tool data — the client model treats it as data, not as a directive. The author authors this column knowing it will land as data on browse. Adversarial scope content is fundamentally an "edit-permission" problem (same scope where any field could carry adversarial text). No new attack surface vs. `description` or `name`.
+
+## Why rename rather than re-use `mcp_prompt`
+
+- **`mcp_prompt` implied "a prompt for MCP"**, fitting the v5.10.0 slash-command framing. With the slash-command path removed, the name misleads. `mcp_system_context` says what the field is: scope-level system-style context for MCP-side consumption.
+- **One-time cost.** v5.10.0 was released minutes ago; renaming now incurs one extra migration and a small code sweep. The alternative — living with the misnomer — multiplies the cost over every future code reader.
+
+## Why no auto-migration of v5.10.0 `mcp_prompt` content (the column is renamed, content preserved)
+
+The column rename preserves data. Any author who populated `mcp_prompt` on UAT during v5.10.0's brief window will find their content under `mcp_system_context` after deploy. They may want to revisit it now that the behaviour is "context passthrough" rather than "picker entry" — different content suits the different role — but the data isn't lost.
+
+## Consequences
+
+- One new SQLite migration `m050_rename_mcp_prompt_to_mcp_system_context.py` (idempotent column rename).
+- One new Supabase migration `m054_rename_mcp_prompt_to_mcp_system_context.sql` (idempotent column rename via `information_schema` guard).
+- Pydantic `CollectionUpdate` / `CollectionResponse` / `SetUpdate` / `SetResponse` field renamed `mcp_prompt` → `mcp_system_context`.
+- `update_collection` and `update_set` keyword arg renamed correspondingly.
+- `app/prompts/service.py:list_scope_prompts` stripped of scope-level SELECTs; emits named-prompt entries only. Docstring and code length significantly reduced.
+- `iris-client` `IrisSet` and `Collection` models field renamed.
+- Frontend state variable + textarea + label + helper text renamed and reworded. The textarea now says "MCP system context" with a placeholder explaining "Passed through as data on MCP get_set responses".
+- `mcp/src/iris_mcp/links.py:_STRIPPED_KEYS` unchanged — still just `("system_prompt",)`. New test `mcp/tests/test_links_passes_mcp_system_context.py` pins the contract that `mcp_system_context` passes through.
+- Existing `mcp/tests/test_links_strip_system_prompt.py` unchanged — ADR-151 still in force.
+- 5 new tests; existing scope-index tests rewritten to assert the new contract (picker = named prompts only; scope content is data-passthrough). 233 tests pass; only the pre-existing `test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO).
+
+## Out of scope (deferred)
+
+- Inheritance for `mcp_system_context`. Set-scope content does not currently merge with parent-Collection content on the tool response. If authors find they want both layered, revisit then. Today: whichever scope is being browsed contributes its own column.
+- A second strip table for scope columns that authors might want stripped. Not asked for; deferred.
+- Migration tooling to copy v5.10.0 `mcp_prompt` body to `system_prompt` or named prompts. Authors handle by hand if they want different content distribution post-rename.
+
+## See also
+
+- [ADR-150](ADR-150-Scope-Level-System-Prompts.md) — original `system_prompt` foundation; Iris-AI auto-apply behaviour preserved unchanged.
+- [ADR-151](ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md) — `system_prompt` strip at MCP boundary; still in force, complemented now by ADR-156's explicit passthrough exception for `mcp_system_context`.
+- [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md) — MCP `prompts` channel; this ADR removes the scope-level entry but keeps the channel for ADR-154 named prompts.
+- [ADR-153](ADR-153-Drop-Redundant-iris-Prefix-From-MCP-Prompt-Names.md) — naming convention unchanged.
+- [ADR-154](ADR-154-Multiple-Named-Prompts-per-Scope.md) — picker entries; now the *only* contents of the picker.
+- [ADR-155](ADR-155-Strict-Split-Iris-AI-vs-MCP-Scope-Prompts.md) — superseded in part. The split column survives (renamed); the slash-command exposure does not.
+- [SPEC-156-A](specs/SPEC-156-A-MCP-System-Context-Data-Passthrough.md) — schema, code-rename map, MCP boundary contract, test plan.

--- a/docs/adrs/specs/SPEC-156-A-MCP-System-Context-Data-Passthrough.md
+++ b/docs/adrs/specs/SPEC-156-A-MCP-System-Context-Data-Passthrough.md
@@ -1,0 +1,106 @@
+# SPEC-156-A: Scope `mcp_system_context` data passthrough
+
+ADR: [ADR-156](../ADR-156-MCP-System-Context-Data-Passthrough.md)
+
+## Database
+
+### SQLite migration `backend/app/migrations/m050_rename_mcp_prompt_to_mcp_system_context.py`
+
+Idempotent column rename on both `collections` and `sets`. PRAGMA-checks both sides of the rename so re-running on an already-renamed DB is a no-op.
+
+```sql
+ALTER TABLE collections RENAME COLUMN mcp_prompt TO mcp_system_context;
+ALTER TABLE sets        RENAME COLUMN mcp_prompt TO mcp_system_context;
+```
+
+### Supabase migration `backend/app/migrations/supabase/m054_rename_mcp_prompt_to_mcp_system_context.sql`
+
+Same rename via `information_schema.columns` guards. Idempotent.
+
+## Backend
+
+### Code rename (`mcp_prompt` → `mcp_system_context`)
+
+| File | What changes |
+|---|---|
+| `backend/app/collections/models.py` | `CollectionUpdate.mcp_prompt` → `mcp_system_context`; same on `CollectionResponse` |
+| `backend/app/collections/service.py` | `_COLLECTION_COLUMNS` SQL column ref; `_row_to_dict` key; `update_collection(...)` keyword arg |
+| `backend/app/collections/router.py` | `update` endpoint passes `body.mcp_system_context` through |
+| `backend/app/sets/models.py` | `SetUpdate.mcp_system_context`; `SetResponse.mcp_system_context` |
+| `backend/app/sets/service.py` | `_SET_COLUMNS`; `_row_to_dict`; `update_set(...)` keyword |
+| `backend/app/sets/router.py` | `update` endpoint passes through |
+
+### Scope-prompt index
+
+`backend/app/prompts/service.py:list_scope_prompts` now returns **named prompts only** (ADR-154 entries). The two scope-level SELECTs (`mcp_prompt` and previously `system_prompt`) are removed. Docstring rewritten.
+
+### Ask Iris path
+
+`backend/app/ai/scope_prompts.py` unchanged. Continues to use `system_prompt`. ADR-150 behaviour preserved.
+
+## iris-client
+
+`iris-client/src/iris_client/models/core.py`:
+- `IrisSet`: `mcp_prompt` field renamed → `mcp_system_context`
+- `Collection`: `mcp_prompt` field renamed → `mcp_system_context`
+
+`IrisClient.list_scope_prompts()` is unchanged in shape; what it now returns from the server is named-prompt entries only.
+
+## MCP server
+
+### `mcp/src/iris_mcp/links.py:_STRIPPED_KEYS`
+
+Unchanged: `("system_prompt",)`. The new `mcp_system_context` field is deliberately NOT in this list — it flows through every MCP tool response (`get_set`, `list_sets`, `get_collection`, `list_collections`, search results) as a regular data field.
+
+### `mcp/src/iris_mcp/prompts.py`
+
+No code changes — the MCP picker continues to consume `client.list_scope_prompts()`, which now returns only named-prompt entries.
+
+## Web GUI
+
+`/sets/[id]` and `/collections/[id]` edit pages: the "MCP prompt" textarea introduced in v5.10.0 (ADR-155) is:
+- renamed to **"MCP system context"** (visible label)
+- placeholder text rewritten: "Passed through as data on MCP get_set responses, so it lands as initial context when an MCP client is browsing this Set. Not applied in Iris AI."
+- helper text rewritten: "Initial context for MCP clients (Claude Desktop / Claude Code) when retrieving this Set via the iris MCP server. Does NOT auto-apply in Iris AI and is NOT a slash-command prompt."
+
+JS state variable: `mcpPrompt` → `mcpSystemContext`. PUT body field: `mcp_prompt` → `mcp_system_context`.
+
+## Tests
+
+| File | What |
+|---|---|
+| `backend/tests/test_migrations/test_mcp_system_context_rename.py` | 5 new cases — SQLite + Supabase rename, idempotency on both sides |
+| `backend/tests/test_prompts/test_router.py` | Rewritten under ADR-156 contract: picker is named-prompts only, scope content does NOT appear in picker, anonymous read still works |
+| `backend/tests/test_prompts/test_router_named_prompts_extension.py` | ADR-155 strict-split tests replaced with ADR-156 data-passthrough tests (mcp_system_context appears on get_set, not in picker; system_prompt still on backend response — strip is MCP-boundary) |
+| `mcp/tests/test_links_passes_mcp_system_context.py` | 4 new cases — mcp_system_context survives `with_web_url`, `with_web_urls_list`, `with_web_urls_search` on Sets and Collections |
+| `mcp/tests/test_links_strip_system_prompt.py` | Unchanged — ADR-151 strip still in force |
+| `frontend/tests/unit/mcpSystemContext.test.ts` | Renamed from `mcpPrompt.test.ts`, field references updated |
+
+## End-to-end verification
+
+```bash
+# 1. Apply Supabase m054 to the UAT DB:
+./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
+
+# 2. On UAT, navigate to /sets/<doview-book-set-id>.
+#    Confirm the "MCP prompt" textarea label is now "MCP system context".
+#    Confirm any v5.10.0 content previously authored is preserved (column was renamed, not dropped).
+
+# 3. In Claude Code with Iris MCP connected:
+#    Run /mcp__iris__get_set with the DoView Book set_id.
+#    Confirm the response includes `mcp_system_context` as a field with the authored content.
+#    Confirm `system_prompt` is NOT in the response (ADR-151 strip still applies).
+
+# 4. Open the MCP prompt picker — confirm:
+#    - No `/iris:set:<uuid>` entry for any scope (ADR-156 removes the scope-level slash command).
+#    - Named prompts authored on a scope still appear as `/iris:set:<uuid>:<name>`.
+
+# 5. In Iris's web AI (Ask Iris on a question scoped to the DoView Book set):
+#    Confirm system_prompt is still auto-applied (Iris-AI behaviour unchanged).
+```
+
+## Out of scope (deferred per ADR-156)
+
+- Inheritance for `mcp_system_context`.
+- Per-mode system_prompt split.
+- Migration tooling to redistribute v5.10.0 `mcp_prompt` content.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.10.0",
+	"version": "5.11.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/collections/[id]/+page.svelte
+++ b/frontend/src/routes/collections/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	let name = $state('');
 	let description = $state('');
 	let systemPrompt = $state('');
-	let mcpPrompt = $state('');
+	let mcpSystemContext = $state('');
 
 	let showDeleteDialog = $state(false);
 	let deleting = $state(false);
@@ -43,7 +43,7 @@
 			name = collectionData.name;
 			description = collectionData.description ?? '';
 			systemPrompt = collectionData.system_prompt ?? '';
-			mcpPrompt = (collectionData as IrisCollection & { mcp_prompt?: string | null }).mcp_prompt ?? '';
+			mcpSystemContext = (collectionData as IrisCollection & { mcp_system_context?: string | null }).mcp_system_context ?? '';
 		} catch {
 			error = 'Failed to load collection';
 		}
@@ -62,8 +62,8 @@
 			const sanitizedPrompt = systemPrompt.trim()
 				? DOMPurify.sanitize(systemPrompt.trim())
 				: null;
-			const sanitizedMcpPrompt = mcpPrompt.trim()
-				? DOMPurify.sanitize(mcpPrompt.trim())
+			const sanitizedMcpSystemContext = mcpSystemContext.trim()
+				? DOMPurify.sanitize(mcpSystemContext.trim())
 				: null;
 
 			await apiFetch<IrisCollection>(`/api/collections/${collectionId}`, {
@@ -72,7 +72,7 @@
 					name: sanitizedName,
 					description: sanitizedDesc,
 					system_prompt: sanitizedPrompt,
-					mcp_prompt: sanitizedMcpPrompt,
+					mcp_system_context: sanitizedMcpSystemContext,
 				}),
 			});
 
@@ -174,22 +174,22 @@
 			</p>
 		</div>
 
-		<!-- MCP prompt (ADR-155, v5.10.0): the inverse of system_prompt -->
+		<!-- MCP system context (ADR-156, v5.11.0): data passthrough on get_collection -->
 		<div class="mt-4">
-			<label for="collection-edit-mcp-prompt" class="text-sm font-medium" style="color: var(--color-fg)">
-				MCP prompt
+			<label for="collection-edit-mcp-system-context" class="text-sm font-medium" style="color: var(--color-fg)">
+				MCP system context
 			</label>
 			<textarea
-				id="collection-edit-mcp-prompt"
-				bind:value={mcpPrompt}
+				id="collection-edit-mcp-system-context"
+				bind:value={mcpSystemContext}
 				rows="6"
 				maxlength="20000"
-				placeholder="Optional. Surfaced through MCP as /iris:collection:<uuid>. Not applied in Iris AI."
+				placeholder="Optional. Passed through as data on MCP get_collection responses, so it lands as initial context when an MCP client is browsing this Collection. Not applied in Iris AI."
 				class="mt-1 w-full rounded border px-3 py-2 text-sm"
 				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
 			></textarea>
 			<p class="mt-1 text-xs" style="color: var(--color-muted)">
-				The opposite of System prompt. Sent to MCP clients (Claude Desktop / Claude Code) via the prompt picker. Does NOT auto-apply in Iris AI.
+				Initial context for MCP clients (Claude Desktop / Claude Code) when retrieving this Collection via the iris MCP server. Does NOT auto-apply in Iris AI and is NOT a slash-command prompt.
 			</p>
 		</div>
 

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -24,7 +24,7 @@
 	let thumbnailFile = $state<File | null>(null);
 	let collectionId = $state<string | null>(null);
 	let systemPrompt = $state('');
-	let mcpPrompt = $state('');
+	let mcpSystemContext = $state('');
 
 	let showDeleteDialog = $state(false);
 	let deleting = $state(false);
@@ -53,7 +53,7 @@
 			thumbnailDiagramId = setData.thumbnail_diagram_id;
 			collectionId = setData.collection_id ?? null;
 			systemPrompt = setData.system_prompt ?? '';
-			mcpPrompt = (setData as IrisSet & { mcp_prompt?: string | null }).mcp_prompt ?? '';
+			mcpSystemContext = (setData as IrisSet & { mcp_system_context?: string | null }).mcp_system_context ?? '';
 		} catch {
 			error = 'Failed to load set';
 		}
@@ -72,8 +72,8 @@
 			const sanitizedPrompt = systemPrompt.trim()
 				? DOMPurify.sanitize(systemPrompt.trim())
 				: null;
-			const sanitizedMcpPrompt = mcpPrompt.trim()
-				? DOMPurify.sanitize(mcpPrompt.trim())
+			const sanitizedMcpSystemContext = mcpSystemContext.trim()
+				? DOMPurify.sanitize(mcpSystemContext.trim())
 				: null;
 
 			await apiFetch<IrisSet>(`/api/sets/${setId}`, {
@@ -85,7 +85,7 @@
 					thumbnail_diagram_id: thumbnailSource === 'model' ? thumbnailDiagramId : null,
 					collection_id: collectionId,
 					system_prompt: sanitizedPrompt,
-					mcp_prompt: sanitizedMcpPrompt,
+					mcp_system_context: sanitizedMcpSystemContext,
 				}),
 			});
 
@@ -234,22 +234,22 @@
 			</p>
 		</div>
 
-		<!-- MCP prompt (ADR-155, v5.10.0): the inverse of system_prompt -->
+		<!-- MCP system context (ADR-156, v5.11.0): data passthrough on get_set -->
 		<div class="mt-4">
-			<label for="set-edit-mcp-prompt" class="text-sm font-medium" style="color: var(--color-fg)">
-				MCP prompt
+			<label for="set-edit-mcp-system-context" class="text-sm font-medium" style="color: var(--color-fg)">
+				MCP system context
 			</label>
 			<textarea
-				id="set-edit-mcp-prompt"
-				bind:value={mcpPrompt}
+				id="set-edit-mcp-system-context"
+				bind:value={mcpSystemContext}
 				rows="6"
 				maxlength="20000"
-				placeholder="Optional. Surfaced through MCP as /iris:set:<uuid>. Not applied in Iris AI."
+				placeholder="Optional. Passed through as data on MCP get_set responses, so it lands as initial context when an MCP client is browsing this Set. Not applied in Iris AI."
 				class="mt-1 w-full rounded border px-3 py-2 text-sm"
 				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: var(--font-mono, monospace)"
 			></textarea>
 			<p class="mt-1 text-xs" style="color: var(--color-muted)">
-				The opposite of System prompt. Sent to MCP clients (Claude Desktop / Claude Code) via the prompt picker. Does NOT auto-apply in Iris AI.
+				Initial context for MCP clients (Claude Desktop / Claude Code) when retrieving this Set via the iris MCP server. Does NOT auto-apply in Iris AI and is NOT a slash-command prompt.
 			</p>
 		</div>
 

--- a/frontend/tests/unit/mcpSystemContext.test.ts
+++ b/frontend/tests/unit/mcpSystemContext.test.ts
@@ -2,7 +2,7 @@
  * ADR-155 (v5.10.0): strict-split scope prompts.
  *
  * - `system_prompt`: auto-applies in Iris AI, not surfaced via MCP.
- * - `mcp_prompt`: surfaced via MCP picker as `set:<uuid>` /
+ * - `mcp_system_context`: surfaced via MCP picker as `set:<uuid>` /
  *   `collection:<uuid>`, never auto-applies in Iris AI.
  *
  * Lightweight unit tests aligned with this repo's frontend testing
@@ -12,7 +12,7 @@
 import { describe, expect, it } from 'vitest';
 
 describe('Set edit page PUT payload shape (ADR-155)', () => {
-	it('PUT body separates system_prompt and mcp_prompt', () => {
+	it('PUT body separates system_prompt and mcp_system_context', () => {
 		// Mirrors handleSave composition in routes/sets/[id]/+page.svelte
 		const payload = {
 			name: 'DoView Book',
@@ -21,27 +21,27 @@ describe('Set edit page PUT payload shape (ADR-155)', () => {
 			thumbnail_diagram_id: null,
 			collection_id: null,
 			system_prompt: 'Iris-AI directive.',
-			mcp_prompt: 'MCP-only directive.',
+			mcp_system_context: 'MCP-only directive.',
 		};
-		expect(payload.system_prompt).not.toBe(payload.mcp_prompt);
+		expect(payload.system_prompt).not.toBe(payload.mcp_system_context);
 		expect(Object.keys(payload)).toContain('system_prompt');
-		expect(Object.keys(payload)).toContain('mcp_prompt');
+		expect(Object.keys(payload)).toContain('mcp_system_context');
 	});
 
-	it('mcp_prompt is null when textarea is empty', () => {
+	it('mcp_system_context is null when textarea is empty', () => {
 		const mcpPromptInput = '   ';
 		const sanitized = mcpPromptInput.trim() ? mcpPromptInput.trim() : null;
 		expect(sanitized).toBeNull();
 	});
 
-	it('system_prompt and mcp_prompt are independent', () => {
-		// Author populates only mcp_prompt — system_prompt should remain null.
+	it('system_prompt and mcp_system_context are independent', () => {
+		// Author populates only mcp_system_context — system_prompt should remain null.
 		const payload = {
 			system_prompt: null,
-			mcp_prompt: 'MCP-only directive.',
+			mcp_system_context: 'MCP-only directive.',
 		};
 		expect(payload.system_prompt).toBeNull();
-		expect(payload.mcp_prompt).toBe('MCP-only directive.');
+		expect(payload.mcp_system_context).toBe('MCP-only directive.');
 	});
 });
 
@@ -51,9 +51,9 @@ describe('Collection edit page PUT payload shape (ADR-155)', () => {
 			name: 'NZISM',
 			description: null,
 			system_prompt: 'Cite the control number.',
-			mcp_prompt: 'Format responses in markdown.',
+			mcp_system_context: 'Format responses in markdown.',
 		};
 		expect(payload.system_prompt).toBeDefined();
-		expect(payload.mcp_prompt).toBeDefined();
+		expect(payload.mcp_system_context).toBeDefined();
 	});
 });

--- a/iris-client/src/iris_client/models/core.py
+++ b/iris-client/src/iris_client/models/core.py
@@ -112,12 +112,12 @@ class IrisSet(EntityBase):
 
     collection_id: str | None = None
     system_prompt: str | None = None
-    mcp_prompt: str | None = None  # ADR-155 (v5.10.0): MCP-only directive
+    mcp_system_context: str | None = None  # ADR-155 (v5.10.0): MCP-only directive
 
 
 class Collection(EntityBase):
     system_prompt: str | None = None
-    mcp_prompt: str | None = None  # ADR-155 (v5.10.0): MCP-only directive
+    mcp_system_context: str | None = None  # ADR-155 (v5.10.0): MCP-only directive
 
 
 class ScopePromptIndexEntry(_Permissive):

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.10.0"
+version = "5.11.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/tests/test_links_passes_mcp_system_context.py
+++ b/mcp/tests/test_links_passes_mcp_system_context.py
@@ -1,0 +1,87 @@
+"""v5.11.0 / ADR-156: scope `mcp_system_context` is data passthrough.
+
+ADR-151 (v5.8.2) strips `system_prompt` from MCP tool responses
+because that column is server-side-only directive content and lets in
+prompt-injection vectors when treated as untrusted data. ADR-156
+introduces a SECOND scope column, `mcp_system_context`, with the
+opposite intent: it is *meant* to flow through MCP tool responses as
+initial context for the model when a user is browsing the scope. The
+v5.8.2 strip must therefore NOT touch this column.
+
+These tests pin the contract: `mcp_system_context` survives the
+links.py boundary unchanged in the same payload shapes the
+`system_prompt` tests cover.
+"""
+
+from __future__ import annotations
+
+import json
+
+from iris_mcp.links import with_web_url, with_web_urls_list, with_web_urls_search
+
+WEB = "https://iris-uat.chrisbarlow.nz"
+
+
+class TestMcpSystemContextPassesThrough:
+    def test_with_web_url_keeps_mcp_system_context_on_set(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "id": "set-1", "name": "DoView Book",
+            "system_prompt": "Iris-AI only.",
+            "mcp_system_context": "MCP browsing context for DoView Book.",
+            "description": "Visual companion.",
+        })
+        out = json.loads(with_web_url(payload, "set"))
+        # system_prompt is stripped (ADR-151)…
+        assert "system_prompt" not in out
+        # …but mcp_system_context passes through (ADR-156).
+        assert out["mcp_system_context"] == "MCP browsing context for DoView Book."
+
+    def test_with_web_url_keeps_mcp_system_context_on_collection(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "id": "coll-1", "name": "NZISM",
+            "system_prompt": "Iris-AI only.",
+            "mcp_system_context": "MCP browsing context for NZISM.",
+        })
+        out = json.loads(with_web_url(payload, "collection"))
+        assert "system_prompt" not in out
+        assert out["mcp_system_context"] == "MCP browsing context for NZISM."
+
+    def test_with_web_urls_list_keeps_mcp_system_context_per_item(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps([
+            {"id": "s1", "name": "A",
+             "system_prompt": "iris-internal-A",
+             "mcp_system_context": "mcp-A"},
+            {"id": "s2", "name": "B",
+             "system_prompt": "iris-internal-B",
+             "mcp_system_context": "mcp-B"},
+            {"id": "s3", "name": "C"},  # neither column populated
+        ])
+        out = json.loads(with_web_urls_list(payload, "set"))
+        # system_prompt stripped on all, mcp_system_context preserved.
+        assert all("system_prompt" not in item for item in out)
+        assert out[0]["mcp_system_context"] == "mcp-A"
+        assert out[1]["mcp_system_context"] == "mcp-B"
+        # Item without the column is unaffected.
+        assert "mcp_system_context" not in out[2]
+
+    def test_with_web_urls_search_keeps_mcp_system_context_per_result(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps({
+            "query": "x",
+            "results": [
+                {"result_type": "set", "id": "s1", "name": "S1",
+                 "system_prompt": "iris-only",
+                 "mcp_system_context": "mcp-passthrough"},
+                {"result_type": "collection", "id": "c1", "name": "C1",
+                 "system_prompt": "iris-only",
+                 "mcp_system_context": "coll-passthrough"},
+            ],
+        })
+        out = json.loads(with_web_urls_search(payload))
+        for r in out["results"]:
+            assert "system_prompt" not in r
+        assert out["results"][0]["mcp_system_context"] == "mcp-passthrough"
+        assert out["results"][1]["mcp_system_context"] == "coll-passthrough"


### PR DESCRIPTION
## Summary

Repositions v5.10.0's `mcp_prompt` slash-command exposure as **data passthrough** instead. The content authors want attached to a scope is initial context for an MCP client browsing the scope, not a directive the user picks.

- **Rename**: `mcp_prompt` → `mcp_system_context` on Collections and Sets (SQLite m050 + Supabase m054, idempotent rename, data preserved).
- **Remove** scope-level entries from the MCP `prompts` channel. Picker now contains named prompts only (ADR-154 unchanged).
- **Let it flow through MCP tool responses** — `mcp_system_context` is NOT in `links.py:_STRIPPED_KEYS`, so it passes through `get_set` / `list_sets` / `get_collection` / `list_collections` / search results as scope data.
- `system_prompt` continues to auto-apply in Iris AI and continues to be stripped from MCP tool responses (ADR-150 / ADR-151 unchanged).

See [ADR-156](docs/adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) and [SPEC-156-A](docs/adrs/specs/SPEC-156-A-MCP-System-Context-Data-Passthrough.md).

## Why supersede ADR-155 a day after

The slash-command exposure introduced in v5.10.0 was wrong for the actual job (context-passthrough, not user-picked directive). v5.10.0 was released minutes before this work began — no production content depends on it yet. Doing the right thing now is cheap.

## Test plan

- [x] `test_migrations/test_mcp_system_context_rename.py` — 5 new (SQLite + Supabase rename + idempotency)
- [x] `mcp/tests/test_links_passes_mcp_system_context.py` — 4 new (passthrough survives `with_web_url` / `with_web_urls_list` / `with_web_urls_search` on sets and collections)
- [x] `test_prompts/test_router.py` rewritten under ADR-156 contract (picker = named prompts only; scope content is data-passthrough)
- [x] `test_prompts/test_router_named_prompts_extension.py` strict-split tests replaced with passthrough/visibility tests
- [x] `frontend/tests/unit/mcpSystemContext.test.ts` (renamed from `mcpPrompt.test.ts`)
- [x] `mcp/tests/test_links_strip_system_prompt.py` unchanged — ADR-151 still in force
- [x] All v5.8.x / v5.9.x test suites pass unchanged. **233 tests total pass.** Only pre-existing unrelated failure: `test_no_extra_rls_tables` (issue 88 Phase 4 TODO).

## UAT

After deploy:

```bash
./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
```

Migration m054 renames the column in place (idempotent). Any content authored in v5.10.0 is preserved under the new column name.

In Claude Code with Iris MCP connected:
- Run `mcp__iris__get_set` against the DoView Book Set ID → confirm `mcp_system_context` appears as a field in the response.
- Open the MCP prompt picker → confirm no `/iris:set:<uuid>` entry for any scope. Named prompts (`/iris:set:<uuid>:<name>`) still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)