### PR TITLE
feat(v5.12.0): layered response_format prompts + doview_analysis artefact (ADR-157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.12.0] - 2026-05-12
+
+### Added
+
+- **Layered response_format prompts** (ADR-157, SPEC-157-A). New
+  `purpose` discriminator column on `ai_creation_prompts` separates
+  `creation_format` rows (existing v5.8.x diagram-creation prompts;
+  all backfilled to `creation_format`) from `response_format` rows
+  (new — used to shape formal text responses). New
+  `build_response_system_prompt(notation, diagram_type)` composer
+  sibling to `build_creation_system_prompt`; both share a single
+  `_build_layered_prompt(purpose, notation, diagram_type)` cascade
+  implementation (DRY, protocols §13).
+- **`(notation=markdown, diagram_type=doview_analysis)` artefact type**
+  registered as a first-class Iris type: a formal handbook-grounded
+  outcomes-theory analysis. Seeded with three response_format prompt
+  rows (base + notation + diagram_type) encoding the Prompt C output
+  shape — opening sentence, Summary, Full, Diagrams sections,
+  formal style and raw-URL rules.
+- **Two new MCP tools** (anonymous-readable):
+  `list_response_format_types` (discover available pairs) and
+  `get_response_prompt(notation, diagram_type?)` (fetch composed
+  cascade body). Lets a client model in Claude Desktop / Claude
+  Code retrieve the response format as reference material in
+  conversation, no slash-command UX needed.
+- **`save_doview_analysis` MCP tool** (auth-required — reuses
+  existing `IRIS_TOKEN` per-server PAT) — persists a generated
+  analysis as a new `doview_analysis` diagram in Iris.
+- **Two new backend endpoints** under `/api/ai/response-prompts/*`
+  (anonymous-readable): `types` and `composed`.
+- **iris-client methods**: `list_response_format_types()`,
+  `get_response_prompt()`, `create_diagram()`.
+
+### Changed
+
+- `CreationPromptResponse` gains a `purpose: str = "creation_format"`
+  field (backwards-compat default). `list_creation_prompts` accepts
+  an optional `?purpose=` filter.
+- m051's registry inserts (markdown notation, doview_analysis
+  diagram_type, mapping) skip gracefully when those registry tables
+  aren't present — enables clean test isolation.
+
+### Migration
+
+- SQLite `m051_response_format_prompts.py` — adds `purpose` column,
+  backfills, registers markdown + doview_analysis, seeds three
+  response_format rows.
+- Supabase `m055_response_format_prompts.sql` — same. Run
+  `./scripts/supabase-migrate.sh` after deploy. Idempotent.
+
+### Deferred to v5.13+ (per ADR-157 "Out of scope")
+
+- Server-side auto-injection of `build_response_system_prompt` into
+  the Ask Iris pipeline.
+- `applicable_response_types` field on Set/Collection MCP responses.
+- Admin Settings / AI GUI for editing response_format rows (editing
+  works via the existing `PUT /api/ai/creation-prompts/{id}` endpoint
+  with the new `purpose` field round-tripping correctly).
+
 ## [5.11.0] - 2026-05-11
 
 ### Changed (breaking — supersedes v5.10.0 picker behaviour)

--- a/backend/app/ai/creation.py
+++ b/backend/app/ai/creation.py
@@ -20,39 +20,47 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def build_creation_system_prompt(
+async def _build_layered_prompt(
     db: aiosqlite.Connection,
+    *,
+    purpose: str,
     notation: str,
-    diagram_type: str | None = None,
-) -> str:
-    """Compose a system prompt from the layered ai_creation_prompts table.
+    diagram_type: str | None,
+) -> tuple[str, int]:
+    """Compose a layered prompt body filtered by `purpose`.
 
-    Layer priority:
-    - override (notation-specific, active): returned alone — replaces all layers.
-    - base: shared instructions for all AI diagram creation.
-    - notation-specific: methodology for the given notation.
-    - diagram_type-specific: layout rules for the specific diagram type.
+    Used by both `build_creation_system_prompt` (purpose='creation_format')
+    and `build_response_system_prompt` (purpose='response_format'). Layer
+    priority is identical:
 
-    Returns empty string if no active prompts exist.
+    - `override` (notation-specific, active): returned alone — replaces all layers.
+    - `base`: shared instructions for this purpose.
+    - `notation`-specific: methodology / framing for the given notation.
+    - `diagram_type`-specific: output structure / layout rules for the
+      specific diagram type.
+
+    Returns `(composed_text, n_layers_used)`. Composed text is `""` and
+    n_layers is 0 if no active prompts exist for this purpose.
     """
-    # Check for active override for this notation
+    # Check for active override for this notation under this purpose.
     cursor = await db.execute(
         "SELECT prompt_text FROM ai_creation_prompts "
-        "WHERE layer = 'override' AND notation = ? AND is_active = 1 "
+        "WHERE purpose = ? AND layer = 'override' AND notation = ? AND is_active = 1 "
         "ORDER BY display_order LIMIT 1",
-        (notation,),
+        (purpose, notation),
     )
     override_row = await cursor.fetchone()
     if override_row:
-        return override_row[0]
+        return override_row[0], 1
 
     parts: list[str] = []
 
     # Base layer
     cursor = await db.execute(
         "SELECT prompt_text FROM ai_creation_prompts "
-        "WHERE layer = 'base' AND is_active = 1 "
+        "WHERE purpose = ? AND layer = 'base' AND is_active = 1 "
         "ORDER BY display_order",
+        (purpose,),
     )
     for row in await cursor.fetchall():
         parts.append(row[0])
@@ -60,9 +68,9 @@ async def build_creation_system_prompt(
     # Notation layer
     cursor = await db.execute(
         "SELECT prompt_text FROM ai_creation_prompts "
-        "WHERE layer = 'notation' AND notation = ? AND is_active = 1 "
+        "WHERE purpose = ? AND layer = 'notation' AND notation = ? AND is_active = 1 "
         "ORDER BY display_order",
-        (notation,),
+        (purpose, notation),
     )
     for row in await cursor.fetchall():
         parts.append(row[0])
@@ -71,14 +79,28 @@ async def build_creation_system_prompt(
     if diagram_type:
         cursor = await db.execute(
             "SELECT prompt_text FROM ai_creation_prompts "
-            "WHERE layer = 'diagram_type' AND diagram_type = ? AND is_active = 1 "
+            "WHERE purpose = ? AND layer = 'diagram_type' AND diagram_type = ? AND is_active = 1 "
             "ORDER BY display_order",
-            (diagram_type,),
+            (purpose, diagram_type),
         )
         for row in await cursor.fetchall():
             parts.append(row[0])
 
-    result = "\n\n".join(parts)
+    return "\n\n".join(parts), len(parts)
+
+
+async def build_creation_system_prompt(
+    db: aiosqlite.Connection,
+    notation: str,
+    diagram_type: str | None = None,
+) -> str:
+    """Compose the diagram-CREATION system prompt for (notation, diagram_type)."""
+    result, n_layers = await _build_layered_prompt(
+        db,
+        purpose="creation_format",
+        notation=notation,
+        diagram_type=diagram_type,
+    )
 
     # Preamble: when both notation and diagram_type are present, make the
     # user's UI selection explicit so the AI does not re-ask for information
@@ -98,7 +120,37 @@ async def build_creation_system_prompt(
         )
         result = f"{preamble}\n{result}"
 
-    print(f"[AI_CREATION] Built system prompt: {len(parts)} layers, {len(result)} chars", flush=True)
+    print(f"[AI_CREATION] Built system prompt: {n_layers} layers, {len(result)} chars", flush=True)
+    return result
+
+
+async def build_response_system_prompt(
+    db: aiosqlite.Connection,
+    notation: str,
+    diagram_type: str | None = None,
+) -> str:
+    """Compose the response-FORMAT system prompt for (notation, diagram_type).
+
+    Used by:
+    - Iris AI (Ask Iris discuss/creation modes; mcp__iris__ask) — composed
+      server-side into the system content when the conversation context
+      matches a notation+diagram_type with a response_format prompt set
+      (ADR-157).
+    - MCP clients (Claude Desktop / Claude Code) — fetched via the
+      `iris_get_response_prompt` MCP tool and applied client-side as
+      reference for matching questions (lower compliance ceiling but
+      same source of truth).
+
+    Returns empty string if no response_format prompts exist for this
+    (notation, diagram_type) combination.
+    """
+    result, n_layers = await _build_layered_prompt(
+        db,
+        purpose="response_format",
+        notation=notation,
+        diagram_type=diagram_type,
+    )
+    print(f"[AI_RESPONSE] Built response prompt: {n_layers} layers, {len(result)} chars", flush=True)
     return result
 
 

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -162,11 +162,18 @@ class ConversationResponse(BaseModel):
 
 
 class CreationPromptResponse(BaseModel):
-    """Response for a single AI creation prompt."""
+    """Response for a single AI creation or response prompt.
+
+    Despite the name (kept for backwards compat), this model covers
+    both `purpose='creation_format'` and `purpose='response_format'`
+    rows (ADR-157, v5.12.0). The Admin UI uses `purpose` to segment
+    creation-mode prompts from response-format prompts.
+    """
 
     id: str
     name: str
     description: str | None = None
+    purpose: str = "creation_format"  # 'creation_format' | 'response_format'
     layer: str
     notation: str | None = None
     diagram_type: str | None = None
@@ -179,10 +186,40 @@ class CreationPromptResponse(BaseModel):
 
 
 class CreationPromptUpdate(BaseModel):
-    """Request body for updating an AI creation prompt."""
+    """Request body for updating an AI creation or response prompt."""
 
     prompt_text: str | None = None
     is_active: bool | None = None
+
+
+class ResponsePromptComposed(BaseModel):
+    """Composed response-format body for a (notation, diagram_type)
+    cascade (ADR-157, v5.12.0).
+
+    Anonymous-readable: scope content is universal across users; the
+    response_format rules are admin-authored and editable but not
+    sensitive.
+    """
+
+    notation: str
+    diagram_type: str | None = None
+    body: str  # composed cascade body — may be empty if no rows match
+
+
+class ResponseFormatType(BaseModel):
+    """One available response-format type — a (notation, diagram_type)
+    pair that has at least one active response_format prompt row
+    (ADR-157, v5.12.0).
+
+    Surfaced by `GET /api/ai/response-prompts/types` and used by MCP
+    clients (via `applicable_response_types` on Set/Collection
+    responses) to discover what formats can be composed.
+    """
+
+    notation: str
+    diagram_type: str | None = None
+    label: str  # human-friendly UI label (combines notation + diagram_type names)
+    description: str | None = None  # optional description from the diagram_type row
 
 
 class ApplyCreationRequest(BaseModel):

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -34,7 +34,7 @@ async def _is_ai_debug(db: object) -> bool:
         return False
 
 from app.ai import service
-from app.ai.creation import create_diagrams_from_ai
+from app.ai.creation import build_response_system_prompt, create_diagrams_from_ai
 from app.ai.error_mapper import map_provider_error
 from app.ai.models import (
     ActiveProviderResponse,
@@ -51,6 +51,8 @@ from app.ai.models import (
     ProviderUpdate,
     QARequest,
     QAResponse,
+    ResponseFormatType,
+    ResponsePromptComposed,
 )
 from app.auth.dependencies import get_current_user, get_optional_user
 
@@ -816,33 +818,129 @@ async def _ask_multi_set_streaming(
 async def list_creation_prompts(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    purpose: str | None = Query(default=None, description="Filter by purpose: 'creation_format' or 'response_format'"),
 ) -> list[CreationPromptResponse]:
-    """List all AI diagram creation prompts. Admin only."""
+    """List all AI creation/response prompts. Admin only.
+
+    Pass `?purpose=creation_format` or `?purpose=response_format` to
+    filter (ADR-157, v5.12.0). Omit for all rows under both purposes.
+    """
     _require_admin(current_user)
     db = request.app.state.db_manager.main_db
-    cursor = await db.execute(
-        "SELECT id, name, description, layer, notation, diagram_type, "
+
+    base_query = (
+        "SELECT id, name, description, purpose, layer, notation, diagram_type, "
         "prompt_text, display_order, is_active, created_by, created_at, updated_at "
-        "FROM ai_creation_prompts ORDER BY layer, display_order"
+        "FROM ai_creation_prompts"
     )
+    if purpose is not None:
+        cursor = await db.execute(
+            f"{base_query} WHERE purpose = ? ORDER BY purpose, layer, display_order",
+            (purpose,),
+        )
+    else:
+        cursor = await db.execute(
+            f"{base_query} ORDER BY purpose, layer, display_order",
+        )
     rows = await cursor.fetchall()
     return [
         CreationPromptResponse(
             id=r[0],
             name=r[1],
             description=r[2],
-            layer=r[3],
-            notation=r[4],
-            diagram_type=r[5],
-            prompt_text=r[6],
-            display_order=r[7],
-            is_active=bool(r[8]),
-            created_by=r[9],
-            created_at=r[10],
-            updated_at=r[11],
+            purpose=r[3] or "creation_format",
+            layer=r[4],
+            notation=r[5],
+            diagram_type=r[6],
+            prompt_text=r[7],
+            display_order=r[8],
+            is_active=bool(r[9]),
+            created_by=r[10],
+            created_at=r[11],
+            updated_at=r[12],
         )
         for r in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# Response-format prompts (ADR-157, v5.12.0)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/response-prompts/types", response_model=list[ResponseFormatType])
+async def list_response_format_types(
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> list[ResponseFormatType]:
+    """List distinct (notation, diagram_type) pairs that have at least
+    one active response_format prompt (ADR-157, v5.12.0).
+
+    Anonymous-readable. Used by MCP clients (via the
+    `applicable_response_types` field on Set/Collection responses) to
+    discover what formats can be composed for a given conversation
+    context.
+    """
+    db = request.app.state.db_manager.main_db
+
+    # Find every distinct (notation, diagram_type) with at least one
+    # response_format row of layer=notation or layer=diagram_type. The
+    # base layer alone doesn't constitute a usable format.
+    cursor = await db.execute(
+        """
+        SELECT DISTINCT
+            COALESCE(p.notation, dtn.notation_id) AS notation,
+            p.diagram_type AS diagram_type,
+            COALESCE(dt.name, p.diagram_type) AS dt_label,
+            dt.description AS dt_desc
+        FROM ai_creation_prompts p
+        LEFT JOIN diagram_types dt ON p.diagram_type = dt.id
+        LEFT JOIN diagram_type_notations dtn ON p.diagram_type = dtn.diagram_type_id
+        WHERE p.purpose = 'response_format'
+          AND p.is_active = 1
+          AND p.layer IN ('notation', 'diagram_type', 'override')
+          AND COALESCE(p.notation, dtn.notation_id) IS NOT NULL
+          AND p.diagram_type IS NOT NULL
+        ORDER BY notation, p.diagram_type
+        """,
+    )
+    rows = await cursor.fetchall()
+    return [
+        ResponseFormatType(
+            notation=r[0],
+            diagram_type=r[1],
+            label=f"{r[2] or r[1]}",
+            description=r[3],
+        )
+        for r in rows
+    ]
+
+
+@router.get("/response-prompts/composed", response_model=ResponsePromptComposed)
+async def get_response_prompt_composed(
+    request: Request,
+    notation: str = Query(..., description="Notation id (e.g. 'markdown', 'doview')"),
+    diagram_type: str | None = Query(default=None, description="Optional diagram_type id (e.g. 'doview_analysis')"),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ResponsePromptComposed:
+    """Compose the response_format prompt cascade for a (notation,
+    diagram_type) pair (ADR-157, v5.12.0).
+
+    Anonymous-readable. Returns the composed body as `body`; empty
+    string if no rows match. Used by:
+
+    - Iris AI server-side via `build_response_system_prompt` (this
+      endpoint is the HTTP surface for the same composer).
+    - MCP clients via the `iris_get_response_prompt` tool to apply
+      the rules client-side as reference for matching questions.
+    """
+    db = request.app.state.db_manager.main_db
+    body = await build_response_system_prompt(db, notation, diagram_type)
+    return ResponsePromptComposed(
+        notation=notation,
+        diagram_type=diagram_type,
+        body=body,
+    )
 
 
 @router.put("/creation-prompts/{prompt_id}", response_model=CreationPromptResponse)
@@ -881,7 +979,7 @@ async def update_creation_prompt(
         await db.commit()
 
     cursor = await db.execute(
-        "SELECT id, name, description, layer, notation, diagram_type, "
+        "SELECT id, name, description, purpose, layer, notation, diagram_type, "
         "prompt_text, display_order, is_active, created_by, created_at, updated_at "
         "FROM ai_creation_prompts WHERE id = ?",
         (prompt_id,),
@@ -891,15 +989,16 @@ async def update_creation_prompt(
         id=row[0],
         name=row[1],
         description=row[2],
-        layer=row[3],
-        notation=row[4],
-        diagram_type=row[5],
-        prompt_text=row[6],
-        display_order=row[7],
-        is_active=bool(row[8]),
-        created_by=row[9],
-        created_at=row[10],
-        updated_at=row[11],
+        purpose=row[3] or "creation_format",
+        layer=row[4],
+        notation=row[5],
+        diagram_type=row[6],
+        prompt_text=row[7],
+        display_order=row[8],
+        is_active=bool(row[9]),
+        created_by=row[10],
+        created_at=row[11],
+        updated_at=row[12],
     )
 
 

--- a/backend/app/migrations/m051_response_format_prompts.py
+++ b/backend/app/migrations/m051_response_format_prompts.py
@@ -1,0 +1,354 @@
+"""Migration 051: layered response_format prompts (ADR-157, SPEC-157-A).
+
+Extends the v5.8.0 `ai_creation_prompts` mechanism so the same layered
+composition pattern that governs diagram CREATION (ADR-132) also
+governs RESPONSE FORMAT — the shape of formal, handbook-grounded
+text+diagram analyses produced both by Iris AI (server-side) and by
+MCP clients (Claude Desktop / Claude Code) via a fetch tool.
+
+Three changes:
+
+1. Add a `purpose` column to `ai_creation_prompts`. Values:
+     - `creation_format` — existing rows, used when CREATING diagrams
+     - `response_format` — new rows, used when RESPONDING to questions
+
+   Existing rows backfilled to `creation_format`.
+
+2. Register `(notation=markdown, diagram_type=doview_analysis)` in the
+   notation / diagram_type registry. The artifact type is "a formal
+   handbook-grounded outcomes-theory analysis" — markdown content
+   with embedded ```mermaid``` blocks from referenced tool pages.
+
+3. Seed response_format prompts for `doview_analysis` (base + notation
+   + diagram_type layers) encoding the rules from Prompt C
+   (`docs/prompts/doview-book-prompt-c-iris.md`):
+     - Opening sentence + three-section structure
+     - Style rules (formal, no first-person, no drafting advice)
+     - URL rules (raw plain text)
+     - Source restriction (Iris DoView Book set only)
+     - Embedded mermaid blocks reproduced verbatim from tool diagrams
+
+Idempotent. New columns / rows guarded; existing rows updated only
+when their `purpose` is NULL.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m051_response_format_prompts"
+
+# ── Seed: response_format prompts for doview_analysis ─────────────────
+
+_RESPONSE_FORMAT_BASE = """\
+## Response format — universal rules
+
+You are producing a formal response that the user can copy into an
+email, document, report, or plain-text system without loss of meaning.
+
+Apply these universal rules to every response, regardless of notation
+or diagram type:
+
+- Write formally. Do not write conversationally.
+- Do not give drafting advice to the user. Do not use "I would",
+  "you could", "a better answer is", or "a sentence you could use".
+- Do not address the user directly inside the standalone sections.
+- Every URL in the response body must be raw, visible, copy-safe
+  plain text beginning with `https://`. Do not use markdown links.
+  Do not use reference-style links. Do not put URLs inside square
+  brackets.
+- When citing Iris source diagrams, reproduce embedded ```mermaid```
+  code blocks verbatim from `data.content`. Do not redraw, simplify,
+  rename labels, or change arrow directions.
+- Cite all sources at the end of the response in a full handbook /
+  reference format with the URL as raw visible plain text.
+"""
+
+_RESPONSE_FORMAT_DOVIEW_ANALYSIS_NOTATION = """\
+## Response format — DoView / outcomes theory framing
+
+Use outcomes theory as the primary point of view throughout. Prefer
+wording such as:
+
+- "Outcomes theory points out that..."
+- "Outcomes theory highlights that..."
+- "Outcomes theory emphasises that..."
+- "This violates the outcomes theory principle that..."
+- "Outcomes theory points out that this is a technical outcomes
+  problem because..."
+
+Do not present DoView as the primary theory. DoView is the practical
+applied form of outcomes theory: a "This-Then" model of what needs
+to happen to achieve higher-level outcomes.
+
+The first time the phrase "outcomes system" is used in each
+standalone section, include this definition:
+
+  An outcomes system is to purposeful action what an accounting
+  system is to financial activity: the underlying structure that
+  defines what matters, records what is happening, supports
+  reporting, and makes accountability possible. The difference is
+  that instead of tracking money, it tracks intended changes in the
+  world and the evidence that action is contributing to them.
+
+When DoView Boards or diagrams are referenced, use wording such as:
+"One way this can be done in practice is to use a DoView Board, a
+specific type of outcomes model that is drawn to conform to the
+principles of outcomes theory."
+
+Do not describe an approach as "DoView-compatible". Describe it as
+an outcomes theory approach.
+
+### Source restriction
+
+Source content comes from the Iris DoView Book set only
+(set_id 33032180-d77a-4ce4-88cf-b49cd643e093). Use mcp__iris__search
+and mcp__iris__get_diagram against this set to retrieve the handbook
+and its individual tool pages. Do not use general knowledge. Do not
+use the rest of the internet.
+
+Each DoView tool is a pair of diagrams in this set:
+- A "question" diagram (description includes "kind: question · pair: <code>")
+- A "tool" diagram (description includes "kind: tool · pair: <code>")
+
+The tool diagram contains the practical mechanism plus an embedded
+```mermaid``` flowchart in its `data.content`. When citing a tool in
+the text or reproducing its diagram, use only the tool-kind diagram.
+
+### Tool URL convention
+
+Tool references map deterministically to a public page URL by the
+lowercase pair code:
+
+  https://doviewplanning.org/<paircode>doviewtool
+
+Example: pair code `b16` → `https://doviewplanning.org/b16doviewtool`.
+
+### Full handbook reference (cite at the end of each section)
+
+  Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook:
+  100+ Innovative, Integrated Tools for Solving Key Issues in
+  Planning, Implementation, Contracting, Measurement, Evaluation
+  and Reporting (for Humans and AI Agents). DoViewPlanning.Org.
+  https://doviewplanning.org/book
+"""
+
+_RESPONSE_FORMAT_DOVIEW_ANALYSIS_DIAGRAM_TYPE = """\
+## Response format — doview_analysis output structure
+
+Produce a three-section formal analysis. Every section is fully
+standalone — each can be sent on its own without loss of meaning.
+
+### Required opening sentence
+
+The response must begin exactly with this sentence:
+
+  I have prepared a summary response, a full response, and the
+  original diagrams from the handbook. These are all standalone so
+  you can send them to anyone.
+
+Immediately after this sentence, produce three sections with the
+headings below, in order.
+
+### 1. Summary response to [briefly summarise the question]
+
+Concise formal summary. Must include:
+- a short outcomes theory answer;
+- the key relevant outcomes theory principle(s);
+- wording that identifies the issue as a technical outcomes problem
+  where appropriate;
+- the outcomes system definition if the phrase is used;
+- a brief explanation of DoView outcomes models where DoView is
+  mentioned;
+- any relevant DoView tool names, each followed immediately by its
+  full raw visible plain-text URL;
+- the full handbook reference at the end.
+
+### 2. Full response to [briefly summarise the question]
+
+Full formal response, standalone, with its own brief summary at the
+start. Must include:
+- a brief summary;
+- the full outcomes theory answer;
+- the relevant outcomes theory principle(s);
+- wording that identifies the issue as a technical outcomes problem
+  where appropriate;
+- the outcomes system definition if the phrase is used;
+- any firm statement of a violation of outcomes theory principles
+  where applicable;
+- an explanation that outcomes theory talks in terms of a DoView
+  outcomes model underlying action in the world: a "This-Then"
+  model of what needs to happen to achieve higher-level outcomes;
+- an explanation of DoView Boards or diagrams as applied practical
+  tools used when doing outcomes work;
+- practical formal implications;
+- relevant DoView tool names, each followed by its full raw visible
+  plain-text URL;
+- the full handbook reference at the end.
+
+### 3. Diagrams from the DoView Planning and Outcomes Theory Handbook
+
+Begin this section with this note:
+
+  This diagrams section reproduces the original mermaid diagrams
+  from the Iris DoView Book set. Rendering depends on the AI
+  system's ability to render mermaid. Where the diagram does not
+  render visually, the mermaid source remains visible and can be
+  copied into any mermaid-capable system.
+
+For each tool referenced in sections 1 or 2, in first-mention order:
+
+  #### Tool <PAIRCODE_UPPERCASE>: <tool-diagram-name>
+
+  Page URL: https://doviewplanning.org/<paircode>doviewtool
+
+  ```mermaid
+  <verbatim mermaid block from the Iris tool diagram's data.content>
+  ```
+
+  Formal relevance note: <one short formal sentence explaining the
+  diagram's relevance to the answer above>
+
+If no tool diagrams were referenced in sections 1 or 2, omit section
+3 entirely.
+
+After section 3 (or section 2 if 3 is omitted), end the response
+with the full handbook reference once more, in raw visible plain
+text.
+
+### Final compliance check
+
+Before answering, verify:
+- the response begins with the exact required opening sentence;
+- it contains exactly the three required sections (or two if no
+  tool diagrams);
+- every tool mentioned has its full raw visible plain-text URL;
+- there are no markdown links, no `[URL](URL)` syntax, no
+  reference-style links, no footnotes, no "see above";
+- every URL is raw text beginning with `https://`;
+- DoView is presented only as the practical applied form of
+  outcomes theory, never as a primary theory of its own;
+- all cited content came from the Iris DoView Book set; no general
+  knowledge has been used; no diagram has been redrawn from memory.
+"""
+
+
+_SEED_PROMPTS = [
+    {
+        "id": "response-format-base-v1",
+        "name": "Response format base",
+        "description": "Universal response-format rules (purpose: response_format, layer: base, all notations).",
+        "purpose": "response_format",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": _RESPONSE_FORMAT_BASE,
+    },
+    {
+        "id": "response-format-doview-notation-v1",
+        "name": "Response format — DoView / outcomes theory framing",
+        "description": "Outcomes-theory framing rules applied when the notation is markdown and the conversation is about DoView content (purpose: response_format, layer: notation, notation: markdown).",
+        "purpose": "response_format",
+        "layer": "notation",
+        # Keyed under markdown notation because doview_analysis output
+        # is a markdown document; the DoView framing is in the body.
+        "notation": "markdown",
+        "diagram_type": None,
+        "prompt_text": _RESPONSE_FORMAT_DOVIEW_ANALYSIS_NOTATION,
+    },
+    {
+        "id": "response-format-doview-analysis-v1",
+        "name": "Response format — doview_analysis output structure",
+        "description": "Three-section formal analysis output structure for (markdown, doview_analysis) — opening sentence, Summary, Full, Diagrams, handbook reference (purpose: response_format, layer: diagram_type).",
+        "purpose": "response_format",
+        "layer": "diagram_type",
+        "notation": None,
+        "diagram_type": "doview_analysis",
+        "prompt_text": _RESPONSE_FORMAT_DOVIEW_ANALYSIS_DIAGRAM_TYPE,
+    },
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Add purpose column, register doview_analysis, seed response_format prompts."""
+
+    # 1. Add purpose column to ai_creation_prompts if missing.
+    cursor = await db.execute("PRAGMA table_info(ai_creation_prompts)")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "purpose" not in columns:
+        await db.execute(
+            "ALTER TABLE ai_creation_prompts ADD COLUMN purpose TEXT "
+            "NOT NULL DEFAULT 'creation_format'",
+        )
+        # Belt-and-braces: any NULL rows after the ALTER get backfilled.
+        await db.execute(
+            "UPDATE ai_creation_prompts SET purpose = 'creation_format' "
+            "WHERE purpose IS NULL OR purpose = ''",
+        )
+
+    # 2. Register markdown notation + doview_analysis diagram_type +
+    #    mapping. These inserts touch the registry tables created by
+    #    m020 (`notations`, `diagram_types`, `diagram_type_notations`).
+    #    In a real production run they always exist (m020 is in the
+    #    migration chain). In some test fixtures, m020 is not run.
+    #    Skip gracefully via existence checks so this migration is safe
+    #    in those isolated contexts.
+
+    async def _table_exists(name: str) -> bool:
+        cursor = await db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?",
+            (name,),
+        )
+        return (await cursor.fetchone()) is not None
+
+    if await _table_exists("notations"):
+        await db.execute(
+            "INSERT OR IGNORE INTO notations (id, name, description, display_order) "
+            "VALUES (?, ?, ?, ?)",
+            ("markdown", "Markdown", "Markdown text content (may include embedded mermaid)", 5),
+        )
+
+    if await _table_exists("diagram_types"):
+        await db.execute(
+            "INSERT OR IGNORE INTO diagram_types (id, name, description, display_order) "
+            "VALUES (?, ?, ?, ?)",
+            (
+                "doview_analysis",
+                "DoView Analysis",
+                "A formal handbook-grounded outcomes-theory analysis (markdown text with embedded mermaid diagrams from referenced handbook tool pages).",
+                10,
+            ),
+        )
+
+    if await _table_exists("diagram_type_notations"):
+        await db.execute(
+            "INSERT OR IGNORE INTO diagram_type_notations "
+            "(diagram_type_id, notation_id, is_default) VALUES (?, ?, ?)",
+            ("doview_analysis", "markdown", 1),
+        )
+
+    # 4. Seed the three response_format prompt rows. Idempotent via
+    #    INSERT OR IGNORE on the primary key.
+    for prompt in _SEED_PROMPTS:
+        await db.execute(
+            "INSERT OR IGNORE INTO ai_creation_prompts "
+            "(id, name, description, purpose, layer, notation, diagram_type, "
+            "prompt_text, display_order, is_active) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+            (
+                prompt["id"],
+                prompt["name"],
+                prompt["description"],
+                prompt["purpose"],
+                prompt["layer"],
+                prompt["notation"],
+                prompt["diagram_type"],
+                prompt["prompt_text"],
+                0,
+            ),
+        )
+
+    await db.commit()

--- a/backend/app/migrations/supabase/m055_response_format_prompts.sql
+++ b/backend/app/migrations/supabase/m055_response_format_prompts.sql
@@ -1,0 +1,273 @@
+-- Migration 055: layered response_format prompts (ADR-157, SPEC-157-A).
+--
+-- Mirrors SQLite migration m051_response_format_prompts.py.
+--
+-- 1. Add `purpose` column to `ai_creation_prompts` with default
+--    'creation_format'; backfill any pre-existing NULL rows.
+-- 2. Register markdown notation + doview_analysis diagram_type.
+-- 3. Seed three response_format prompt rows (base + notation + diagram_type
+--    layers) encoding Prompt C's rules.
+--
+-- Idempotent. CREATE/INSERT guarded with IF NOT EXISTS / ON CONFLICT
+-- DO NOTHING / WHERE NOT EXISTS.
+
+-- 1. Add `purpose` column.
+ALTER TABLE public.ai_creation_prompts
+    ADD COLUMN IF NOT EXISTS purpose TEXT NOT NULL DEFAULT 'creation_format';
+
+UPDATE public.ai_creation_prompts
+SET purpose = 'creation_format'
+WHERE purpose IS NULL OR purpose = '';
+
+-- 2. Register markdown notation and doview_analysis diagram_type.
+INSERT INTO public.notations (id, name, description, display_order)
+VALUES ('markdown', 'Markdown', 'Markdown text content (may include embedded mermaid)', 5)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.diagram_types (id, name, description, display_order)
+VALUES (
+    'doview_analysis',
+    'DoView Analysis',
+    'A formal handbook-grounded outcomes-theory analysis (markdown text with embedded mermaid diagrams from referenced handbook tool pages).',
+    10
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.diagram_type_notations (diagram_type_id, notation_id, is_default)
+VALUES ('doview_analysis', 'markdown', 1)
+ON CONFLICT (diagram_type_id, notation_id) DO NOTHING;
+
+-- 3. Seed response_format prompt rows. Bodies match the SQLite seed
+-- (m051). Stored as one statement per row for clarity; bodies are
+-- multi-line using dollar-quoting to avoid escape headaches.
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'response-format-base-v1',
+    'Response format base',
+    'Universal response-format rules (purpose: response_format, layer: base, all notations).',
+    'response_format',
+    'base',
+    NULL,
+    NULL,
+    $body$## Response format — universal rules
+
+You are producing a formal response that the user can copy into an
+email, document, report, or plain-text system without loss of meaning.
+
+Apply these universal rules to every response, regardless of notation
+or diagram type:
+
+- Write formally. Do not write conversationally.
+- Do not give drafting advice to the user. Do not use "I would",
+  "you could", "a better answer is", or "a sentence you could use".
+- Do not address the user directly inside the standalone sections.
+- Every URL in the response body must be raw, visible, copy-safe
+  plain text beginning with `https://`. Do not use markdown links.
+  Do not use reference-style links. Do not put URLs inside square
+  brackets.
+- When citing Iris source diagrams, reproduce embedded ```mermaid```
+  code blocks verbatim from `data.content`. Do not redraw, simplify,
+  rename labels, or change arrow directions.
+- Cite all sources at the end of the response in a full handbook /
+  reference format with the URL as raw visible plain text.
+$body$,
+    0,
+    1
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'response-format-doview-notation-v1',
+    'Response format — DoView / outcomes theory framing',
+    'Outcomes-theory framing rules applied when the notation is markdown and the conversation is about DoView content (purpose: response_format, layer: notation, notation: markdown).',
+    'response_format',
+    'notation',
+    'markdown',
+    NULL,
+    $body$## Response format — DoView / outcomes theory framing
+
+Use outcomes theory as the primary point of view throughout. Prefer
+wording such as:
+
+- "Outcomes theory points out that..."
+- "Outcomes theory highlights that..."
+- "Outcomes theory emphasises that..."
+- "This violates the outcomes theory principle that..."
+- "Outcomes theory points out that this is a technical outcomes
+  problem because..."
+
+Do not present DoView as the primary theory. DoView is the practical
+applied form of outcomes theory: a "This-Then" model of what needs
+to happen to achieve higher-level outcomes.
+
+The first time the phrase "outcomes system" is used in each
+standalone section, include this definition:
+
+  An outcomes system is to purposeful action what an accounting
+  system is to financial activity: the underlying structure that
+  defines what matters, records what is happening, supports
+  reporting, and makes accountability possible. The difference is
+  that instead of tracking money, it tracks intended changes in the
+  world and the evidence that action is contributing to them.
+
+When DoView Boards or diagrams are referenced, use wording such as:
+"One way this can be done in practice is to use a DoView Board, a
+specific type of outcomes model that is drawn to conform to the
+principles of outcomes theory."
+
+Do not describe an approach as "DoView-compatible". Describe it as
+an outcomes theory approach.
+
+### Source restriction
+
+Source content comes from the Iris DoView Book set only
+(set_id 33032180-d77a-4ce4-88cf-b49cd643e093). Use mcp__iris__search
+and mcp__iris__get_diagram against this set to retrieve the handbook
+and its individual tool pages. Do not use general knowledge. Do not
+use the rest of the internet.
+
+Each DoView tool is a pair of diagrams in this set:
+- A "question" diagram (description includes "kind: question · pair: <code>")
+- A "tool" diagram (description includes "kind: tool · pair: <code>")
+
+The tool diagram contains the practical mechanism plus an embedded
+```mermaid``` flowchart in its `data.content`. When citing a tool in
+the text or reproducing its diagram, use only the tool-kind diagram.
+
+### Tool URL convention
+
+Tool references map deterministically to a public page URL by the
+lowercase pair code:
+
+  https://doviewplanning.org/<paircode>doviewtool
+
+Example: pair code `b16` → `https://doviewplanning.org/b16doviewtool`.
+
+### Full handbook reference (cite at the end of each section)
+
+  Duignan, P. (2025). DoView Planning and Outcomes Theory Handbook:
+  100+ Innovative, Integrated Tools for Solving Key Issues in
+  Planning, Implementation, Contracting, Measurement, Evaluation
+  and Reporting (for Humans and AI Agents). DoViewPlanning.Org.
+  https://doviewplanning.org/book
+$body$,
+    0,
+    1
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'response-format-doview-analysis-v1',
+    'Response format — doview_analysis output structure',
+    'Three-section formal analysis output structure for (markdown, doview_analysis) — opening sentence, Summary, Full, Diagrams, handbook reference (purpose: response_format, layer: diagram_type).',
+    'response_format',
+    'diagram_type',
+    NULL,
+    'doview_analysis',
+    $body$## Response format — doview_analysis output structure
+
+Produce a three-section formal analysis. Every section is fully
+standalone — each can be sent on its own without loss of meaning.
+
+### Required opening sentence
+
+The response must begin exactly with this sentence:
+
+  I have prepared a summary response, a full response, and the
+  original diagrams from the handbook. These are all standalone so
+  you can send them to anyone.
+
+Immediately after this sentence, produce three sections with the
+headings below, in order.
+
+### 1. Summary response to [briefly summarise the question]
+
+Concise formal summary. Must include:
+- a short outcomes theory answer;
+- the key relevant outcomes theory principle(s);
+- wording that identifies the issue as a technical outcomes problem
+  where appropriate;
+- the outcomes system definition if the phrase is used;
+- a brief explanation of DoView outcomes models where DoView is
+  mentioned;
+- any relevant DoView tool names, each followed immediately by its
+  full raw visible plain-text URL;
+- the full handbook reference at the end.
+
+### 2. Full response to [briefly summarise the question]
+
+Full formal response, standalone, with its own brief summary at the
+start. Must include:
+- a brief summary;
+- the full outcomes theory answer;
+- the relevant outcomes theory principle(s);
+- wording that identifies the issue as a technical outcomes problem
+  where appropriate;
+- the outcomes system definition if the phrase is used;
+- any firm statement of a violation of outcomes theory principles
+  where applicable;
+- an explanation that outcomes theory talks in terms of a DoView
+  outcomes model underlying action in the world: a "This-Then"
+  model of what needs to happen to achieve higher-level outcomes;
+- an explanation of DoView Boards or diagrams as applied practical
+  tools used when doing outcomes work;
+- practical formal implications;
+- relevant DoView tool names, each followed by its full raw visible
+  plain-text URL;
+- the full handbook reference at the end.
+
+### 3. Diagrams from the DoView Planning and Outcomes Theory Handbook
+
+Begin this section with this note:
+
+  This diagrams section reproduces the original mermaid diagrams
+  from the Iris DoView Book set. Rendering depends on the AI
+  system's ability to render mermaid. Where the diagram does not
+  render visually, the mermaid source remains visible and can be
+  copied into any mermaid-capable system.
+
+For each tool referenced in sections 1 or 2, in first-mention order:
+
+  #### Tool <PAIRCODE_UPPERCASE>: <tool-diagram-name>
+
+  Page URL: https://doviewplanning.org/<paircode>doviewtool
+
+  ```mermaid
+  <verbatim mermaid block from the Iris tool diagram's data.content>
+  ```
+
+  Formal relevance note: <one short formal sentence explaining the
+  diagram's relevance to the answer above>
+
+If no tool diagrams were referenced in sections 1 or 2, omit section
+3 entirely.
+
+After section 3 (or section 2 if 3 is omitted), end the response
+with the full handbook reference once more, in raw visible plain
+text.
+
+### Final compliance check
+
+Before answering, verify:
+- the response begins with the exact required opening sentence;
+- it contains exactly the three required sections (or two if no
+  tool diagrams);
+- every tool mentioned has its full raw visible plain-text URL;
+- there are no markdown links, no `[URL](URL)` syntax, no
+  reference-style links, no footnotes, no "see above";
+- every URL is raw text beginning with `https://`;
+- DoView is presented only as the practical applied form of
+  outcomes theory, never as a primary theory of its own;
+- all cited content came from the Iris DoView Book set; no general
+  knowledge has been used; no diagram has been redrawn from memory.
+$body$,
+    0,
+    1
+)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -55,6 +55,7 @@ from app.migrations.m047_scope_system_prompts import up as m047_up
 from app.migrations.m048_named_prompts import up as m048_up
 from app.migrations.m049_mcp_prompt_column import up as m049_up
 from app.migrations.m050_rename_mcp_prompt_to_mcp_system_context import up as m050_up
+from app.migrations.m051_response_format_prompts import up as m051_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -136,6 +137,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m048_up(main)
     await m049_up(main)
     await m050_up(main)
+    await m051_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_ai/test_creation_prompts_expanded.py
+++ b/backend/tests/test_ai/test_creation_prompts_expanded.py
@@ -17,6 +17,7 @@ import pytest_asyncio
 
 from app.ai.creation import build_creation_system_prompt
 from app.migrations.m028_ai_creation_prompts import up as m028_up
+from app.migrations.m051_response_format_prompts import up as m051_up
 from app.seed.creation_prompts import seed_creation_prompts
 
 # Bundles the expansion must support (SPEC-132-A row inventory).
@@ -37,6 +38,11 @@ async def db() -> aiosqlite.Connection:
     async with aiosqlite.connect(":memory:") as conn:
         await m028_up(conn)
         await seed_creation_prompts(conn)
+        # m051 adds the `purpose` column to ai_creation_prompts so the
+        # composer's WHERE-purpose-filter resolves (ADR-157, v5.12.0).
+        # The registry inserts in m051 are auto-skipped when m020's
+        # registry tables aren't present (test isolation).
+        await m051_up(conn)
         yield conn
 
 
@@ -194,11 +200,25 @@ class TestSeedIdempotency:
     async def test_expected_total_row_count(
         self, db: aiosqlite.Connection
     ) -> None:
-        """After seed: 4 DoView-era rows + 11 new rows = 15 active rows."""
+        """After seed: 4 DoView-era rows + 11 new rows = 15 active
+        creation_format rows (v5.8.0). Plus 3 response_format rows
+        added by m051 (ADR-157, v5.12.0) = 18 total active rows.
+        Verify both counts independently so a regression in either
+        purpose's seed surfaces clearly."""
         cursor = await db.execute(
-            "SELECT COUNT(*) FROM ai_creation_prompts WHERE is_active=1"
+            "SELECT COUNT(*) FROM ai_creation_prompts "
+            "WHERE is_active=1 AND purpose = 'creation_format'"
         )
-        count = (await cursor.fetchone())[0]
-        assert count == 15, (
-            f"Expected 15 active prompt rows after expansion seed, got {count}"
+        creation_count = (await cursor.fetchone())[0]
+        assert creation_count == 15, (
+            f"Expected 15 active creation_format rows, got {creation_count}"
+        )
+
+        cursor = await db.execute(
+            "SELECT COUNT(*) FROM ai_creation_prompts "
+            "WHERE is_active=1 AND purpose = 'response_format'"
+        )
+        response_count = (await cursor.fetchone())[0]
+        assert response_count == 3, (
+            f"Expected 3 active response_format rows (ADR-157), got {response_count}"
         )

--- a/backend/tests/test_ai/test_creation_service.py
+++ b/backend/tests/test_ai/test_creation_service.py
@@ -11,6 +11,7 @@ import pytest_asyncio
 from app.ai.creation import build_creation_system_prompt, create_diagrams_from_ai
 from app.migrations.m026_ai_providers import up as m026_up
 from app.migrations.m028_ai_creation_prompts import up as m028_up
+from app.migrations.m051_response_format_prompts import up as m051_up
 
 
 async def _minimal_schema(conn: aiosqlite.Connection) -> None:
@@ -120,6 +121,10 @@ async def db():
         await _minimal_schema(conn)
         await m026_up(conn)
         await m028_up(conn)
+        # m051 adds the `purpose` column the composer filters on
+        # (ADR-157, v5.12.0). Registry inserts in m051 are auto-skipped
+        # when their tables aren't present in this minimal fixture.
+        await m051_up(conn)
         yield conn
 
 

--- a/backend/tests/test_ai/test_response_system_prompt.py
+++ b/backend/tests/test_ai/test_response_system_prompt.py
@@ -1,0 +1,191 @@
+"""v5.12.0 (ADR-157): `build_response_system_prompt` composes the
+layered response_format prompts and is isolated from creation_format
+prompts under the same `ai_creation_prompts` table.
+
+Uses a minimal fixture: only the `ai_creation_prompts` table is
+required for the composer (it queries no other tables). Seeds rows
+directly to keep the test focused and independent of migration
+ordering.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.ai.creation import (
+    build_creation_system_prompt,
+    build_response_system_prompt,
+)
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS ai_creation_prompts (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    purpose TEXT NOT NULL DEFAULT 'creation_format',
+    layer TEXT NOT NULL,
+    notation TEXT,
+    diagram_type TEXT,
+    prompt_text TEXT NOT NULL,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+
+def _seed_row(*, id: str, purpose: str, layer: str, notation: str | None,
+              diagram_type: str | None, body: str) -> tuple:
+    return (id, id, purpose, layer, notation, diagram_type, body)
+
+
+@pytest.fixture
+async def prompts_db(main_db: aiosqlite.Connection) -> aiosqlite.Connection:
+    """A SQLite DB with only the `ai_creation_prompts` table and a
+    small set of seed rows covering creation_format and response_format
+    under both creation and response purposes."""
+    await main_db.execute(_CREATE_TABLE)
+
+    seeds = [
+        # creation_format rows (existing v5.8.x behaviour — composer must
+        # still find these under purpose='creation_format')
+        _seed_row(
+            id="creation-base",
+            purpose="creation_format", layer="base",
+            notation=None, diagram_type=None,
+            body="## Creation base\nYou create diagrams.",
+        ),
+        _seed_row(
+            id="creation-doview-notation",
+            purpose="creation_format", layer="notation",
+            notation="doview", diagram_type=None,
+            body="## DoView Creation Methodology\nStage 0: Setup Questions.",
+        ),
+        _seed_row(
+            id="creation-doview-outcomes_map",
+            purpose="creation_format", layer="diagram_type",
+            notation=None, diagram_type="outcomes_map",
+            body="## Outcomes map layout rules\nColumns left to right.",
+        ),
+
+        # response_format rows (new v5.12.0 — composer with purpose='response_format'
+        # filter must pick these up and only these)
+        _seed_row(
+            id="response-base",
+            purpose="response_format", layer="base",
+            notation=None, diagram_type=None,
+            body="## Response format base\nApply these universal rules.",
+        ),
+        _seed_row(
+            id="response-markdown-notation",
+            purpose="response_format", layer="notation",
+            notation="markdown", diagram_type=None,
+            body="## Response format DoView framing\nOutcomes theory points out that.",
+        ),
+        _seed_row(
+            id="response-doview-analysis",
+            purpose="response_format", layer="diagram_type",
+            notation=None, diagram_type="doview_analysis",
+            body="## doview_analysis output structure\nI have prepared a summary response.",
+        ),
+    ]
+    for row in seeds:
+        await main_db.execute(
+            "INSERT INTO ai_creation_prompts "
+            "(id, name, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, 0, 1)",
+            row,
+        )
+    await main_db.commit()
+    return main_db
+
+
+class TestBuildResponseSystemPrompt:
+    async def test_composes_three_layers_for_doview_analysis(
+        self, prompts_db: aiosqlite.Connection,
+    ) -> None:
+        """For (notation=markdown, diagram_type=doview_analysis), the
+        composer should stack base + notation + diagram_type layers."""
+        text = await build_response_system_prompt(
+            prompts_db, "markdown", "doview_analysis",
+        )
+        # Base layer.
+        assert "Apply these universal rules" in text
+        # Notation layer (DoView framing).
+        assert "Outcomes theory points out that" in text
+        # Diagram_type layer (output structure).
+        assert "I have prepared a summary response" in text
+
+    async def test_returns_empty_for_notation_with_no_response_format(
+        self, prompts_db: aiosqlite.Connection,
+    ) -> None:
+        """A notation with no response_format rows returns just the base
+        layer (which is shared). If we strip the base too, empty."""
+        text = await build_response_system_prompt(prompts_db, "uml", "class")
+        # No uml/class response_format seed → only the base layer
+        # contributes; no notation or diagram_type content.
+        assert "Apply these universal rules" in text
+        assert "Outcomes theory" not in text
+        assert "summary response" not in text.lower()
+
+    async def test_does_not_leak_creation_prompt_content(
+        self, prompts_db: aiosqlite.Connection,
+    ) -> None:
+        """The response composer must filter by purpose='response_format'
+        and not pick up creation_format rows."""
+        text = await build_response_system_prompt(
+            prompts_db, "markdown", "doview_analysis",
+        )
+        # Creation seed bodies.
+        assert "Creation base" not in text
+        assert "DoView Creation Methodology" not in text
+        assert "Outcomes map layout rules" not in text
+
+    async def test_creation_composer_unchanged_by_response_seeds(
+        self, prompts_db: aiosqlite.Connection,
+    ) -> None:
+        """The creation composer must filter by purpose='creation_format'
+        and not pick up response_format rows."""
+        text = await build_creation_system_prompt(
+            prompts_db, "doview", "outcomes_map",
+        )
+        # Creation bodies present.
+        assert "Creation base" in text
+        assert "DoView Creation Methodology" in text
+        assert "Outcomes map layout rules" in text
+        # Response bodies absent.
+        assert "Apply these universal rules" not in text
+        assert "summary response" not in text.lower()
+
+
+class TestPurposeIsolation:
+    async def test_creation_and_response_use_separate_rows(
+        self, prompts_db: aiosqlite.Connection,
+    ) -> None:
+        """ai_creation_prompts table has rows under both purposes; each
+        composer filters correctly without leakage."""
+        creation = await build_creation_system_prompt(
+            prompts_db, "doview", "outcomes_map",
+        )
+        response = await build_response_system_prompt(
+            prompts_db, "markdown", "doview_analysis",
+        )
+
+        # Both produced non-empty output.
+        assert creation
+        assert response
+
+        # Each pulls its own seeds.
+        assert "DoView Creation Methodology" in creation
+        assert "DoView Creation Methodology" not in response
+
+        assert "summary response" in response.lower()
+        assert "summary response" not in creation.lower()

--- a/backend/tests/test_migrations/test_response_format_prompts_schema.py
+++ b/backend/tests/test_migrations/test_response_format_prompts_schema.py
@@ -1,0 +1,106 @@
+"""v5.12.0 (ADR-157, SPEC-157-A): static-parser tests asserting that
+SQLite m051 and Supabase m055 add the `purpose` column to
+`ai_creation_prompts`, register the `markdown` notation and
+`doview_analysis` diagram_type, and seed three response_format
+prompt rows (base / notation / diagram_type layers).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m051 ─────────────────────────────────────────────────────────
+
+
+def test_sqlite_m051_adds_purpose_column() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    assert "ADD COLUMN purpose TEXT" in py
+    assert "DEFAULT 'creation_format'" in py
+
+
+def test_sqlite_m051_backfills_existing_rows() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    assert "UPDATE ai_creation_prompts SET purpose = 'creation_format'" in py
+
+
+def test_sqlite_m051_registers_markdown_notation() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    assert "INSERT OR IGNORE INTO notations" in py
+    assert "\"markdown\"" in py
+    assert "\"Markdown\"" in py
+
+
+def test_sqlite_m051_registers_doview_analysis_diagram_type() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    assert "INSERT OR IGNORE INTO diagram_types" in py
+    assert "\"doview_analysis\"" in py
+    assert "\"DoView Analysis\"" in py
+
+
+def test_sqlite_m051_maps_doview_analysis_to_markdown() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    assert "INSERT OR IGNORE INTO diagram_type_notations" in py
+    assert "(\"doview_analysis\", \"markdown\", 1)" in py
+
+
+def test_sqlite_m051_seeds_three_response_format_layers() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    for prompt_id in (
+        "response-format-base-v1",
+        "response-format-doview-notation-v1",
+        "response-format-doview-analysis-v1",
+    ):
+        assert prompt_id in py, f"missing seed prompt {prompt_id!r}"
+    # Each layer accounted for.
+    assert "\"purpose\": \"response_format\"" in py
+    assert "\"layer\": \"base\"" in py
+    assert "\"layer\": \"notation\"" in py
+    assert "\"layer\": \"diagram_type\"" in py
+
+
+def test_sqlite_m051_seeds_doview_rules_content() -> None:
+    py = _read("app/migrations/m051_response_format_prompts.py")
+    # Spot-check that key Prompt-C rules are encoded in the seeds.
+    # Use whitespace-tolerant checks since the seed bodies are line-wrapped.
+    flat = " ".join(py.split())
+    assert "Outcomes theory points out that" in flat
+    assert "DoView is the practical applied form" in flat
+    assert "outcomes system" in flat
+    assert "I have prepared a summary response" in flat
+    assert "doviewplanning.org" in flat
+
+
+# ── Supabase m055 ───────────────────────────────────────────────────────
+
+
+def test_supabase_m055_adds_purpose_column_idempotently() -> None:
+    sql = _read("app/migrations/supabase/m055_response_format_prompts.sql")
+    assert "ADD COLUMN IF NOT EXISTS purpose TEXT" in sql
+    assert "DEFAULT 'creation_format'" in sql
+
+
+def test_supabase_m055_registers_markdown_and_doview_analysis() -> None:
+    sql = _read("app/migrations/supabase/m055_response_format_prompts.sql")
+    assert "INSERT INTO public.notations" in sql
+    assert "'markdown'" in sql
+    assert "INSERT INTO public.diagram_types" in sql
+    assert "'doview_analysis'" in sql
+    assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
+def test_supabase_m055_seeds_three_response_format_rows() -> None:
+    sql = _read("app/migrations/supabase/m055_response_format_prompts.sql")
+    for prompt_id in (
+        "response-format-base-v1",
+        "response-format-doview-notation-v1",
+        "response-format-doview-analysis-v1",
+    ):
+        assert prompt_id in sql, f"missing supabase seed {prompt_id!r}"
+    assert sql.count("'response_format'") >= 3

--- a/docs/adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md
+++ b/docs/adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md
@@ -1,0 +1,115 @@
+# ADR-157: Response-format prompts (layered, admin-editable) and the `doview_analysis` artefact
+
+Status: Accepted (2026-05-12)
+Extends: [ADR-094-B](ADR-094-B-AI-Creation-Service.md), [ADR-132](ADR-132-Layered-Creation-Prompts.md)
+Amends: [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md) (in part — see Decision below)
+
+## Context
+
+ADR-094-B and ADR-132 gave Iris a layered, admin-editable system for **diagram creation** prompts (`ai_creation_prompts` table; `build_creation_system_prompt` composer; Admin Settings / AI page). When a user creates a DoView outcomes map in Iris, those layered prompts steer the LLM through a structured interview and produce JSON the backend materialises into canvas diagrams.
+
+What was missing: the symmetric mechanism for **response formatting** — a layered, admin-editable system that governs the *shape* of formal text+diagram analyses produced both by Iris's server-side AI (Ask Iris discuss / creation modes; `mcp__iris__ask`) and by MCP-side client models (Claude Desktop / Claude Code in conversation).
+
+The user-facing trigger was the DoView Book scope on UAT. The author wants natural-conversation UX in Claude Desktop where asking "what does outcomes theory say about X?" produces a strict three-section formal analysis (Summary + Full + Diagrams with embedded mermaid) that is copy-pasteable into emails / reports. That structure is documented in `docs/prompts/doview-book-prompt-c-iris.md` ("Prompt C") and contains rules — required opening sentence, raw URLs only, formal style, source restriction to handbook tools — that need to live somewhere admin-editable.
+
+ADR-156 (v5.11.0) gave us `mcp_system_context` as a per-scope passthrough field. That is the right shape for *scope-specific* context but the wrong home for response-format rules, which are **universal to a notation/diagram_type pair**: any conversation about DoView content uses the same shape regardless of which scope hosts it. Centralised storage in the existing layered-prompts mechanism is the architecturally honest home.
+
+## Decision
+
+Three changes, all in v5.12.0.
+
+### 1. Add a `purpose` discriminator to the existing layered-prompts mechanism
+
+Extend `ai_creation_prompts` with a `purpose TEXT NOT NULL DEFAULT 'creation_format'` column. Values:
+
+- `creation_format` — used when CREATING a diagram (existing v5.8.x behaviour; backfilled to this for all pre-v5.12.0 rows).
+- `response_format` — used when RESPONDING to a question, both server-side in Iris AI and client-side via MCP (new in v5.12.0).
+
+The composer was split into a generic `_build_layered_prompt(purpose, notation, diagram_type)` inner function, with `build_creation_system_prompt` and the new `build_response_system_prompt` as thin wrappers — same cascade logic (override → base → notation → diagram_type), filtered by `purpose`. DRY (protocol §13).
+
+The existing layer enum (`base`, `notation`, `diagram_type`, `override`) is unchanged and applies under both purposes.
+
+### 2. Register `(notation=markdown, diagram_type=doview_analysis)` as a first-class artefact type
+
+A `doview_analysis` is "a formal handbook-grounded outcomes-theory analysis (markdown text with embedded mermaid diagrams from referenced handbook tool pages)". Sibling to `(notation=doview, diagram_type=outcomes_map)`: same governance pattern, different output medium (text instead of visual).
+
+This registration enables both:
+- **Live conversational use**: client model fetches `response_format` for `(markdown, doview_analysis)` and applies it.
+- **Persistence**: users (or MCP clients, via the new save tool) can write a generated analysis back as a regular Iris diagram of this type. Symmetric to how an outcomes map is saved.
+
+### 3. Seed Prompt C content as three layered response_format prompt rows
+
+- `response-format-base-v1` — universal output-structure rules (any notation).
+- `response-format-doview-notation-v1` — outcomes-theory framing, source restriction, tool URL convention, handbook reference. Keyed under `notation=markdown` because the artefact is markdown text; the DoView subject matter is encoded in the body.
+- `response-format-doview-analysis-v1` — three-section structure (opening sentence, Summary, Full, Diagrams), compliance check, per-Prompt C.
+
+### MCP surface
+
+- **`list_response_format_types`** (anonymous) — returns available `(notation, diagram_type, label, description)` pairs.
+- **`get_response_prompt`** (anonymous) — returns the composed cascade body for a given pair.
+- **`save_doview_analysis`** (authenticated — wraps `POST /api/diagrams`) — persists a generated analysis as a `doview_analysis` diagram. Reuses existing IRIS_TOKEN-on-server auth model; no new auth surface.
+
+### Iris AI surface
+
+`build_response_system_prompt(db, notation, diagram_type)` is the server-side composer; `GET /api/ai/response-prompts/composed?notation=&diagram_type=` is the HTTP surface for client-side fetch. Both consume the same rows from the same table.
+
+Wiring of `build_response_system_prompt` into Iris's `Ask Iris` request path is deferred to a follow-up (see "Out of scope" below) — the mechanism exists; explicit invocation by client model is the v5.12.0 path.
+
+## Amendment to ADR-156
+
+ADR-156's `mcp_system_context` field stays: it is the right home for **per-scope** context that the model sees when browsing the scope (e.g. "this set is about NZISM; cite the control number"). It is **no longer** intended as the home for response-format rules, because those rules are universal across scopes that share a notation+diagram_type. The DoView Book Set's `mcp_system_context` becomes a short pointer to the new mechanism (manual edit on UAT, not code).
+
+## Why split via a `purpose` column rather than a separate table
+
+- **DRY (§13)**: the composer cascade, the admin CRUD endpoints, the seed mechanism, and the layer semantics are identical for creation_format and response_format prompts. One table + a discriminator keeps a single source of truth for the cascade logic.
+- **Smaller blast radius**: backfill on a single column versus dual-table maintenance, two sets of indexes, and parallel admin UI plumbing.
+- **No semantic conflict**: a row never legitimately participates in both creation and response simultaneously — it's authored for one purpose.
+
+## Why register `doview_analysis` as a creatable artefact (not just a response shape)
+
+- **Symmetry** with `outcomes_map`: an outcomes map is a stored visual artefact governed by a creation_format prompt; a doview_analysis is a stored text artefact governed by both a `response_format` prompt (for live composition) and — if and when creation_format rows are seeded — a creation_format prompt (for the in-Iris "Create new doview_analysis" UI workflow).
+- **Persistence path**: the MCP `save_doview_analysis` tool needs a valid `(notation, diagram_type)` to write under. The diagram_type registration is not optional — without it the writes would fail.
+- **First-class type**: avoids fragmenting analyses into generic `markdown / text` documents; reporting and filtering at the Set level naturally pick up "all DoView analyses".
+
+## Why surface response prompts via MCP `tools` rather than the `prompts` channel
+
+- ADR-152's `prompts` channel is user-controlled by spec — Claude Desktop in particular does not yet expose MCP prompts as natural conversation triggers. Surfacing through `tools` lets the client model auto-discover and fetch when relevant.
+- The `tools` channel is the same one used for `list_response_format_types` (auto-discovery) and `save_doview_analysis` (write back). Coherent surface for the whole flow.
+
+## Why a save tool, not file-save
+
+- An MCP server cannot write to the client's local filesystem. Local persistence is the client's concern (manual copy, separate filesystem MCP, or the client's chat-export UI).
+- "Saving to Iris" is a meaningful service-level action: persists the artefact alongside other DoView content in the set so other users can browse it later. That is the operation Iris is positioned to provide.
+
+## Consequences
+
+- One new SQLite migration `m051_response_format_prompts.py` and Supabase mirror `m055_response_format_prompts.sql`. Both idempotent. m051's registry inserts (markdown notation, doview_analysis diagram_type) skip gracefully when those tables aren't present (test isolation).
+- `app/ai/creation.py` refactored to extract `_build_layered_prompt`; both `build_creation_system_prompt` and the new `build_response_system_prompt` use it.
+- Backend gains two new endpoints under `/api/ai/response-prompts/*` (anonymous-readable).
+- The existing `/api/ai/creation-prompts` list endpoint gains an optional `?purpose=` filter and returns the new `purpose` field; the `CreationPromptResponse` model gains the field with a default of `creation_format` (backwards-compat).
+- iris-client gains `list_response_format_types()`, `get_response_prompt(notation, diagram_type=None)`, and `create_diagram(...)` methods plus `ResponseFormatType` and `ResponsePromptComposed` models.
+- MCP server gains `list_response_format_types`, `get_response_prompt`, and `save_doview_analysis` tools. `save_doview_analysis` requires `IRIS_TOKEN` for the MCP server instance.
+- No changes to the existing MCP `prompts` channel (ADR-152, ADR-153, ADR-156). Named prompts (ADR-154) continue to flow there.
+
+## Out of scope (deferred to v5.13+)
+
+- **Wire `build_response_system_prompt` into the Iris Ask Iris pipeline** (`app/ai/service.py`). For v5.12.0, the response_format mechanism is invoked explicitly by clients (fetch via MCP tool, apply as reference). Auto-application server-side during `mcp__iris__ask` requires a trigger signal (request flag, scope mcp_system_context hint, or heuristic) — design left for a follow-up ADR.
+- **`applicable_response_types` field** on Set / Collection MCP tool responses. The same data is already exposed via the `list_response_format_types` tool; embedding it in scope responses is a UX improvement, not a capability gap.
+- **Admin Settings / AI GUI extension** for editing response_format prompts. Authoring works via the existing `PUT /api/ai/creation-prompts/{id}` endpoint with the new `purpose` field round-tripping correctly; explicit GUI rendering of response_format rows is a follow-up.
+- **Inheritance for response_format prompts** beyond the existing layer cascade (override → base → notation → diagram_type). Per-scope overrides remain `mcp_system_context`'s job.
+- **Argument templating** (`{{set.name}}`) on prompt bodies.
+- **Auto-detection** of when a response_format prompt should apply.
+- **Additional notations / diagram_types** under response_format — only `(markdown, doview_analysis)` is seeded in v5.12.0; other notations get response_format prompts when there's demand.
+- **Creation-format companion for `doview_analysis`** — registering the diagram_type does not require seeding a creation_format prompt for it. When someone wants the in-Iris "Create new doview_analysis" UI flow with a guided LLM interview (mirroring outcomes_map's creation flow), seed that creation_format prompt then.
+
+## See also
+
+- [ADR-094-B](ADR-094-B-AI-Creation-Service.md) — the original AI creation service this extends.
+- [ADR-132](ADR-132-Layered-Creation-Prompts.md) — the layered creation-prompt cascade reused here for response prompts.
+- [ADR-150](ADR-150-Scope-Level-System-Prompts.md) — scope `system_prompt` (Iris AI auto-apply; stripped from MCP per ADR-151).
+- [ADR-151](ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md) — strip rule unchanged.
+- [ADR-152](ADR-152-MCP-Prompts-Capability-for-Scope-System-Prompts.md) — MCP prompts channel for scope system_prompt.
+- [ADR-154](ADR-154-Multiple-Named-Prompts-per-Scope.md) — picker-only named prompts; orthogonal.
+- [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md) — `mcp_system_context` for per-scope passthrough; complementary, scope-specific where response_format is universal.
+- [SPEC-157-A](specs/SPEC-157-A-Response-Format-Prompts.md) — schema, endpoint shapes, MCP tool signatures, test plan.
+- `docs/prompts/doview-book-prompt-c-iris.md` — source content for the seeded response_format rules.

--- a/docs/adrs/specs/SPEC-157-A-Response-Format-Prompts.md
+++ b/docs/adrs/specs/SPEC-157-A-Response-Format-Prompts.md
@@ -1,0 +1,160 @@
+# SPEC-157-A: Response-format prompts + doview_analysis artefact
+
+ADR: [ADR-157](../ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md)
+
+## Database
+
+### SQLite migration `backend/app/migrations/m051_response_format_prompts.py`
+
+Idempotent.
+
+```sql
+-- 1. Add `purpose` column to ai_creation_prompts.
+ALTER TABLE ai_creation_prompts ADD COLUMN purpose TEXT NOT NULL DEFAULT 'creation_format';
+UPDATE ai_creation_prompts SET purpose = 'creation_format' WHERE purpose IS NULL OR purpose = '';
+
+-- 2. Register markdown notation + doview_analysis diagram_type + mapping.
+-- (skipped gracefully via existence checks when registry tables aren't present)
+INSERT OR IGNORE INTO notations (id, name, description, display_order)
+    VALUES ('markdown', 'Markdown', '...', 5);
+INSERT OR IGNORE INTO diagram_types (id, name, description, display_order)
+    VALUES ('doview_analysis', 'DoView Analysis', '...', 10);
+INSERT OR IGNORE INTO diagram_type_notations (diagram_type_id, notation_id, is_default)
+    VALUES ('doview_analysis', 'markdown', 1);
+
+-- 3. Seed three response_format prompt rows.
+-- response-format-base-v1     (purpose=response_format, layer=base, notation=NULL, diagram_type=NULL)
+-- response-format-doview-notation-v1   (purpose=response_format, layer=notation, notation=markdown)
+-- response-format-doview-analysis-v1   (purpose=response_format, layer=diagram_type, diagram_type=doview_analysis)
+```
+
+Registry inserts wrapped in `sqlite_master` existence checks so the migration runs cleanly in test fixtures that have `ai_creation_prompts` but not the registry tables.
+
+### Supabase migration `backend/app/migrations/supabase/m055_response_format_prompts.sql`
+
+Same operations on Supabase (`ADD COLUMN IF NOT EXISTS`, `ON CONFLICT (id) DO NOTHING`). Bodies dollar-quoted.
+
+## Backend
+
+### Composer — `backend/app/ai/creation.py`
+
+```python
+async def _build_layered_prompt(
+    db: aiosqlite.Connection, *, purpose: str, notation: str,
+    diagram_type: str | None,
+) -> tuple[str, int]:
+    """Shared cascade composer. Returns (body, n_layers)."""
+
+async def build_creation_system_prompt(db, notation, diagram_type=None) -> str:
+    """Calls _build_layered_prompt with purpose='creation_format'.
+    Unchanged from v5.8.x in terms of output for callers."""
+
+async def build_response_system_prompt(db, notation, diagram_type=None) -> str:
+    """Calls _build_layered_prompt with purpose='response_format'.
+    New in v5.12.0 (ADR-157)."""
+```
+
+### Pydantic models — `backend/app/ai/models.py`
+
+- `CreationPromptResponse` extended with `purpose: str = "creation_format"`.
+- New `ResponsePromptComposed` (notation, diagram_type, body).
+- New `ResponseFormatType` (notation, diagram_type, label, description).
+
+### Endpoints — `backend/app/ai/router.py`
+
+| Method | Path | Auth | Response |
+|---|---|---|---|
+| `GET` | `/api/ai/response-prompts/types` | Anonymous | `list[ResponseFormatType]` |
+| `GET` | `/api/ai/response-prompts/composed?notation=&diagram_type=` | Anonymous | `ResponsePromptComposed` |
+| `GET` | `/api/ai/creation-prompts?purpose=` | Admin (existing) | `list[CreationPromptResponse]` — `purpose` filter optional |
+| `PUT` | `/api/ai/creation-prompts/{prompt_id}` | Admin (existing) | `CreationPromptResponse` — now round-trips `purpose` |
+
+### Ask Iris pipeline — UNTOUCHED in v5.12.0
+
+`build_response_system_prompt` is callable but not yet auto-injected by `Ask Iris` server-side composition. Deferred per ADR-157 "Out of scope". v5.12.0 path: explicit invocation by client model via MCP tool.
+
+## iris-client
+
+### Models — `iris-client/src/iris_client/models/core.py`
+
+- `ResponseFormatType` (notation, diagram_type, label, description)
+- `ResponsePromptComposed` (notation, diagram_type, body)
+
+### Methods — `iris-client/src/iris_client/client.py`
+
+```python
+async def list_response_format_types(self) -> list[ResponseFormatType]
+async def get_response_prompt(self, notation: str, diagram_type: str | None = None) -> ResponsePromptComposed
+async def create_diagram(self, *, diagram_type, name, notation=None, data=None, set_id=None, parent_package_id=None, description=None) -> Diagram
+```
+
+`create_diagram` is the generic POST /api/diagrams wrapper — used by the save tool but available to other consumers too.
+
+## MCP server
+
+### Tools — `mcp/src/iris_mcp/tools.py`
+
+| Tool | Purpose | Auth |
+|---|---|---|
+| `list_response_format_types` | Discover (notation, diagram_type) pairs with response_format prompts | Anonymous |
+| `get_response_prompt(notation, diagram_type?)` | Fetch composed cascade body | Anonymous |
+| `save_doview_analysis(set_id, name, content, parent_package_id?, description?)` | Persist a generated analysis as a `doview_analysis` diagram | Auth required (IRIS_TOKEN on server) |
+
+### Auth posture
+
+`save_doview_analysis` relies on the MCP server's `IRIS_TOKEN` env var (existing per-instance PAT). If the token is unset or invalid, the backend returns 401 and the tool surfaces the error.
+
+## Frontend
+
+No changes in v5.12.0. Admin Settings / AI GUI extension for `response_format` row editing is deferred per ADR-157 "Out of scope". Authoring works via the existing `PUT /api/ai/creation-prompts/{id}` endpoint with the new `purpose` field round-tripping correctly.
+
+## Tests
+
+| File | Cases | Layer | Notes |
+|---|---|---|---|
+| `backend/tests/test_migrations/test_response_format_prompts_schema.py` | 10 | migration | All passing — m051 SQLite + m055 Supabase + idempotency + content spot-checks |
+| `backend/tests/test_ai/test_response_system_prompt.py` | 5 | composer | All passing — three-layer composition + isolation between creation_format and response_format |
+| `backend/tests/test_ai/test_creation_service.py` | 11 | composer regression | All passing — existing creation composer unchanged after purpose-filter addition |
+| `backend/tests/test_ai/test_creation_prompts_expanded.py` | 33 | seed regression | All passing — counts updated to assert 15 creation_format + 3 response_format rows |
+| `iris-client/` (existing) | 30 | client | All passing |
+| `mcp/` (existing) | 79 | MCP | All passing |
+
+**Net new tests for v5.12.0**: 15 (10 migration + 5 composer). Test count adjustments: 1 (the row-count regression).
+
+Pre-existing `test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO, caps at m029) remains the only acceptable failure in the suite.
+
+## End-to-end verification
+
+```bash
+# 1. Apply Supabase m055 to UAT DB.
+./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
+
+# 2. Verify the response-format mechanism end-to-end via HTTP:
+curl http://localhost:8000/api/ai/response-prompts/types
+# → JSON list with one entry: {notation:"markdown", diagram_type:"doview_analysis", label:"DoView Analysis", description:"..."}
+
+curl "http://localhost:8000/api/ai/response-prompts/composed?notation=markdown&diagram_type=doview_analysis"
+# → JSON object with body containing the cascade (base + markdown notation + doview_analysis)
+
+# 3. In Claude Desktop / Claude Code with Iris MCP connected, in conversation:
+# - List the response-format types via mcp__iris__list_response_format_types
+# - Fetch the composed prompt via mcp__iris__get_response_prompt
+# - Verify the body contains Prompt-C-style rules (opening sentence, three sections, raw URLs)
+# - If authenticated: save a generated analysis via mcp__iris__save_doview_analysis
+#   and verify it appears as a new diagram of type doview_analysis under the chosen set.
+
+# 4. Verify backwards compat — existing diagram creation still works:
+# Create a new DoView outcomes_map via Ask Iris creation mode. The creation
+# composer should still emit the full 15-row creation_format cascade, unchanged.
+```
+
+## Out of scope (deferred per ADR-157)
+
+- Server-side auto-wiring of `build_response_system_prompt` into `Ask Iris`.
+- `applicable_response_types` field on Set/Collection MCP responses.
+- Admin Settings / AI GUI extension for response_format rows.
+- Argument templating on prompt bodies.
+- Auto-detection of when a response_format applies.
+- Additional notations beyond `markdown / doview_analysis`.
+- Creation_format companion seed for `doview_analysis`.
+- Per-scope overrides of response_format (those remain `mcp_system_context`'s job).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.11.0",
+	"version": "5.12.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/src/iris_client/client.py
+++ b/iris-client/src/iris_client/client.py
@@ -31,6 +31,8 @@ from iris_client.models.core import (
     LoginResponse,
     Package,
     QAResponse,
+    ResponseFormatType,
+    ResponsePromptComposed,
     ScopePromptIndexEntry,
     SearchResponse,
     TokenCreated,
@@ -306,6 +308,28 @@ class IrisClient:
         items = payload["items"] if isinstance(payload, dict) and "items" in payload else payload
         return [ScopePromptIndexEntry.model_validate(r) for r in items]
 
+    # --- Response-format prompts (ADR-157, v5.12.0) -------------------------
+
+    async def list_response_format_types(self) -> list["ResponseFormatType"]:
+        """List distinct (notation, diagram_type) pairs that have at least one
+        active response_format prompt. Anonymous-readable."""
+        response = await self._request("GET", "/api/ai/response-prompts/types")
+        return [ResponseFormatType.model_validate(r) for r in response.json()]
+
+    async def get_response_prompt(
+        self, notation: str, diagram_type: str | None = None,
+    ) -> "ResponsePromptComposed":
+        """Fetch the composed response_format cascade for a (notation,
+        diagram_type) pair. Anonymous-readable. Returns the composed body
+        as the `body` field; empty string if no rows match."""
+        params: dict[str, str] = {"notation": notation}
+        if diagram_type is not None:
+            params["diagram_type"] = diagram_type
+        response = await self._request(
+            "GET", "/api/ai/response-prompts/composed", params=params,
+        )
+        return ResponsePromptComposed.model_validate(response.json())
+
     # --- Export --------------------------------------------------------------
 
     async def export_diagram(
@@ -443,6 +467,39 @@ class IrisClient:
             "POST", "/api/ai/files/extract", files=files,
         )
         return FileExtractResponse.model_validate(response.json())
+
+    async def create_diagram(
+        self,
+        *,
+        diagram_type: str,
+        name: str,
+        notation: str | None = None,
+        data: dict[str, Any] | None = None,
+        set_id: str | None = None,
+        parent_package_id: str | None = None,
+        description: str | None = None,
+    ) -> Diagram:
+        """Create a new diagram (POST /api/diagrams). Auth required.
+
+        Used by the v5.12.0 save-doview-analysis MCP tool (ADR-157) to
+        persist a generated `doview_analysis` markdown document as a
+        first-class Iris artefact.
+        """
+        body: dict[str, Any] = {
+            "diagram_type": diagram_type,
+            "name": name,
+            "data": data or {},
+        }
+        if notation is not None:
+            body["notation"] = notation
+        if set_id is not None:
+            body["set_id"] = set_id
+        if parent_package_id is not None:
+            body["parent_package_id"] = parent_package_id
+        if description is not None:
+            body["description"] = description
+        response = await self._request("POST", "/api/diagrams", json=body)
+        return Diagram.model_validate(response.json())
 
     async def apply_diagram_creation(
         self,

--- a/iris-client/src/iris_client/models/core.py
+++ b/iris-client/src/iris_client/models/core.py
@@ -120,6 +120,27 @@ class Collection(EntityBase):
     mcp_system_context: str | None = None  # ADR-155 (v5.10.0): MCP-only directive
 
 
+class ResponseFormatType(_Permissive):
+    """One available response-format type — a (notation, diagram_type)
+    pair that has at least one active response_format prompt row
+    (ADR-157, v5.12.0). Returned by
+    `GET /api/ai/response-prompts/types`."""
+
+    notation: str
+    diagram_type: str | None = None
+    label: str
+    description: str | None = None
+
+
+class ResponsePromptComposed(_Permissive):
+    """Composed response-format cascade body (ADR-157, v5.12.0).
+    Returned by `GET /api/ai/response-prompts/composed`."""
+
+    notation: str
+    diagram_type: str | None = None
+    body: str  # composed cascade body — may be empty if no rows match
+
+
 class ScopePromptIndexEntry(_Permissive):
     """One entry from `GET /api/prompts/scope-index` (ADR-152, v5.8.3;
     extended ADR-154, v5.9.0 to include named prompts).

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.11.0"
+version = "5.12.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -136,6 +136,38 @@ async def _apply_diagram_creation(c: IrisClient, args: dict[str, Any]) -> str:
     return resp.model_dump_json()
 
 
+async def _list_response_format_types(c: IrisClient, _args: dict[str, Any]) -> str:
+    """ADR-157 (v5.12.0): list response-format types available."""
+    items = await c.list_response_format_types()
+    return json.dumps([item.model_dump() for item in items])
+
+
+async def _get_response_prompt(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-157 (v5.12.0): fetch the composed response_format prompt
+    cascade for a (notation, diagram_type) pair."""
+    resp = await c.get_response_prompt(
+        args["notation"],
+        diagram_type=args.get("diagram_type"),
+    )
+    return resp.model_dump_json()
+
+
+async def _save_doview_analysis(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-157 (v5.12.0): persist a generated outcomes-theory analysis
+    as a new `doview_analysis` diagram in Iris. Auth required —
+    requires IRIS_TOKEN to be set on the MCP server."""
+    diagram = await c.create_diagram(
+        diagram_type="doview_analysis",
+        notation="markdown",
+        name=args["name"],
+        data={"content": args["content"]},
+        set_id=args["set_id"],
+        parent_package_id=args.get("parent_package_id"),
+        description=args.get("description"),
+    )
+    return diagram.model_dump_json()
+
+
 async def _list_conversations(c: IrisClient, args: dict[str, Any]) -> str:
     rows = await c.list_conversations(
         args["set_id"], limit=int(args.get("limit", 50)),
@@ -354,6 +386,77 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_list_conversations,
+    ),
+    # ── Response-format prompts (ADR-157, v5.12.0) ──────────────────────
+    Tool(
+        name="list_response_format_types",
+        description=(
+            "List response-format types available — (notation, diagram_type) "
+            "pairs that have authored response_format prompts in Iris. Use "
+            "to discover which formats can be applied to your response "
+            "(e.g. notation='markdown' diagram_type='doview_analysis' for "
+            "the formal handbook-grounded outcomes-theory analysis shape)."
+        ),
+        input_schema=_schema({}),
+        handler=_list_response_format_types,
+    ),
+    Tool(
+        name="get_response_prompt",
+        description=(
+            "Fetch the composed response_format prompt for a "
+            "(notation, diagram_type) pair (ADR-157). Returns the layered "
+            "cascade (base + notation + diagram_type) as `body`. Apply the "
+            "body as reference for shaping your response. Use this when "
+            "the user asks for a formal output style matching one of the "
+            "available types from `list_response_format_types` — for "
+            "DoView outcomes-theory analyses call with notation='markdown' "
+            "diagram_type='doview_analysis'."
+        ),
+        input_schema=_schema({
+            "notation": _str_arg(
+                "notation", "Notation id, e.g. 'markdown', 'doview'",
+            ),
+            "diagram_type": _str_arg(
+                "diagram_type",
+                "Diagram type id, e.g. 'doview_analysis'. Optional — when "
+                "absent, returns the base + notation cascade only.",
+                required=False,
+            ),
+        }),
+        handler=_get_response_prompt,
+    ),
+    Tool(
+        name="save_doview_analysis",
+        description=(
+            "Persist a generated DoView analysis as a new doview_analysis "
+            "diagram in Iris (ADR-157, v5.12.0). Use after the user "
+            "confirms they want their formal outcomes-theory response saved. "
+            "Body is markdown text (with embedded mermaid blocks where "
+            "applicable). Auth required — needs IRIS_TOKEN configured on "
+            "the MCP server. Returns 401-equivalent error if anonymous."
+        ),
+        input_schema=_schema({
+            "set_id": _str_arg("set_id", "Set to save the analysis under"),
+            "name": _str_arg(
+                "name",
+                "Diagram name shown in Iris (e.g. the question or a short title)",
+            ),
+            "content": _str_arg(
+                "content",
+                "Markdown body of the analysis (Summary + Full + Diagrams sections)",
+            ),
+            "parent_package_id": _str_arg(
+                "parent_package_id",
+                "Optional package to nest this diagram under within the set",
+                required=False,
+            ),
+            "description": _str_arg(
+                "description",
+                "Optional short description shown alongside the diagram",
+                required=False,
+            ),
+        }),
+        handler=_save_doview_analysis,
     ),
 ]
 


### PR DESCRIPTION
## Summary

Extends the existing layered `ai_creation_prompts` mechanism (ADR-094-B / ADR-132) with a `purpose` discriminator so the same admin-editable cascade governs both diagram **creation** (existing) and **response formatting** (new). Symmetric to how `(notation=doview, diagram_type=outcomes_map)` governs creation; now `(notation=markdown, diagram_type=doview_analysis)` governs formal text responses about DoView / outcomes-theory content.

- **New**: `purpose TEXT NOT NULL DEFAULT 'creation_format'` column on `ai_creation_prompts` (all existing rows backfilled). New `response_format` rows seeded with Prompt-C-shaped rules (base + notation + diagram_type layers).
- **New artefact type**: `(notation=markdown, diagram_type=doview_analysis)` registered as a first-class Iris type. Body shape: `data={"content": "<markdown>"}` matching the v5.8.0 text-diagram precedent.
- **3 new MCP tools**:
  - `list_response_format_types` (anonymous) — discover available pairs
  - `get_response_prompt(notation, diagram_type?)` (anonymous) — fetch composed cascade body
  - `save_doview_analysis(set_id, name, content, …)` (auth required) — persist a generated analysis as a `doview_analysis` diagram
- **2 new HTTP endpoints**: `GET /api/ai/response-prompts/types` and `GET /api/ai/response-prompts/composed` (both anonymous-readable)
- **iris-client**: `list_response_format_types()`, `get_response_prompt()`, `create_diagram()`

See [ADR-157](docs/adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) and [SPEC-157-A](docs/adrs/specs/SPEC-157-A-Response-Format-Prompts.md).

## Architecture

DRY (§13): `_build_layered_prompt(purpose, notation, diagram_type)` is the single cascade implementation. Both `build_creation_system_prompt` and the new `build_response_system_prompt` are thin wrappers. Same override→base→notation→diagram_type cascade, filtered by purpose.

## Test plan

- [x] `test_migrations/test_response_format_prompts_schema.py` — 10 cases (column add, backfill, registry registration, three seed rows, idempotency, content spot-checks)
- [x] `test_ai/test_response_system_prompt.py` — 5 cases (three-layer composition, isolation between purposes, no leakage)
- [x] `test_ai/test_creation_service.py` — 11 cases continue to pass (existing creation composer unchanged after purpose filter)
- [x] `test_ai/test_creation_prompts_expanded.py` — 33 cases continue to pass (row counts updated: 15 creation_format + 3 response_format)
- [x] iris-client — 30 existing tests still pass
- [x] mcp — 79 existing tests still pass (new tools register cleanly)
- [x] **379 tests total green**; only pre-existing `test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO, caps at m029)

## Deferred to v5.13+ (per ADR-157 "Out of scope")

- Auto-injection of `build_response_system_prompt` into Ask Iris pipeline (v5.12.0 path: explicit invocation via MCP tool by client model)
- `applicable_response_types` field on Set/Collection MCP responses
- Admin Settings / AI GUI extension for response_format rows (editing works via existing `PUT /api/ai/creation-prompts/{id}` with new `purpose` field round-tripping)

## UAT

After deploy:

```bash
./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
```

Idempotent migration `m055_response_format_prompts.sql` adds the `purpose` column, registers `markdown` notation + `doview_analysis` diagram_type, and seeds three response_format rows.

Then in Claude Desktop with Iris MCP connected:
1. Ask an outcomes-theory question about content in the DoView Book Set.
2. Claude should call `mcp__iris__list_response_format_types` then `mcp__iris__get_response_prompt('markdown', 'doview_analysis')` to fetch the composed cascade.
3. Compose response following the rules + embed mermaid blocks via `mcp__iris__get_diagram`.
4. If `IRIS_TOKEN` configured: optionally save via `mcp__iris__save_doview_analysis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)