### PR TITLE
fix(v5.12.1): Supabase m055 is_default must be TRUE not 1 (boolean column)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.12.1] - 2026-05-12
+
+### Fixed
+
+- **Supabase migration `m055_response_format_prompts.sql` failed with
+  `column "is_default" is of type boolean but expression is of type
+  integer` (42804)** when run against the Supabase Postgres schema.
+  `diagram_type_notations.is_default` is `BOOLEAN` on Postgres but
+  `INTEGER` on SQLite; v5.12.0's m055 used `1` (the SQLite
+  convention) without casting. Changed to `TRUE` to match every
+  other Supabase migration's convention (m020 / m028 / m044 etc.).
+  Added a regression test that pins this. Re-run
+  `./scripts/supabase-migrate.sh` against the UAT DB; idempotent —
+  the failed v5.12.0 row insert will now succeed.
+
 ## [5.12.0] - 2026-05-12
 
 ### Added

--- a/backend/app/migrations/supabase/m055_response_format_prompts.sql
+++ b/backend/app/migrations/supabase/m055_response_format_prompts.sql
@@ -33,8 +33,9 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
+-- Postgres `is_default` is boolean (Supabase schema); SQLite uses 1.
 INSERT INTO public.diagram_type_notations (diagram_type_id, notation_id, is_default)
-VALUES ('doview_analysis', 'markdown', 1)
+VALUES ('doview_analysis', 'markdown', TRUE)
 ON CONFLICT (diagram_type_id, notation_id) DO NOTHING;
 
 -- 3. Seed response_format prompt rows. Bodies match the SQLite seed

--- a/backend/tests/test_migrations/test_response_format_prompts_schema.py
+++ b/backend/tests/test_migrations/test_response_format_prompts_schema.py
@@ -95,6 +95,19 @@ def test_supabase_m055_registers_markdown_and_doview_analysis() -> None:
     assert "ON CONFLICT (id) DO NOTHING" in sql
 
 
+def test_supabase_m055_uses_boolean_literal_for_is_default() -> None:
+    """v5.12.1 regression: `diagram_type_notations.is_default` is boolean
+    on Postgres (Supabase). Using `1` (integer, SQLite convention)
+    triggers `column "is_default" is of type boolean but expression is
+    of type integer`. The Supabase migration must use TRUE/FALSE."""
+    sql = _read("app/migrations/supabase/m055_response_format_prompts.sql")
+    # The doview_analysis ↔ markdown mapping must use a boolean literal.
+    assert "VALUES ('doview_analysis', 'markdown', TRUE)" in sql, (
+        "is_default must be `TRUE` (boolean), not `1` (integer), "
+        "on the Postgres-backed Supabase schema."
+    )
+
+
 def test_supabase_m055_seeds_three_response_format_rows() -> None:
     sql = _read("app/migrations/supabase/m055_response_format_prompts.sql")
     for prompt_id in (

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.12.0",
+	"version": "5.12.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.12.0"
+version = "5.12.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

v5.12.0's `m055_response_format_prompts.sql` failed against the live Supabase schema with:

```
ERROR: 42804: column "is_default" is of type boolean but expression is of type integer
LINE 37: VALUES ('doview_analysis', 'markdown', 1)
                                                ^
```

`diagram_type_notations.is_default` is `BOOLEAN` on Postgres but `INTEGER` on SQLite. m055 used the SQLite-style `1` without casting.

**Fix**: `1` → `TRUE`, matching every other Supabase migration's convention (m020, m028, m044, etc.).

Added a regression test that pins this so the same bug class doesn't recur in future migrations.

## Test plan

- [x] `test_supabase_m055_uses_boolean_literal_for_is_default` — asserts `VALUES ('doview_analysis', 'markdown', TRUE)` exact match.
- [x] All 11 existing migration tests for response_format_prompts continue to pass.

## UAT

Re-run after merge:

```bash
./scripts/supabase-migrate.sh "postgresql://postgres:PASSWORD@db.<project>.supabase.co:5432/postgres"
```

m055 is idempotent (`ON CONFLICT DO NOTHING`, `ADD COLUMN IF NOT EXISTS`). Everything that succeeded on the v5.12.0 run will no-op; only the failed `diagram_type_notations` insert will now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)