### PR TITLE
feat(v5.13.0): admin AI prompts CRUD + MCP set-structure overview (ADR-158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.0] - 2026-05-12
+
+### Added
+
+- **Admin AI prompts management** (ADR-158, SPEC-158-A). The
+  `/admin/settings/ai` prompts section gets a full CRUD redesign:
+  - Filter row above the table (purpose / layer / notation /
+    diagram_type / status / search / sort / reset) mirroring the
+    `/views/+page.svelte` inline pattern. URL-state-backed for
+    `purpose` and `layer` (sharable / bookmarkable filtering).
+  - "Purpose" badge column distinguishing creation_format from
+    response_format rows.
+  - "Applies to" column resolving the cascade clearly — e.g.
+    "Any notation × process diagrams" for the previously confusing
+    `(layer=diagram_type, notation=NULL, diagram_type=process)`
+    rows like "ArchiMate Process Layout". Addresses the user-
+    reported confusion about the cascade design.
+  - Status toggle (single click toggles `is_active`).
+  - Per-row Delete with confirm dialog (consistent with the
+    existing providers section).
+  - "+ Add prompt" inline form with live conflict-check ($derived
+    against the loaded list — Save disables when the chosen
+    `(purpose, layer, notation, diagram_type)` already has an
+    active row, with an inline note naming the conflict).
+  - Edit modal extended to allow editing name, description,
+    notation, diagram_type alongside prompt_text. Purpose and layer
+    remain immutable (delete-and-recreate to move between).
+- **Backend `/api/ai/creation-prompts` POST + DELETE + extended PUT**
+  (ADR-158, admin-only). POST validates uniqueness on
+  `(purpose, layer, notation, diagram_type)` for `is_active=true`
+  rows — 409 conflict response names the existing prompt.
+  Inactive rows can coexist on the same tuple (lets admins stage
+  replacements before disabling the current).
+- **`SetResponse.package_count` and `SetResponse.package_count_root`**
+  (ADR-158). Tells MCP clients the structural breadth of a set
+  upfront so they know whether `package_hierarchy` is worth a call
+  or whether `list_packages` will fit in one page.
+- **`iris_package_hierarchy` MCP tool** (ADR-158). Returns the
+  complete package tree for a set as nested `PackageHierarchyNode`
+  objects in a single call. Fixes the user-reported issue where
+  Claude Desktop saw only chapters E-J of a 10-chapter set
+  because `list_packages` paginates and older chapters sort to
+  page 2+ under the default `updated_at DESC` ordering.
+- **`iris-client.list_packages` pagination** — `page`, `page_size`,
+  `parent_package_id` parameters now exposed (the backend already
+  supported them). MCP `list_packages` tool schema gains the same.
+- **`iris-client.diagram_hierarchy` method** — renamed from the
+  previously misnamed `package_hierarchy` (which actually hit
+  `/api/diagrams/hierarchy`). Latent bug; no prior callers, so
+  rename is non-breaking. The new `package_hierarchy` correctly
+  hits `/api/packages/hierarchy`.
+
+### Changed
+
+- `CreationPromptResponse` and the existing `PUT
+  /api/ai/creation-prompts/{id}` endpoint now round-trip the new
+  `purpose` field correctly (was added in v5.12.0 but the response
+  pathway only partially propagated it).
+- MCP `list_packages` tool description rewritten to flag pagination
+  explicitly and cross-reference `package_hierarchy` as the
+  preferred structural-overview tool.
+
+### Documentation
+
+- ADR-158 + SPEC-158-A.
+- `docs/prompts/doview-book-mcp-system-context.md` updated with
+  v5.13.0 hints: prefer `iris_package_hierarchy` over `list_packages`
+  for chapter discovery; offer save-paths to the user (both Iris
+  persistence AND markdown-in-chat).
+
+### Migration
+
+- **No DB migration**. v5.13.0 has no schema changes — it uses
+  existing `is_active`, `purpose`, `notation`, `diagram_type`
+  columns on `ai_creation_prompts` and existing
+  `parent_package_id` / `is_deleted` / `set_id` on `packages`.
+
+### Tests
+
+46 new tests across migration / backend / iris-client / MCP /
+frontend layers; ~430+ tests pass total. Only pre-existing
+`test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO).
+
 ## [5.12.2] - 2026-05-12
 
 ### Fixed

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -185,9 +185,44 @@ class CreationPromptResponse(BaseModel):
     updated_at: str
 
 
-class CreationPromptUpdate(BaseModel):
-    """Request body for updating an AI creation or response prompt."""
+class CreationPromptCreate(BaseModel):
+    """Request body for creating a new AI creation or response prompt.
 
+    Conflict detection (ADR-158, v5.13.0): the server returns 409 if
+    another `is_active=true` row already exists with the same
+    `(purpose, layer, notation, diagram_type)` tuple. Stage a
+    replacement by setting the existing row to `is_active=false`
+    first, OR pick a different combination.
+    """
+
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    purpose: Literal["creation_format", "response_format"] = "creation_format"
+    layer: Literal["base", "notation", "diagram_type", "override"]
+    notation: str | None = None
+    diagram_type: str | None = None
+    prompt_text: str = Field(min_length=1)
+    display_order: int = 0
+    is_active: bool = True
+
+
+class CreationPromptUpdate(BaseModel):
+    """Request body for updating an AI creation or response prompt.
+
+    v5.13.0 (ADR-158): extends the v5.8.x update surface to allow
+    editing `name`, `description`, `notation`, `diagram_type`, and
+    `display_order` in addition to `prompt_text` and `is_active`.
+    Conflict detection re-runs when any of `(purpose, layer, notation,
+    diagram_type)` changes while `is_active=true`. `purpose` and
+    `layer` themselves are immutable once created (use delete + create
+    if you need to move a prompt between purposes or layers).
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    notation: str | None = None
+    diagram_type: str | None = None
+    display_order: int | None = None
     prompt_text: str | None = None
     is_active: bool | None = None
 

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -41,6 +41,7 @@ from app.ai.models import (
     ApplyCreationRequest,
     ApplyCreationResponse,
     ConversationResponse,
+    CreationPromptCreate,
     CreationPromptResponse,
     CreationPromptUpdate,
     FileExtractResponse,
@@ -950,18 +951,59 @@ async def update_creation_prompt(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> CreationPromptResponse:
-    """Update an AI creation prompt. Admin only."""
+    """Update an AI creation prompt. Admin only.
+
+    v5.13.0 (ADR-158): extended to accept name/description/notation/
+    diagram_type/display_order in addition to prompt_text/is_active.
+    Re-validates the conflict tuple on update if any of (notation,
+    diagram_type) change while is_active=true.
+    """
     _require_admin(current_user)
     db = request.app.state.db_manager.main_db
 
     cursor = await db.execute(
-        "SELECT id FROM ai_creation_prompts WHERE id = ?", (prompt_id,)
+        "SELECT purpose, layer, notation, diagram_type, is_active "
+        "FROM ai_creation_prompts WHERE id = ?", (prompt_id,),
     )
-    if await cursor.fetchone() is None:
+    existing = await cursor.fetchone()
+    if existing is None:
         raise HTTPException(status_code=404, detail="Creation prompt not found")
+
+    # Resolve final tuple values (post-update) for conflict detection.
+    final_purpose = existing[0] or "creation_format"
+    final_layer = existing[1]
+    final_notation = body.notation if body.notation is not None else existing[2]
+    final_diagram_type = body.diagram_type if body.diagram_type is not None else existing[3]
+    final_is_active = body.is_active if body.is_active is not None else bool(existing[4])
+
+    # Conflict check: if the final row would be active, ensure no OTHER
+    # active row already exists with the same (purpose, layer, notation,
+    # diagram_type) tuple.
+    if final_is_active:
+        await _ensure_no_active_conflict(
+            db, prompt_id=prompt_id,
+            purpose=final_purpose, layer=final_layer,
+            notation=final_notation, diagram_type=final_diagram_type,
+        )
 
     updates: list[str] = []
     params: list[Any] = []
+    if body.name is not None:
+        updates.append("name = ?")
+        params.append(body.name)
+    if body.description is not None:
+        updates.append("description = ?")
+        params.append(body.description)
+    if body.notation is not None:
+        # Treat empty string as "clear to NULL"
+        updates.append("notation = ?")
+        params.append(body.notation if body.notation else None)
+    if body.diagram_type is not None:
+        updates.append("diagram_type = ?")
+        params.append(body.diagram_type if body.diagram_type else None)
+    if body.display_order is not None:
+        updates.append("display_order = ?")
+        params.append(body.display_order)
     if body.prompt_text is not None:
         updates.append("prompt_text = ?")
         params.append(body.prompt_text)
@@ -1000,6 +1042,151 @@ async def update_creation_prompt(
         created_at=row[11],
         updated_at=row[12],
     )
+
+
+# ── ADR-158 (v5.13.0): POST + DELETE for creation prompts ──────────────
+
+
+def _slugify(name: str) -> str:
+    """Produce an id-safe slug from a human-readable name."""
+    import re
+    slug = re.sub(r"[^a-z0-9-]+", "-", name.lower()).strip("-")
+    return slug or "prompt"
+
+
+async def _ensure_no_active_conflict(
+    db: Any,
+    *,
+    prompt_id: str | None,
+    purpose: str,
+    layer: str,
+    notation: str | None,
+    diagram_type: str | None,
+) -> None:
+    """Raise 409 if another is_active=true row has the same
+    (purpose, layer, notation, diagram_type) tuple. `prompt_id` is
+    excluded from the check (so a PUT on the row itself doesn't
+    self-conflict)."""
+    query = (
+        "SELECT id, name FROM ai_creation_prompts "
+        "WHERE purpose = ? AND layer = ? AND is_active = 1 "
+        "AND COALESCE(notation, '') = COALESCE(?, '') "
+        "AND COALESCE(diagram_type, '') = COALESCE(?, '') "
+    )
+    params: list[Any] = [purpose, layer, notation, diagram_type]
+    if prompt_id is not None:
+        query += "AND id != ? "
+        params.append(prompt_id)
+    query += "LIMIT 1"
+
+    cursor = await db.execute(query, tuple(params))
+    row = await cursor.fetchone()
+    if row is not None:
+        msg = (
+            f"An active prompt already exists for "
+            f"(purpose={purpose}, layer={layer}, "
+            f"notation={notation or 'NULL'}, "
+            f"diagram_type={diagram_type or 'NULL'}): "
+            f"'{row[1]}' ({row[0]}). Disable that prompt first or pick "
+            f"a different combination."
+        )
+        raise HTTPException(status_code=409, detail=msg)
+
+
+@router.post("/creation-prompts", response_model=CreationPromptResponse, status_code=201)
+async def create_creation_prompt(
+    body: CreationPromptCreate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> CreationPromptResponse:
+    """Create a new AI creation or response prompt (ADR-158, v5.13.0). Admin only."""
+    _require_admin(current_user)
+    db = request.app.state.db_manager.main_db
+
+    # Conflict check (only when the new row is active).
+    if body.is_active:
+        await _ensure_no_active_conflict(
+            db, prompt_id=None,
+            purpose=body.purpose, layer=body.layer,
+            notation=body.notation, diagram_type=body.diagram_type,
+        )
+
+    # Auto-generate a slug-based id with collision suffix if needed.
+    base_slug = _slugify(body.name)
+    prompt_id = base_slug
+    suffix = 1
+    while True:
+        cursor = await db.execute(
+            "SELECT 1 FROM ai_creation_prompts WHERE id = ?", (prompt_id,),
+        )
+        if (await cursor.fetchone()) is None:
+            break
+        suffix += 1
+        prompt_id = f"{base_slug}-{suffix}"
+
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO ai_creation_prompts "
+        "(id, name, description, purpose, layer, notation, diagram_type, "
+        "prompt_text, display_order, is_active, created_by, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            prompt_id,
+            body.name,
+            body.description,
+            body.purpose,
+            body.layer,
+            body.notation,
+            body.diagram_type,
+            body.prompt_text,
+            body.display_order,
+            body.is_active,
+            current_user.get("id"),
+            now,
+            now,
+        ),
+    )
+    await db.commit()
+
+    return CreationPromptResponse(
+        id=prompt_id,
+        name=body.name,
+        description=body.description,
+        purpose=body.purpose,
+        layer=body.layer,
+        notation=body.notation,
+        diagram_type=body.diagram_type,
+        prompt_text=body.prompt_text,
+        display_order=body.display_order,
+        is_active=body.is_active,
+        created_by=current_user.get("id"),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@router.delete("/creation-prompts/{prompt_id}", status_code=204)
+async def delete_creation_prompt(
+    prompt_id: str,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> None:
+    """Hard-delete an AI creation/response prompt (ADR-158, v5.13.0). Admin only.
+
+    No foreign keys point at this row. To preserve content while
+    suppressing it from the cascade, use PUT with `{is_active: false}`
+    instead.
+    """
+    _require_admin(current_user)
+    db = request.app.state.db_manager.main_db
+    cursor = await db.execute(
+        "SELECT id FROM ai_creation_prompts WHERE id = ?", (prompt_id,),
+    )
+    if (await cursor.fetchone()) is None:
+        raise HTTPException(status_code=404, detail="Creation prompt not found")
+
+    await db.execute("DELETE FROM ai_creation_prompts WHERE id = ?", (prompt_id,))
+    await db.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/sets/models.py
+++ b/backend/app/sets/models.py
@@ -39,6 +39,9 @@ class SetResponse(BaseModel):
     collection_name: str | None = None
     diagram_count: int = 0
     element_count: int = 0
+    # ADR-158 (v5.13.0): structural breadth signals for MCP clients.
+    package_count: int = 0
+    package_count_root: int = 0
     thumbnail_source: str | None = None
     thumbnail_diagram_id: str | None = None
     has_thumbnail_image: bool = False

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -77,6 +77,8 @@ async def create_set(
         "collection_name": None,
         "diagram_count": 0,
         "element_count": 0,
+        "package_count": 0,
+        "package_count_root": 0,
         "thumbnail_source": None,
         "thumbnail_diagram_id": None,
         "has_thumbnail_image": False,
@@ -115,6 +117,22 @@ async def get_set(
         (set_id,),
     )
     result["element_count"] = (await ec.fetchone())[0]
+
+    # Count packages in this set (ADR-158, v5.13.0): give MCP clients
+    # an upfront signal that pagination matters when calling list_packages
+    # on big sets, and a quick hint of structural breadth.
+    pc = await db.execute(
+        "SELECT COUNT(*) FROM packages WHERE set_id = ? AND is_deleted = 0",
+        (set_id,),
+    )
+    result["package_count"] = (await pc.fetchone())[0]
+
+    pcr = await db.execute(
+        "SELECT COUNT(*) FROM packages "
+        "WHERE set_id = ? AND is_deleted = 0 AND parent_package_id IS NULL",
+        (set_id,),
+    )
+    result["package_count_root"] = (await pcr.fetchone())[0]
 
     return result
 
@@ -156,6 +174,20 @@ async def list_sets(
             (set_id,),
         )
         item["element_count"] = (await ec.fetchone())[0]
+
+        # Package counts (ADR-158, v5.13.0)
+        pc = await db.execute(
+            "SELECT COUNT(*) FROM packages WHERE set_id = ? AND is_deleted = 0",
+            (set_id,),
+        )
+        item["package_count"] = (await pc.fetchone())[0]
+
+        pcr = await db.execute(
+            "SELECT COUNT(*) FROM packages "
+            "WHERE set_id = ? AND is_deleted = 0 AND parent_package_id IS NULL",
+            (set_id,),
+        )
+        item["package_count_root"] = (await pcr.fetchone())[0]
 
         # Include thumbnail diagram data for client-side rendering (DRY)
         thumb_id = row[8]  # thumbnail_diagram_id

--- a/backend/tests/test_ai/test_creation_prompts_crud.py
+++ b/backend/tests/test_ai/test_creation_prompts_crud.py
@@ -1,0 +1,313 @@
+"""ADR-158 (v5.13.0): POST + DELETE + extended PUT on
+`/api/ai/creation-prompts` with conflict detection on the
+(purpose, layer, notation, diagram_type) tuple for is_active rows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _new_prompt_body(**overrides) -> dict:
+    """Default to (purpose=response_format, layer=diagram_type,
+    notation=simple, diagram_type=component) — a tuple NOT covered by
+    any seeded row (m051 only seeds response_format for diagram_type=
+    doview_analysis), so create succeeds by default. Override
+    `diagram_type` / `notation` / `purpose` to deliberately collide
+    with seeded creation_format rows in conflict-detection tests.
+    """
+    body = {
+        "name": "My New Prompt",
+        "description": "Test prompt",
+        "purpose": "response_format",
+        "layer": "diagram_type",
+        "notation": "simple",
+        "diagram_type": "component",
+        "prompt_text": "Some prompt body.",
+        "display_order": 0,
+        "is_active": True,
+    }
+    body.update(overrides)
+    return body
+
+
+class TestCreate:
+    async def test_post_creates_prompt(self, client: httpx.AsyncClient) -> None:
+        headers = await _admin_headers(client)
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(name="X", notation="uml", diagram_type="class"),
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["name"] == "X"
+        assert body["purpose"] == "response_format"
+        assert body["layer"] == "diagram_type"
+        assert body["notation"] == "uml"
+        assert body["diagram_type"] == "class"
+        assert body["is_active"] is True
+        # slug-based id
+        assert body["id"] == "x"
+
+    async def test_post_409_on_conflict_with_active_row(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """The creation_format outcomes_map row is seeded and active
+        with (creation_format, diagram_type, NULL, outcomes_map). A
+        second active row with the same tuple should 409."""
+        headers = await _admin_headers(client)
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(
+                name="Conflicting outcomes_map",
+                purpose="creation_format",
+                notation=None,
+                diagram_type="outcomes_map",
+            ),
+            headers=headers,
+        )
+        assert resp.status_code == 409, resp.text
+        detail = resp.json()["detail"]
+        assert "already exists" in detail.lower()
+        assert "outcomes_map" in detail
+
+    async def test_post_allowed_when_inactive(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """An inactive row can coexist with an active one on the same
+        tuple — lets admins stage a replacement before swapping."""
+        headers = await _admin_headers(client)
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(
+                name="Staged replacement",
+                purpose="creation_format",
+                notation=None,
+                diagram_type="outcomes_map",
+                is_active=False,
+            ),
+            headers=headers,
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["is_active"] is False
+
+    async def test_post_collision_suffix_for_duplicate_names(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        first = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(name="My Prompt", notation="uml", diagram_type="class"),
+            headers=headers,
+        )
+        second = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(name="My Prompt", notation="uml", diagram_type="sequence"),
+            headers=headers,
+        )
+        assert first.json()["id"] == "my-prompt"
+        assert second.json()["id"] == "my-prompt-2"
+
+    async def test_post_requires_admin(self, client: httpx.AsyncClient) -> None:
+        """Non-admin gets 403 (or 401 if not authenticated)."""
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(),
+            # no auth header
+        )
+        assert resp.status_code in (401, 403)
+
+    async def test_post_rejects_invalid_purpose(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(purpose="bogus"),
+            headers=headers,
+        )
+        assert resp.status_code == 422
+
+
+class TestDelete:
+    async def test_delete_hard_deletes(self, client: httpx.AsyncClient) -> None:
+        headers = await _admin_headers(client)
+        created = (await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(name="To Delete", notation="archimate", diagram_type="class"),
+            headers=headers,
+        )).json()
+
+        delete_resp = await client.delete(
+            f"/api/ai/creation-prompts/{created['id']}", headers=headers,
+        )
+        assert delete_resp.status_code == 204
+
+        # Confirm it's gone (PUT 404s on it now).
+        put_resp = await client.put(
+            f"/api/ai/creation-prompts/{created['id']}",
+            json={"is_active": False}, headers=headers,
+        )
+        assert put_resp.status_code == 404
+
+    async def test_delete_404_when_missing(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        resp = await client.delete(
+            "/api/ai/creation-prompts/no-such-id", headers=headers,
+        )
+        assert resp.status_code == 404
+
+
+class TestPutExtended:
+    async def test_put_updates_name(self, client: httpx.AsyncClient) -> None:
+        headers = await _admin_headers(client)
+        created = (await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(name="Original", notation="c4", diagram_type="component"),
+            headers=headers,
+        )).json()
+
+        resp = await client.put(
+            f"/api/ai/creation-prompts/{created['id']}",
+            json={"name": "Renamed", "description": "New desc"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["name"] == "Renamed"
+        assert body["description"] == "New desc"
+
+    async def test_put_409_on_tuple_conflict(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Changing the tuple to one already covered by another active
+        creation_format row should 409."""
+        headers = await _admin_headers(client)
+        # Create a response_format prompt on a free tuple.
+        created = (await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(
+                name="My Tuple", purpose="creation_format",
+                notation="archimate", diagram_type="sequence",
+            ),
+            headers=headers,
+        )).json()
+        assert created.get("id"), f"create failed: {created!r}"
+
+        # Try moving it onto (creation_format, diagram_type, NULL, outcomes_map)
+        # which is seeded and active.
+        resp = await client.put(
+            f"/api/ai/creation-prompts/{created['id']}",
+            json={"notation": "", "diagram_type": "outcomes_map"},
+            headers=headers,
+        )
+        assert resp.status_code == 409, resp.text
+
+    async def test_put_allows_self_no_conflict(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Editing a row's prompt_text shouldn't self-conflict on its
+        own tuple."""
+        headers = await _admin_headers(client)
+        # Find an existing active row.
+        listing = (await client.get(
+            "/api/ai/creation-prompts", headers=headers,
+        )).json()
+        target = next(r for r in listing if r["is_active"])
+
+        resp = await client.put(
+            f"/api/ai/creation-prompts/{target['id']}",
+            json={"prompt_text": "Updated text"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["prompt_text"] == "Updated text"
+
+    async def test_put_can_deactivate_then_create_replacement(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """The staging workflow: deactivate existing, then create new."""
+        headers = await _admin_headers(client)
+        listing = (await client.get(
+            "/api/ai/creation-prompts?purpose=creation_format",
+            headers=headers,
+        )).json()
+        existing = next(
+            r for r in listing
+            if r["layer"] == "diagram_type" and r["diagram_type"] == "outcomes_map"
+            and r["is_active"]
+        )
+
+        # Deactivate the existing row.
+        deact = await client.put(
+            f"/api/ai/creation-prompts/{existing['id']}",
+            json={"is_active": False}, headers=headers,
+        )
+        assert deact.status_code == 200
+
+        # Now creating a replacement on the same tuple should succeed.
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            json=_new_prompt_body(
+                name="Replacement outcomes_map",
+                diagram_type="outcomes_map",
+            ),
+            headers=headers,
+        )
+        assert resp.status_code == 201

--- a/backend/tests/test_sets/test_package_counts.py
+++ b/backend/tests/test_sets/test_package_counts.py
@@ -1,0 +1,162 @@
+"""ADR-158 / v5.13.0: Set responses include `package_count` and
+`package_count_root` so MCP clients see structural breadth without
+needing to paginate `list_packages` to discover scope.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+class TestPackageCountsOnGetSet:
+    async def test_empty_set_has_zero_counts(self, client: httpx.AsyncClient) -> None:
+        headers = await _auth_headers(client)
+        s = (await client.post("/api/sets", json={"name": "empty"}, headers=headers)).json()
+
+        resp = await client.get(f"/api/sets/{s['id']}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["package_count"] == 0
+        assert body["package_count_root"] == 0
+
+    async def test_counts_root_packages_only_at_root_field(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        s = (await client.post("/api/sets", json={"name": "tree"}, headers=headers)).json()
+
+        # 3 root packages + 2 children = 5 total, 3 root.
+        roots = []
+        for name in ("Chapter A", "Chapter B", "Chapter C"):
+            r = (await client.post(
+                "/api/packages",
+                json={"name": name, "set_id": s["id"]},
+                headers=headers,
+            )).json()
+            roots.append(r["id"])
+
+        # Two children under Chapter A.
+        for name in ("A.1", "A.2"):
+            await client.post(
+                "/api/packages",
+                json={"name": name, "set_id": s["id"], "parent_package_id": roots[0]},
+                headers=headers,
+            )
+
+        resp = await client.get(f"/api/sets/{s['id']}")
+        body = resp.json()
+        assert body["package_count"] == 5
+        assert body["package_count_root"] == 3
+
+    async def test_list_sets_includes_package_counts(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """The list endpoint must populate the new fields too — the MCP
+        get_set tool returns this shape, but list_sets is the broader
+        catalogue and matters for navigation."""
+        headers = await _auth_headers(client)
+        s = (await client.post(
+            "/api/sets", json={"name": "listed"}, headers=headers,
+        )).json()
+        await client.post(
+            "/api/packages",
+            json={"name": "Only Root", "set_id": s["id"]},
+            headers=headers,
+        )
+
+        resp = await client.get("/api/sets")
+        items = resp.json()["items"]
+        ours = next(i for i in items if i["id"] == s["id"])
+        assert ours["package_count"] == 1
+        assert ours["package_count_root"] == 1
+
+    async def test_create_response_initialises_counts_to_zero(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """The create endpoint also must populate these so client code
+        that uses the create response doesn't see KeyError."""
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/sets", json={"name": "fresh"}, headers=headers,
+        )
+        body = resp.json()
+        assert body["package_count"] == 0
+        assert body["package_count_root"] == 0
+
+    async def test_soft_deleted_packages_excluded(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Counts must reflect live state, not historic. The DELETE
+        endpoint requires `If-Match: <version>` header for optimistic
+        concurrency."""
+        headers = await _auth_headers(client)
+        s = (await client.post(
+            "/api/sets", json={"name": "delete-test"}, headers=headers,
+        )).json()
+        p = (await client.post(
+            "/api/packages",
+            json={"name": "to-delete", "set_id": s["id"]},
+            headers=headers,
+        )).json()
+        delete_resp = await client.delete(
+            f"/api/packages/{p['id']}",
+            headers={**headers, "If-Match": str(p["current_version"])},
+        )
+        assert delete_resp.status_code == 204
+
+        body = (await client.get(f"/api/sets/{s['id']}")).json()
+        assert body["package_count"] == 0
+        assert body["package_count_root"] == 0

--- a/docs/adrs/ADR-158-Admin-Prompts-Management-and-MCP-Set-Structure.md
+++ b/docs/adrs/ADR-158-Admin-Prompts-Management-and-MCP-Set-Structure.md
@@ -1,0 +1,108 @@
+# ADR-158: Admin AI prompts management redesign + MCP set-structure overview
+
+Status: Accepted (2026-05-12)
+Extends: [ADR-094-B](ADR-094-B-AI-Creation-Service.md), [ADR-132](ADR-132-Layered-Creation-Prompts.md), [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md)
+
+## Context
+
+Two unrelated-but-coincident pain points emerged from real UAT usage of v5.12.x.
+
+### Problem 1 — Admin prompts management
+
+The `ai_creation_prompts` table grew from 4 seeded rows in v5.8.0 to 18 in v5.12.0 (15 creation_format + 3 response_format under ADR-157). The admin AI page (`/admin/settings/ai`) showed all rows in a flat list with no filtering, no status toggle, no add, no delete, and edit only updated `prompt_text`. Adding new prompts via API was possible only by direct DB writes. Authoring at scale was painful.
+
+A secondary UX concern: rows like "ArchiMate Process Layout" have `notation=NULL` (intentional under ADR-132's cascade — the row applies to ANY notation that has the `process` diagram_type), but the UI showed `notation: —`, leaving authors to guess what the row actually applies to.
+
+### Problem 2 — MCP set-structure overview
+
+When asked to "jump into the doview book set", Claude Desktop listed top-level chapters E-J but missed A-D. Root cause: `iris-client.list_packages()` didn't expose pagination, so the MCP handler always got the first 50 packages ordered by `updated_at DESC`. Older chapters (A-D — seeded first, never updated) sorted to page 2+. `get_set` returned no `package_count`, no top-level summary, no hint that more existed. The backend already had `/api/packages/hierarchy?set_id=X` returning the complete tree — just not exposed via MCP.
+
+The intended outcome:
+- Admins can find, filter, toggle, add, edit, and delete prompts from the GUI with conflict detection.
+- The cascade behaviour is visible in the UI ("Any notation × Process diagrams" instead of "notation: —").
+- MCP clients see complete set structure without paginating, and know when pagination is needed when they do use it.
+
+Mnemos was considered as a primitive for set-structure summaries and **rejected**. ADR-111's MNEMOS extension is a semantic retrieval layer (ChromaDB vector index for Ask AI), not a hierarchy primitive. No package indexing, no rollups, no scope-level summary API. Different concern entirely.
+
+## Decision
+
+### Part A: Admin prompts management
+
+1. **Extend the existing `/api/ai/creation-prompts` API** with full CRUD:
+   - `POST /api/ai/creation-prompts` (admin) — creates a new row. Body: `{name, description, purpose, layer, notation?, diagram_type?, prompt_text, display_order?, is_active?}`. Auto-generates a slug-based `id` with collision suffix.
+   - `DELETE /api/ai/creation-prompts/{id}` (admin) — hard delete (no FKs).
+   - `PUT /api/ai/creation-prompts/{id}` extended (admin) to accept `name`, `description`, `notation`, `diagram_type`, `display_order` updates (previously only `prompt_text` and `is_active`).
+   - **Conflict detection** on `(purpose, layer, notation, diagram_type)` for `is_active=true` rows: POST returns 409; PUT returns 409 if a column change would conflict. Inactive rows can coexist on the same tuple (lets admins stage a replacement before disabling the current).
+
+2. **Rewrite the prompts section of `/admin/settings/ai/+page.svelte`** with:
+   - Filter row above the table (purpose / layer / notation / diagram_type / status / search / sort / reset) mirroring `/views/+page.svelte`'s inline pattern. URL-state for `purpose` and `layer` only (matches `/views` scope-filter convention). Other filters session-only.
+   - New "Purpose" column with badge.
+   - New "Applies to" column resolving the cascade clearly — e.g. `(layer=diagram_type, notation=NULL, diagram_type=process)` renders as **"Any notation × process diagrams"**. Addresses the user's "ArchiMate Process Layout has no notation" confusion.
+   - "Status" column becomes a toggle (single-click `PUT {is_active: <new>}`).
+   - "Actions" column gains Delete (with confirm dialog).
+   - "+ Add prompt" button opens an inline create form with live conflict-check (Save disables when the tuple already has an active row, with an inline note naming the conflicting prompt).
+   - Edit modal extended to allow editing name / description / notation / diagram_type (purpose and layer remain immutable post-create — delete-and-recreate to move between).
+
+3. **No filter-bar component extraction** — `/views` doesn't have one and a third screen isn't on the horizon. Avoid over-engineering.
+
+### Part B: MCP set-structure overview
+
+4. **Add `package_count` and `package_count_root` fields to `SetResponse`.** Computed inline in `app/sets/service.py:get_set` and `list_sets` via cheap `COUNT(*)` queries. Lets MCP clients see structural breadth upfront.
+
+5. **Extend `iris-client.list_packages()` with pagination** (`page`, `page_size`, `parent_package_id`). The backend endpoint already supported these — the iris-client signature just didn't expose them.
+
+6. **Add `iris-client.package_hierarchy(set_id, root_id=None)`** wrapping the existing `GET /api/packages/hierarchy` endpoint. Returns a typed list of `PackageHierarchyNode`. Fix a latent bug where the prior misnamed method `package_hierarchy` actually hit `/api/diagrams/hierarchy` — renamed to `diagram_hierarchy` (no prior callers).
+
+7. **New MCP tool `package_hierarchy`** wrapping the new iris-client method. Tool description prefers this over `list_packages` for structural overview. The primary fix — one call returns every chapter regardless of count or update-time ordering.
+
+8. **Extend the `list_packages` MCP tool** with `page`, `page_size`, `parent_package_id` schema. Update the description to flag pagination explicitly so client models know they may need to paginate big sets or prefer `package_hierarchy` for a single-call overview.
+
+## Why a `purpose`/`layer`/`notation`/`diagram_type` tuple conflict for `is_active=true` only
+
+- **Inactive rows must coexist for the staging workflow.** A v5.13.0 admin wants to draft a replacement, review it, then swap it in by toggling the active flag — without deleting their working text or going through a rename dance.
+- **Active rows must be unique on the tuple** because the composer cascade is deterministic — two active rows with the same tuple would be a non-deterministic merge that nobody asked for.
+- **The conflict message names the offending row** so admins can quickly find and disable it.
+
+## Why the new "Applies to" column instead of renaming seed rows
+
+Renaming "ArchiMate Process Layout" → "Process Layout (any notation)" would lose the original authoring intent (the prompt body still naturally reads as ArchiMate-flavoured for that layout) and rewrite history for no real win. Surfacing the cascade in a dedicated column makes the intent visible at a glance for any row, including future authored ones. Same data, better UI.
+
+## Why `package_hierarchy` as a new MCP tool rather than embedding the tree in `get_set`
+
+- **Predictability of tool-data size.** `get_set` is called everywhere; the response shape matters for context budgets. Big sets (hundreds of packages) would inflate every `get_set` payload. A separate `package_hierarchy` tool is opt-in — the model calls it only when it wants a tree.
+- **The breadth signal stays cheap.** `get_set` gains two scalar fields (`package_count`, `package_count_root`) so the model knows whether to bother calling `package_hierarchy` at all.
+- **Discoverability via tool description.** `list_packages` and `get_set` descriptions both cross-reference `package_hierarchy` as the preferred structural-overview tool.
+
+## Why fix the latent `package_hierarchy` → `/api/diagrams/hierarchy` bug now
+
+The bug had no callers (zero usages of the iris-client method across the codebase), so the rename is non-breaking. Better to fix while the surface is in flux for ADR-158 than to add a second method `package_hierarchy_tree` alongside the misnamed one. The renamed `diagram_hierarchy` still works for anyone who knew about the old behaviour.
+
+## Consequences
+
+- No DB migrations. The `is_active` column already exists; no new schema needed.
+- Backend: 1 new POST endpoint, 1 new DELETE endpoint, extended PUT, two new fields on `SetResponse`, conflict-detection helper.
+- iris-client: extended `list_packages` signature with optional pagination + filter; new `package_hierarchy` method; renamed broken `package_hierarchy` to `diagram_hierarchy`; new `PackageHierarchyNode` model.
+- MCP: 1 new tool (`package_hierarchy`), extended `list_packages` tool schema.
+- Frontend: prompts section of `/admin/settings/ai` rewritten with filter row, status toggle, add/delete, "Applies to" column, conflict check.
+- 34 new tests across backend, iris-client, MCP, frontend.
+- `docs/prompts/doview-book-mcp-system-context.md` updated to mention `iris_package_hierarchy` as the preferred chapter-list tool.
+
+## Out of scope (deferred)
+
+- **Filter-bar component extraction**: deferred until a third screen wants the same pattern.
+- **Soft-delete on creation_prompts**: hard delete with `is_active=false` as the soft alternative is sufficient.
+- **Renaming existing seed rows**: covered by the new "Applies to" column.
+- **Cascade preview** (showing the full composed system content for a given selector): nice future addition.
+- **Server-side pagination on the admin prompts table**: row count is bounded (~50 today, ~200 max), client-side `$derived` is sufficient.
+- **Multi-tenant prompt scoping**: ADR-157 already addresses scope-specific overrides via `mcp_system_context`.
+- **Embedding the package tree in `get_set`**: explicit `package_hierarchy` tool is the right boundary.
+- **Auto-application** of response_format prompts in the Ask Iris pipeline (still deferred per ADR-157).
+
+## See also
+
+- [ADR-094-B](ADR-094-B-AI-Creation-Service.md) — AI diagram creation service.
+- [ADR-111](ADR-111-MNEMOS-Semantic-Retrieval.md) — Mnemos extension (considered and rejected for this).
+- [ADR-132](ADR-132-Layered-Creation-Prompts.md) — the cascade this PUT extends.
+- [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — the `purpose` discriminator and `doview_analysis` artefact this admin GUI now manages.
+- [SPEC-158-A](specs/SPEC-158-A-Admin-Prompts-Management-and-MCP-Set-Structure.md) — schema (none), endpoint shapes, MCP wiring, frontend wiring, test plan.
+- `docs/prompts/doview-book-mcp-system-context.md` — references `iris_package_hierarchy` as the preferred chapter-list tool.

--- a/docs/adrs/specs/SPEC-158-A-Admin-Prompts-Management-and-MCP-Set-Structure.md
+++ b/docs/adrs/specs/SPEC-158-A-Admin-Prompts-Management-and-MCP-Set-Structure.md
@@ -1,0 +1,150 @@
+# SPEC-158-A: Admin AI prompts management + MCP set-structure overview
+
+ADR: [ADR-158](../ADR-158-Admin-Prompts-Management-and-MCP-Set-Structure.md)
+
+## Database
+
+**No schema changes.** `is_active`, `purpose` (added in m051), `notation`, `diagram_type` columns on `ai_creation_prompts` are sufficient. `packages.parent_package_id`, `packages.is_deleted`, `packages.set_id` already exist.
+
+## Backend
+
+### `/api/ai/creation-prompts` CRUD (admin-only, ADR-158, v5.13.0)
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `POST` | `/api/ai/creation-prompts` | Admin | Create new prompt; 409 on `(purpose, layer, notation, diagram_type)` conflict for `is_active=true` rows |
+| `DELETE` | `/api/ai/creation-prompts/{id}` | Admin | Hard delete |
+| `PUT` | `/api/ai/creation-prompts/{id}` (extended) | Admin | Now accepts name/description/notation/diagram_type/display_order in addition to prompt_text/is_active. Re-validates conflict tuple on column changes for active rows. |
+| `GET` | `/api/ai/creation-prompts?purpose=` | Admin (existing) | unchanged from v5.12.0 |
+
+**Models** (`backend/app/ai/models.py`):
+- `CreationPromptCreate` — new. `name`, `description?`, `purpose: Literal['creation_format', 'response_format']`, `layer: Literal['base', 'notation', 'diagram_type', 'override']`, `notation?`, `diagram_type?`, `prompt_text`, `display_order=0`, `is_active=True`.
+- `CreationPromptUpdate` — extended with `name?`, `description?`, `notation?`, `diagram_type?`, `display_order?`. `purpose` and `layer` remain immutable.
+
+**Conflict helper** (`backend/app/ai/router.py`): `_ensure_no_active_conflict(db, *, prompt_id, purpose, layer, notation, diagram_type)` raises 409 with a message naming the conflicting prompt. `prompt_id` excluded from the lookup (so PUT on the row itself doesn't self-conflict).
+
+**Slug helper**: id auto-generated as `_slugify(name)` with `-2`, `-3`, … suffix on collision.
+
+### Set responses gain package counts
+
+`backend/app/sets/service.py`:
+- `get_set` adds `package_count` (total non-deleted) and `package_count_root` (`parent_package_id IS NULL`) via two cheap `COUNT(*)` queries.
+- `list_sets` adds the same per row in its loop.
+- `create_set` initialises both to 0 in the synthetic return dict.
+
+`backend/app/sets/models.py`:
+- `SetResponse.package_count: int = 0`
+- `SetResponse.package_count_root: int = 0`
+
+## iris-client
+
+`iris-client/src/iris_client/client.py`:
+
+```python
+async def list_packages(
+    self,
+    *,
+    set_id: str | None = None,
+    collection_id: str | None = None,
+    parent_package_id: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> list[Package]:
+    """ADR-158: pagination + parent_package_id filter."""
+
+async def package_hierarchy(
+    self, *, set_id: str | None = None, root_id: str | None = None,
+) -> list[PackageHierarchyNode]:
+    """ADR-158: hits /api/packages/hierarchy. Returns nested tree."""
+
+async def diagram_hierarchy(
+    self, *, set_id: str | None = None, root_id: str | None = None,
+) -> dict[str, Any]:
+    """Renamed from the misnamed pre-v5.13.0 `package_hierarchy` —
+    actually hits /api/diagrams/hierarchy. No prior callers."""
+```
+
+`iris-client/src/iris_client/models/core.py`:
+- `PackageHierarchyNode` — `id`, `name`, `parent_package_id`, `children: list[PackageHierarchyNode]`. Self-referential under `from __future__ import annotations`.
+
+## MCP server
+
+`mcp/src/iris_mcp/tools.py`:
+
+| Tool | New / Extended | Description (truncated) |
+|---|---|---|
+| `list_packages` | Extended | "Paginated. Sets with more than 50 packages REQUIRE iterating pages, or you will miss content. For a structural overview, prefer `package_hierarchy`." Schema gains `page`, `page_size`, `parent_package_id`, `collection_id`. |
+| `package_hierarchy` | New | "Return the complete package tree for a set as nested PackageHierarchyNode objects in a SINGLE call. Prefer this over `list_packages` for structural overview / chapter list / table-of-contents." |
+
+## Frontend
+
+`frontend/src/routes/admin/settings/ai/+page.svelte` — prompts section rewritten:
+
+- **Filter row** (inline, no extracted component, mirrors `/views/+page.svelte` pattern):
+  - Purpose dropdown · Layer dropdown · Notation dropdown · Diagram type dropdown · Status dropdown · text search · Sort dropdown · Reset link · result count
+  - URL state: `?purpose=`, `?layer=` (other filters session-only)
+- **Table columns**: Name (with description), Purpose (badge), Layer, Applies to, Status (toggle button), Actions (Edit + Delete)
+- **`appliesToLabel(p)` helper** resolves the cascade for display:
+  - `base` → "Any notation × Any diagram type"
+  - `notation` (with notation set) → "{notation} × any diagram type"
+  - `diagram_type` (notation NULL or empty) → "Any notation × {diagram_type} diagrams"
+  - `diagram_type` (notation set) → "{notation} × {diagram_type} diagrams"
+  - `override` (with notation) → "Override: {notation} (replaces all layers)"
+- **Status toggle**: single click PUTs `{is_active: !current}`.
+- **+ Add prompt** button opens an inline create form with live conflict-check ($derived against the loaded list — Save disables when the tuple already has an active row, with an inline note naming the conflict).
+- **Delete** uses an inline confirmation dialog (consistent with the providers section's existing pattern in the same file).
+- **Edit modal** extended to allow editing name, description, notation, diagram_type alongside prompt_text. Purpose and layer remain immutable in the UI (consistent with backend PUT semantics).
+- **Notations + diagram types** sourced from `/api/notations` and `/api/diagram-types` at mount.
+
+`frontend/src/lib/types/api.ts` — no changes (the inline `CreationPrompt` type in the page handles the new `purpose` field; iris-client model updates are independent).
+
+## Tests
+
+| File | Cases | Layer |
+|---|---|---|
+| `backend/tests/test_sets/test_package_counts.py` | 5 (empty set, root vs nested counts, list_sets propagation, create-response defaults, soft-delete excluded) | backend |
+| `backend/tests/test_ai/test_creation_prompts_crud.py` | 12 (POST happy path, POST 409 on conflict, POST allowed when inactive, POST collision suffix, POST requires admin, POST validation, DELETE 204, DELETE 404, PUT name update, PUT 409 on tuple change, PUT self no-conflict, PUT staging workflow) | backend |
+| `iris-client/tests/test_packages_pagination.py` | 7 (list_packages defaults, page+page_size, parent_package_id filter; package_hierarchy typed nodes, set_id+root_id, empty; diagram_hierarchy rename) | iris-client |
+| `mcp/tests/test_tools_package_hierarchy.py` | 7 (package_hierarchy nested tree, root_id, empty; list_packages pagination passthrough, defaults; tool registration, description mentions pagination) | MCP |
+| `frontend/tests/unit/adminPromptsFilters.test.ts` | 15 (`appliesToLabel` 6 cases including the empty-notation-as-NULL coercion; filter logic 6 cases; conflict detection 3 cases) | frontend |
+
+**Total**: 46 new tests for v5.13.0. Combined with v5.8.x → v5.12.x suite, the codebase tests stand at ~430+ green. Pre-existing `test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO) remains the only acceptable failure.
+
+## End-to-end verification (after deploy)
+
+```bash
+# 1. NO migration to run — v5.13.0 has no schema changes.
+
+# 2. Admin AI prompts page (browser):
+#    Navigate to /admin/settings/ai
+#    - Verify filter row at top of "AI Prompts" section
+#    - Filter by purpose=response_format → only the 3 ADR-157 rows
+#    - Filter by layer=diagram_type → 11+ diagram_type-layer rows
+#    - "Applies to" column reads "Any notation × process diagrams" for
+#      creation-archimate-process-v1
+#    - Click status toggle → row goes muted (opacity 0.55) and shows ○ inactive
+#    - Click "+ Add prompt" → inline form opens
+#    - Pick (creation_format, diagram_type, NULL, outcomes_map) →
+#      "An active prompt already exists for this combination: 'DoView
+#      Outcomes Map Layout'. Disable that prompt first or pick a
+#      different combination." and Save is disabled
+#    - Toggle the existing outcomes_map row to inactive → conflict
+#      clears, Save enables
+#    - Delete row → confirm dialog → row removed
+
+# 3. MCP set-structure overview (Claude Desktop):
+#    Ask: "Give me the complete chapter list for the doview book set"
+#    Expected:
+#    - Claude sees package_count_root on the set
+#    - Calls iris_package_hierarchy('33032180-d77a-4ce4-88cf-b49cd643e093')
+#    - Returns all 10 root chapters A-J in a single call
+```
+
+## Out of scope (deferred per ADR-158)
+
+- Filter-bar reusable component extraction.
+- Server-side pagination on the admin prompts table.
+- Renaming existing seed rows.
+- Embedding the package tree in `get_set` responses.
+- Cascade preview ("show me the full composed system content for X notation/diagram_type").
+- Auto-application of response_format prompts in Ask Iris (still deferred per ADR-157).

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -20,13 +20,48 @@ Then compose the response using:
   - mcp__iris__search to find relevant tool pages in this set
   - mcp__iris__get_diagram to retrieve mermaid blocks from data.content
 
-To persist the analysis as a doview_analysis diagram in Iris:
-  iris_save_doview_analysis(set_id, name, content)
-(requires IRIS_TOKEN on the MCP server.)
+After producing the analysis, offer the user BOTH of the following save paths
+(do not assume only one is wanted):
+  1. Save into Iris as a doview_analysis diagram via:
+       iris_save_doview_analysis(set_id, name, content)
+     (requires IRIS_TOKEN on the MCP server.)
+     When suggesting an Iris save, recommend a sensible parent_package_id
+     based on the analysis topic — e.g. AI-related analyses fit naturally
+     under the J series (parent_package_id covering AI applications);
+     evaluation-method analyses fit under G; introduction/adoption topics
+     fit under I; etc. If unsure, suggest top-level (no parent_package_id)
+     or ask. The user may also redirect to a different set entirely.
+  2. Provide as a markdown artefact in the chat so the user can copy /
+     save it locally without involving Iris's database. The chat content
+     IS the markdown — no additional tool call is needed; just confirm
+     the analysis is presented above and offer to copy/export.
 
 Discover what other response formats are available:
   list_response_format_types
+
+Find available top-level packages (chapters) for nesting suggestions:
+  list_packages(set_id=<this-set>, parent_package_id=None)  -- root chapters
+  iris_package_hierarchy(set_id=<this-set>)  -- full tree (preferred — single call)
 ```
+
+## v5.13.0 update — save-options offer
+
+Updated to instruct the local AI client to offer **both** save paths
+after producing a doview_analysis:
+- Save into Iris (auth-required, persists as a `doview_analysis` diagram)
+- Provide as a markdown artefact in chat (anonymous, local copy/paste)
+
+The universal "offer both save paths" behaviour belongs in the
+`response-format-doview-analysis-v1` row's body (the response_format
+prompt). Once v5.13.0's admin GUI ships, edit that row via
+`/admin/settings/ai` to add the universal save-options guidance —
+then this scope-specific doc can be trimmed to just the chapter-
+nesting hint. Until then this doc is the single source of guidance.
+
+Also updated to mention `iris_package_hierarchy` (ADR-158, v5.13.0)
+as the preferred single-call mechanism to get the chapter list for
+the user to choose a parent_package_id when saving — addresses the
+"only saw E-J" pagination problem.
 
 ## Why this content (and not the strict format rules)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.12.2",
+	"version": "5.13.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/admin/settings/ai/+page.svelte
+++ b/frontend/src/routes/admin/settings/ai/+page.svelte
@@ -6,6 +6,7 @@
 		id: string;
 		name: string;
 		description: string | null;
+		purpose: string;  // 'creation_format' | 'response_format' (v5.12.0+)
 		layer: string;
 		notation: string | null;
 		diagram_type: string | null;
@@ -13,6 +14,28 @@
 		display_order: number;
 		is_active: boolean;
 	};
+
+	type Notation = { id: string; name: string };
+	type DiagramType = { id: string; name: string };
+
+	const PURPOSES = ['creation_format', 'response_format'] as const;
+	const LAYERS = ['base', 'notation', 'diagram_type', 'override'] as const;
+
+	function appliesToLabel(p: { layer: string; notation: string | null; diagram_type: string | null }): string {
+		// ADR-158 (v5.13.0): make the cascade behaviour visible — addresses the
+		// "ArchiMate Process Layout has no notation" confusion. Coerce empty
+		// strings to null so the live-preview hint in the create form works
+		// when the user picks "— none —".
+		const n = p.notation || null;
+		const d = p.diagram_type || null;
+		if (p.layer === 'base') return 'Any notation × Any diagram type';
+		if (p.layer === 'override') return n ? `Override: ${n} (replaces all layers)` : 'Override (no notation set — invalid)';
+		if (p.layer === 'notation') return n ? `${n} × any diagram type` : 'Notation layer (no notation set — invalid)';
+		// layer === 'diagram_type'
+		const notationPart = n ?? 'Any notation';
+		const dtPart = d ?? '?';
+		return `${notationPart} × ${dtPart} diagrams`;
+	}
 
 	const PROVIDER_TYPES = ['openai', 'anthropic', 'ollama', 'lmstudio', 'openrouter', 'custom'] as const;
 
@@ -217,16 +240,55 @@
 		}
 	}
 
-	// ── Creation Prompts ───────────────────────────────────────────────────────
+	// ── Creation Prompts (v5.13.0 / ADR-158: filter + CRUD redesign) ──────────
 	let creationPrompts = $state<CreationPrompt[]>([]);
 	let promptsLoading = $state(true);
+	let promptError = $state<string | null>(null);
+	let availableNotations = $state<Notation[]>([]);
+	let availableDiagramTypes = $state<DiagramType[]>([]);
+
+	// Filter state (URL-state-backed for purpose + layer; matches /views convention).
+	const urlPurpose = typeof window !== 'undefined'
+		? new URLSearchParams(window.location.search).get('purpose')
+		: null;
+	const urlLayer = typeof window !== 'undefined'
+		? new URLSearchParams(window.location.search).get('layer')
+		: null;
+	let purposeFilter = $state(urlPurpose ?? '');
+	let layerFilter = $state(urlLayer ?? '');
+	let notationFilter = $state('');
+	let diagramTypeFilter = $state('');
+	let statusFilter = $state(''); // '', 'active', 'inactive'
+	let searchText = $state('');
+	let sortBy = $state<'name' | 'layer' | 'updated'>('layer');
+
+	// Edit / add / delete state.
 	let editingPrompt = $state<CreationPrompt | null>(null);
 	let promptEditText = $state('');
+	let promptEditName = $state('');
+	let promptEditDescription = $state('');
+	let promptEditNotation = $state('');
+	let promptEditDiagramType = $state('');
 	let promptSaving = $state(false);
-	let promptError = $state<string | null>(null);
+
+	let creatingPrompt = $state(false);
+	let createForm = $state({
+		name: '',
+		description: '',
+		purpose: 'creation_format' as 'creation_format' | 'response_format',
+		layer: 'diagram_type' as typeof LAYERS[number],
+		notation: '',
+		diagram_type: '',
+		prompt_text: '',
+	});
+	let createSaving = $state(false);
+	let createError = $state<string | null>(null);
+
+	let deletingPromptId = $state<string | null>(null);
 
 	$effect(() => {
 		loadCreationPrompts();
+		loadAxes();
 	});
 
 	async function loadCreationPrompts() {
@@ -239,9 +301,77 @@
 		promptsLoading = false;
 	}
 
+	async function loadAxes() {
+		try {
+			availableNotations = await apiFetch<Notation[]>('/api/notations');
+		} catch {
+			availableNotations = [];
+		}
+		try {
+			availableDiagramTypes = await apiFetch<DiagramType[]>('/api/diagram-types');
+		} catch {
+			availableDiagramTypes = [];
+		}
+	}
+
+	const filteredPrompts = $derived.by(() => {
+		const q = searchText.toLowerCase().trim();
+		return creationPrompts
+			.filter((p) => {
+				if (purposeFilter && (p.purpose ?? 'creation_format') !== purposeFilter) return false;
+				if (layerFilter && p.layer !== layerFilter) return false;
+				if (notationFilter && (p.notation ?? '') !== notationFilter) return false;
+				if (diagramTypeFilter && (p.diagram_type ?? '') !== diagramTypeFilter) return false;
+				if (statusFilter === 'active' && !p.is_active) return false;
+				if (statusFilter === 'inactive' && p.is_active) return false;
+				if (q) {
+					if (!p.name.toLowerCase().includes(q)
+						&& !(p.description?.toLowerCase().includes(q) ?? false)) {
+						return false;
+					}
+				}
+				return true;
+			})
+			.sort((a, b) => {
+				if (sortBy === 'name') return a.name.localeCompare(b.name);
+				if (sortBy === 'updated') return 0;  // server already returns by purpose, layer, display_order
+				// 'layer'
+				const layerOrder = ['base', 'notation', 'diagram_type', 'override'];
+				const ai = layerOrder.indexOf(a.layer);
+				const bi = layerOrder.indexOf(b.layer);
+				if (ai !== bi) return ai - bi;
+				return a.name.localeCompare(b.name);
+			});
+	});
+
+	function resetFilters() {
+		purposeFilter = '';
+		layerFilter = '';
+		notationFilter = '';
+		diagramTypeFilter = '';
+		statusFilter = '';
+		searchText = '';
+		sortBy = 'layer';
+	}
+
+	// Sync purpose + layer filters to URL params for shareability (matches /views).
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		const url = new URL(window.location.href);
+		if (purposeFilter) url.searchParams.set('purpose', purposeFilter);
+		else url.searchParams.delete('purpose');
+		if (layerFilter) url.searchParams.set('layer', layerFilter);
+		else url.searchParams.delete('layer');
+		window.history.replaceState({}, '', url);
+	});
+
 	function openPromptEdit(p: CreationPrompt) {
 		editingPrompt = p;
 		promptEditText = p.prompt_text;
+		promptEditName = p.name;
+		promptEditDescription = p.description ?? '';
+		promptEditNotation = p.notation ?? '';
+		promptEditDiagramType = p.diagram_type ?? '';
 		promptError = null;
 	}
 
@@ -256,7 +386,13 @@
 		try {
 			await apiFetch(`/api/ai/creation-prompts/${editingPrompt.id}`, {
 				method: 'PUT',
-				body: JSON.stringify({ prompt_text: promptEditText }),
+				body: JSON.stringify({
+					name: promptEditName,
+					description: promptEditDescription || null,
+					notation: promptEditNotation,
+					diagram_type: promptEditDiagramType,
+					prompt_text: promptEditText,
+				}),
 			});
 			closePromptEdit();
 			await loadCreationPrompts();
@@ -264,6 +400,88 @@
 			promptError = e instanceof ApiError ? e.message : 'Save failed';
 		}
 		promptSaving = false;
+	}
+
+	async function togglePromptActive(p: CreationPrompt) {
+		try {
+			await apiFetch(`/api/ai/creation-prompts/${p.id}`, {
+				method: 'PUT',
+				body: JSON.stringify({ is_active: !p.is_active }),
+			});
+			await loadCreationPrompts();
+		} catch (e) {
+			promptError = e instanceof ApiError ? e.message : 'Toggle failed';
+		}
+	}
+
+	function openCreatePrompt() {
+		creatingPrompt = true;
+		createForm = {
+			name: '',
+			description: '',
+			purpose: 'creation_format',
+			layer: 'diagram_type',
+			notation: '',
+			diagram_type: '',
+			prompt_text: '',
+		};
+		createError = null;
+	}
+
+	function closeCreatePrompt() {
+		creatingPrompt = false;
+		createError = null;
+	}
+
+	const createConflict = $derived.by(() => {
+		// Live conflict check: does an active row already cover this (purpose, layer, notation, diagram_type)?
+		if (!creatingPrompt) return null;
+		const conflict = creationPrompts.find((p) =>
+			p.is_active
+			&& (p.purpose ?? 'creation_format') === createForm.purpose
+			&& p.layer === createForm.layer
+			&& (p.notation ?? '') === createForm.notation
+			&& (p.diagram_type ?? '') === createForm.diagram_type
+		);
+		return conflict ? conflict.name : null;
+	});
+
+	async function saveCreatePrompt() {
+		createSaving = true;
+		createError = null;
+		try {
+			const body: Record<string, unknown> = {
+				name: createForm.name,
+				description: createForm.description || null,
+				purpose: createForm.purpose,
+				layer: createForm.layer,
+				prompt_text: createForm.prompt_text,
+				is_active: true,
+			};
+			if (createForm.notation) body.notation = createForm.notation;
+			if (createForm.diagram_type) body.diagram_type = createForm.diagram_type;
+			await apiFetch('/api/ai/creation-prompts', {
+				method: 'POST',
+				body: JSON.stringify(body),
+			});
+			closeCreatePrompt();
+			await loadCreationPrompts();
+		} catch (e) {
+			createError = e instanceof ApiError ? e.message : 'Create failed';
+		}
+		createSaving = false;
+	}
+
+	async function confirmDeletePrompt() {
+		if (!deletingPromptId) return;
+		try {
+			await apiFetch(`/api/ai/creation-prompts/${deletingPromptId}`, { method: 'DELETE' });
+			deletingPromptId = null;
+			await loadCreationPrompts();
+		} catch (e) {
+			promptError = e instanceof ApiError ? e.message : 'Delete failed';
+			deletingPromptId = null;
+		}
 	}
 </script>
 
@@ -562,44 +780,248 @@
 	</div>
 {/if}
 
-<!-- ── Creation Prompts Section ──────────────────────────────────────────── -->
+<!-- ── Creation / Response Prompts Section (ADR-158, v5.13.0) ─────────── -->
 <div class="mt-10">
-	<h2 class="mb-1 text-xl font-bold" style="color: var(--color-fg)">Creation Prompts</h2>
-	<p class="mb-4 text-sm" style="color: var(--color-muted)">
-		Layered system prompts used for AI diagram creation. Base layer applies to all; notation and diagram-type layers stack on top.
-	</p>
+	<div class="mb-3 flex items-center justify-between">
+		<div>
+			<h2 class="text-xl font-bold" style="color: var(--color-fg)">AI Prompts</h2>
+			<p class="mt-1 text-sm" style="color: var(--color-muted)">
+				Layered prompts used for diagram creation (ADR-094-B / ADR-132) and response formatting (ADR-157). Filter, edit, enable/disable, add, and delete from this page. The cascade applies in order: override (replaces all) > base > notation > diagram_type.
+			</p>
+		</div>
+		<button
+			onclick={openCreatePrompt}
+			class="rounded px-4 py-2 text-sm text-white"
+			style="background-color: var(--color-primary); white-space: nowrap"
+		>
+			+ Add prompt
+		</button>
+	</div>
+
+	{#if promptError}
+		<div role="alert" class="mb-3 rounded border p-3 text-sm"
+			style="border-color: var(--color-danger); color: var(--color-danger)">{promptError}</div>
+	{/if}
+
+	<!-- Filter row (mirrors /views inline pattern) -->
+	<div class="mb-3 flex flex-wrap items-center gap-2 rounded border p-3"
+		style="border-color: var(--color-border); background: var(--color-surface)">
+		<select
+			bind:value={purposeFilter}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Filter by purpose"
+		>
+			<option value="">All purposes</option>
+			{#each PURPOSES as p}
+				<option value={p}>{p}</option>
+			{/each}
+		</select>
+		<select
+			bind:value={layerFilter}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Filter by layer"
+		>
+			<option value="">All layers</option>
+			{#each LAYERS as l}
+				<option value={l}>{l}</option>
+			{/each}
+		</select>
+		<select
+			bind:value={notationFilter}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Filter by notation"
+		>
+			<option value="">All notations</option>
+			{#each availableNotations as n (n.id)}
+				<option value={n.id}>{n.name}</option>
+			{/each}
+		</select>
+		<select
+			bind:value={diagramTypeFilter}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Filter by diagram type"
+		>
+			<option value="">All diagram types</option>
+			{#each availableDiagramTypes as d (d.id)}
+				<option value={d.id}>{d.name}</option>
+			{/each}
+		</select>
+		<select
+			bind:value={statusFilter}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Filter by status"
+		>
+			<option value="">All statuses</option>
+			<option value="active">Active only</option>
+			<option value="inactive">Inactive only</option>
+		</select>
+		<input
+			type="text"
+			bind:value={searchText}
+			placeholder="Search name + description..."
+			class="flex-1 rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); min-width: 200px"
+			aria-label="Search prompts"
+		/>
+		<select
+			bind:value={sortBy}
+			class="rounded border px-2 py-1 text-sm"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			aria-label="Sort by"
+		>
+			<option value="layer">Sort: layer</option>
+			<option value="name">Sort: name</option>
+		</select>
+		<button
+			onclick={resetFilters}
+			class="text-sm underline"
+			style="color: var(--color-muted)"
+		>
+			Reset filters
+		</button>
+		<span class="ml-auto text-xs" style="color: var(--color-muted)">
+			{filteredPrompts.length} of {creationPrompts.length}
+		</span>
+	</div>
+
+	{#if creatingPrompt}
+		<div class="mb-3 rounded border p-4"
+			style="border-color: var(--color-border); background: var(--color-surface)">
+			<h3 class="mb-3 text-base font-semibold" style="color: var(--color-fg)">New prompt</h3>
+			{#if createError}
+				<div role="alert" class="mb-3 rounded border p-3 text-sm"
+					style="border-color: var(--color-danger); color: var(--color-danger)">{createError}</div>
+			{/if}
+			<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Name
+					<input type="text" bind:value={createForm.name}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" />
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Description (optional)
+					<input type="text" bind:value={createForm.description}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" />
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Purpose
+					<select bind:value={createForm.purpose}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						{#each PURPOSES as p}
+							<option value={p}>{p}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Layer
+					<select bind:value={createForm.layer}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						{#each LAYERS as l}
+							<option value={l}>{l}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Notation (optional)
+					<select bind:value={createForm.notation}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						<option value="">— none —</option>
+						{#each availableNotations as n (n.id)}
+							<option value={n.id}>{n.name}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Diagram type (optional)
+					<select bind:value={createForm.diagram_type}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						<option value="">— none —</option>
+						{#each availableDiagramTypes as d (d.id)}
+							<option value={d.id}>{d.name}</option>
+						{/each}
+					</select>
+				</label>
+			</div>
+			<label class="mt-3 flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+				Prompt text
+				<textarea bind:value={createForm.prompt_text} rows="10"
+					class="rounded border px-2 py-1 font-mono text-xs"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); resize: vertical"></textarea>
+			</label>
+			<p class="mt-2 text-xs" style="color: var(--color-muted)">
+				Will apply to: <strong>{appliesToLabel({ layer: createForm.layer, notation: createForm.notation || null, diagram_type: createForm.diagram_type || null })}</strong>
+			</p>
+			{#if createConflict}
+				<p class="mt-2 text-xs" style="color: var(--color-danger)">
+					An active prompt already exists for this combination: <strong>{createConflict}</strong>. Disable that prompt first or pick a different combination.
+				</p>
+			{/if}
+			<div class="mt-3 flex justify-end gap-3">
+				<button onclick={closeCreatePrompt}
+					class="rounded border px-4 py-2 text-sm"
+					style="border-color: var(--color-border); color: var(--color-fg)">
+					Cancel
+				</button>
+				<button onclick={saveCreatePrompt} disabled={createSaving || !createForm.name || !createForm.prompt_text || createConflict !== null}
+					class="rounded px-4 py-2 text-sm text-white disabled:opacity-50"
+					style="background-color: var(--color-primary)">
+					{createSaving ? 'Saving…' : 'Create'}
+				</button>
+			</div>
+		</div>
+	{/if}
 
 	{#if promptsLoading}
 		<p style="color: var(--color-muted)">Loading…</p>
-	{:else if creationPrompts.length === 0}
-		<p class="text-sm" style="color: var(--color-muted)">No creation prompts found.</p>
+	{:else if filteredPrompts.length === 0}
+		<p class="text-sm" style="color: var(--color-muted)">
+			{creationPrompts.length === 0 ? 'No prompts found.' : 'No prompts match these filters.'}
+		</p>
 	{:else}
 		<div class="overflow-x-auto rounded border" style="border-color: var(--color-border)">
 			<table class="w-full text-sm" style="color: var(--color-fg)">
 				<thead>
 					<tr style="background: var(--color-surface); border-bottom: 1px solid var(--color-border)">
 						<th class="px-4 py-2 text-left font-medium">Name</th>
+						<th class="px-4 py-2 text-left font-medium">Purpose</th>
 						<th class="px-4 py-2 text-left font-medium">Layer</th>
-						<th class="px-4 py-2 text-left font-medium">Notation</th>
-						<th class="px-4 py-2 text-left font-medium">Diagram type</th>
+						<th class="px-4 py-2 text-left font-medium">Applies to</th>
 						<th class="px-4 py-2 text-left font-medium">Status</th>
 						<th class="px-4 py-2 text-right font-medium">Actions</th>
 					</tr>
 				</thead>
 				<tbody>
-					{#each creationPrompts as p (p.id)}
-						<tr style="border-bottom: 1px solid var(--color-border)">
+					{#each filteredPrompts as p (p.id)}
+						<tr style="border-bottom: 1px solid var(--color-border); opacity: {p.is_active ? '1' : '0.55'}">
 							<td class="px-4 py-2">
 								<div class="font-medium">{p.name}</div>
 								{#if p.description}
 									<div class="text-xs" style="color: var(--color-muted)">{p.description}</div>
 								{/if}
 							</td>
+							<td class="px-4 py-2 font-mono text-xs">{p.purpose ?? 'creation_format'}</td>
 							<td class="px-4 py-2 font-mono text-xs">{p.layer}</td>
-							<td class="px-4 py-2 text-xs">{p.notation ?? '—'}</td>
-							<td class="px-4 py-2 text-xs">{p.diagram_type ?? '—'}</td>
-							<td class="px-4 py-2 text-xs" style="color: {p.is_active ? 'var(--color-success, #16a34a)' : 'var(--color-muted)'}">
-								{p.is_active ? 'active' : 'inactive'}
+							<td class="px-4 py-2 text-xs">{appliesToLabel(p)}</td>
+							<td class="px-4 py-2 text-xs">
+								<button
+									onclick={() => togglePromptActive(p)}
+									class="rounded px-2 py-1 text-xs"
+									style="border: 1px solid var(--color-border); color: {p.is_active ? 'var(--color-success, #16a34a)' : 'var(--color-muted)'}; background: var(--color-bg)"
+									aria-label="Toggle active status"
+								>
+									{p.is_active ? '● active' : '○ inactive'}
+								</button>
 							</td>
 							<td class="px-4 py-2 text-right">
 								<button
@@ -608,6 +1030,13 @@
 									style="border: 1px solid var(--color-border); color: var(--color-fg)"
 								>
 									Edit
+								</button>
+								<button
+									onclick={() => { deletingPromptId = p.id; }}
+									class="ml-2 rounded px-2 py-1 text-xs"
+									style="border: 1px solid var(--color-border); color: var(--color-danger)"
+								>
+									Delete
 								</button>
 							</td>
 						</tr>
@@ -618,18 +1047,17 @@
 	{/if}
 </div>
 
-<!-- Edit prompt modal -->
+<!-- Edit prompt modal (ADR-158, v5.13.0: extended to edit name/description/notation/diagram_type) -->
 {#if editingPrompt}
-	<div role="dialog" aria-modal="true" aria-label="Edit creation prompt"
+	<div role="dialog" aria-modal="true" aria-label="Edit AI prompt"
 		class="fixed inset-0 z-50 flex items-center justify-center"
 		style="background: rgba(0,0,0,0.5)">
-		<div class="w-full max-w-2xl overflow-y-auto rounded border p-6 shadow-xl"
+		<div class="w-full max-w-3xl overflow-y-auto rounded border p-6 shadow-xl"
 			style="max-height: 90vh; background: var(--color-bg); border-color: var(--color-border)">
-			<h2 class="mb-1 text-lg font-semibold" style="color: var(--color-fg)">{editingPrompt.name}</h2>
+			<h2 class="mb-1 text-lg font-semibold" style="color: var(--color-fg)">Edit prompt</h2>
 			<p class="mb-4 text-xs" style="color: var(--color-muted)">
-				layer: {editingPrompt.layer}
-				{#if editingPrompt.notation} · notation: {editingPrompt.notation}{/if}
-				{#if editingPrompt.diagram_type} · diagram_type: {editingPrompt.diagram_type}{/if}
+				purpose: {editingPrompt.purpose ?? 'creation_format'} · layer: {editingPrompt.layer}
+				(both immutable — delete and re-create to move between purposes/layers)
 			</p>
 
 			{#if promptError}
@@ -637,7 +1065,44 @@
 					style="border-color: var(--color-danger); color: var(--color-danger)">{promptError}</div>
 			{/if}
 
-			<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+			<div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Name
+					<input type="text" bind:value={promptEditName}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" />
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Description
+					<input type="text" bind:value={promptEditDescription}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" />
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Notation
+					<select bind:value={promptEditNotation}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						<option value="">— none —</option>
+						{#each availableNotations as n (n.id)}
+							<option value={n.id}>{n.name}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
+					Diagram type
+					<select bind:value={promptEditDiagramType}
+						class="rounded border px-2 py-1 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
+						<option value="">— none —</option>
+						{#each availableDiagramTypes as d (d.id)}
+							<option value={d.id}>{d.name}</option>
+						{/each}
+					</select>
+				</label>
+			</div>
+
+			<label class="mt-4 flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
 				Prompt text
 				<textarea
 					bind:value={promptEditText}
@@ -646,6 +1111,10 @@
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); resize: vertical"
 				></textarea>
 			</label>
+
+			<p class="mt-2 text-xs" style="color: var(--color-muted)">
+				Will apply to: <strong>{appliesToLabel({ layer: editingPrompt.layer, notation: promptEditNotation || null, diagram_type: promptEditDiagramType || null })}</strong>
+			</p>
 
 			<div class="mt-4 flex justify-end gap-3">
 				<button onclick={closePromptEdit}
@@ -657,6 +1126,34 @@
 					class="rounded px-4 py-2 text-sm text-white disabled:opacity-50"
 					style="background-color: var(--color-primary)">
 					{promptSaving ? 'Saving…' : 'Save'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<!-- Delete prompt confirmation (ADR-158, v5.13.0) -->
+{#if deletingPromptId}
+	{@const pp = creationPrompts.find(x => x.id === deletingPromptId)}
+	<div role="dialog" aria-modal="true" aria-label="Confirm delete prompt"
+		class="fixed inset-0 z-50 flex items-center justify-center"
+		style="background: rgba(0,0,0,0.5)">
+		<div class="rounded border p-6 shadow-xl"
+			style="background: var(--color-bg); border-color: var(--color-border); min-width: 360px">
+			<h2 class="mb-2 text-base font-semibold" style="color: var(--color-fg)">Delete prompt?</h2>
+			<p class="mb-4 text-sm" style="color: var(--color-muted)">
+				Delete <strong>{pp?.name}</strong>? This is a hard delete. To preserve content while suppressing it from the cascade, use the inactive toggle instead.
+			</p>
+			<div class="flex justify-end gap-3">
+				<button onclick={() => { deletingPromptId = null; }}
+					class="rounded border px-4 py-2 text-sm"
+					style="border-color: var(--color-border); color: var(--color-fg)">
+					Cancel
+				</button>
+				<button onclick={confirmDeletePrompt}
+					class="rounded px-4 py-2 text-sm text-white"
+					style="background-color: var(--color-danger)">
+					Delete
 				</button>
 			</div>
 		</div>

--- a/frontend/tests/unit/adminPromptsFilters.test.ts
+++ b/frontend/tests/unit/adminPromptsFilters.test.ts
@@ -1,0 +1,212 @@
+/**
+ * ADR-158 (v5.13.0): admin AI prompts page filter logic and the
+ * "Applies to" cascade label helper.
+ *
+ * The helper's job is to make ADR-132's intentional design (a
+ * `layer=diagram_type` row with `notation=NULL` applies across all
+ * notations) visually obvious — addresses the "ArchiMate Process
+ * Layout has no notation set, why?" confusion the user reported.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// Inline copy of the helper so tests don't pull in Svelte runtime;
+// keep this in sync with `appliesToLabel` in
+// `frontend/src/routes/admin/settings/ai/+page.svelte`.
+function appliesToLabel(p: {
+	layer: string;
+	notation: string | null;
+	diagram_type: string | null;
+}): string {
+	const n = p.notation || null;  // empty string → null
+	const d = p.diagram_type || null;
+	if (p.layer === 'base') return 'Any notation × Any diagram type';
+	if (p.layer === 'override') {
+		return n
+			? `Override: ${n} (replaces all layers)`
+			: 'Override (no notation set — invalid)';
+	}
+	if (p.layer === 'notation') {
+		return n
+			? `${n} × any diagram type`
+			: 'Notation layer (no notation set — invalid)';
+	}
+	const notationPart = n ?? 'Any notation';
+	const dtPart = d ?? '?';
+	return `${notationPart} × ${dtPart} diagrams`;
+}
+
+describe('appliesToLabel — cascade UI hint', () => {
+	it('base layer is universal', () => {
+		expect(appliesToLabel({ layer: 'base', notation: null, diagram_type: null })).toBe(
+			'Any notation × Any diagram type',
+		);
+	});
+
+	it('notation layer with notation set names the notation', () => {
+		expect(
+			appliesToLabel({ layer: 'notation', notation: 'doview', diagram_type: null }),
+		).toBe('doview × any diagram type');
+	});
+
+	it('override names the notation it replaces', () => {
+		expect(
+			appliesToLabel({ layer: 'override', notation: 'doview', diagram_type: null }),
+		).toBe('Override: doview (replaces all layers)');
+	});
+
+	it('diagram_type layer with NULL notation explicitly says "Any notation"', () => {
+		// This is the row the user found confusing — "ArchiMate Process Layout"
+		// in the seed data has notation=NULL because it applies to ANY notation
+		// that has the `process` diagram_type. The label needs to say that
+		// explicitly so the cascade design is visible.
+		expect(
+			appliesToLabel({ layer: 'diagram_type', notation: null, diagram_type: 'process' }),
+		).toBe('Any notation × process diagrams');
+	});
+
+	it('diagram_type layer with notation specifies both axes', () => {
+		expect(
+			appliesToLabel({
+				layer: 'diagram_type',
+				notation: 'archimate',
+				diagram_type: 'process',
+			}),
+		).toBe('archimate × process diagrams');
+	});
+
+	it('diagram_type layer with empty notation behaves like NULL', () => {
+		expect(
+			appliesToLabel({ layer: 'diagram_type', notation: '', diagram_type: 'class' }),
+		).toBe('Any notation × class diagrams');
+	});
+});
+
+describe('Filter logic', () => {
+	type Row = {
+		id: string;
+		name: string;
+		description: string | null;
+		purpose: string;
+		layer: string;
+		notation: string | null;
+		diagram_type: string | null;
+		is_active: boolean;
+	};
+
+	function applyFilters(
+		rows: Row[],
+		filters: {
+			purpose?: string;
+			layer?: string;
+			notation?: string;
+			diagramType?: string;
+			status?: '' | 'active' | 'inactive';
+			search?: string;
+		},
+	): Row[] {
+		const q = (filters.search ?? '').toLowerCase().trim();
+		return rows.filter((p) => {
+			if (filters.purpose && (p.purpose ?? 'creation_format') !== filters.purpose) return false;
+			if (filters.layer && p.layer !== filters.layer) return false;
+			if (filters.notation && (p.notation ?? '') !== filters.notation) return false;
+			if (filters.diagramType && (p.diagram_type ?? '') !== filters.diagramType) return false;
+			if (filters.status === 'active' && !p.is_active) return false;
+			if (filters.status === 'inactive' && p.is_active) return false;
+			if (q) {
+				if (
+					!p.name.toLowerCase().includes(q)
+					&& !(p.description?.toLowerCase().includes(q) ?? false)
+				) {
+					return false;
+				}
+			}
+			return true;
+		});
+	}
+
+	const sample: Row[] = [
+		{ id: '1', name: 'A', description: null, purpose: 'creation_format', layer: 'base', notation: null, diagram_type: null, is_active: true },
+		{ id: '2', name: 'B', description: 'doview methodology', purpose: 'creation_format', layer: 'notation', notation: 'doview', diagram_type: null, is_active: true },
+		{ id: '3', name: 'C', description: null, purpose: 'response_format', layer: 'diagram_type', notation: null, diagram_type: 'doview_analysis', is_active: false },
+		{ id: '4', name: 'D', description: null, purpose: 'response_format', layer: 'base', notation: null, diagram_type: null, is_active: true },
+	];
+
+	it('filter by purpose', () => {
+		expect(applyFilters(sample, { purpose: 'response_format' }).map(r => r.id)).toEqual(['3', '4']);
+	});
+
+	it('filter by layer', () => {
+		expect(applyFilters(sample, { layer: 'base' }).map(r => r.id)).toEqual(['1', '4']);
+	});
+
+	it('filter by status active', () => {
+		expect(applyFilters(sample, { status: 'active' }).map(r => r.id)).toEqual(['1', '2', '4']);
+	});
+
+	it('filter by status inactive', () => {
+		expect(applyFilters(sample, { status: 'inactive' }).map(r => r.id)).toEqual(['3']);
+	});
+
+	it('search matches name or description', () => {
+		expect(applyFilters(sample, { search: 'doview' }).map(r => r.id)).toEqual(['2']);
+	});
+
+	it('combined filters narrow the result', () => {
+		expect(
+			applyFilters(sample, { purpose: 'response_format', status: 'active' }).map(r => r.id),
+		).toEqual(['4']);
+	});
+});
+
+describe('Conflict detection logic', () => {
+	type Row = {
+		id: string;
+		purpose: string;
+		layer: string;
+		notation: string | null;
+		diagram_type: string | null;
+		is_active: boolean;
+		name: string;
+	};
+
+	function findActiveConflict(
+		rows: Row[],
+		candidate: { purpose: string; layer: string; notation: string; diagram_type: string },
+	): Row | null {
+		return rows.find((p) =>
+			p.is_active
+			&& (p.purpose ?? 'creation_format') === candidate.purpose
+			&& p.layer === candidate.layer
+			&& (p.notation ?? '') === candidate.notation
+			&& (p.diagram_type ?? '') === candidate.diagram_type,
+		) ?? null;
+	}
+
+	const rows: Row[] = [
+		{ id: 'existing-active', name: 'Existing', purpose: 'creation_format', layer: 'diagram_type', notation: null, diagram_type: 'outcomes_map', is_active: true },
+		{ id: 'existing-inactive', name: 'Old', purpose: 'creation_format', layer: 'diagram_type', notation: null, diagram_type: 'outcomes_map', is_active: false },
+	];
+
+	it('detects conflict on same tuple as active row', () => {
+		const conflict = findActiveConflict(rows, {
+			purpose: 'creation_format', layer: 'diagram_type', notation: '', diagram_type: 'outcomes_map',
+		});
+		expect(conflict?.id).toBe('existing-active');
+	});
+
+	it('does not conflict when only an inactive row matches', () => {
+		const conflict = findActiveConflict(
+			rows.filter((r) => !r.is_active),
+			{ purpose: 'creation_format', layer: 'diagram_type', notation: '', diagram_type: 'outcomes_map' },
+		);
+		expect(conflict).toBeNull();
+	});
+
+	it('does not conflict when notation differs', () => {
+		const conflict = findActiveConflict(rows, {
+			purpose: 'creation_format', layer: 'diagram_type', notation: 'simple', diagram_type: 'outcomes_map',
+		});
+		expect(conflict).toBeNull();
+	});
+});

--- a/iris-client/src/iris_client/client.py
+++ b/iris-client/src/iris_client/client.py
@@ -30,6 +30,7 @@ from iris_client.models.core import (
     IrisSet,
     LoginResponse,
     Package,
+    PackageHierarchyNode,
     QAResponse,
     ResponseFormatType,
     ResponsePromptComposed,
@@ -244,11 +245,30 @@ class IrisClient:
     # --- Packages ------------------------------------------------------------
 
     async def list_packages(
-        self, *, set_id: str | None = None,
+        self,
+        *,
+        set_id: str | None = None,
+        collection_id: str | None = None,
+        parent_package_id: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
     ) -> list[Package]:
-        params: dict[str, Any] = {}
+        """List packages. ADR-158 (v5.13.0): supports pagination
+        (`page`, `page_size`) and `parent_package_id` filter so callers
+        can walk the tree level-by-level (`parent_package_id=None` for
+        roots, or a specific package ID for its direct children).
+
+        The backend defaults to `page_size=50, max 100`. For a full
+        structural overview, prefer `package_hierarchy()` — one call
+        returns the entire tree.
+        """
+        params: dict[str, Any] = {"page": page, "page_size": page_size}
         if set_id:
             params["set_id"] = set_id
+        if collection_id:
+            params["collection_id"] = collection_id
+        if parent_package_id is not None:
+            params["parent_package_id"] = parent_package_id
         response = await self._request("GET", "/api/packages", params=params)
         payload = response.json()
         items = payload["items"] if isinstance(payload, dict) and "items" in payload else payload
@@ -260,7 +280,31 @@ class IrisClient:
 
     async def package_hierarchy(
         self, *, set_id: str | None = None, root_id: str | None = None,
+    ) -> list[PackageHierarchyNode]:
+        """Return the complete package hierarchy for a set as a nested
+        tree (ADR-158, v5.13.0). Each node carries `id`, `name`,
+        `parent_package_id`, and `children`. Use this for structural
+        overview instead of paginating `list_packages` repeatedly.
+        """
+        params: dict[str, Any] = {}
+        if set_id:
+            params["set_id"] = set_id
+        if root_id:
+            params["root_id"] = root_id
+        response = await self._request(
+            "GET", "/api/packages/hierarchy", params=params,
+        )
+        payload = response.json()
+        # Endpoint returns a list of root nodes (each with nested children).
+        return [PackageHierarchyNode.model_validate(node) for node in payload]
+
+    async def diagram_hierarchy(
+        self, *, set_id: str | None = None, root_id: str | None = None,
     ) -> dict[str, Any]:
+        """Return the diagram hierarchy (NOT the package hierarchy).
+        Hits `/api/diagrams/hierarchy`. Renamed in v5.13.0 from the
+        misnamed `package_hierarchy`; previously had no callers so the
+        rename is non-breaking."""
         params: dict[str, Any] = {}
         if set_id:
             params["set_id"] = set_id

--- a/iris-client/src/iris_client/models/core.py
+++ b/iris-client/src/iris_client/models/core.py
@@ -107,6 +107,17 @@ class Package(EntityBase):
     parent_package_id: str | None = None
 
 
+class PackageHierarchyNode(_Permissive):
+    """One node in a package hierarchy tree (ADR-158, v5.13.0).
+    Returned by `IrisClient.package_hierarchy()` and the MCP
+    `iris_package_hierarchy` tool."""
+
+    id: str
+    name: str
+    parent_package_id: str | None = None
+    children: list[PackageHierarchyNode] = Field(default_factory=list)
+
+
 class IrisSet(EntityBase):
     """Named `IrisSet` because `Set` collides with builtins."""
 

--- a/iris-client/tests/test_packages_pagination.py
+++ b/iris-client/tests/test_packages_pagination.py
@@ -1,0 +1,118 @@
+"""ADR-158 (v5.13.0): list_packages accepts pagination + parent_package_id
+filter; package_hierarchy returns the full tree as a typed list of
+PackageHierarchyNode (one call, no pagination needed).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from iris_client import IrisClient
+
+BASE = "http://iris.test"
+
+
+class TestListPackagesPagination:
+    @pytest.mark.asyncio
+    async def test_default_params(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(200, json={"items": [], "total": 0, "page": 1, "page_size": 50}),
+        )
+        await pat_client.list_packages()
+        assert dict(route.calls.last.request.url.params) == {"page": "1", "page_size": "50"}
+
+    @pytest.mark.asyncio
+    async def test_passes_page_and_page_size(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(200, json={"items": [], "total": 0, "page": 2, "page_size": 25}),
+        )
+        await pat_client.list_packages(set_id="s-1", page=2, page_size=25)
+        params = dict(route.calls.last.request.url.params)
+        assert params["page"] == "2"
+        assert params["page_size"] == "25"
+        assert params["set_id"] == "s-1"
+
+    @pytest.mark.asyncio
+    async def test_passes_parent_package_id_filter(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(200, json={"items": [], "total": 0, "page": 1, "page_size": 50}),
+        )
+        await pat_client.list_packages(set_id="s-1", parent_package_id="parent-1")
+        params = dict(route.calls.last.request.url.params)
+        assert params["parent_package_id"] == "parent-1"
+
+
+class TestPackageHierarchy:
+    @pytest.mark.asyncio
+    async def test_returns_typed_nodes(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/packages/hierarchy").mock(
+            return_value=httpx.Response(200, json=[
+                {
+                    "id": "p-A",
+                    "name": "Chapter A",
+                    "parent_package_id": None,
+                    "children": [
+                        {"id": "p-A1", "name": "A.1", "parent_package_id": "p-A", "children": []},
+                    ],
+                },
+                {"id": "p-B", "name": "Chapter B", "parent_package_id": None, "children": []},
+            ]),
+        )
+
+        tree = await pat_client.package_hierarchy(set_id="s-1")
+        assert len(tree) == 2
+        assert tree[0].name == "Chapter A"
+        assert len(tree[0].children) == 1
+        assert tree[0].children[0].name == "A.1"
+        assert tree[1].name == "Chapter B"
+        assert tree[1].children == []
+
+    @pytest.mark.asyncio
+    async def test_passes_set_id_and_root_id(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/packages/hierarchy").mock(
+            return_value=httpx.Response(200, json=[]),
+        )
+        await pat_client.package_hierarchy(set_id="s-1", root_id="r-1")
+        params = dict(route.calls.last.request.url.params)
+        assert params["set_id"] == "s-1"
+        assert params["root_id"] == "r-1"
+
+    @pytest.mark.asyncio
+    async def test_empty_hierarchy(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/packages/hierarchy").mock(
+            return_value=httpx.Response(200, json=[]),
+        )
+        tree = await pat_client.package_hierarchy(set_id="empty-set")
+        assert tree == []
+
+
+class TestDiagramHierarchyRename:
+    @pytest.mark.asyncio
+    async def test_diagram_hierarchy_hits_diagrams_endpoint(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        """The pre-v5.13.0 `package_hierarchy` method was actually
+        hitting /api/diagrams/hierarchy — a latent bug. v5.13.0
+        renamed it to `diagram_hierarchy` (its true semantic) and
+        added a real `package_hierarchy` that hits the correct path.
+        """
+        route = respx_mock.get(f"{BASE}/api/diagrams/hierarchy").mock(
+            return_value=httpx.Response(200, json={"tree": []}),
+        )
+        result = await pat_client.diagram_hierarchy(set_id="s-1")
+        assert route.called
+        assert result == {"tree": []}

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.12.2"
+version = "5.13.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -82,8 +82,27 @@ async def _get_package(c: IrisClient, args: dict[str, Any]) -> str:
 
 
 async def _list_packages(c: IrisClient, args: dict[str, Any]) -> str:
-    rows = await c.list_packages(set_id=args.get("set_id"))
+    """ADR-158 (v5.13.0): accepts page/page_size/parent_package_id so
+    a model can walk big sets without missing chapters that paginate
+    onto page 2+."""
+    rows = await c.list_packages(
+        set_id=args.get("set_id"),
+        collection_id=args.get("collection_id"),
+        parent_package_id=args.get("parent_package_id"),
+        page=args.get("page", 1),
+        page_size=args.get("page_size", 50),
+    )
     return with_web_urls_list(json.dumps([r.model_dump() for r in rows]), "package")
+
+
+async def _package_hierarchy(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-158 (v5.13.0): return the complete package tree in one call.
+    Prefer this over `list_packages` for structural overview."""
+    nodes = await c.package_hierarchy(
+        set_id=args.get("set_id"),
+        root_id=args.get("root_id"),
+    )
+    return json.dumps([node.model_dump() for node in nodes])
 
 
 async def _list_sets(c: IrisClient, args: dict[str, Any]) -> str:
@@ -230,11 +249,61 @@ TOOLS: list[Tool] = [
     ),
     Tool(
         name="list_packages",
-        description="List packages, optionally scoped to a set.",
+        description=(
+            "List packages, optionally scoped to a set or collection. "
+            "Paginated — defaults to page=1, page_size=50 (max 100). "
+            "Sets with more than 50 packages REQUIRE iterating pages, "
+            "or you will miss content. For a structural overview of "
+            "an entire set in one call, prefer `package_hierarchy` "
+            "instead. Use `parent_package_id` to filter to direct "
+            "children of a specific package; pass `parent_package_id` "
+            "as omitted to get all packages (including children at "
+            "every depth, in updated_at DESC order). Set's "
+            "`package_count_root` and `package_count` fields on "
+            "`get_set` indicate how many to expect."
+        ),
         input_schema=_schema({
             "set_id": _str_arg("set_id", "Scope to a set", required=False),
+            "collection_id": _str_arg(
+                "collection_id", "Scope to a collection", required=False,
+            ),
+            "parent_package_id": _str_arg(
+                "parent_package_id",
+                "Filter to direct children of this package id",
+                required=False,
+            ),
+            "page": (
+                {"type": "integer", "description": "Page number (1-indexed)", "default": 1, "minimum": 1},
+                False,
+            ),
+            "page_size": (
+                {"type": "integer", "description": "Results per page (max 100)", "default": 50, "minimum": 1, "maximum": 100},
+                False,
+            ),
         }),
         handler=_list_packages,
+    ),
+    Tool(
+        name="package_hierarchy",
+        description=(
+            "Return the complete package tree for a set as nested "
+            "PackageHierarchyNode objects in a SINGLE call (ADR-158, "
+            "v5.13.0). Prefer this over `list_packages` whenever you "
+            "want a structural overview / chapter list / table-of-"
+            "contents — `list_packages` paginates and big sets miss "
+            "older chapters. The response is the list of root nodes; "
+            "each node carries `id`, `name`, `parent_package_id`, "
+            "`children`. Use `root_id` to scope to a sub-tree."
+        ),
+        input_schema=_schema({
+            "set_id": _str_arg("set_id", "Scope to a set", required=False),
+            "root_id": _str_arg(
+                "root_id",
+                "Optional sub-tree root: only return descendants of this package",
+                required=False,
+            ),
+        }),
+        handler=_package_hierarchy,
     ),
     Tool(
         name="get_package",

--- a/mcp/tests/test_tools_package_hierarchy.py
+++ b/mcp/tests/test_tools_package_hierarchy.py
@@ -1,0 +1,127 @@
+"""ADR-158 (v5.13.0): the `package_hierarchy` MCP tool returns a
+complete package tree in a single call, and the `list_packages` tool
+gained pagination + parent_package_id filter for level-by-level walks.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from iris_client.models.core import Package, PackageHierarchyNode
+
+from iris_mcp.tools import TOOLS
+
+
+def _tool_by_name(name: str):
+    return next(t for t in TOOLS if t.name == name)
+
+
+def _stub_client(*, package_hierarchy_result=None, list_packages_result=None):
+    client: Any = MagicMock()
+    if package_hierarchy_result is not None:
+        client.package_hierarchy = AsyncMock(return_value=package_hierarchy_result)
+    if list_packages_result is not None:
+        client.list_packages = AsyncMock(return_value=list_packages_result)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_package_hierarchy_tool_returns_nested_tree() -> None:
+    tree = [
+        PackageHierarchyNode(
+            id="p-A", name="Chapter A", parent_package_id=None,
+            children=[
+                PackageHierarchyNode(id="p-A1", name="A.1", parent_package_id="p-A", children=[]),
+            ],
+        ),
+        PackageHierarchyNode(
+            id="p-B", name="Chapter B", parent_package_id=None, children=[],
+        ),
+    ]
+    client = _stub_client(package_hierarchy_result=tree)
+    tool = _tool_by_name("package_hierarchy")
+
+    result = await tool.handler(client, {"set_id": "s-1"})
+    import json
+    nodes = json.loads(result)
+    assert len(nodes) == 2
+    assert nodes[0]["name"] == "Chapter A"
+    assert len(nodes[0]["children"]) == 1
+    assert nodes[0]["children"][0]["name"] == "A.1"
+    client.package_hierarchy.assert_awaited_once_with(set_id="s-1", root_id=None)
+
+
+@pytest.mark.asyncio
+async def test_package_hierarchy_tool_accepts_root_id() -> None:
+    client = _stub_client(package_hierarchy_result=[])
+    tool = _tool_by_name("package_hierarchy")
+
+    await tool.handler(client, {"set_id": "s-1", "root_id": "r-1"})
+    client.package_hierarchy.assert_awaited_once_with(set_id="s-1", root_id="r-1")
+
+
+@pytest.mark.asyncio
+async def test_package_hierarchy_tool_returns_empty_list_when_no_packages() -> None:
+    client = _stub_client(package_hierarchy_result=[])
+    tool = _tool_by_name("package_hierarchy")
+
+    result = await tool.handler(client, {"set_id": "empty"})
+    import json
+    assert json.loads(result) == []
+
+
+@pytest.mark.asyncio
+async def test_list_packages_tool_passes_pagination() -> None:
+    pkg = Package(
+        id="p-1", name="Pkg 1", parent_package_id=None,
+        current_version=1,
+        created_at="2026-05-12T00:00:00Z", created_by="u-1",
+        updated_at="2026-05-12T00:00:00Z",
+    )
+    client = _stub_client(list_packages_result=[pkg])
+    tool = _tool_by_name("list_packages")
+
+    await tool.handler(client, {
+        "set_id": "s-1",
+        "page": 2,
+        "page_size": 25,
+        "parent_package_id": "parent-1",
+    })
+    client.list_packages.assert_awaited_once_with(
+        set_id="s-1",
+        collection_id=None,
+        parent_package_id="parent-1",
+        page=2,
+        page_size=25,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_packages_tool_default_pagination() -> None:
+    client = _stub_client(list_packages_result=[])
+    tool = _tool_by_name("list_packages")
+
+    await tool.handler(client, {"set_id": "s-1"})
+    # Defaults: page=1, page_size=50
+    client.list_packages.assert_awaited_once_with(
+        set_id="s-1",
+        collection_id=None,
+        parent_package_id=None,
+        page=1,
+        page_size=50,
+    )
+
+
+def test_package_hierarchy_tool_is_registered() -> None:
+    tool = _tool_by_name("package_hierarchy")
+    assert tool.name == "package_hierarchy"
+    assert "complete package tree" in tool.description.lower() or "table-of-contents" in tool.description.lower()
+
+
+def test_list_packages_tool_description_mentions_pagination() -> None:
+    tool = _tool_by_name("list_packages")
+    desc_lower = tool.description.lower()
+    assert "page" in desc_lower
+    assert "package_hierarchy" in tool.description  # Cross-reference to preferred tool


### PR DESCRIPTION
## Summary

Two improvements driven by real UAT usage of v5.12.x.

**Part A — Admin AI prompts management.** With 18 rows in the table (15 creation_format + 3 response_format under ADR-157), the admin AI page was unusable:
- Filter row mirroring `/views/+page.svelte` (purpose, layer, notation, diagram_type, status, search, sort, reset). URL-state for `purpose` + `layer`.
- "Purpose" badge + "Applies to" cascade-resolution column. The "ArchiMate Process Layout has no notation set, why?" confusion is fixed — the row now reads **"Any notation × process diagrams"** with the cascade behaviour explicit.
- Status as one-click toggle (PUT `{is_active: !current}`).
- **+ Add prompt** inline form with live conflict-check ($derived against the loaded list — Save disables when the `(purpose, layer, notation, diagram_type)` tuple already has an active row).
- Per-row Delete with confirm dialog.
- Edit modal extended to allow name/description/notation/diagram_type.
- New backend POST + DELETE; PUT extended to round-trip all fields. Conflict detection on the tuple for active rows; inactive rows can coexist (staging workflow).

**Part B — MCP set-structure overview.** Claude Desktop missed chapters A-D of a 10-chapter set because `iris-client.list_packages` didn't expose pagination — the MCP handler always got the first 50 packages ordered by `updated_at DESC`, pushing older chapters to page 2+.
- New `iris_package_hierarchy(set_id)` MCP tool — single call returns the complete tree. Wraps the existing `/api/packages/hierarchy` backend endpoint that was just never exposed via MCP.
- `iris-client.list_packages` now accepts `page`, `page_size`, `parent_package_id`. MCP `list_packages` tool gains the same with a description that flags pagination explicitly and points at `package_hierarchy` as the preferred overview tool.
- `SetResponse` gains `package_count` + `package_count_root` so models see the structural breadth upfront.
- Latent bug fix: pre-v5.13.0 `iris-client.package_hierarchy` was misnamed — it actually hit `/api/diagrams/hierarchy`. Renamed to `diagram_hierarchy` (no prior callers, non-breaking). The new `package_hierarchy` correctly hits `/api/packages/hierarchy`.

See [ADR-158](docs/adrs/ADR-158-Admin-Prompts-Management-and-MCP-Set-Structure.md) and [SPEC-158-A](docs/adrs/specs/SPEC-158-A-Admin-Prompts-Management-and-MCP-Set-Structure.md).

## Architecture choices flagged in the ADR

- Hard-block 409 on `(purpose, layer, notation, diagram_type)` for active rows; inactive rows can coexist on the same tuple to enable staging.
- No filter-bar component extraction (defer until a 3rd screen wants the pattern; `/views` is inline, this matches).
- "Applies to" column instead of renaming seeded rows (preserves authoring intent; surface in UI instead).
- New `package_hierarchy` MCP tool instead of embedding the tree in `get_set` (predictable response sizes; opt-in by the model when it wants the overview).

## Test plan

- [x] `test_ai/test_creation_prompts_crud.py` — 12 cases (POST happy + 409 + inactive coexistence + slug collision + admin gate + validation; DELETE 204 + 404; PUT name update + tuple conflict + self no-conflict + staging workflow)
- [x] `test_sets/test_package_counts.py` — 5 cases (zero, root vs nested, list_sets propagation, create-response, soft-delete excluded)
- [x] `iris-client/tests/test_packages_pagination.py` — 7 cases (list_packages defaults + page/page_size + parent_package_id; package_hierarchy nested + scoped + empty; diagram_hierarchy rename)
- [x] `mcp/tests/test_tools_package_hierarchy.py` — 7 cases (tool happy path + root_id + empty + pagination passthrough + defaults + registration + description)
- [x] `frontend/tests/unit/adminPromptsFilters.test.ts` — 15 cases (`appliesToLabel` 6 incl. empty-notation-as-NULL; filter logic 6; conflict detection 3)
- [x] **439 tests total green** (289 backend + 37 iris-client + 86 mcp + 27 frontend). Only pre-existing `test_no_extra_rls_tables` failure (issue 88 Phase 4 TODO).

## UAT

**No migration to run** — v5.13.0 has no schema changes. After Render redeploys from `render-supabase-uat`:

1. `/admin/settings/ai` should show the new filter row, Purpose + Applies-to columns, status toggle, add/delete actions.
2. In Claude Desktop ask "give me the complete chapter list for the doview book set" — should return all 10 chapters A-J via a single `iris_package_hierarchy` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)