### PR TITLE
fix(v5.13.1): admin AI prompts filter dropdowns hit correct registry paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.1] - 2026-05-12
+
+### Fixed
+
+- **Admin AI prompts page — Notation and Diagram type filter
+  dropdowns were empty.** v5.13.0 called `/api/notations` and
+  `/api/diagram-types`; the registry endpoints actually live at
+  `/api/registry/notations` and `/api/registry/diagram-types` per
+  ADR-079. `apiFetch` returned 404, the catch swallowed the error,
+  and the dropdowns rendered with only the placeholder option.
+  Frontend now hits the correct paths.
+
 ## [5.13.0] - 2026-05-12
 
 ### Added

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.13.0",
+	"version": "5.13.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/admin/settings/ai/+page.svelte
+++ b/frontend/src/routes/admin/settings/ai/+page.svelte
@@ -302,13 +302,14 @@
 	}
 
 	async function loadAxes() {
+		// Endpoints live under /api/registry per ADR-079 (admin-only).
 		try {
-			availableNotations = await apiFetch<Notation[]>('/api/notations');
+			availableNotations = await apiFetch<Notation[]>('/api/registry/notations');
 		} catch {
 			availableNotations = [];
 		}
 		try {
-			availableDiagramTypes = await apiFetch<DiagramType[]>('/api/diagram-types');
+			availableDiagramTypes = await apiFetch<DiagramType[]>('/api/registry/diagram-types');
 		} catch {
 			availableDiagramTypes = [];
 		}

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.13.0"
+version = "5.13.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

v5.13.0 called \`/api/notations\` and \`/api/diagram-types\` from the admin AI prompts filter row. The registry endpoints actually live at \`/api/registry/notations\` and \`/api/registry/diagram-types\` per ADR-079. \`apiFetch\` returned 404, the \`catch\` silently set the arrays to \`[]\`, and the dropdowns rendered with only their placeholder option.

Two path string changes in \`loadAxes()\`. No schema or model changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)