### PR TITLE
docs: restore orient-first menu + explicit analysis/diagram routing in mcp_system_context

### DIFF
--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -11,57 +11,133 @@ Per ADR-156 (`mcp_system_context` semantics) and ADR-157 (response_format layere
 Paste the following into the **MCP system context** textarea on the DoView Book Set edit page:
 
 ```text
-This set hosts Dr Paul Duignan's DoView Planning and Outcomes Theory Handbook.
+This set is the visual companion to Dr Paul Duignan's DoView outcomes-
+mapping methodology and outcomes-theory body of work (the "Outcomes
+Theory" book in Iris; previously named "DoView Book").
 
-For formal outcomes-theory analyses, fetch the response format via:
-  iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')
+ORIENT FIRST — do not jump into a tool action without a menu.
 
-Then compose the response using:
-  - mcp__iris__search to find relevant tool pages in this set
-  - mcp__iris__get_diagram to retrieve mermaid blocks from data.content
+When a user opens or asks about this set, the FIRST response should:
+  1. Briefly describe the set's purpose (one or two sentences).
+  2. Use iris_package_hierarchy(set_id=<this-set>) — NOT list_packages,
+     which paginates and misses older chapters — to list the chapter
+     structure (Part A through Part J, with brief one-line descriptions).
+  3. Offer a menu of common next steps and wait for the user to choose.
+     If your client supports a structured multiple-choice question UI
+     (Claude Code's AskUserQuestion, similar affordances in other
+     clients), use it; otherwise present the options as a bulleted list
+     and let the user reply free-form. The menu:
+       - "Pull up a specific chapter or diagram (e.g. J03 - Using AI to
+          Speed Up DoView Planning)"
+       - "Ask a cross-package question (e.g. 'what are the recurring
+          causal-link conventions across the diagrams?')"
+       - "Generate a new DoView outcomes-theory analysis on a topic the
+          user describes, grounded in this handbook, and optionally save
+          it back here"
+       - "Browse a particular chapter's diagrams in detail"
 
-After producing the analysis, offer the user BOTH of the following save paths
-(do not assume only one is wanted):
-  1. Save into Iris as a doview_analysis diagram via:
-       iris_save_doview_analysis(set_id, name, content)
-     (requires IRIS_TOKEN on the MCP server.)
-     When suggesting an Iris save, recommend a sensible parent_package_id
-     based on the analysis topic — e.g. AI-related analyses fit naturally
-     under the J series (parent_package_id covering AI applications);
-     evaluation-method analyses fit under G; introduction/adoption topics
-     fit under I; etc. If unsure, suggest top-level (no parent_package_id)
-     or ask. The user may also redirect to a different set entirely.
-  2. Provide as a markdown artefact in the chat so the user can copy /
-     save it locally without involving Iris's database. The chat content
-     IS the markdown — no additional tool call is needed; just confirm
-     the analysis is presented above and offer to copy/export.
+DO NOT generate an analysis or fetch a response prompt on the first
+turn unless the user has explicitly asked for one. Open with the menu.
 
-Discover what other response formats are available:
+────────────────────────────────────────────────────────────────────
+Two different "DoView" outputs the user might ask for — different paths
+────────────────────────────────────────────────────────────────────
+
+A. WRITTEN OUTCOMES-THEORY ANALYSIS (prose + embedded mermaid diagrams
+   from referenced handbook tool pages). This is the doview_analysis
+   flow. Use this when the user says "generate a DoView analysis",
+   "analyse X from an outcomes-theory perspective", "what does
+   outcomes theory say about Y", or similar text-output requests.
+
+   Steps:
+     1. Fetch the response format rules:
+          iris_get_response_prompt(notation='markdown',
+                                   diagram_type='doview_analysis')
+     2. Compose the response in-conversation following those rules,
+        using mcp__iris__search + mcp__iris__get_diagram against this
+        set for handbook source material.
+     3. AFTER producing the analysis, offer BOTH save paths (do not
+        assume only one is wanted):
+          (i) Save into Iris as a doview_analysis diagram:
+                iris_save_doview_analysis(set_id, name, content,
+                                          parent_package_id?)
+              (auth required — if no IRIS_TOKEN, returns an auth
+              error; in that case the markdown is already in chat
+              for copy/paste.)
+              When suggesting a parent_package_id, recommend a
+              sensible chapter — AI-related → J series; evaluation
+              → G; introduction/adoption → I; alignment → C;
+              indicators → D; contracting → E; reporting → H;
+              fundamentals → A; drawing/strategy → B; performance
+              improvement → F. If unsure, suggest top-level or
+              ask. The user may also redirect to a different set.
+         (ii) Leave the markdown in chat so the user can copy /
+              save it locally. The chat content IS the markdown —
+              no additional tool call is needed.
+
+   DO NOT use mcp__iris__ask for this flow. mcp__iris__ask is for
+   Iris's own internal Q&A and creation flows; it would route the
+   work back through Iris's backend LLM (costly, slower, and not
+   what the user asked for here).
+
+B. NEW VISUAL DOVIEW DIAGRAM (a new notation=doview outcomes_map or
+   overview-style page that will appear in the set as a real Iris
+   diagram). Use this when the user says "create a new DoView
+   diagram", "draw an outcomes map for X", "build the theory of
+   change as a diagram", etc.
+
+   For this case, the guided creation flow (Stages 0-3, the 13
+   drafting steps, balance checks, the "This-Then" methodology)
+   is best done through Iris's web UI:
+     https://iris-uat.chrisbarlow.nz/sets/<this-set-id>
+   Open the set, click "New diagram", pick notation=DoView,
+   diagram_type=outcomes_map. The Ask Iris panel will walk through
+   the methodology and materialise the result as real diagrams.
+
+   Direct generation through MCP is possible (mcp__iris__ask with
+   mode='creation', then apply_diagram_creation) but loses the
+   guided-conversation rhythm that the methodology depends on.
+   Recommend the web UI for this case unless the user explicitly
+   prefers the MCP path.
+
+────────────────────────────────────────────────────────────────────
+Discoverability helpers
+────────────────────────────────────────────────────────────────────
+
   list_response_format_types
+    What output formats are available (e.g. doview_analysis).
 
-Find available top-level packages (chapters) for nesting suggestions:
-  list_packages(set_id=<this-set>, parent_package_id=None)  -- root chapters
-  iris_package_hierarchy(set_id=<this-set>)  -- full tree (preferred — single call)
+  iris_package_hierarchy(set_id=<this-set>)
+    Complete chapter tree, single call. Preferred over list_packages.
 ```
 
-## v5.13.0 update — save-options offer
+## Revision history
 
-Updated to instruct the local AI client to offer **both** save paths
-after producing a doview_analysis:
-- Save into Iris (auth-required, persists as a `doview_analysis` diagram)
-- Provide as a markdown artefact in chat (anonymous, local copy/paste)
+**Post-v5.13.1 fix (this revision).** Restored the orient-first /
+offer-menu pattern that was implicit in pre-v5.12 conversations but
+got drowned out when more prescriptive routing was added. Explicit
+about which path each user-request shape maps to:
+- "analysis" → `iris_get_response_prompt` + compose + optional save
+- "diagram" → web UI (guided creation)
+- `mcp__iris__ask` is explicitly NOT the path for either (was being
+  defaulted to incorrectly).
+Also reflects the set rename: "DoView Book" → "Outcomes Theory" in
+the prose, while keeping the file name stable.
 
-The universal "offer both save paths" behaviour belongs in the
-`response-format-doview-analysis-v1` row's body (the response_format
-prompt). Once v5.13.0's admin GUI ships, edit that row via
-`/admin/settings/ai` to add the universal save-options guidance —
-then this scope-specific doc can be trimmed to just the chapter-
-nesting hint. Until then this doc is the single source of guidance.
+**v5.13.0 — package_hierarchy hint.** Mentions
+`iris_package_hierarchy` (ADR-158) as the preferred single-call
+mechanism to get the chapter list; resolves the "only saw E-J"
+pagination problem.
 
-Also updated to mention `iris_package_hierarchy` (ADR-158, v5.13.0)
-as the preferred single-call mechanism to get the chapter list for
-the user to choose a parent_package_id when saving — addresses the
-"only saw E-J" pagination problem.
+**v5.12.0 — save-options offer.** Instructs the client to offer both
+save paths after producing a doview_analysis (Iris save + markdown
+artefact in chat).
+
+The "offer both save paths" + "orient first" behaviours arguably
+belong in the `response-format-doview-analysis-v1` row's body so
+they apply universally, not just on this Set. Until that row is
+amended via `/admin/settings/ai`, this scope-specific doc is the
+single source of guidance.
 
 ## Why this content (and not the strict format rules)
 


### PR DESCRIPTION
## Summary

Two regressions in the v5.13.0 mcp_system_context content reported by user testing:

1. **Orient-first menu lost.** Pre-v5.12 conversations opened with "here's what's in the set; want me to (a) pull up a chapter, (b) ask a cross-package question, (c) generate a new analysis, (d) browse a chapter?". The more prescriptive v5.12.0+ guidance drowned this out — Claude now jumps straight into action without offering options.

2. **Wrong tool for "generate a new DoView analysis".** Claude defaults to \`mcp__iris__ask\` (Iris's own backend Q&A path) instead of the response_format flow that v5.12.0 (ADR-157) was specifically designed for. The intended path is \`iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')\` followed by local composition.

## Fix

Content update to \`docs/prompts/doview-book-mcp-system-context.md\` with three structural changes:

- **ORIENT FIRST.** Explicit instruction to open with a brief description + chapter hierarchy (via \`iris_package_hierarchy\`) + menu of next steps. Recommends AskUserQuestion-style structured choice if the client supports it, bulleted list otherwise.
- **Two clear paths.** "Analysis" requests → \`iris_get_response_prompt\` + compose + optional save. "Diagram" requests → recommend web UI for guided creation. Explicit "DO NOT use mcp__iris__ask for analysis flow".
- **Set rename.** "DoView Book" → "Outcomes Theory" in prose (file name stable).

Docs-only — no code, no schema, no migration. User pastes updated content into the Set's MCP system context field on UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)