### PR TITLE
feat(v5.14.0): scope mcp_system_context in search results (ADR-159) + content trim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.14.0] - 2026-05-12
+
+### Added
+
+- **Scope `mcp_system_context` in search results** (ADR-159,
+  SPEC-159-A). `GET /api/search` results for `result_type=set` and
+  `result_type=collection` now include the matching scope's
+  `mcp_system_context` field. Diagnoses and fixes the root cause of
+  v5.13.x's "orient instructions don't fire" symptom: when Claude
+  Desktop's natural flow was `search` → return link, it never
+  called `get_set` and the orient guidance never landed. With this
+  change, the orient guidance lands on the search hit itself —
+  whether or not Claude follows up with `get_set`.
+- New `mcp_system_context: str | None` field on:
+  - `backend/app/search/models.py:SearchResult`
+  - `iris-client/src/iris_client/models/core.py:SearchResult`
+  Only populated for set / collection hits; `None` on element /
+  diagram / package hits. The MCP boundary is unchanged — the field
+  is intentionally pass-through per ADR-156, not in `_STRIPPED_KEYS`.
+
+### Changed (docs / canonical mcp_system_context content)
+
+- **Trimmed the canonical Outcomes Theory Set `mcp_system_context`
+  content** from ~140 lines to ~50 (target ~60). Same orient-first
+  with four-option-menu intent, far less text. Verbose flow
+  descriptions can live in the response_format prompt body
+  (admin-editable via `/admin/settings/ai`) where they belong as
+  universal rules, not on every per-scope context field.
+
+### Migration
+
+- **No DB migration.** Schema unchanged — `mcp_system_context`
+  columns on sets / collections already exist (added in m050 / m054
+  per ADR-156).
+
+### Tests
+
+- 8 net new tests (4 backend search, 4 iris-client model). Combined
+  suite ~447+ tests pass; only pre-existing `test_no_extra_rls_tables`
+  + `test_search/test_rebuild.py` fixture failures remain.
+
 ## [5.13.3] - 2026-05-12
 
 ### Changed (docs / canonical mcp_system_context content)

--- a/backend/app/search/models.py
+++ b/backend/app/search/models.py
@@ -6,10 +6,16 @@ from pydantic import BaseModel
 
 
 class SearchResult(BaseModel):
-    """A single search result."""
+    """A single search result.
+
+    v5.14.0 (ADR-159): Set/Collection hits now carry their
+    `mcp_system_context` so an MCP client model sees the scope's
+    orient guidance immediately on a search match — no follow-up
+    `get_set` / `get_collection` call needed for the context to land.
+    """
 
     id: str
-    result_type: str  # "element" or "diagram"
+    result_type: str  # "element" | "diagram" | "package" | "set" | "collection"
     name: str
     description: str | None = None
     type_detail: str  # element_type or diagram_type
@@ -19,6 +25,8 @@ class SearchResult(BaseModel):
     set_name: str | None = None
     collection_name: str | None = None
     package_name: str | None = None
+    # Only populated for set / collection hits (ADR-159).
+    mcp_system_context: str | None = None
 
 
 class SearchResponse(BaseModel):

--- a/backend/app/search/service.py
+++ b/backend/app/search/service.py
@@ -456,7 +456,9 @@ async def _search_sqlite(
 
     # Sets
     if not set_id:  # Don't search sets when already filtered to a specific set
-        _SET_COLS = "f.set_id, s.name, s.description, f.rank, c.id, c.name"
+        # ADR-159 (v5.14.0): include s.mcp_system_context so the orient
+        # guidance lands on the search hit, not just on get_set.
+        _SET_COLS = "f.set_id, s.name, s.description, f.rank, c.id, c.name, s.mcp_system_context"
         _SET_JOINS = (
             "FROM sets_fts f "
             "JOIN sets s ON s.id = f.set_id "
@@ -489,6 +491,7 @@ async def _search_sqlite(
                 "set_id": row[0],
                 "set_name": row[1],
                 "collection_name": row[5],
+                "mcp_system_context": row[6],
             }
             for row in set_rows
         )
@@ -496,7 +499,7 @@ async def _search_sqlite(
     # Collections
     if not set_id and not collection_id:
         cursor = await db.execute(
-            "SELECT f.collection_id, c.name, c.description, f.rank "
+            "SELECT f.collection_id, c.name, c.description, f.rank, c.mcp_system_context "
             "FROM collections_fts f "
             "JOIN collections c ON c.id = f.collection_id "
             "WHERE collections_fts MATCH ? "
@@ -513,6 +516,7 @@ async def _search_sqlite(
                 "description": row[2] or None,
                 "rank": float(row[3]),
                 "deep_link": f"/collections",
+                "mcp_system_context": row[4],
             }
             for row in collection_rows
         )
@@ -699,10 +703,12 @@ async def _search_postgres(
 
     # Sets (ADR-125). Skipped when already scoped to a specific set.
     if not set_id:
+        # ADR-159 (v5.14.0): include s.mcp_system_context.
         _PG_SET = (
             "SELECT s.id, s.name, s.description, "
             "ts_rank(s.search_vector, to_tsquery('english', ?)) AS rank, "
-            "col.id AS collection_id, col.name AS collection_name "
+            "col.id AS collection_id, col.name AS collection_name, "
+            "s.mcp_system_context "
             "FROM sets s "
             "LEFT JOIN collections col ON s.collection_id = col.id "
         )
@@ -735,6 +741,7 @@ async def _search_postgres(
                 "set_id": row[0],
                 "set_name": row[1],
                 "collection_name": row[5],
+                "mcp_system_context": row[6],
             }
             for row in set_rows
         )
@@ -743,7 +750,8 @@ async def _search_postgres(
     if not set_id and not collection_id:
         cursor = await db.execute(
             "SELECT c.id, c.name, c.description, "
-            "ts_rank(c.search_vector, to_tsquery('english', ?)) AS rank "
+            "ts_rank(c.search_vector, to_tsquery('english', ?)) AS rank, "
+            "c.mcp_system_context "
             "FROM collections c "
             "WHERE c.search_vector @@ to_tsquery('english', ?) "
             "AND c.is_deleted = FALSE "
@@ -760,6 +768,7 @@ async def _search_postgres(
                 "description": row[2] or None,
                 "rank": float(row[3]),
                 "deep_link": "/collections",
+                "mcp_system_context": row[4],
             }
             for row in collection_rows
         )

--- a/backend/tests/test_search/test_mcp_system_context_in_results.py
+++ b/backend/tests/test_search/test_mcp_system_context_in_results.py
@@ -1,0 +1,151 @@
+"""ADR-159 (v5.14.0): search results for Set / Collection hits include
+their `mcp_system_context` field so an MCP client model sees the
+scope's orient guidance immediately on a search match — no follow-up
+`get_set` / `get_collection` call needed for the context to land.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+class TestSearchHitsCarryMcpSystemContext:
+    async def test_set_hit_includes_mcp_system_context_when_populated(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        s = (await client.post(
+            "/api/sets", json={"name": "Outcomes Theory Book"}, headers=headers,
+        )).json()
+        await client.put(
+            f"/api/sets/{s['id']}",
+            json={
+                "name": "Outcomes Theory Book",
+                "mcp_system_context": "Orient first — offer the four-option menu.",
+            },
+            headers=headers,
+        )
+
+        resp = await client.get("/api/search?q=outcomes")
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        set_hit = next((r for r in results if r["result_type"] == "set"), None)
+        assert set_hit is not None, "Set should appear in search results"
+        assert set_hit["mcp_system_context"] == "Orient first — offer the four-option menu."
+
+    async def test_set_hit_mcp_system_context_is_null_when_unpopulated(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        await client.post(
+            "/api/sets", json={"name": "Unconfigured set"}, headers=headers,
+        )
+
+        resp = await client.get("/api/search?q=unconfigured")
+        results = resp.json()["results"]
+        set_hit = next((r for r in results if r["result_type"] == "set"), None)
+        assert set_hit is not None
+        assert set_hit["mcp_system_context"] is None
+
+    async def test_collection_hit_includes_mcp_system_context(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _admin_headers(client)
+        c = (await client.post(
+            "/api/collections", json={"name": "DoView Strategy Models"}, headers=headers,
+        )).json()
+        await client.put(
+            f"/api/collections/{c['id']}",
+            json={
+                "name": "DoView Strategy Models",
+                "mcp_system_context": "Use this collection to bootstrap DoView modelling exercises.",
+            },
+            headers=headers,
+        )
+
+        resp = await client.get("/api/search?q=doview")
+        results = resp.json()["results"]
+        coll_hit = next((r for r in results if r["result_type"] == "collection"), None)
+        assert coll_hit is not None
+        assert coll_hit["mcp_system_context"] == "Use this collection to bootstrap DoView modelling exercises."
+
+    async def test_non_scope_hits_do_not_have_mcp_system_context(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Element / diagram / package hits don't carry mcp_system_context
+        — the field is only meaningful on Set / Collection scopes."""
+        headers = await _admin_headers(client)
+        s = (await client.post(
+            "/api/sets", json={"name": "carrier"}, headers=headers,
+        )).json()
+        await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "text",
+                "name": "Findable diagram",
+                "notation": "markdown",
+                "data": {"content": "# A findable diagram"},
+                "set_id": s["id"],
+            },
+            headers=headers,
+        )
+
+        resp = await client.get("/api/search?q=findable")
+        results = resp.json()["results"]
+        diagram_hit = next((r for r in results if r["result_type"] == "diagram"), None)
+        if diagram_hit is not None:
+            # Field may be absent (Pydantic excludes unset) or present-and-None.
+            assert diagram_hit.get("mcp_system_context") is None

--- a/docs/adrs/ADR-159-Scope-Context-In-Search-Results.md
+++ b/docs/adrs/ADR-159-Scope-Context-In-Search-Results.md
@@ -1,0 +1,62 @@
+# ADR-159: Scope `mcp_system_context` in search results
+
+Status: Accepted (2026-05-12)
+Extends: [ADR-125](ADR-125-Search-Across-Sets-Collections.md), [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md)
+
+## Context
+
+ADR-156 (v5.11.0) established `mcp_system_context` as a per-scope data passthrough field — Set / Collection orient guidance that flows through MCP tool responses on `get_set` / `get_collection` (and `list_sets` / `list_collections`). The intent: a model browsing a scope sees the scope's context as part of the entity payload, no separate prompt-fetch round-trip.
+
+In real Claude Desktop testing of v5.13.x, the orient instructions were not landing. Diagnosis: when a user said "open the outcomes theory book in iris", Claude's natural flow was `search('outcomes theory book')` → returned the matched Set with id, name, deep_link → reply with the URL and a brief follow-up question. **Claude never called `get_set`.** The `mcp_system_context` content — no matter how rigid or well-worded — never reached Claude's context, so the orient-first-with-menu pattern didn't fire.
+
+The fix has to be at the search response shape, not at the content. Otherwise the orient instructions only land on a `get_set` call that may never happen.
+
+## Decision
+
+Extend search results for `result_type=set` and `result_type=collection` hits to include the matching scope's `mcp_system_context` field. Specifically:
+
+- `backend/app/search/models.py:SearchResult` gains `mcp_system_context: str | None = None`. Only populated for `set` / `collection` hits; `None` (or absent) on element / diagram / package / other hits.
+- `backend/app/search/service.py` updates the SQLite and Postgres SET / COLLECTION result branches to SELECT the `mcp_system_context` column and include it in the result dict.
+- `iris-client.SearchResult` model gains the same field for type access.
+- The MCP layer requires no changes — `mcp_system_context` is not in `_STRIPPED_KEYS` (per ADR-156), so it flows through search responses as data the same way it does for `get_set`.
+
+## Why include it in search results, not in some other channel
+
+- **Search is the natural entry point.** "Open the outcomes theory book" → `search`. The orient guidance has to be present in the response Claude actually receives.
+- **A separate `iris_get_scope_context(set_id)` MCP tool would help only if Claude knew to call it** — same trigger problem one level deeper. Putting the content directly on the search hit removes the need for any additional tool call.
+- **Bandwidth cost is negligible.** A `mcp_system_context` is at most ~1 KB; even a search returning 20 hits adds <20 KB total. Models tolerate this easily; the alternative (an entirely missed orient) is worse.
+- **No new strip rule needed.** ADR-156 already established that `mcp_system_context` is intentionally pass-through data (in contrast to `system_prompt`, which is server-side-only and stripped at the MCP boundary). Search results are tool data; the same rules apply.
+
+## Why not also include `package_count` / `package_count_root` / other ScopeResponse fields
+
+- **Search hits are intentionally lean.** Adding count fields would inflate every search response with metadata most calls don't need. `mcp_system_context` is justified specifically because it's the orient-instruction channel — it has to land on first contact. Counts are nice-to-have and can come from a follow-up `get_set` if the model wants them.
+- **`get_set` already returns `package_count` / `package_count_root`** (ADR-158). If a model wants the structural breadth signal, `get_set` is one tool call away.
+
+## Why not extend `iris-client.search()` signature
+
+The signature stays as-is. The new field is purely additive on the response payload. Existing callers that only access `.id`, `.name`, etc. continue to work unchanged.
+
+## Consequences
+
+- Backend: 4 SQL changes (Sets / Collections × SQLite / Postgres) plus model field addition.
+- iris-client: model field addition.
+- MCP: zero code change (passthrough).
+- Frontend: zero impact (the web UI doesn't render `mcp_system_context` in search-results UI).
+- Search results are slightly larger when scope hits are present, by the size of the populated `mcp_system_context` (typically a few hundred bytes to ~1 KB per hit). Negligible.
+- 4 new backend tests + 4 new iris-client tests.
+- Doc trim: canonical content for the Outcomes Theory Set's `mcp_system_context` field cut from ~140 lines to ~50 lines, since the verbose flow descriptions can live in the response_format prompt body (where they belong) once an admin amends that row via `/admin/settings/ai`.
+
+## Out of scope (deferred)
+
+- Surfacing `mcp_system_context` on `list_packages` or `list_diagrams` results (these are sub-scope; the field is per-scope-root).
+- Scope context in MCP `prompts` channel responses (that channel has its own protocol and isn't a discovery surface for sets).
+- A dedicated `iris_get_scope_context(set_id)` MCP tool (would have the same trigger-reliability problem this ADR is fixing).
+
+## See also
+
+- [ADR-125](ADR-125-Search-Across-Sets-Collections.md) — the search endpoint this ADR extends.
+- [ADR-150](ADR-150-Scope-Level-System-Prompts.md) — `system_prompt` (Iris-AI auto-apply; not affected here).
+- [ADR-151](ADR-151-MCP-Boundary-Strips-Scope-System-Prompts.md) — strip rule (still in force for `system_prompt`; `mcp_system_context` is not stripped).
+- [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md) — the field this ADR makes more discoverable.
+- [SPEC-159-A](specs/SPEC-159-A-Scope-Context-In-Search-Results.md) — schema and test plan.
+- `docs/prompts/doview-book-mcp-system-context.md` — the canonical content this surfaces.

--- a/docs/adrs/specs/SPEC-159-A-Scope-Context-In-Search-Results.md
+++ b/docs/adrs/specs/SPEC-159-A-Scope-Context-In-Search-Results.md
@@ -1,0 +1,76 @@
+# SPEC-159-A: Scope `mcp_system_context` in search results
+
+ADR: [ADR-159](../ADR-159-Scope-Context-In-Search-Results.md)
+
+## Database
+
+**No schema changes.** `sets.mcp_system_context` and `collections.mcp_system_context` columns already exist (added in m050 / m054 per ADR-156).
+
+## Backend
+
+### `app/search/models.py:SearchResult`
+
+Field added:
+
+```python
+mcp_system_context: str | None = None
+# Only populated for set / collection hits (ADR-159).
+```
+
+### `app/search/service.py`
+
+Four query branches updated. Each adds `s.mcp_system_context` (or `c.mcp_system_context`) to the SELECT and the result dict:
+
+- SQLite, sets branch (`_search_sqlite` set hits)
+- SQLite, collections branch (`_search_sqlite` collection hits)
+- Postgres, sets branch (`_search_postgres` set hits)
+- Postgres, collections branch (`_search_postgres` collection hits)
+
+For non-scope hits (`element` / `diagram` / `package`), the field is unset on the dict and serialises to `null` (or is omitted, depending on Pydantic config).
+
+## iris-client
+
+`iris-client/src/iris_client/models/core.py:SearchResult` gains the same field. `_Permissive` base means pre-v5.14.0 server payloads (without the field) continue to validate, defaulting to `None`.
+
+## MCP server
+
+**No code changes.** The strip helper (`mcp/src/iris_mcp/links.py:_STRIPPED_KEYS`) is `("system_prompt",)`. `mcp_system_context` is intentionally pass-through per ADR-156, so it flows through search results as data the same way it does on `get_set` / `list_sets`.
+
+## Frontend
+
+**No changes.** The web UI doesn't render `mcp_system_context` in search-results UI. The frontend `SearchResult` typed wrapper (if any) tolerates the new field via `_Permissive`-equivalent extras-allowed config.
+
+## Tests
+
+| File | Cases | Layer |
+|---|---|---|
+| `backend/tests/test_search/test_mcp_system_context_in_results.py` | 4 — set hit populated; set hit null; collection hit populated; non-scope hit absent | backend |
+| `iris-client/tests/test_search_mcp_system_context.py` | 4 — set with field; collection with field; legacy payload validates without field; non-scope hit | iris-client |
+
+8 net new tests for v5.14.0.
+
+Pre-existing 11 failures in `tests/test_search/test_rebuild.py` (fixture issue, not search-result-shape) are unrelated and continue to be the only acceptable failures alongside `test_no_extra_rls_tables` (issue 88 Phase 4 TODO).
+
+## End-to-end verification
+
+```bash
+# 1. Configure mcp_system_context on a Set:
+curl -X PUT http://localhost:8000/api/sets/<set-id> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Outcomes Theory Book", "mcp_system_context": "Orient first."}'
+
+# 2. Search for it:
+curl "http://localhost:8000/api/search?q=outcomes"
+# Expected: results[].mcp_system_context = "Orient first." for the set hit.
+
+# 3. In Claude Desktop with Iris MCP connected, ask "open the outcomes theory book in iris".
+#    Claude should call search, see the mcp_system_context on the hit,
+#    and orient with the four-option menu before doing anything else.
+```
+
+## Out of scope (deferred)
+
+- Surfacing on `list_packages` / `list_diagrams` results (sub-scope; not the orient channel).
+- Dedicated `iris_get_scope_context(set_id)` MCP tool (same trigger problem).
+- Search-results UI rendering of `mcp_system_context` (admin-facing; not user-facing).

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -1,205 +1,80 @@
-# DoView Book Set — `mcp_system_context` content
+# DoView / Outcomes-Theory Set — `mcp_system_context` content
 
-Canonical paste-ready content for the **MCP system context** field on the DoView Book Set (`/sets/33032180-d77a-4ce4-88cf-b49cd643e093`).
+Canonical paste-ready content for the **MCP system context** field on the Outcomes Theory Set (`/sets/33032180-d77a-4ce4-88cf-b49cd643e093`, previously named "DoView Book"). The same content flows through both `get_set` and (since v5.14.0 / ADR-159) `search` results, so an MCP client model sees the orient guidance the moment the set is matched — no follow-up `get_set` call required.
 
-This pointer is what an MCP client model (Claude Desktop / Claude Code) sees when it calls `mcp__iris__get_set` on the DoView Book Set. It is intentionally short — it orients the model to the response-format workflow without trying to encode formatting rules in tool data (those live in the layered response_format prompts seeded by SQLite m051 / Supabase m055, fetched at runtime via `iris_get_response_prompt`).
-
-Per ADR-156 (`mcp_system_context` semantics) and ADR-157 (response_format layered prompts).
-
-## Content
-
-Paste the following into the **MCP system context** textarea on the DoView Book Set edit page:
+## Content (paste this into the field on UAT)
 
 ```text
-This set is the visual companion to Dr Paul Duignan's DoView outcomes-
-mapping methodology and outcomes-theory body of work (the "Outcomes
-Theory" book in Iris; previously named "DoView Book").
+This set is the visual companion to Dr Paul Duignan's outcomes-theory body of work and DoView outcomes-mapping methodology.
 
-ORIENT FIRST — do not jump into a tool action without a menu.
+ORIENT FIRST. On the first turn, before doing any other tool action:
+  1. Briefly describe the set (one sentence).
+  2. Call iris_package_hierarchy(set_id=<this-set>) — NOT list_packages — and list the chapters (Part A through Part J) with one-line descriptions.
+  3. Offer ALL FOUR options below. Use a structured multi-choice UI if your client has one (Claude Code: AskUserQuestion). Otherwise present as a numbered list (1./2./3./4.), one option per line.
 
-When a user opens or asks about this set, the FIRST response should:
-  1. Briefly describe the set's purpose (one or two sentences).
-  2. Use iris_package_hierarchy(set_id=<this-set>) — NOT list_packages,
-     which paginates and misses older chapters — to list the chapter
-     structure (Part A through Part J, with brief one-line descriptions).
-  3. Offer the user a menu of common next steps and wait for the user
-     to choose. THIS IS MANDATORY. Offer ALL FOUR of the options below.
-     Do not abbreviate to two or three. Do not paraphrase the options
-     into a single sentence. The four options are not equivalent —
-     each leads to a different workflow — so present them as four
-     distinct choices.
-
-  Use a structured question / multi-choice UI if your client has one:
-    - Claude Code: call the AskUserQuestion tool with the four options
-      below as `options`. (One question, multiSelect=false.)
-    - Claude Desktop, claude.ai, generic MCP clients: AskUserQuestion
-      is not in your tool surface; instead, present the four options
-      as a numbered list (1./2./3./4.) with each on its own line so
-      the user can reply by number.
-
-  THE FOUR OPTIONS (use this exact wording, fill in the example):
+  THE FOUR OPTIONS — verbatim, all four, every time:
 
     1. Pull up a specific chapter or diagram from the handbook
-       (e.g. <suggest one relevant chapter based on what the user
-       said when opening the set, like "J06 - Mathematization of
-       Outcomes Theory and DoView Planning"; otherwise suggest any
-       chapter that looked interesting in the hierarchy).
+       (e.g. J06 — Mathematization of Outcomes Theory).
 
     2. Ask a cross-package question via Iris AI
-       (e.g. "What are the recurring causal-link conventions across
-       the diagrams?" — uses mcp__iris__ask).
+       (e.g. "What are the recurring causal-link conventions?" — uses mcp__iris__ask).
 
-    3. Generate a new DoView outcomes-theory analysis on a topic
-       the user describes, grounded in this handbook, with an
-       option to save it back into this set as a doview_analysis
-       diagram. (Uses the iris_get_response_prompt + compose
-       locally flow described in section A below, NOT
-       mcp__iris__ask.)
+    3. Generate a new DoView outcomes-theory analysis on a topic the user describes,
+       grounded in this handbook, with an option to save it back into this set.
+       Path: iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')
+       → compose locally → optionally iris_save_doview_analysis. NOT mcp__iris__ask.
 
     4. Browse a particular chapter's diagrams in detail
-       (uses iris_package_hierarchy filtered to a chapter, then
-       mcp__iris__get_diagram on each diagram in turn).
+       (iris_package_hierarchy filtered to a chapter, then mcp__iris__get_diagram on each).
 
-  After the user picks, proceed with the chosen workflow. DO NOT
-  skip this menu step on the first turn — even if the user's
-  opening request seems to imply action ("open the book"), still
-  orient + offer the four-option menu before doing anything else.
-  If the user's opening request explicitly asks for one of the
-  four (e.g. "open the book and generate me a DoView analysis of
-  X"), present a one-line acknowledgement of the inferred choice
-  and the menu of the other three options in case they want to
-  redirect, then proceed.
+If the user's opening request explicitly asks for one option, briefly acknowledge it and present the menu of the other three so they can redirect.
 
-DO NOT generate an analysis or fetch a response prompt on the first
-turn unless the user has explicitly asked for one. Open with the menu.
+PATH DETAILS
 
-────────────────────────────────────────────────────────────────────
-Two different "DoView" outputs the user might ask for — different paths
-────────────────────────────────────────────────────────────────────
+A. ANALYSIS (option 3 above) — written outcomes-theory analysis with embedded mermaid:
+   - Fetch rules: iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')
+   - Compose using mcp__iris__search + mcp__iris__get_diagram against this set
+   - After producing, offer BOTH save paths:
+       (i) iris_save_doview_analysis(set_id, name, content, parent_package_id?) —
+           auth required (IRIS_TOKEN). Suggest a parent_package_id by topic:
+           AI → J series; evaluation → G; introduction/adoption → I; alignment → C;
+           indicators → D; contracting → E; reporting → H; fundamentals → A;
+           drawing/strategy → B; performance improvement → F.
+       (ii) Leave the markdown in chat for copy/paste — it IS the markdown.
 
-A. WRITTEN OUTCOMES-THEORY ANALYSIS (prose + embedded mermaid diagrams
-   from referenced handbook tool pages). This is the doview_analysis
-   flow. Use this when the user says "generate a DoView analysis",
-   "analyse X from an outcomes-theory perspective", "what does
-   outcomes theory say about Y", or similar text-output requests.
+B. NEW VISUAL DOVIEW DIAGRAM (a notation=doview outcomes_map):
+   The guided creation flow (Stages 0-3, 13 drafting steps, balance checks) is best done in Iris's web UI:
+     https://iris-uat.chrisbarlow.nz/sets/33032180-d77a-4ce4-88cf-b49cd643e093
+   Open the set → New diagram → notation=DoView → diagram_type=outcomes_map. Recommend the web UI for this case.
 
-   Steps:
-     1. Fetch the response format rules:
-          iris_get_response_prompt(notation='markdown',
-                                   diagram_type='doview_analysis')
-     2. Compose the response in-conversation following those rules,
-        using mcp__iris__search + mcp__iris__get_diagram against this
-        set for handbook source material.
-     3. AFTER producing the analysis, offer BOTH save paths (do not
-        assume only one is wanted):
-          (i) Save into Iris as a doview_analysis diagram:
-                iris_save_doview_analysis(set_id, name, content,
-                                          parent_package_id?)
-              (auth required — if no IRIS_TOKEN, returns an auth
-              error; in that case the markdown is already in chat
-              for copy/paste.)
-              When suggesting a parent_package_id, recommend a
-              sensible chapter — AI-related → J series; evaluation
-              → G; introduction/adoption → I; alignment → C;
-              indicators → D; contracting → E; reporting → H;
-              fundamentals → A; drawing/strategy → B; performance
-              improvement → F. If unsure, suggest top-level or
-              ask. The user may also redirect to a different set.
-         (ii) Leave the markdown in chat so the user can copy /
-              save it locally. The chat content IS the markdown —
-              no additional tool call is needed.
+DISCOVERABILITY
 
-   DO NOT use mcp__iris__ask for this flow. mcp__iris__ask is for
-   Iris's own internal Q&A and creation flows; it would route the
-   work back through Iris's backend LLM (costly, slower, and not
-   what the user asked for here).
-
-B. NEW VISUAL DOVIEW DIAGRAM (a new notation=doview outcomes_map or
-   overview-style page that will appear in the set as a real Iris
-   diagram). Use this when the user says "create a new DoView
-   diagram", "draw an outcomes map for X", "build the theory of
-   change as a diagram", etc.
-
-   For this case, the guided creation flow (Stages 0-3, the 13
-   drafting steps, balance checks, the "This-Then" methodology)
-   is best done through Iris's web UI:
-     https://iris-uat.chrisbarlow.nz/sets/<this-set-id>
-   Open the set, click "New diagram", pick notation=DoView,
-   diagram_type=outcomes_map. The Ask Iris panel will walk through
-   the methodology and materialise the result as real diagrams.
-
-   Direct generation through MCP is possible (mcp__iris__ask with
-   mode='creation', then apply_diagram_creation) but loses the
-   guided-conversation rhythm that the methodology depends on.
-   Recommend the web UI for this case unless the user explicitly
-   prefers the MCP path.
-
-────────────────────────────────────────────────────────────────────
-Discoverability helpers
-────────────────────────────────────────────────────────────────────
-
-  list_response_format_types
-    What output formats are available (e.g. doview_analysis).
-
-  iris_package_hierarchy(set_id=<this-set>)
-    Complete chapter tree, single call. Preferred over list_packages.
+  list_response_format_types — what formats are available
+  iris_package_hierarchy(set_id=<this-set>) — chapter tree, single call
 ```
+
+## Why this works
+
+- **Orient lands on first turn whether Claude calls `search` or `get_set`** — v5.14.0 (ADR-159) extended search results for Set / Collection hits to include `mcp_system_context`. Claude's natural "search → return link" flow now also surfaces this content.
+- **The four options are mandatory and verbatim** — paraphrasing got Claude down to 2 options in v5.13.x. Explicit "all four, every time" + verbatim wording fixes that.
+- **AskUserQuestion is conditional** — Claude Code has it; Claude Desktop / claude.ai / generic MCP clients don't (yet). Numbered list is the fallback.
+- **Routing for "generate analysis" is explicit** — `iris_get_response_prompt`, NOT `mcp__iris__ask`. v5.13.x left this implicit and Claude defaulted to the wrong path.
 
 ## Revision history
 
-**Post-v5.13.1 fix (this revision).** Restored the orient-first /
-offer-menu pattern that was implicit in pre-v5.12 conversations but
-got drowned out when more prescriptive routing was added. Explicit
-about which path each user-request shape maps to:
-- "analysis" → `iris_get_response_prompt` + compose + optional save
-- "diagram" → web UI (guided creation)
-- `mcp__iris__ask` is explicitly NOT the path for either (was being
-  defaulted to incorrectly).
-Also reflects the set rename: "DoView Book" → "Outcomes Theory" in
-the prose, while keeping the file name stable.
+- **v5.14.0 (this revision).** Trimmed from ~140 lines to ~50 (target was ~60). Same orient-first-with-four-option-menu intent, far less text. Surfaced through search results too (ADR-159) so the orient lands on first turn regardless of whether Claude calls `get_set` or just `search`.
+- **v5.13.3.** Made the four-option menu mandatory and verbatim. Honest note about AskUserQuestion availability.
+- **v5.13.2.** Restored orient-first / offer-menu pattern; explicit analysis-vs-diagram routing; "DO NOT use mcp__iris__ask for analysis flow".
+- **v5.13.0.** Mention `iris_package_hierarchy` (ADR-158) as the preferred chapter-list call.
+- **v5.12.0.** Save-options offer added (Iris save + markdown artefact).
 
-**v5.13.0 — package_hierarchy hint.** Mentions
-`iris_package_hierarchy` (ADR-158) as the preferred single-call
-mechanism to get the chapter list; resolves the "only saw E-J"
-pagination problem.
-
-**v5.12.0 — save-options offer.** Instructs the client to offer both
-save paths after producing a doview_analysis (Iris save + markdown
-artefact in chat).
-
-The "offer both save paths" + "orient first" behaviours arguably
-belong in the `response-format-doview-analysis-v1` row's body so
-they apply universally, not just on this Set. Until that row is
-amended via `/admin/settings/ai`, this scope-specific doc is the
-single source of guidance.
-
-## Why this content (and not the strict format rules)
-
-- The DoView Book Set is one scope; the response_format rules are universal to any `(notation=markdown, diagram_type=doview_analysis)` conversation regardless of scope. They belong in the layered prompts table (admin-editable, central), not duplicated into per-scope passthrough fields. ADR-157 establishes this split.
-- Embedding the strict Prompt-C rules directly in `mcp_system_context` would:
-  - Trigger prompt-injection treatment (the client model sees scope tool data as untrusted; long directive content in tool data is treated as informational, not authoritative).
-  - Duplicate content that's already in the response_format prompt rows.
-  - Make the rules un-editable from a central admin surface.
-- The fetch step (`iris_get_response_prompt`) is a deliberate model action — the response_format cascade body arrives as the response to a tool call the model chose to make. That's a stronger trust signal than scope tool data.
-
-## Smoke test after pasting
-
-In a fresh Claude Desktop conversation with Iris MCP connected:
-
-> "Give me an outcomes-theory analysis of siloing program steps in the DoView Book Set."
-
-Expected flow:
-1. Claude calls `mcp__iris__get_set` → sees the pointer.
-2. Claude calls `mcp__iris__get_response_prompt('markdown', 'doview_analysis')` → fetches the cascade (~300 lines of Prompt C rules).
-3. Claude calls `mcp__iris__search` + `mcp__iris__get_diagram` to gather handbook material.
-4. Claude composes a three-section formal response (Summary + Full + Diagrams with verbatim mermaid blocks + raw handbook URLs).
-5. Claude offers to save via `iris_save_doview_analysis`.
-
-If Claude doesn't reach for `iris_get_response_prompt` reliably, sharpen this content's signal (e.g. lead with "For outcomes-theory questions about this set, **always** call iris_get_response_prompt…"). The current phrasing is intentionally conservative; tighten if real usage shows under-triggering.
+The "offer both save paths" + "orient first" behaviours arguably belong in the `response-format-doview-analysis-v1` row's body so they apply universally, not just on this Set. Until that row is amended via `/admin/settings/ai`, this scope-specific doc is the single source of guidance.
 
 ## See also
 
-- [ADR-156](../adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for (per-scope context, data passthrough).
+- [ADR-156](../adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for (per-scope context, data passthrough on `get_set` / `get_collection`).
 - [ADR-157](../adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — where the response_format rules live (universal layered prompts, admin-editable).
-- [SPEC-157-A](../adrs/specs/SPEC-157-A-Response-Format-Prompts.md) — schema and endpoint shapes for the response_format mechanism.
-- [`doview-book-prompt-c-iris.md`](./doview-book-prompt-c-iris.md) — the source content from which the seeded response_format prompts (`response-format-base-v1`, `response-format-doview-notation-v1`, `response-format-doview-analysis-v1`) were derived.
+- [ADR-159](../adrs/ADR-159-Scope-Context-In-Search-Results.md) — search results carry `mcp_system_context` so orient lands on first turn.
+- [SPEC-157-A](../adrs/specs/SPEC-157-A-Response-Format-Prompts.md) — schema for the response_format mechanism.
+- [`doview-book-prompt-c-iris.md`](./doview-book-prompt-c-iris.md) — the source content from which the seeded response_format prompts were derived.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.13.3",
+	"version": "5.14.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/src/iris_client/models/core.py
+++ b/iris-client/src/iris_client/models/core.py
@@ -68,6 +68,10 @@ class SearchResult(_Permissive):
     set_id: str | None = None
     set_name: str | None = None
     collection_name: str | None = None
+    # ADR-159 (v5.14.0): only populated for set / collection hits.
+    # Lets MCP clients see the scope's orient guidance immediately on
+    # a search match without a follow-up get_set/get_collection call.
+    mcp_system_context: str | None = None
 
 
 class SearchResponse(_Permissive):

--- a/iris-client/tests/test_search_mcp_system_context.py
+++ b/iris-client/tests/test_search_mcp_system_context.py
@@ -1,0 +1,50 @@
+"""ADR-159 (v5.14.0): SearchResult model accepts the new
+`mcp_system_context` field on Set / Collection hits."""
+
+from __future__ import annotations
+
+from iris_client.models.core import SearchResult
+
+
+def test_set_hit_with_mcp_system_context() -> None:
+    r = SearchResult.model_validate({
+        "id": "s-1",
+        "result_type": "set",
+        "name": "Outcomes Theory Book",
+        "set_id": "s-1",
+        "set_name": "Outcomes Theory Book",
+        "mcp_system_context": "Orient first.",
+    })
+    assert r.result_type == "set"
+    assert r.mcp_system_context == "Orient first."
+
+
+def test_collection_hit_with_mcp_system_context() -> None:
+    r = SearchResult.model_validate({
+        "id": "c-1",
+        "result_type": "collection",
+        "name": "DoView models",
+        "mcp_system_context": "Bootstrap DoView modelling here.",
+    })
+    assert r.result_type == "collection"
+    assert r.mcp_system_context == "Bootstrap DoView modelling here."
+
+
+def test_legacy_set_hit_without_field_still_validates() -> None:
+    """Backwards compat: pre-v5.14.0 backend payload doesn't have the
+    field. Field defaults to None on the model."""
+    r = SearchResult.model_validate({
+        "id": "s-1",
+        "result_type": "set",
+        "name": "Old set",
+    })
+    assert r.mcp_system_context is None
+
+
+def test_non_scope_hit_has_none_mcp_system_context() -> None:
+    r = SearchResult.model_validate({
+        "id": "d-1",
+        "result_type": "diagram",
+        "name": "Some diagram",
+    })
+    assert r.mcp_system_context is None

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.13.3"
+version = "5.14.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Diagnoses and fixes the v5.13.x \"orient instructions don't fire\" symptom in Claude Desktop. Root cause: Claude's natural flow was \`search('outcomes theory book')\` → return link → done, never calling \`get_set\`. Since \`mcp_system_context\` only flowed through \`get_set\` / \`get_collection\` per ADR-156, the orient guidance never landed.

**Fix** — extend search results for \`result_type=set\` and \`result_type=collection\` hits to include the matching scope's \`mcp_system_context\`. Whether Claude calls \`get_set\` or just \`search\`, the orient guidance lands.

Plus: trim the canonical content from ~140 lines to ~50 lines (target ~60). Same orient-first-with-four-option-menu intent, far less text.

See [ADR-159](docs/adrs/ADR-159-Scope-Context-In-Search-Results.md) and [SPEC-159-A](docs/adrs/specs/SPEC-159-A-Scope-Context-In-Search-Results.md).

## Changes

- Backend: \`SearchResult\` model + 4 SQL branches (SQLite × Postgres × Sets × Collections).
- iris-client: \`SearchResult\` model field added.
- MCP: zero code change (field intentionally pass-through per ADR-156 — not in \`_STRIPPED_KEYS\`).
- Canonical content for the Outcomes Theory Set's mcp_system_context trimmed and restructured.
- ADR-159 + SPEC-159-A.

## Test plan

- [x] \`test_search/test_mcp_system_context_in_results.py\` — 4 cases (set hit populated; set hit null; collection hit populated; non-scope hit absent)
- [x] \`iris-client/tests/test_search_mcp_system_context.py\` — 4 cases (set/collection round-trip; legacy payload validates without field; non-scope hit None)
- [x] 264 backend pass in the touched areas
- [x] iris-client + MCP suites unchanged

## UAT

**No migration to run** — schema already has the columns from m050/m054.

After Render redeploys: paste the trimmed content from \`docs/prompts/doview-book-mcp-system-context.md\` into the Set's MCP system context field. Then in Claude Desktop ask "open the outcomes theory book in iris" — Claude should orient with the four-option menu on first turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)