### PR TITLE
release(v5.13.3): make 4-option orient menu mandatory + AskUserQuestion note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.13.3] - 2026-05-12
+
+### Changed (docs / canonical mcp_system_context content)
+
+- **Made the four-option orient menu mandatory and verbatim.**
+  v5.13.2 instructed the client to "offer a menu of common next
+  steps" but didn't require all four options to appear every time,
+  so Claude paraphrased and offered only 2 ("specific chapter" /
+  "cross-package question"), dropping the analysis-generation and
+  chapter-browse options. The doc now states it's MANDATORY to
+  offer all four, with their exact wording, and explicitly forbids
+  paraphrasing or abbreviating to two/three.
+- **Honest note on AskUserQuestion availability.** AskUserQuestion
+  is a Claude Code tool, not in Claude Desktop / claude.ai / most
+  generic MCP clients today. The doc says: use AskUserQuestion if
+  available; otherwise present a numbered list (1./2./3./4.) with
+  each option on its own line.
+
 ## [5.13.2] - 2026-05-12
 
 ### Changed (docs / canonical mcp_system_context content)

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -22,19 +22,53 @@ When a user opens or asks about this set, the FIRST response should:
   2. Use iris_package_hierarchy(set_id=<this-set>) — NOT list_packages,
      which paginates and misses older chapters — to list the chapter
      structure (Part A through Part J, with brief one-line descriptions).
-  3. Offer a menu of common next steps and wait for the user to choose.
-     If your client supports a structured multiple-choice question UI
-     (Claude Code's AskUserQuestion, similar affordances in other
-     clients), use it; otherwise present the options as a bulleted list
-     and let the user reply free-form. The menu:
-       - "Pull up a specific chapter or diagram (e.g. J03 - Using AI to
-          Speed Up DoView Planning)"
-       - "Ask a cross-package question (e.g. 'what are the recurring
-          causal-link conventions across the diagrams?')"
-       - "Generate a new DoView outcomes-theory analysis on a topic the
-          user describes, grounded in this handbook, and optionally save
-          it back here"
-       - "Browse a particular chapter's diagrams in detail"
+  3. Offer the user a menu of common next steps and wait for the user
+     to choose. THIS IS MANDATORY. Offer ALL FOUR of the options below.
+     Do not abbreviate to two or three. Do not paraphrase the options
+     into a single sentence. The four options are not equivalent —
+     each leads to a different workflow — so present them as four
+     distinct choices.
+
+  Use a structured question / multi-choice UI if your client has one:
+    - Claude Code: call the AskUserQuestion tool with the four options
+      below as `options`. (One question, multiSelect=false.)
+    - Claude Desktop, claude.ai, generic MCP clients: AskUserQuestion
+      is not in your tool surface; instead, present the four options
+      as a numbered list (1./2./3./4.) with each on its own line so
+      the user can reply by number.
+
+  THE FOUR OPTIONS (use this exact wording, fill in the example):
+
+    1. Pull up a specific chapter or diagram from the handbook
+       (e.g. <suggest one relevant chapter based on what the user
+       said when opening the set, like "J06 - Mathematization of
+       Outcomes Theory and DoView Planning"; otherwise suggest any
+       chapter that looked interesting in the hierarchy).
+
+    2. Ask a cross-package question via Iris AI
+       (e.g. "What are the recurring causal-link conventions across
+       the diagrams?" — uses mcp__iris__ask).
+
+    3. Generate a new DoView outcomes-theory analysis on a topic
+       the user describes, grounded in this handbook, with an
+       option to save it back into this set as a doview_analysis
+       diagram. (Uses the iris_get_response_prompt + compose
+       locally flow described in section A below, NOT
+       mcp__iris__ask.)
+
+    4. Browse a particular chapter's diagrams in detail
+       (uses iris_package_hierarchy filtered to a chapter, then
+       mcp__iris__get_diagram on each diagram in turn).
+
+  After the user picks, proceed with the chosen workflow. DO NOT
+  skip this menu step on the first turn — even if the user's
+  opening request seems to imply action ("open the book"), still
+  orient + offer the four-option menu before doing anything else.
+  If the user's opening request explicitly asks for one of the
+  four (e.g. "open the book and generate me a DoView analysis of
+  X"), present a one-line acknowledgement of the inferred choice
+  and the menu of the other three options in case they want to
+  redirect, then proceed.
 
 DO NOT generate an analysis or fetch a response prompt on the first
 turn unless the user has explicitly asked for one. Open with the menu.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.13.2",
+	"version": "5.13.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.13.2"
+version = "5.13.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
v5.13.2 left room for Claude to paraphrase/abbreviate the 4-option menu down to 2 options. User testing confirmed this happened: the analysis-generation and chapter-browse options were dropped. v5.13.3 makes all four options mandatory and verbatim, with explicit forbidding of paraphrasing.

Also clarifies AskUserQuestion availability — it's a Claude Code feature, not currently in Claude Desktop's tool surface. Doc instructs the client to use AskUserQuestion if available; otherwise present a numbered list.

Docs/content only. User pastes updated content into the Set's MCP system context field on UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)