### PR TITLE
release(v5.16.0): MCP entity-creation tools + destination flow (ADR-161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.16.0] - 2026-05-12
+
+### Added
+
+- **MCP entity-creation tools** (ADR-161, SPEC-161-A). Three new
+  MCP tools — `create_collection`, `create_set`, `create_package` —
+  let an MCP client (Claude Desktop, Claude Code) stitch a
+  destination tree in-conversation when the user asks to save
+  something somewhere new. Closes the v5.15.0 workflow cliff where
+  Claude had to ask the user to leave the conversation, create the
+  set manually, copy its id, and paste it back. The three tools
+  wrap the existing `POST /api/{collections,sets,packages}`
+  endpoints (no backend change — already auth-gated and tested).
+- **iris-client gains `create_collection()`, `create_set()`,
+  `create_package()`** mirroring the new MCP tools. Returns the
+  existing permissive `Collection` / `IrisSet` / `Package` models
+  unchanged — same shapes the read methods already use.
+- **Destination-confirmation preamble on every write tool's
+  description.** `save_doview_analysis`, `create_collection`,
+  `create_set`, and `create_package` all carry the same
+  `BEFORE CALLING, confirm with the user where they want this saved`
+  block, instructing the model to offer four options (existing set,
+  new set in existing collection, new collection + new set,
+  optionally + new package) before the save. Pattern applies to
+  every future write tool by copy-paste.
+- **Shared `_auth_required_payload(action)` helper in
+  `mcp/src/iris_mcp/tools.py`** factored out of v5.15.0's
+  `save_doview_analysis` 401 branch. Every write tool now returns
+  the same `auth_required` payload shape, so the pairing-recovery
+  flow handles every tool uniformly.
+
+### Changed
+
+- **`save_doview_analysis` description** now references the new
+  destination-confirmation flow instead of the v5.12.x topic-to-
+  package heuristic. Signature unchanged.
+- **Canonical `doview-book-mcp-system-context.md`** drops the
+  static topic-to-package mapping (which only made sense when the
+  Outcomes Theory Book set was the only destination) in favour of
+  "ask the user where; use the create_* tools if a new container
+  is needed."
+
+### Fixed
+
+- **Default Notation dropdown** on `/settings` now lists all 7
+  notation IDs registered in the backend (added `doview`,
+  `markdown`, `bpmn` — `simple` / `uml` / `archimate` / `c4`
+  were already there). User-spotted: the preference was
+  inconsistent with what's authorable.
+
+### Migration
+
+- **No DB migration.** Backend endpoints already exist.
+- v5.15.0 pairing flow covers the new tools' auth needs unchanged.
+
+### Tests
+
+- 17 net new tests: 7 iris-client (`test_create_endpoints.py`),
+  10 MCP (`test_tools_create.py`), 8 frontend
+  (`settingsNotationDropdown.test.ts` — one per notation + count
+  check). Combined MCP suite now 112 (was 102).
+
 ## [5.15.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -305,9 +305,11 @@ persists at `~/.iris-mcp/<hash>.json` (mode 0600) and remains valid
 for ~90 days. Set `IRIS_TOKEN` explicitly only if you want to
 override the persisted credential (e.g. for CI / scripted setups).
 
-Exposes ~19 tools (search, list/get for every entity, export, ask-AI,
-apply-diagram-creation, conversations) plus `iris://` resource URIs
-for JSON export bundles. When `IRIS_WEB_URL` is set, every tool
+Exposes ~22 tools (search, list/get for every entity, export, ask-AI,
+apply-diagram-creation, conversations, plus `create_collection` /
+`create_set` / `create_package` for organising destinations from
+v5.16.0, and `iris_authenticate` for in-app credential setup from
+v5.15.0) plus `iris://` resource URIs for JSON export bundles. When `IRIS_WEB_URL` is set, every tool
 response that carries an entity id also carries a resolved front-end
 URL so MCP-using LLMs link back to the live UI without guessing
 hosts. See [`mcp/README.md`](mcp/README.md) and

--- a/docs/adrs/ADR-161-MCP-Entity-Creation-and-Destination-Flow.md
+++ b/docs/adrs/ADR-161-MCP-Entity-Creation-and-Destination-Flow.md
@@ -1,0 +1,71 @@
+# ADR-161: MCP entity-creation tools + destination-confirmation flow
+
+Status: Accepted (2026-05-12)
+Extends: [ADR-131](ADR-131-MCP-Server-Architecture.md), [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md), [ADR-160](ADR-160-MCP-Pairing-Code-Authentication.md)
+
+## Context
+
+In real Claude Desktop use of v5.15.0, a user asked to save a generated DoView analysis "under a new set called 'DoView Analysis' in the Outcomes Theory collection." Claude correctly identified that the Iris MCP exposes no tool for creating new sets, collections, or packages — only `save_doview_analysis` against an existing `set_id` — and was forced to ask the user to leave the conversation, create the set manually in the web UI, copy its id, and paste it back. That's the same workflow cliff `iris_authenticate` was introduced to remove for the auth side; we now hit the same shape on the **organisation** side.
+
+Two changes are needed, both generic (not tied to `save_doview_analysis`):
+
+1. **MCP can create new sets, collections, and packages** so destination trees can be stitched in-conversation.
+2. **Save tools confirm destination up-front** instead of guessing or trapping the user in a late-bound "give me a set_id" loop.
+
+The backend already has the create endpoints (`POST /api/{collections,sets,packages}`) gated behind the same `get_current_user` dependency `save_doview_analysis` uses, so v5.15.0's pairing/PAT flow covers them with **zero backend change**.
+
+## Decision
+
+Add three new MCP tools — `create_collection`, `create_set`, `create_package` — each a thin wrapper over the existing iris-client + backend endpoint. Each new tool catches `IrisAuthError` and returns the same structured `auth_required` payload `save_doview_analysis` uses, so the v5.15.0 pairing-recovery flow handles every write tool uniformly.
+
+Add a **destination-confirmation preamble** to every write tool's `description` (starting with `save_doview_analysis` and the three new create_* tools). The preamble instructs the model to confirm "where do you want this saved?" with the user before the save call, offering: existing set, new set in existing collection, new collection + new set, optionally + new package. AskUserQuestion if the client supports it; numbered list otherwise.
+
+## Why three first-class tools, not a fat `save_doview_analysis(set_name=, collection_name=)` shortcut
+
+- **Separation of concerns.** Saving content and organising containers are different intents. Mixing them couples save semantics to container creation and makes the save endpoint harder to evolve.
+- **Reuse for any future write tool.** A future `save_element`, `save_relationship`, or `save_package` benefits from the same primitives without each one re-implementing "find-or-create the container."
+- **Cleaner failure mode.** A combined call has two failure modes (container creation failed; save failed); two separate calls leave a clean, recoverable trail — the user can see exactly which step failed.
+- **Existing precedent.** v5.15.0's `iris_authenticate` is a first-class tool, not a side-effect of `save_doview_analysis(authenticate=)`. Same shape here.
+
+## Why each tool's description carries the destination preamble, not response_format / mcp_system_context
+
+- **Universality without configuration.** Every MCP client sees tool descriptions; not every client fetches `get_response_prompt` or hits a scope with `mcp_system_context` set.
+- **Travels with the tool.** Adding a new write tool in a future release copies the preamble template — no separate doc edit, no risk of drift.
+- **Avoids the v5.13.x "context never landed" problem.** The orient instructions in `mcp_system_context` were silently missed when Claude went straight to `search`. Tool descriptions are loaded every session.
+- **Trade-off accepted.** Descriptions get longer. Negligible bandwidth cost; vastly outweighed by reliability.
+
+## Why no backend changes
+
+- All three create endpoints already exist (`POST /api/collections`, `POST /api/sets`, `POST /api/packages`) with the right Pydantic shapes (`CollectionCreate`, `SetCreate`, `PackageCreate`) and the same `get_current_user` dependency `save_doview_analysis` uses.
+- The PAT issued by the v5.15.0 pairing flow already satisfies that dependency. No new permission model needed.
+- Backend tests for the create endpoints already exist and pass.
+
+## Why bundle the `/settings` Default Notation dropdown fix in this release
+
+`frontend/src/routes/settings/+page.svelte`'s Default Notation `<select>` lists only 4 of the 7 notation IDs in the registry (`doview`, `markdown`, `bpmn` are missing). User-spotted in this v5.15.0 → v5.16.0 conversation; small enough to ride along with the entity-creation work. Touches the same `/settings` page area; same release cadence. Avoiding a separate one-line release.
+
+## Consequences
+
+- iris-client gains `create_collection`, `create_set`, `create_package` methods.
+- MCP gains three new tools wrapping them, each returning the v5.15.0 `auth_required` payload on 401.
+- `save_doview_analysis` description gets the destination-confirmation preamble (no signature change).
+- Three new tools' descriptions carry the same preamble + cross-references to each other.
+- `docs/prompts/doview-book-mcp-system-context.md` drops the static topic-mapping heuristic (parent_package_id by topic) in favour of "ask the user; create_* if needed."
+- `/settings` notation dropdown gains 3 missing options.
+- ~17 new tests across iris-client (6), MCP (10), frontend (1).
+- No DB migration. No backend change. No frontend route change.
+
+## Out of scope (deferred)
+
+- **Element / relationship creation MCP tools** — addressable by the same pattern; defer to a future release when the demand is real.
+- **Bulk container creation** (e.g. "create this whole set with these 5 packages in one shot") — would be a `setup_workspace`-style tool; defer until there's a real workflow asking for it.
+- **Server-side find-or-create idempotency** — if a user runs `create_set(name="X")` twice, two sets get created. Idempotency keying is a future enhancement.
+- **MCP-side caching of recently-created ids** — Claude tracks them in conversation; explicit caching adds state with no clear win.
+- **Container deletion / rename MCP tools** — write-but-not-create; same auth path, but defer until needed.
+
+## See also
+
+- [ADR-131](ADR-131-MCP-Server-Architecture.md) — iris-mcp stdio architecture.
+- [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — response_format mechanism (alternative location for the preamble that was rejected).
+- [ADR-160](ADR-160-MCP-Pairing-Code-Authentication.md) — the auth flow these new tools rely on.
+- [SPEC-161-A](specs/SPEC-161-A-MCP-Entity-Creation-and-Destination-Flow.md) — method/tool shapes, preamble text, test plan.

--- a/docs/adrs/specs/SPEC-161-A-MCP-Entity-Creation-and-Destination-Flow.md
+++ b/docs/adrs/specs/SPEC-161-A-MCP-Entity-Creation-and-Destination-Flow.md
@@ -1,0 +1,173 @@
+# SPEC-161-A: MCP entity-creation tools + destination-confirmation flow
+
+ADR: [ADR-161](../ADR-161-MCP-Entity-Creation-and-Destination-Flow.md)
+
+## Database
+
+**No schema changes.** All three target endpoints (`POST /api/collections`, `POST /api/sets`, `POST /api/packages`) already exist with their Pydantic request models (`CollectionCreate`, `SetCreate`, `PackageCreate`).
+
+## Backend
+
+**No changes.** The endpoints already gate on `get_current_user` (`backend/app/auth/dependencies.py`). v5.15.0's pairing-issued PATs satisfy this dependency without modification.
+
+## iris-client
+
+Three new methods on `IrisClient` (`iris-client/src/iris_client/client.py`):
+
+```python
+async def create_collection(
+    self, name: str, *, description: str | None = None,
+) -> Collection:
+    """POST /api/collections. Auth required."""
+
+async def create_set(
+    self,
+    name: str,
+    *,
+    collection_id: str | None = None,
+    description: str | None = None,
+) -> IrisSet:
+    """POST /api/sets. Auth required."""
+
+async def create_package(
+    self,
+    name: str,
+    *,
+    set_id: str | None = None,
+    parent_package_id: str | None = None,
+    description: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Package:
+    """POST /api/packages. Auth required."""
+```
+
+Reuses the existing permissive response models `Collection`, `IrisSet`, `Package` from `iris-client/src/iris_client/models/core.py`. No new models.
+
+## MCP server
+
+### Three new tools
+
+In `mcp/src/iris_mcp/tools.py`:
+
+| Tool name | Required arg | Optional args | Wraps |
+|---|---|---|---|
+| `create_collection` | `name` | `description` | `client.create_collection` |
+| `create_set` | `name` | `collection_id`, `description` | `client.create_set` |
+| `create_package` | `name` | `set_id`, `parent_package_id`, `description`, `metadata` | `client.create_package` |
+
+Each handler:
+- Calls the matching iris-client method.
+- On `IrisAuthError`, returns `_auth_required_payload(action)` (shared helper extracted from the existing `_save_doview_analysis` 401 branch).
+- On success, returns the new entity's `.model_dump_json()`.
+
+### Shared `_auth_required_payload` helper
+
+Extract from `_save_doview_analysis`'s existing 401 branch:
+
+```python
+def _auth_required_payload(action: str) -> str:
+    """v5.15.0 / ADR-160 pairing-recovery payload. Used by every
+    write tool's 401 branch so the recovery instructions are
+    identical across tools."""
+    return json.dumps({
+        "success": False,
+        "error": "auth_required",
+        "message": (
+            f"{action} failed — this MCP connection isn't authenticated"
+            f" yet.\n\nTo fix:\n  1. Visit {_pairing_url()}\n"
+            "  2. Click 'Generate pairing code'\n"
+            "  3. Paste the code back here, and I'll call iris_authenticate.\n\n"
+            "(After that, this MCP connection stays authenticated"
+            " for ~90 days on this machine.)"
+        ),
+        "pairing_url": _pairing_url(),
+        "next_tool": "iris_authenticate",
+    })
+```
+
+Update `_save_doview_analysis`'s 401 branch to call this helper. New create_* handlers use it directly.
+
+### Destination-confirmation preamble
+
+Constant in `mcp/src/iris_mcp/tools.py`:
+
+```python
+_DESTINATION_PREAMBLE = """
+BEFORE CALLING, confirm with the user where they want this saved.
+
+Options to offer the user (use AskUserQuestion when the client
+supports it; otherwise a numbered list):
+
+  1. An existing set (or set + parent package) the user names.
+     Use list_collections / list_sets / package_hierarchy to
+     resolve human names to ids.
+  2. A new set in an existing collection.
+     Call create_set(name=..., collection_id=<existing>) first,
+     then save against the returned set.id.
+  3. A new collection and a new set.
+     Call create_collection(name=...) then
+     create_set(name=..., collection_id=<new>), then save.
+  4. (Optional) Also nest under a new package.
+     Call create_package(name=..., set_id=<chosen>) and pass its
+     id as parent_package_id.
+
+Only call this save tool once the user has chosen / confirmed a
+destination. Do not pick a destination silently.
+""".strip()
+```
+
+The preamble is injected into the descriptions of:
+- `save_doview_analysis` (existing; description gets the preamble appended).
+- `create_collection`, `create_set`, `create_package` (new; descriptions reference the preamble as the calling context, plus their own operational details).
+
+### Tool descriptions (new tools)
+
+- `create_collection`: "Create a new top-level Collection in Iris (ADR-161, v5.16.0). Use after the user has confirmed they want a new collection — see destination-confirmation guidance below. Returns the new collection's id and metadata; pass the id to `create_set(collection_id=…)` to nest a set inside it. Auth required (the v5.15.0 pairing flow covers this)."
+- `create_set`: "Create a new Set in Iris (ADR-161, v5.16.0). Pass collection_id=… to nest under an existing collection, or omit for a top-level (uncollected) set. Use after the user has confirmed they want a new set — see destination-confirmation guidance below. Returns the new set's id; pass it as save_doview_analysis(set_id=…) or create_package(set_id=…). Auth required."
+- `create_package`: "Create a new Package in Iris (ADR-161, v5.16.0). A package is a folder inside a set; use this to organise multiple diagrams under a shared parent. Pass set_id=<chosen set> and parent_package_id=<parent> to nest, or omit parent_package_id for a root-level package. Use after the user has confirmed they want a new package — see destination-confirmation guidance below. Auth required."
+
+The preamble (`_DESTINATION_PREAMBLE`) is concatenated to each of the above plus `save_doview_analysis`.
+
+## Frontend
+
+### Default Notation dropdown fix
+
+`frontend/src/routes/settings/+page.svelte` — extend the existing `<select id="settings-notation">` block with three options after `c4`:
+
+```svelte
+<option value="doview">DoView — outcomes-based theory of change</option>
+<option value="markdown">Markdown — text content with embedded mermaid</option>
+<option value="bpmn">BPMN — business process model and notation (preview)</option>
+```
+
+Values verified against migrations m027 (`doview`), m043 (`bpmn`), m051 (`markdown`). No store changes.
+
+## Tests
+
+| File | Cases | Layer |
+|---|---|---|
+| `iris-client/tests/test_create_endpoints.py` | 6 — create_collection happy; create_set with/without collection_id; create_package with optional parent + metadata; IrisAuthError mapping on 401; permissive-model extra-fields | iris-client |
+| `mcp/tests/test_tools_create.py` | 10 — three happy paths; three auth_required payloads (assert structure: success=False, error="auth_required", pairing_url, next_tool="iris_authenticate"); preamble appears in save_doview_analysis.description; preamble appears in each create_ tool's description; the new tools appear in `tool_definitions()` with non-empty `inputSchema.properties` | mcp |
+| `frontend/tests/unit/settingsNotationDropdown.test.ts` | 1 — all 7 notation IDs (simple, uml, archimate, c4, doview, markdown, bpmn) appear as option values | frontend |
+
+**Total**: 17 new tests for v5.16.0.
+
+## End-to-end verification
+
+After UAT deploy:
+
+1. In Claude Desktop with v5.15.0 pairing token persisted, ask: "save the analysis under a new collection called 'My Outcomes Work' and a new set called 'Pilot DoView'."
+2. Confirm Claude offers the four-option destination menu (AskUserQuestion or numbered list).
+3. Pick "new collection + new set" — confirm Claude calls `create_collection`, then `create_set(collection_id=<new>)`, then `save_doview_analysis(set_id=<new>, …)`.
+4. Browse `/collections` — confirm the new collection + set exist and the diagram is inside.
+5. Repeat with "new set under existing collection" — only `create_set` called.
+6. Repeat with "new package under existing set" — only `create_package` called.
+7. Revoke the active PAT in Iris; re-run any create_ flow — every tool should return the same `auth_required` payload pointing at `/settings/mcp-pairing`.
+8. Open `/settings` — confirm Default Notation dropdown lists all 7 notations.
+
+## Out of scope (deferred)
+
+- Element / relationship MCP write tools.
+- Bulk container creation in one call.
+- Server-side find-or-create idempotency for the create endpoints.
+- Container delete / rename MCP tools.

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -37,10 +37,15 @@ A. ANALYSIS (option 3 above) — written outcomes-theory analysis with embedded 
    - Compose using mcp__iris__search + mcp__iris__get_diagram against this set
    - After producing, offer BOTH save paths:
        (i) iris_save_doview_analysis(set_id, name, content, parent_package_id?) —
-           auth required. Suggest a parent_package_id by topic:
-           AI → J series; evaluation → G; introduction/adoption → I; alignment → C;
-           indicators → D; contracting → E; reporting → H; fundamentals → A;
-           drawing/strategy → B; performance improvement → F.
+           auth required. BEFORE CALLING, ask the user WHERE to save:
+             • an existing set + parent package they name; OR
+             • a new set in an existing collection (call create_set first); OR
+             • a new collection + new set (call create_collection, then create_set); OR
+             • optionally also nest under a new package (call create_package).
+           Use AskUserQuestion when available; numbered list otherwise. Don't
+           pick a destination silently. The v5.16.0 entity-creation tools
+           (create_collection / create_set / create_package, ADR-161) cover
+           the new-container cases without leaving the conversation.
            If the save fails with error="auth_required" (v5.15.0+, ADR-160),
            follow the returned guidance: ask the user to visit
            /settings/mcp-pairing, generate a pairing code, and paste it back.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.15.0",
+	"version": "5.16.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -141,6 +141,9 @@
 			<option value="uml">UML — class, object, use case, state, activity</option>
 			<option value="archimate">ArchiMate — business, application, technology layers</option>
 			<option value="c4">C4 — person, software system, container, component</option>
+			<option value="doview">DoView — outcomes-based theory of change</option>
+			<option value="markdown">Markdown — text content with embedded mermaid</option>
+			<option value="bpmn">BPMN — business process model and notation (preview)</option>
 		</select>
 	</div>
 </section>

--- a/frontend/tests/unit/settingsNotationDropdown.test.ts
+++ b/frontend/tests/unit/settingsNotationDropdown.test.ts
@@ -1,0 +1,36 @@
+/**
+ * v5.16.0 (ADR-161, SPEC-161-A): the Default Notation dropdown on
+ * /settings must list every notation ID registered in the backend
+ * (simple, uml, archimate, c4, doview, markdown, bpmn). v5.15.x
+ * shipped with only the first 4; the missing 3 (doview, markdown,
+ * bpmn) made the user preference inconsistent with what's authorable.
+ */
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PAGE = resolve(__dirname, '../../src/routes/settings/+page.svelte');
+
+describe('Default Notation dropdown', () => {
+	const source = readFileSync(PAGE, 'utf-8');
+
+	it.each([
+		['simple'],
+		['uml'],
+		['archimate'],
+		['c4'],
+		['doview'],
+		['markdown'],
+		['bpmn'],
+	])('lists "%s" as an <option> value', (notationId) => {
+		expect(source).toContain(`<option value="${notationId}">`);
+	});
+
+	it('has all 7 notation options inside settings-notation select', () => {
+		const selectStart = source.indexOf('id="settings-notation"');
+		const selectEnd = source.indexOf('</select>', selectStart);
+		const block = source.slice(selectStart, selectEnd);
+		const matches = block.match(/<option value="[^"]+"/g) ?? [];
+		expect(matches).toHaveLength(7);
+	});
+});

--- a/iris-client/src/iris_client/client.py
+++ b/iris-client/src/iris_client/client.py
@@ -392,6 +392,69 @@ class IrisClient:
         response = await self._request("GET", f"/api/collections/{collection_id}")
         return Collection.model_validate(response.json())
 
+    # --- Entity creation (ADR-161, v5.16.0) ---------------------------------
+
+    async def create_collection(
+        self, name: str, *, description: str | None = None,
+    ) -> Collection:
+        """Create a new top-level Collection. Auth required.
+
+        Backend POST /api/collections (CollectionCreate). The
+        permissive Collection model accepts the returned payload.
+        """
+        body: dict[str, Any] = {"name": name}
+        if description is not None:
+            body["description"] = description
+        response = await self._request("POST", "/api/collections", json=body)
+        return Collection.model_validate(response.json())
+
+    async def create_set(
+        self,
+        name: str,
+        *,
+        collection_id: str | None = None,
+        description: str | None = None,
+    ) -> IrisSet:
+        """Create a new Set. Auth required.
+
+        Pass `collection_id=None` for a top-level (uncollected) set,
+        or a collection's id to nest the set inside it.
+        """
+        body: dict[str, Any] = {"name": name}
+        if collection_id is not None:
+            body["collection_id"] = collection_id
+        if description is not None:
+            body["description"] = description
+        response = await self._request("POST", "/api/sets", json=body)
+        return IrisSet.model_validate(response.json())
+
+    async def create_package(
+        self,
+        name: str,
+        *,
+        set_id: str | None = None,
+        parent_package_id: str | None = None,
+        description: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> Package:
+        """Create a new Package. Auth required.
+
+        A package is a folder inside a set. Pass `set_id=` to anchor
+        the package; pass `parent_package_id=` to nest it under
+        another package; omit both for a free-standing root package.
+        """
+        body: dict[str, Any] = {"name": name}
+        if set_id is not None:
+            body["set_id"] = set_id
+        if parent_package_id is not None:
+            body["parent_package_id"] = parent_package_id
+        if description is not None:
+            body["description"] = description
+        if metadata is not None:
+            body["metadata"] = metadata
+        response = await self._request("POST", "/api/packages", json=body)
+        return Package.model_validate(response.json())
+
     # --- Scope prompts (ADR-152) --------------------------------------------
 
     async def list_scope_prompts(self) -> list[ScopePromptIndexEntry]:

--- a/iris-client/tests/test_create_endpoints.py
+++ b/iris-client/tests/test_create_endpoints.py
@@ -1,0 +1,191 @@
+"""iris-client entity-creation methods (ADR-161, SPEC-161-A).
+
+Covers create_collection, create_set, create_package — the three
+write methods added in v5.16.0 to support MCP-side organisation of
+new destinations before saving content.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from iris_client import IrisClient
+from iris_client.exceptions import IrisAuthError
+from iris_client.models.core import Collection, IrisSet, Package
+
+
+class TestCreateCollection:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post("http://iris.test/api/collections").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "col-1",
+                    "name": "Outcomes Work",
+                    "description": None,
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                },
+            ),
+        )
+        result = await pat_client.create_collection(
+            "Outcomes Work", description=None,
+        )
+        assert isinstance(result, Collection)
+        assert result.id == "col-1"
+        assert result.name == "Outcomes Work"
+        sent = route.calls.last.request.content.decode()
+        # Optional fields omitted when None.
+        assert '"description"' not in sent
+        assert '"name":"Outcomes Work"' in sent
+
+
+class TestCreateSet:
+    @pytest.mark.asyncio
+    async def test_with_collection_id(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post("http://iris.test/api/sets").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "set-1",
+                    "name": "Pilot DoView",
+                    "description": "first pilot",
+                    "collection_id": "col-1",
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                },
+            ),
+        )
+        result = await pat_client.create_set(
+            "Pilot DoView", collection_id="col-1", description="first pilot",
+        )
+        assert isinstance(result, IrisSet)
+        assert result.id == "set-1"
+        sent = route.calls.last.request.content.decode()
+        assert '"collection_id":"col-1"' in sent
+        assert '"description":"first pilot"' in sent
+
+    @pytest.mark.asyncio
+    async def test_top_level_omits_collection_id(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post("http://iris.test/api/sets").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "set-1",
+                    "name": "Standalone",
+                    "description": None,
+                    "collection_id": None,
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                },
+            ),
+        )
+        await pat_client.create_set("Standalone")
+        sent = route.calls.last.request.content.decode()
+        assert '"collection_id"' not in sent
+        assert '"description"' not in sent
+
+
+class TestCreatePackage:
+    @pytest.mark.asyncio
+    async def test_with_set_and_parent(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post("http://iris.test/api/packages").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "pkg-1",
+                    "name": "Section A",
+                    "description": None,
+                    "set_id": "set-1",
+                    "parent_package_id": "pkg-root",
+                    "metadata": {"order": 1},
+                    "current_version": 1,
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                },
+            ),
+        )
+        result = await pat_client.create_package(
+            "Section A",
+            set_id="set-1",
+            parent_package_id="pkg-root",
+            metadata={"order": 1},
+        )
+        assert isinstance(result, Package)
+        sent = route.calls.last.request.content.decode()
+        assert '"set_id":"set-1"' in sent
+        assert '"parent_package_id":"pkg-root"' in sent
+        assert '"metadata"' in sent
+
+    @pytest.mark.asyncio
+    async def test_minimal_omits_all_optionals(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post("http://iris.test/api/packages").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "pkg-1",
+                    "name": "Loose",
+                    "description": None,
+                    "set_id": None,
+                    "parent_package_id": None,
+                    "current_version": 1,
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                },
+            ),
+        )
+        await pat_client.create_package("Loose")
+        sent = route.calls.last.request.content.decode()
+        assert '"set_id"' not in sent
+        assert '"parent_package_id"' not in sent
+        assert '"description"' not in sent
+        assert '"metadata"' not in sent
+
+
+class TestAuthErrorMapping:
+    @pytest.mark.asyncio
+    async def test_401_raises_iris_auth_error(
+        self, anon_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post("http://iris.test/api/collections").mock(
+            return_value=httpx.Response(
+                401, json={"detail": "Not authenticated"},
+            ),
+        )
+        with pytest.raises(IrisAuthError):
+            await anon_client.create_collection("Whatever")
+
+
+class TestPermissiveModel:
+    @pytest.mark.asyncio
+    async def test_future_server_field_is_tolerated(
+        self, pat_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post("http://iris.test/api/collections").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "col-1",
+                    "name": "X",
+                    "description": None,
+                    "created_at": "2026-05-12T00:00:00+00:00",
+                    "updated_at": "2026-05-12T00:00:00+00:00",
+                    "future_server_field": "not yet known",
+                },
+            ),
+        )
+        result = await pat_client.create_collection("X")
+        assert result.id == "col-1"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.15.0"
+version = "5.16.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -41,6 +41,56 @@ def _pairing_url() -> str:
     return base.rstrip("/") + PAIRING_PAGE_PATH
 
 
+def _auth_required_payload(action: str) -> str:
+    """ADR-160 / SPEC-161-A: shared 401 → pairing-recovery payload.
+
+    Every write tool (save_doview_analysis, create_collection,
+    create_set, create_package) returns this exact shape on auth
+    failure so the model can extract the next step uniformly:
+    visit the pairing page, generate a code, call iris_authenticate.
+    """
+    return json.dumps({
+        "success": False,
+        "error": "auth_required",
+        "message": (
+            f"{action} failed — this MCP connection isn't"
+            " authenticated yet.\n\n"
+            "To fix:\n"
+            f"  1. Visit {_pairing_url()}\n"
+            "  2. Click 'Generate pairing code'\n"
+            "  3. Paste the code back here, and I'll call iris_authenticate.\n\n"
+            "(After that, this MCP connection stays authenticated"
+            " for ~90 days on this machine.)"
+        ),
+        "pairing_url": _pairing_url(),
+        "next_tool": "iris_authenticate",
+    })
+
+
+_DESTINATION_PREAMBLE = """
+BEFORE CALLING, confirm with the user where they want this saved.
+
+Options to offer the user (use AskUserQuestion when the client
+supports it; otherwise a numbered list):
+
+  1. An existing set (or set + parent package) the user names.
+     Use list_collections / list_sets / package_hierarchy to
+     resolve human names to ids.
+  2. A new set in an existing collection.
+     Call create_set(name=..., collection_id=<existing>) first,
+     then save against the returned set.id.
+  3. A new collection and a new set.
+     Call create_collection(name=...) then
+     create_set(name=..., collection_id=<new>), then save.
+  4. (Optional) Also nest under a new package.
+     Call create_package(name=..., set_id=<chosen>) and pass its
+     id as parent_package_id.
+
+Only call this save tool once the user has chosen / confirmed a
+destination. Do not pick a destination silently.
+""".strip()
+
+
 @dataclass(frozen=True)
 class Tool:
     name: str
@@ -204,27 +254,49 @@ async def _save_doview_analysis(c: IrisClient, args: dict[str, Any]) -> str:
             description=args.get("description"),
         )
     except IrisAuthError:
-        # ADR-160: render the in-conversation pairing-recovery guidance
-        # instead of a bare 401. The next step is a tool call to
-        # iris_authenticate(code) — keep the structure stable so models
-        # can extract it reliably.
-        return json.dumps({
-            "success": False,
-            "error": "auth_required",
-            "message": (
-                "Save to Iris failed — this MCP connection isn't"
-                " authenticated yet.\n\n"
-                "To fix:\n"
-                f"  1. Visit {_pairing_url()}\n"
-                "  2. Click 'Generate pairing code'\n"
-                "  3. Paste the code back here, and I'll call iris_authenticate.\n\n"
-                "(After that, this MCP connection stays authenticated"
-                " for ~90 days on this machine.)"
-            ),
-            "pairing_url": _pairing_url(),
-            "next_tool": "iris_authenticate",
-        })
+        # ADR-160 / SPEC-161-A: shared pairing-recovery payload.
+        return _auth_required_payload("Save to Iris")
     return diagram.model_dump_json()
+
+
+async def _create_collection(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-161 (v5.16.0): create a new Collection."""
+    try:
+        result = await c.create_collection(
+            name=args["name"],
+            description=args.get("description"),
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create collection")
+    return result.model_dump_json()
+
+
+async def _create_set(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-161 (v5.16.0): create a new Set."""
+    try:
+        result = await c.create_set(
+            name=args["name"],
+            collection_id=args.get("collection_id"),
+            description=args.get("description"),
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create set")
+    return result.model_dump_json()
+
+
+async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-161 (v5.16.0): create a new Package."""
+    try:
+        result = await c.create_package(
+            name=args["name"],
+            set_id=args.get("set_id"),
+            parent_package_id=args.get("parent_package_id"),
+            description=args.get("description"),
+            metadata=args.get("metadata"),
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create package")
+    return result.model_dump_json()
 
 
 async def _iris_authenticate(c: IrisClient, args: dict[str, Any]) -> str:
@@ -651,11 +723,11 @@ TOOLS: list[Tool] = [
         name="save_doview_analysis",
         description=(
             "Persist a generated DoView analysis as a new doview_analysis "
-            "diagram in Iris (ADR-157, v5.12.0). Use after the user "
-            "confirms they want their formal outcomes-theory response saved. "
-            "Body is markdown text (with embedded mermaid blocks where "
-            "applicable). Auth required — needs IRIS_TOKEN configured on "
-            "the MCP server. Returns 401-equivalent error if anonymous."
+            "diagram in Iris (ADR-157, v5.12.0). Body is markdown text "
+            "(with embedded mermaid blocks where applicable). Auth required "
+            "— use the iris_authenticate tool (ADR-160) if a previous call "
+            "returned error=auth_required.\n\n"
+            + _DESTINATION_PREAMBLE
         ),
         input_schema=_schema({
             "set_id": _str_arg("set_id", "Set to save the analysis under"),
@@ -679,6 +751,109 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_save_doview_analysis,
+    ),
+    # ── Entity creation (ADR-161, v5.16.0) ─────────────────────────────
+    Tool(
+        name="create_collection",
+        description=(
+            "Create a new top-level Collection in Iris (ADR-161, v5.16.0). "
+            "Use after the user has confirmed they want a new collection — "
+            "see the destination-confirmation guidance below. Returns the "
+            "new collection's id and metadata; pass the id to "
+            "create_set(collection_id=…) to nest a set inside it. Auth "
+            "required (the v5.15.0 pairing flow covers this).\n\n"
+            + _DESTINATION_PREAMBLE
+        ),
+        input_schema=_schema({
+            "name": _str_arg(
+                "name",
+                "Display name for the new collection (1-255 chars)",
+            ),
+            "description": _str_arg(
+                "description",
+                "Optional short description shown alongside the collection",
+                required=False,
+            ),
+        }),
+        handler=_create_collection,
+    ),
+    Tool(
+        name="create_set",
+        description=(
+            "Create a new Set in Iris (ADR-161, v5.16.0). Pass "
+            "collection_id=… to nest under an existing collection, or "
+            "omit it for a top-level (uncollected) set. Use after the "
+            "user has confirmed they want a new set — see the "
+            "destination-confirmation guidance below. Returns the new "
+            "set's id; pass it as save_doview_analysis(set_id=…) or "
+            "create_package(set_id=…). Auth required.\n\n"
+            + _DESTINATION_PREAMBLE
+        ),
+        input_schema=_schema({
+            "name": _str_arg(
+                "name",
+                "Display name for the new set (1-255 chars)",
+            ),
+            "collection_id": _str_arg(
+                "collection_id",
+                "Optional id of an existing collection to nest the set inside",
+                required=False,
+            ),
+            "description": _str_arg(
+                "description",
+                "Optional short description shown alongside the set",
+                required=False,
+            ),
+        }),
+        handler=_create_set,
+    ),
+    Tool(
+        name="create_package",
+        description=(
+            "Create a new Package in Iris (ADR-161, v5.16.0). A package "
+            "is a folder inside a set used to organise multiple diagrams "
+            "under a shared parent. Pass set_id=<chosen set> and "
+            "parent_package_id=<parent> to nest, or omit parent_package_id "
+            "for a root-level package. Use after the user has confirmed "
+            "they want a new package — see the destination-confirmation "
+            "guidance below. Auth required.\n\n"
+            + _DESTINATION_PREAMBLE
+        ),
+        input_schema=_schema({
+            "name": _str_arg(
+                "name",
+                "Display name for the new package (1-255 chars)",
+            ),
+            "set_id": _str_arg(
+                "set_id",
+                "Set this package belongs to (recommended for navigation)",
+                required=False,
+            ),
+            "parent_package_id": _str_arg(
+                "parent_package_id",
+                "Optional parent package; omit for a root-level package "
+                "within the set",
+                required=False,
+            ),
+            "description": _str_arg(
+                "description",
+                "Optional short description shown alongside the package",
+                required=False,
+            ),
+            "metadata": (
+                {
+                    "type": "object",
+                    "description": (
+                        "Optional metadata blob attached to the package. "
+                        "Free-form; consumers may use 'order' or display "
+                        "hints here."
+                    ),
+                    "additionalProperties": True,
+                },
+                False,
+            ),
+        }),
+        handler=_create_package,
     ),
 ]
 

--- a/mcp/tests/test_tools_create.py
+++ b/mcp/tests/test_tools_create.py
@@ -1,0 +1,182 @@
+"""MCP create_* tool tests (ADR-161, SPEC-161-A).
+
+Covers create_collection, create_set, create_package — happy paths,
+auth_required mapping on 401, presence of the destination-confirmation
+preamble in every write tool's description, and presence of the new
+tools in the tool inventory.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+def _entity_payload(**overrides: object) -> dict[str, object]:
+    """Minimal payload that satisfies the iris-client EntityBase model."""
+    base = {
+        "id": "e-1",
+        "name": "Whatever",
+        "description": None,
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestInventory:
+    def test_new_tools_registered(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        assert {"create_collection", "create_set", "create_package"} <= names
+
+    def test_new_tools_have_name_property_in_schema(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        for tool_name in ("create_collection", "create_set", "create_package"):
+            props = defs[tool_name].inputSchema["properties"]
+            assert "name" in props
+            assert defs[tool_name].inputSchema["required"] == ["name"]
+
+
+class TestDestinationPreamble:
+    def test_preamble_in_save_doview_analysis_description(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        assert "BEFORE CALLING, confirm with the user" in defs[
+            "save_doview_analysis"
+        ].description
+
+    def test_preamble_in_each_create_tool_description(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        for tool_name in ("create_collection", "create_set", "create_package"):
+            assert "BEFORE CALLING, confirm with the user" in defs[
+                tool_name
+            ].description, f"preamble missing from {tool_name}"
+
+
+class TestCreateCollection:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/collections").mock(
+            return_value=httpx.Response(
+                201,
+                json=_entity_payload(id="col-1", name="Outcomes Work"),
+            ),
+        )
+        result = await tools.dispatch(
+            "create_collection", client,
+            {"name": "Outcomes Work"},
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "col-1"
+        assert body["name"] == "Outcomes Work"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required_payload(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/collections").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "create_collection", client, {"name": "X"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"
+        assert body["next_tool"] == "iris_authenticate"
+        assert "/settings/mcp-pairing" in body["pairing_url"]
+
+
+class TestCreateSet:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_collection_id(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/sets").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    **_entity_payload(id="set-1", name="Pilot DoView"),
+                    "collection_id": "col-1",
+                },
+            ),
+        )
+        result = await tools.dispatch(
+            "create_set", client,
+            {"name": "Pilot DoView", "collection_id": "col-1"},
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "set-1"
+        sent = route.calls.last.request.content.decode()
+        assert '"collection_id":"col-1"' in sent
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required_payload(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/sets").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "create_set", client, {"name": "X"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"
+
+
+class TestCreatePackage:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_set_and_parent(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    **_entity_payload(id="pkg-1", name="Section A"),
+                    "set_id": "set-1",
+                    "parent_package_id": "pkg-root",
+                    "current_version": 1,
+                    "metadata": {"order": 1},
+                },
+            ),
+        )
+        result = await tools.dispatch(
+            "create_package", client,
+            {
+                "name": "Section A",
+                "set_id": "set-1",
+                "parent_package_id": "pkg-root",
+                "metadata": {"order": 1},
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "pkg-1"
+        sent = route.calls.last.request.content.decode()
+        assert '"set_id":"set-1"' in sent
+        assert '"parent_package_id":"pkg-root"' in sent
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required_payload(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "create_package", client, {"name": "X"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"


### PR DESCRIPTION
## Summary

- **Three new MCP tools** (`create_collection`, `create_set`, `create_package`) so Claude can stitch a destination tree in-conversation when the user asks to save somewhere new — closes the v5.15.0 cliff where Claude had to ask the user to leave the conversation, create the container in the web UI, copy the id, and paste it back.
- **Destination-confirmation preamble** added to every write tool's description (`save_doview_analysis` + the three new create_*). Instructs the model to confirm "where do you want this saved?" up-front, offering existing-set / new-set-in-existing-collection / new-collection-and-set / + optional new-package. Pattern is per-tool so every future write tool inherits by copy-paste.
- **iris-client gains `create_collection`, `create_set`, `create_package`** — thin wrappers over the existing backend endpoints; reuses the existing permissive `Collection` / `IrisSet` / `Package` response models verbatim.
- **Shared `_auth_required_payload` helper** factored out of v5.15.0's `save_doview_analysis` 401 branch so every write tool returns the same `auth_required` payload, handled uniformly by the model.
- **Bundled small fix**: `/settings` Default Notation dropdown was missing `doview`, `markdown`, and `bpmn` (3 of 7 registry notations). User-spotted.
- **No backend changes**: the three create endpoints already exist with the right auth dependency. **No DB migration**: backend untouched.

## Test plan

- [x] iris-client `tests/test_create_endpoints.py` — 7 cases (three happy paths with required/optional field shaping; 401 → IrisAuthError; permissive-model extra-field tolerance; full-suite 53 pass, was 46)
- [x] MCP `tests/test_tools_create.py` — 10 cases (inventory + schema; preamble assertions for save_doview_analysis + the three create_*; three happy paths; three 401 → auth_required payloads; full-suite 112 pass, was 102)
- [x] Frontend `tests/unit/settingsNotationDropdown.test.ts` — 8 cases (one per registered notation ID + total-count check)
- [x] Backend regression sanity (collections + sets + packages + auth = 129 pass)
- [ ] Manual end-to-end on UAT: ask Claude Desktop "save this under a new collection X / new set Y / new package Z" — confirm Claude calls create_collection → create_set → create_package → save_doview_analysis in sequence, with user confirmation at each step

## Migration

- **No DB migration** this release. v5.15.0's pairing flow covers the new tools' auth needs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)