### PR TITLE
release(v5.17.0): generic MCP diagram-creation workflow (ADR-162)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,115 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.17.0] - 2026-05-12
+
+### Added
+
+- **Generic MCP diagram-creation workflow** (ADR-162, SPEC-162-A).
+  Three new MCP tools — `create_diagram`, `list_notations`,
+  `list_diagram_types` — give Claude (or any MCP client) a
+  notation-agnostic path for authoring diagrams locally. The new
+  `create_diagram` tool wraps the existing `POST /api/diagrams`
+  endpoint generically: pass `notation`, `diagram_type`, `name`,
+  `data`, `set_id`, and optional parent_package_id / description.
+  `list_notations` and `list_diagram_types` (the latter carries each
+  diagram_type's compatible notations) let Claude discover what's
+  authorable before composing.
+- **`get_response_prompt` / `list_response_format_types` extended
+  with `purpose` argument.** Default stays `response_format`
+  (backwards-compatible). Pass `purpose='creation_format'` to fetch
+  the layered creation cascade Iris AI uses when generating
+  diagrams — a local-AI MCP client can pull the same Stage 0 setup
+  questions + entity types + layout rules and run the conversation
+  in chat. Backend `/api/ai/response-prompts/{types,composed}` gain
+  the same query parameter.
+- **`build_creation_system_prompt(..., include_ui_selection_preamble=False)`**:
+  the composer can now skip the "User selection already confirmed
+  in UI" suppression preamble. The HTTP endpoint passes False so
+  MCP callers get the raw conversational cascade; `ask(mode='creation')`
+  keeps the suppression (it's correct there).
+- **Workflow guidance lives in the tool description.** The
+  `create_diagram` tool's description carries a creation-flow
+  preamble (discover → fetch creation prompt → guided conversation
+  → confirm destination → compose → save) plus the v5.16.0
+  destination-confirmation preamble. Universal across every MCP
+  client and every scope; no per-scope duplication.
+- **iris-client gains `purpose` kwargs** on `list_response_format_types`
+  and `get_response_prompt`. Defaults preserved.
+
+### Changed
+
+- **Canonical `mcp_system_context` for the Outcomes Theory Book set
+  trimmed.** Removed the path-A (analysis save) and path-B (visual
+  DoView via web UI) step-by-step; both now route through
+  `create_diagram` whose description carries the workflow. ~30
+  lines shorter. Admins on UAT should paste the new content into
+  the set's `mcp_system_context` field.
+- **`save_doview_analysis` deprecated.** Tool description prefixed
+  with a deprecation note pointing at
+  `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`.
+  Behaviour unchanged in v5.17.0; removal scheduled for v6.0.0.
+
+### Fixed
+
+- **Cross-tab auth lost when a new browser window is opened from
+  Claude's pairing-page link.** `loadFromSession` in
+  `frontend/src/lib/stores/auth.svelte.ts` now falls back to
+  `localStorage` when `sessionStorage` is empty (and re-seeds
+  `sessionStorage` so the new tab caches it going forward). The
+  auth store always wrote to both stores; this closes the read
+  side.
+- **Sign-in from `/settings/mcp-pairing` bounced to dashboard.**
+  `/login` now honours a same-origin `?redirect=` query parameter
+  with strict validation (must start with `/`, not `//`, no `://`,
+  no whitespace). The pairing page's sign-in hint uses
+  `/login?redirect=/settings/mcp-pairing`.
+- **`/admin/settings/ai` filter dropdowns didn't constrain each
+  other.** Cascading: picking a notation filters the diagram_type
+  dropdown to compatible types (via `DiagramTypeRegistry.notations`);
+  picking a diagram_type filters notation likewise. Same logic
+  applied to the create-prompt and edit-prompt dialogs. Setting
+  layer=base disables both pickers.
+- **`/admin/settings/ai` "doview shows only 1 prompt" bug.** The
+  row-inclusion predicate exact-matched `p.notation`, hiding
+  diagram_type-layer rows (e.g. `creation-outcomes-map-v1`) whose
+  `notation` column is null but whose `diagram_type` maps to doview
+  via `diagram_type_notations`. Replaced with a notation-agnostic
+  predicate (`isNotationScopeMatch`) that matches direct OR via the
+  diagram_type→notation mapping.
+- **v5.15.0 in-session token-propagation symptom regression test.**
+  New `test_pairing_then_create_set_uses_new_pat_in_same_session`
+  exercises the exact failing flow the user reported: pairing-code
+  exchange → create_set, with the mock backend gated to return 401
+  unless the request carries the exchanged PAT. Closes the v5.15.0
+  test gap that only asserted `client.token == ...` without
+  verifying outgoing-header propagation.
+
+### Housekeeping
+
+- **Stripped user-visible ADR references from the web UI.** Eight
+  mentions removed from `/admin/settings/ai`, `/admin/settings`,
+  and four guide markdown pages (`dashboard.md`, `search.md`,
+  `collections-sets.md`, `knowledge-graph.md`). Code comments
+  retain their ADR references (developers need them).
+
+### Migration
+
+- **No DB migration.** Backend endpoints already existed.
+- Manual: paste the trimmed canonical content from
+  `docs/prompts/doview-book-mcp-system-context.md` into the
+  Outcomes Theory Book set's `mcp_system_context` field on UAT.
+
+### Tests
+
+- 30+ net new tests: 8 backend (response-prompts purpose query),
+  4 iris-client (purpose kwargs), 11 MCP (create_diagram +
+  list_notations + list_diagram_types + preambles +
+  deprecation-note + v5.15.0-symptom regression), 12 frontend
+  (sessionStorage fallback + login redirect-back + cascade
+  helpers + inclusion predicate). Combined MCP suite now 123
+  (was 112); iris-client 57 (was 53).
+
 ## [5.16.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -305,11 +305,16 @@ persists at `~/.iris-mcp/<hash>.json` (mode 0600) and remains valid
 for ~90 days. Set `IRIS_TOKEN` explicitly only if you want to
 override the persisted credential (e.g. for CI / scripted setups).
 
-Exposes ~22 tools (search, list/get for every entity, export, ask-AI,
+Exposes ~30 tools (search, list/get for every entity, export, ask-AI,
 apply-diagram-creation, conversations, plus `create_collection` /
 `create_set` / `create_package` for organising destinations from
-v5.16.0, and `iris_authenticate` for in-app credential setup from
-v5.15.0) plus `iris://` resource URIs for JSON export bundles. When `IRIS_WEB_URL` is set, every tool
+v5.16.0, `iris_authenticate` for in-app credential setup from
+v5.15.0, and `create_diagram` / `list_notations` / `list_diagram_types`
+for the generic local-AI diagram-creation workflow from v5.17.0).
+The legacy `save_doview_analysis` tool is deprecated in v5.17.0
+(prefer `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`)
+and will be removed in v6.0.0. Plus `iris://` resource URIs for
+JSON export bundles. When `IRIS_WEB_URL` is set, every tool
 response that carries an entity id also carries a resolved front-end
 URL so MCP-using LLMs link back to the live UI without guessing
 hosts. See [`mcp/README.md`](mcp/README.md) and

--- a/backend/app/ai/creation.py
+++ b/backend/app/ai/creation.py
@@ -93,8 +93,20 @@ async def build_creation_system_prompt(
     db: aiosqlite.Connection,
     notation: str,
     diagram_type: str | None = None,
+    *,
+    include_ui_selection_preamble: bool = True,
 ) -> str:
-    """Compose the diagram-CREATION system prompt for (notation, diagram_type)."""
+    """Compose the diagram-CREATION system prompt for (notation, diagram_type).
+
+    `include_ui_selection_preamble` (default True) controls the
+    "User selection already confirmed in UI" preamble that suppresses
+    re-asking about notation/diagram_type and subject matter. This is
+    correct when called server-side from ``ask(mode='creation')`` —
+    the web UI has the user's selection plus attached document context.
+    It's incorrect when an external MCP client wants the raw cascade
+    including the conversational guidance (ADR-162, v5.17.0); the HTTP
+    endpoint that exposes this composer passes False there.
+    """
     result, n_layers = await _build_layered_prompt(
         db,
         purpose="creation_format",
@@ -105,7 +117,7 @@ async def build_creation_system_prompt(
     # Preamble: when both notation and diagram_type are present, make the
     # user's UI selection explicit so the AI does not re-ask for information
     # it already has (ADR-132). Also remind the AI to use attached context.
-    if diagram_type:
+    if diagram_type and include_ui_selection_preamble:
         preamble = (
             f"## User selection (already confirmed in UI)\n\n"
             f"- Notation: **{notation}**\n"

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -34,7 +34,11 @@ async def _is_ai_debug(db: object) -> bool:
         return False
 
 from app.ai import service
-from app.ai.creation import build_response_system_prompt, create_diagrams_from_ai
+from app.ai.creation import (
+    build_creation_system_prompt,
+    build_response_system_prompt,
+    create_diagrams_from_ai,
+)
 from app.ai.error_mapper import map_provider_error
 from app.ai.models import (
     ActiveProviderResponse,
@@ -869,24 +873,41 @@ async def list_creation_prompts(
 # ---------------------------------------------------------------------------
 
 
+_VALID_PURPOSES = ("response_format", "creation_format")
+
+
 @router.get("/response-prompts/types", response_model=list[ResponseFormatType])
 async def list_response_format_types(
     request: Request,
+    purpose: str = Query(
+        "response_format",
+        description=(
+            "Which purpose to list. 'response_format' (default) for output-"
+            "shape rules, 'creation_format' for the drafting/composition "
+            "rules used when generating diagrams (ADR-162, v5.17.0)."
+        ),
+    ),
     _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
 ) -> list[ResponseFormatType]:
     """List distinct (notation, diagram_type) pairs that have at least
-    one active response_format prompt (ADR-157, v5.12.0).
+    one active prompt of the requested purpose (ADR-157, v5.12.0; ADR-162, v5.17.0).
 
     Anonymous-readable. Used by MCP clients (via the
     `applicable_response_types` field on Set/Collection responses) to
     discover what formats can be composed for a given conversation
     context.
     """
+    if purpose not in _VALID_PURPOSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"purpose must be one of {_VALID_PURPOSES}",
+        )
+
     db = request.app.state.db_manager.main_db
 
     # Find every distinct (notation, diagram_type) with at least one
-    # response_format row of layer=notation or layer=diagram_type. The
-    # base layer alone doesn't constitute a usable format.
+    # row of the requested purpose at layer=notation or layer=diagram_type.
+    # The base layer alone doesn't constitute a usable format.
     cursor = await db.execute(
         """
         SELECT DISTINCT
@@ -897,13 +918,14 @@ async def list_response_format_types(
         FROM ai_creation_prompts p
         LEFT JOIN diagram_types dt ON p.diagram_type = dt.id
         LEFT JOIN diagram_type_notations dtn ON p.diagram_type = dtn.diagram_type_id
-        WHERE p.purpose = 'response_format'
+        WHERE p.purpose = ?
           AND p.is_active = 1
           AND p.layer IN ('notation', 'diagram_type', 'override')
           AND COALESCE(p.notation, dtn.notation_id) IS NOT NULL
           AND p.diagram_type IS NOT NULL
         ORDER BY notation, p.diagram_type
         """,
+        (purpose,),
     )
     rows = await cursor.fetchall()
     return [
@@ -922,21 +944,48 @@ async def get_response_prompt_composed(
     request: Request,
     notation: str = Query(..., description="Notation id (e.g. 'markdown', 'doview')"),
     diagram_type: str | None = Query(default=None, description="Optional diagram_type id (e.g. 'doview_analysis')"),
+    purpose: str = Query(
+        "response_format",
+        description=(
+            "Which prompt cascade to compose. 'response_format' (default) "
+            "returns the output-shape rules; 'creation_format' returns the "
+            "drafting/composition rules used by Iris AI when generating a "
+            "diagram (ADR-162, v5.17.0)."
+        ),
+    ),
     _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
 ) -> ResponsePromptComposed:
-    """Compose the response_format prompt cascade for a (notation,
-    diagram_type) pair (ADR-157, v5.12.0).
+    """Compose the prompt cascade for a (notation, diagram_type) pair
+    (ADR-157, v5.12.0; ADR-162, v5.17.0).
 
     Anonymous-readable. Returns the composed body as `body`; empty
     string if no rows match. Used by:
 
-    - Iris AI server-side via `build_response_system_prompt` (this
-      endpoint is the HTTP surface for the same composer).
+    - Iris AI server-side via `build_response_system_prompt` /
+      `build_creation_system_prompt` (this endpoint is the HTTP surface
+      for the same composers).
     - MCP clients via the `iris_get_response_prompt` tool to apply
-      the rules client-side as reference for matching questions.
+      the rules client-side as reference for matching questions or for
+      driving local-AI diagram creation (purpose='creation_format').
     """
+    if purpose not in _VALID_PURPOSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"purpose must be one of {_VALID_PURPOSES}",
+        )
+
     db = request.app.state.db_manager.main_db
-    body = await build_response_system_prompt(db, notation, diagram_type)
+    if purpose == "creation_format":
+        # MCP callers want the raw conversational cascade — no
+        # "user selection already confirmed" suppression preamble
+        # (which is only appropriate when Iris AI is called from the
+        # web UI with attached document context). ADR-162.
+        body = await build_creation_system_prompt(
+            db, notation, diagram_type,
+            include_ui_selection_preamble=False,
+        )
+    else:
+        body = await build_response_system_prompt(db, notation, diagram_type)
     return ResponsePromptComposed(
         notation=notation,
         diagram_type=diagram_type,

--- a/backend/tests/test_ai/test_response_prompts_purpose_query.py
+++ b/backend/tests/test_ai/test_response_prompts_purpose_query.py
@@ -1,0 +1,158 @@
+"""v5.17.0 (ADR-162, SPEC-162-A): backend endpoints
+`/api/ai/response-prompts/types` and
+`/api/ai/response-prompts/composed` accept a `?purpose=` query param
+to expose creation_format prompts in addition to response_format,
+giving MCP clients a way to fetch the same drafting cascade Iris AI
+uses when generating diagrams.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+        rate_limit_general=1000,
+        rate_limit_pat=1000,
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+class TestTypesEndpoint:
+    async def test_default_returns_response_format_pairs(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        # Default ?purpose= is response_format; the v5.12.0 seed has
+        # (markdown, doview_analysis) at least.
+        resp = await client.get("/api/ai/response-prompts/types")
+        assert resp.status_code == 200
+        pairs = resp.json()
+        assert any(
+            p["notation"] == "markdown" and p["diagram_type"] == "doview_analysis"
+            for p in pairs
+        )
+
+    async def test_explicit_response_format_same_as_default(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        default = await client.get("/api/ai/response-prompts/types")
+        explicit = await client.get(
+            "/api/ai/response-prompts/types?purpose=response_format",
+        )
+        assert default.json() == explicit.json()
+
+    async def test_creation_format_returns_creation_pairs(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get(
+            "/api/ai/response-prompts/types?purpose=creation_format",
+        )
+        assert resp.status_code == 200
+        pairs = resp.json()
+        # The v5.8.x seed has (doview, outcomes_map) creation_format rows.
+        assert any(
+            p["notation"] == "doview" and p["diagram_type"] == "outcomes_map"
+            for p in pairs
+        ), f"expected (doview, outcomes_map) in {pairs}"
+
+    async def test_invalid_purpose_is_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get(
+            "/api/ai/response-prompts/types?purpose=garbage",
+        )
+        assert resp.status_code == 422
+
+
+class TestComposedEndpoint:
+    async def test_default_returns_response_format_body(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get(
+            "/api/ai/response-prompts/composed"
+            "?notation=markdown&diagram_type=doview_analysis",
+        )
+        assert resp.status_code == 200
+        # Response format body for doview_analysis includes the
+        # required opening sentence.
+        assert "I have prepared a summary response" in resp.json()["body"]
+
+    async def test_creation_format_returns_creation_body(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get(
+            "/api/ai/response-prompts/composed"
+            "?notation=doview&diagram_type=outcomes_map"
+            "&purpose=creation_format",
+        )
+        assert resp.status_code == 200
+        body = resp.json()["body"]
+        # The doview creation cascade includes the Stage 0 setup-questions
+        # conversation (Q1..Q6 — "Describe in a couple of lines or less
+        # what you want a DoView of.") from the seeded creation_format.
+        assert "Stage 0" in body
+        assert "Describe in a couple of lines" in body
+        # And the outcomes_map layout rules (final_outcome type).
+        assert "final_outcome" in body
+
+    async def test_creation_format_HTTP_path_drops_ui_selection_preamble(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """ADR-162: the HTTP-exposed creation cascade must NOT include
+        the 'User selection already confirmed in UI' suppression
+        preamble (which is only correct when Iris AI is called server-
+        side with attached document context). MCP clients need the raw
+        conversational guidance."""
+        resp = await client.get(
+            "/api/ai/response-prompts/composed"
+            "?notation=doview&diagram_type=outcomes_map"
+            "&purpose=creation_format",
+        )
+        body = resp.json()["body"]
+        assert "User selection (already confirmed in UI)" not in body
+        assert "Do NOT ask the user to re-confirm the notation" not in body
+
+    async def test_invalid_purpose_is_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get(
+            "/api/ai/response-prompts/composed"
+            "?notation=doview&purpose=garbage",
+        )
+        assert resp.status_code == 422

--- a/docs/adrs/ADR-162-Generic-MCP-Diagram-Creation-Workflow.md
+++ b/docs/adrs/ADR-162-Generic-MCP-Diagram-Creation-Workflow.md
@@ -1,0 +1,92 @@
+# ADR-162: Generic MCP diagram-creation workflow
+
+Status: Accepted (2026-05-12)
+Extends: [ADR-131](ADR-131-MCP-Server-Architecture.md), [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md), [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md), [ADR-160](ADR-160-MCP-Pairing-Code-Authentication.md), [ADR-161](ADR-161-MCP-Entity-Creation-and-Destination-Flow.md)
+
+## Context
+
+Real Claude Desktop testing of v5.16.0 surfaced a class of issue: the *specific* DoView analysis save flow worked, but creating a *new visual* DoView diagram still required handing the user off to the Iris web UI. The canonical `mcp_system_context` for the Outcomes Theory Book set explicitly routed those requests to the web UI's "guided creation flow."
+
+Investigation showed there is no Svelte wizard — the web UI just opens the canvas and calls `ask(mode='creation', notation='doview')`. The "guided conversation" the user sees is just Iris AI being driven by the existing creation_format prompt cascade (`creation-base-v1` + `creation-doview-notation-v1` + `creation-outcomes-map-v1`). A local model in an MCP client (Claude Desktop / Claude Code) could run the same conversation if it could fetch the same cascade and persist the result.
+
+Two gaps:
+
+1. **The MCP can fetch response_format cascades, but not creation_format cascades.** Both endpoints (`/api/ai/response-prompts/types`, `/api/ai/response-prompts/composed`) hardcode `purpose='response_format'`. The underlying `_build_layered_prompt` already accepts a `purpose` parameter — only the HTTP surface is restrictive.
+2. **There is no generic `create_diagram` MCP tool.** v5.16.0 shipped `create_collection / create_set / create_package` (containers), and v5.12.0 shipped `save_doview_analysis` (markdown doview_analysis only). No tool exists for creating diagrams of any (notation, diagram_type) pair generically.
+
+The user explicitly asked: this should be a **standard workflow pattern for diagram creation via MCP, not specific to DoView**.
+
+In the same release cycle the v5.16.0 testing surfaced four small UX bugs that block the new workflow: cross-tab auth doesn't carry (sessionStorage-only read); login bounces to dashboard instead of back; `/admin/settings/ai` filter dropdowns don't constrain each other; same admin page's row-inclusion logic exact-matches notation and hides legitimate diagram_type-layer rows. They're bundled into this release because they affect the same workflow surface.
+
+## Decision
+
+**Generic diagram-creation workflow** (the headline change):
+
+1. **Backend** — extend both `/api/ai/response-prompts/types` and `/api/ai/response-prompts/composed` with a `?purpose=` query parameter, defaulting to `response_format` for back-compat. When `purpose=creation_format`, the existing `build_creation_system_prompt` is called instead of `build_response_system_prompt`.
+2. **iris-client** — add a `purpose='response_format'` kwarg to `list_response_format_types` and `get_response_prompt`. Both methods pass through to the backend.
+3. **MCP** — three new tools and two extensions:
+   - `create_diagram(set_id, name, notation, diagram_type, data, parent_package_id?, description?)` — generic. Wraps existing `client.create_diagram`. Carries the `_DESTINATION_PREAMBLE` (v5.16.0) plus a new `_CREATION_FLOW_PREAMBLE` describing the discover → fetch → guided conversation → compose → confirm-destination → save flow.
+   - `list_notations` / `list_diagram_types` — discoverability. Wrap the existing `/api/registry/{notations,diagram-types}` endpoints.
+   - `get_response_prompt` / `list_response_format_types` — gain a `purpose` argument, defaulting to `response_format`.
+4. **`save_doview_analysis` deprecation** — two-stage retirement. v5.17.0 keeps the tool working but prefixes its description with a deprecation notice pointing at `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`. v6.0.0 removes it.
+
+**Workflow logic lives in tool descriptions, not in scope context.** The `_CREATION_FLOW_PREAMBLE` is in the `create_diagram` tool description (universal, every MCP client sees it on every session). The canonical `docs/prompts/doview-book-mcp-system-context.md` is trimmed: it no longer contains the diagram-creation step-by-step — it just orients to the Outcomes Theory Book set's purpose and points at `create_diagram` for any new-diagram request.
+
+**Bundled v5.16.0 follow-up fixes:**
+- `auth.svelte.ts` `loadFromSession` falls back to localStorage and re-seeds sessionStorage (fixes cross-tab auth).
+- `/login` accepts `?redirect=` and honours same-origin paths (fixes login dropping users on dashboard).
+- `/admin/settings/ai` filter dropdowns cascade via `DiagramTypeRegistry.notations` (fixes "incompatible combos picker"). Layer=base disables notation/diagram_type fields.
+- `/admin/settings/ai` row-inclusion predicate matches notation directly OR via `diagram_type_notations` mapping (fixes "selecting doview shows only 1 prompt").
+- New regression test exercising the v5.15.0 symptom: `iris_authenticate` → `create_set` in one session must propagate the new bearer to the second call's outgoing header.
+
+## Why workflow logic lives in tool descriptions, not in mcp_system_context
+
+The v5.13.x → v5.16.x evolution surfaced a clear failure mode: workflow guidance duplicated in per-scope `mcp_system_context` drifts and gets stale. Every time we add or change a write tool, every scope's context that mentions the workflow has to be re-pasted. Worse, contexts only fire when their specific scope is in play — workflow guidance doesn't reach other scopes.
+
+Tool descriptions are universal — every MCP client sees them on every session. A single shared constant (`_CREATION_FLOW_PREAMBLE`, `_DESTINATION_PREAMBLE`) injected into every relevant tool's description gives one source of truth. New write tools in future releases inherit by copy-paste.
+
+`mcp_system_context` keeps its proper role: per-scope orientation. "This set is the Outcomes Theory Book; here are the four options of what you can do here" — but no embedded workflow. Reduces ~30 lines of duplication from the canonical content.
+
+## Why extend `get_response_prompt` with `purpose=`, not add a parallel `get_creation_prompt`
+
+- The underlying composer (`_build_layered_prompt`) is already purpose-aware. The HTTP and client layers are the only places where purpose is hardcoded. Surfacing it as a parameter is a one-line server change and a kwarg on the client.
+- Same name, same shape, same return type — only the data dimension changes. A parallel `get_creation_prompt` would duplicate the request/response handling for no benefit.
+- The tool stays semantically accurate: it's fetching a *prompt cascade* for a (notation, diagram_type) pair; whether that cascade is for shaping a response or composing a creation is just a dimension.
+- Trade-off accepted: the tool name `get_response_prompt` is now slightly misleading (it does both response and creation now). Rename deferred to v6.0.0 alongside the `save_doview_analysis` removal.
+
+## Why `create_diagram`, not `save_diagram`
+
+Matches the v5.16.0 `create_collection / create_set / create_package` family. Same prefix means "create a new entity." `save_doview_analysis` was named differently because v5.12.0 chose "save" for its workflow — that choice doesn't generalise. The deprecation path is clean: keep the legacy name working until v6.0.0, point new workflows at `create_diagram`.
+
+## Why two-stage deprecation of `save_doview_analysis`
+
+- Behaviour is preserved end-to-end through `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`. From the user's seat, identical.
+- External references (Iris's own canonical `mcp_system_context`, any user-authored prompts that mention `save_doview_analysis` by name) need a window to migrate.
+- Two-stage retirement matches `iris://` URI scheme migrations and SDK API changes in mature codebases. Avoids breaking changes in a minor release.
+- Removal in v6.0.0 (next major) gives a clear signal.
+
+## Consequences
+
+- 60 LOC backend (purpose param routing), 30 LOC iris-client (kwargs), 150 LOC MCP (3 new tools + 2 extensions + preambles + deprecation), 30 LOC frontend (4 fixes), zero DB migration.
+- Tool count in iris-mcp: 22 → 26 (`create_diagram`, `list_notations`, `list_diagram_types`, plus the extended `get_response_prompt` / `list_response_format_types`).
+- `mcp_system_context` for the Outcomes Theory Book set drops ~30 lines of duplicated workflow guidance; admin must paste the new trimmed content into the field on UAT.
+- 38 new tests across all layers.
+- The v5.15.0 in-session token-propagation symptom now has a guarding regression test.
+
+## Out of scope (deferred)
+
+- **Removing `save_doview_analysis`.** v6.0.0 alongside the `get_response_prompt` rename.
+- **Renaming `get_response_prompt` to `get_diagram_prompt`.** v6.0.0.
+- **A JSON-Schema-based data shape endpoint** (`iris_get_diagram_schema(notation, diagram_type)`). The creation_format prompt describes the shape in prose; a formal schema is a future enhancement.
+- **`create_element` / `create_relationship` MCP tools.** Same pattern would extend; defer until demand.
+- **A `validate_outcomes_map(data)` server-side balance-check tool.** The creation_format prompt embeds rules; a dedicated validator is a future enhancement.
+- **Auto-migration of stored `mcp_system_context` values.** The trimmed content for the Outcomes Theory Book set is manually pasted by an admin on UAT (same pattern as v5.13.x and v5.14.x).
+
+## See also
+
+- [ADR-131](ADR-131-MCP-Server-Architecture.md) — iris-mcp stdio architecture.
+- [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md) — what scope context is for (now without workflow duplication).
+- [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — response_format / creation_format mechanism this ADR extends to MCP.
+- [ADR-160](ADR-160-MCP-Pairing-Code-Authentication.md) — auth flow that covers every write tool unchanged.
+- [ADR-161](ADR-161-MCP-Entity-Creation-and-Destination-Flow.md) — container creation tools `create_diagram` complements.
+- [SPEC-162-A](specs/SPEC-162-A-Generic-MCP-Diagram-Creation-Workflow.md) — endpoint shapes, tool input schemas, frontend fix details, test plan.

--- a/docs/adrs/specs/SPEC-162-A-Generic-MCP-Diagram-Creation-Workflow.md
+++ b/docs/adrs/specs/SPEC-162-A-Generic-MCP-Diagram-Creation-Workflow.md
@@ -1,0 +1,331 @@
+# SPEC-162-A: Generic MCP diagram-creation workflow
+
+ADR: [ADR-162](../ADR-162-Generic-MCP-Diagram-Creation-Workflow.md)
+
+## Database
+
+**No schema changes.**
+
+## Backend
+
+### `backend/app/ai/router.py:872-944`
+
+Both endpoints gain a `purpose: str = Query("response_format")` parameter, validated against `{"response_format", "creation_format"}`. Invalid values return 422.
+
+```python
+@router.get("/response-prompts/types")
+async def list_response_format_types(
+    request: Request,
+    purpose: str = Query("response_format", description="..."),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),
+) -> list[ResponseFormatType]:
+    if purpose not in ("response_format", "creation_format"):
+        raise HTTPException(status_code=422, detail="...")
+    # Existing SQL but with WHERE p.purpose = :purpose parameterised.
+```
+
+```python
+@router.get("/response-prompts/composed")
+async def get_response_prompt_composed(
+    request: Request,
+    notation: str = Query(...),
+    diagram_type: str | None = Query(default=None),
+    purpose: str = Query("response_format"),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),
+) -> ResponsePromptComposed:
+    if purpose == "creation_format":
+        body = await build_creation_system_prompt(db, notation, diagram_type)
+    elif purpose == "response_format":
+        body = await build_response_system_prompt(db, notation, diagram_type)
+    else:
+        raise HTTPException(status_code=422, detail="...")
+    return ResponsePromptComposed(body=body, ...)
+```
+
+Both `build_response_system_prompt` and `build_creation_system_prompt` are already purpose-aware (`backend/app/ai/creation.py`).
+
+### Backend tests (`backend/tests/test_ai/...`)
+
+- Default `?purpose=response_format` behaviour unchanged on both endpoints.
+- `?purpose=creation_format` returns creation cascade on `/composed`.
+- `?purpose=creation_format` returns creation-format pairs on `/types`.
+- `?purpose=garbage` returns 422 on both endpoints.
+
+## iris-client
+
+### Methods (`iris-client/src/iris_client/client.py`)
+
+```python
+async def list_response_format_types(
+    self, *, purpose: str = "response_format",
+) -> list[ResponseFormatType]:
+    response = await self._request(
+        "GET", "/api/ai/response-prompts/types",
+        params={"purpose": purpose},
+    )
+    ...
+
+async def get_response_prompt(
+    self,
+    notation: str,
+    *,
+    diagram_type: str | None = None,
+    purpose: str = "response_format",
+) -> ResponsePromptComposed:
+    params: dict[str, Any] = {"notation": notation, "purpose": purpose}
+    if diagram_type is not None:
+        params["diagram_type"] = diagram_type
+    response = await self._request(
+        "GET", "/api/ai/response-prompts/composed", params=params,
+    )
+    ...
+```
+
+### Tests (`iris-client/tests/test_creation_prompts.py`)
+
+- `purpose='creation_format'` flows through to the request.
+- `purpose='response_format'` is the default (no params provided → same query).
+- Both happy-path return-shape assertions.
+- Tolerates extra fields on response (permissive model).
+
+## MCP server
+
+### New shared constant (`mcp/src/iris_mcp/tools.py`)
+
+```python
+_CREATION_FLOW_PREAMBLE = """
+Generic save for a new diagram of any (notation, diagram_type) pair.
+
+CREATION FLOW (recommended):
+  1. Discover: call list_notations / list_diagram_types if you don't
+     already know which (notation, diagram_type) the user wants.
+  2. Fetch the creation guidance: get_response_prompt(notation=...,
+     diagram_type=..., purpose='creation_format'). The body carries the
+     layered creation cascade (base + notation + diagram_type) used by
+     Iris AI when generating diagrams. For DoView it includes the
+     5-question guided conversation, the entity types, the colour
+     palette, and the outcomes_map layout rules.
+  3. Run the guided conversation IN CHAT with the user. Use
+     AskUserQuestion when supported; numbered list otherwise.
+  4. Compose the `data` JSON locally per the creation prompt's rules.
+     For visual diagrams (notation in doview / archimate / c4 / uml /
+     simple / bpmn), data is a Svelte-Flow-shaped {nodes, edges}
+     payload. For markdown diagrams, data is {"content": "<markdown>"}.
+  5. Confirm destination with the user (see destination preamble below).
+  6. Call create_diagram with the composed data.
+""".strip()
+```
+
+### New tools
+
+| Tool | Required args | Optional args |
+|---|---|---|
+| `create_diagram` | `set_id`, `name`, `notation`, `diagram_type` | `data` (object), `parent_package_id`, `description` |
+| `list_notations` | — | — |
+| `list_diagram_types` | — | — |
+
+`create_diagram` description = `_CREATION_FLOW_PREAMBLE` + `\n\n` + `_DESTINATION_PREAMBLE`. On `IrisAuthError` → `_auth_required_payload("Create diagram")` (v5.16.0 shared helper).
+
+`list_notations` / `list_diagram_types` wrap the existing `/api/registry/notations` and `/api/registry/diagram-types` endpoints respectively.
+
+### Extended tools
+
+`get_response_prompt` and `list_response_format_types` tool definitions gain an optional `purpose` arg in their input schema:
+
+```python
+"purpose": (
+    {
+        "type": "string",
+        "enum": ["response_format", "creation_format"],
+        "default": "response_format",
+        "description": (
+            "Which prompt cascade to fetch. 'response_format' (default) "
+            "for output-shape rules; 'creation_format' for the "
+            "drafting/composition rules Iris AI uses when generating a "
+            "diagram. Pair with create_diagram for local-AI-driven "
+            "diagram creation."
+        ),
+    },
+    False,
+),
+```
+
+Handler passes the arg through to the iris-client method.
+
+### `save_doview_analysis` deprecation
+
+Description rewritten to prefix:
+
+```text
+[Deprecated since v5.17.0 (ADR-162): prefer create_diagram(
+notation='markdown', diagram_type='doview_analysis', set_id=...,
+name=..., data={'content': '<markdown>'}, parent_package_id?). Will be
+removed in v6.0.0.]
+
+[then existing description body unchanged]
+```
+
+Handler body unchanged. Behaviour unchanged.
+
+### Regression test (`mcp/tests/test_tools_authenticate.py`)
+
+New test `test_pairing_then_create_set_uses_new_pat_in_same_session`:
+
+- Mock pairing exchange returns `iris_pat_freshly_minted`.
+- Mock `POST /api/sets`: return 201 iff `Authorization == 'Bearer iris_pat_freshly_minted'`, else 401.
+- Long-lived `c = IrisClient(token=None)`.
+- `await tools.dispatch("iris_authenticate", c, {"credential": "IRIS-..."})` — succeeds.
+- `await tools.dispatch("create_set", c, {"name": "X"})` — must succeed; `"auth_required"` must NOT appear in the result body.
+
+Catches any regression that would re-introduce the v5.15.0 symptom (user reported `iris_authenticate` succeeded but next call still got `auth_required`).
+
+### MCP tests
+
+- `mcp/tests/test_tools_create_diagram.py`:
+  - `create_diagram` happy paths for `doview/outcomes_map`, `markdown/doview_analysis`, `simple/component`.
+  - 401 → `auth_required` payload.
+  - Description carries both preambles.
+- `mcp/tests/test_tools_list_notations_and_diagram_types.py`:
+  - `list_notations` returns all registered notations in display_order.
+  - `list_diagram_types` returns diagram_types with their compatible `notations` arrays.
+
+## Frontend
+
+### Fix #1 — sessionStorage fallback (`frontend/src/lib/stores/auth.svelte.ts`)
+
+```ts
+function loadFromSession(): StoredAuth | null {
+    if (typeof sessionStorage === 'undefined') return null;
+    try {
+        let raw = sessionStorage.getItem(STORAGE_KEY);
+        if (!raw && typeof localStorage !== 'undefined') {
+            raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) sessionStorage.setItem(STORAGE_KEY, raw);
+        }
+        if (!raw) return null;
+        return JSON.parse(raw) as StoredAuth;
+    } catch {
+        return null;
+    }
+}
+```
+
+### Fix #2 — login redirect-back (`frontend/src/routes/login/+page.svelte`)
+
+```ts
+import { page } from '$app/state';
+
+function safeRedirect(): string {
+    const r = page.url.searchParams.get('redirect');
+    if (!r) return '/';
+    // Same-origin path only: must start with /, must NOT start with //,
+    // must NOT contain ://, must NOT contain whitespace.
+    if (!r.startsWith('/')) return '/';
+    if (r.startsWith('//')) return '/';
+    if (r.includes('://')) return '/';
+    if (/\s/.test(r)) return '/';
+    return r;
+}
+
+// Replace each goto('/') with goto(safeRedirect())
+```
+
+`/settings/mcp-pairing` and `/settings` sign-in hints update to point at `/login?redirect=<encoded-current-path>`.
+
+### Fix #3 — cascading filter dropdowns (`frontend/src/routes/admin/settings/ai/+page.svelte`)
+
+Extract helpers:
+
+```ts
+function compatibleDiagramTypes(
+    notationId: string | null,
+    allDts: DiagramTypeRegistry[],
+): DiagramTypeRegistry[] {
+    if (!notationId) return allDts;
+    return allDts.filter(dt =>
+        dt.notations.some(n => n.notation_id === notationId),
+    );
+}
+
+function compatibleNotations(
+    dtId: string | null,
+    allDts: DiagramTypeRegistry[],
+    allNotations: NotationRegistry[],
+): NotationRegistry[] {
+    if (!dtId) return allNotations;
+    const dt = allDts.find(d => d.id === dtId);
+    if (!dt) return allNotations;
+    const validIds = new Set(dt.notations.map(n => n.notation_id));
+    return allNotations.filter(n => validIds.has(n.id));
+}
+```
+
+Apply at three call sites (filter row, create dialog, edit dialog). When `layer === 'base'` in any of those sites, disable both pickers and surface the hint "base layer applies universally (no notation / diagram_type)".
+
+### Fix #4 — inclusion logic (same file)
+
+```ts
+function isNotationScopeMatch(
+    p: { notation: string | null; diagram_type: string | null },
+    notationFilter: string,
+    allDts: DiagramTypeRegistry[],
+): boolean {
+    if (!notationFilter) return true;
+    if ((p.notation ?? '') === notationFilter) return true;
+    if (!p.diagram_type) return false;
+    const dt = allDts.find(d => d.id === p.diagram_type);
+    return !!dt?.notations.some(n => n.notation_id === notationFilter);
+}
+```
+
+`filteredPrompts` uses this in place of the exact-match notation check. `diagramTypeFilter` stays exact-match.
+
+### Frontend tests
+
+| File | Cases |
+|---|---|
+| `frontend/tests/unit/authStoreLocalStorageFallback.test.ts` | 4 — sessionStorage hit (unchanged); sessionStorage empty + localStorage seeded → loaded AND copied back to session; both empty → null; corrupt JSON → null |
+| `frontend/tests/unit/loginRedirectBack.test.ts` | 5 — `?redirect=/x` honoured; missing param → /; `//evil` rejected; `http://evil` rejected; whitespace rejected |
+| `frontend/tests/unit/adminPromptFilterCascade.test.ts` | 4 — compatibleDiagramTypes filters by notations array; compatibleNotations does the reverse; empty notationFilter passes through; both filters consistent across registry shapes |
+| `frontend/tests/unit/adminPromptFilterInclusion.test.ts` | 4 — direct notation match; indirect via diagram_type_notations; base-layer rows excluded from notation filter; unrelated-notation rows excluded |
+
+## Documentation
+
+### `docs/prompts/doview-book-mcp-system-context.md`
+
+Trim. Remove the entire path-A / path-B step-by-step. Replace with the lean orient content described in the plan — chapter overview, four-option menu, single sentence routing diagram-creation requests at `create_diagram` (the tool's description carries the workflow).
+
+### `README.md`
+
+- "Exposes ~22 tools" → "Exposes ~26 tools" with `create_diagram`, `list_notations`, `list_diagram_types` mentioned.
+- Brief one-line note that `save_doview_analysis` is deprecated in v5.17.0, removal in v6.0.0.
+
+### `CHANGELOG.md`
+
+`[5.17.0]` block covers:
+- Generic `create_diagram` MCP tool + `list_notations` + `list_diagram_types` discoverability.
+- `get_response_prompt` / `list_response_format_types` extended with `purpose` (back-compat default).
+- Backend `/api/ai/response-prompts/{types,composed}` extended with `?purpose=` (back-compat default).
+- iris-client method extensions.
+- `save_doview_analysis` deprecated.
+- Frontend fixes: cross-tab auth, login redirect-back, admin filter cascading dropdowns, admin filter inclusion logic.
+- `mcp_system_context` for Outcomes Theory Book set trimmed.
+- v5.15.0-symptom regression test added.
+
+## End-to-end verification
+
+Listed in the plan file. Key flows:
+
+1. New tab opened from Claude's pairing-page link inherits auth state.
+2. Sign in from `/settings/mcp-pairing` returns to that page, not dashboard.
+3. Claude Desktop end-to-end: ask for a new DoView outcomes map → Claude fetches `get_response_prompt(notation='doview', diagram_type='outcomes_map', purpose='creation_format')` → runs the 5-question conversation → confirms destination → calls `create_diagram` → saved diagram appears in Iris.
+4. `/admin/settings/ai` filter dropdowns cascade; selecting `doview` shows all doview-relevant rows (direct + diagram_type-mapped).
+5. v5.15.0 symptom — no longer reproducible; regression test covers it.
+
+## Out of scope (deferred)
+
+- Removal of `save_doview_analysis` (v6.0.0).
+- Rename of `get_response_prompt` to `get_diagram_prompt` (v6.0.0).
+- JSON-Schema data-shape endpoint.
+- `create_element` / `create_relationship` MCP tools.
+- DoView balance-check validator tool.

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -20,46 +20,24 @@ ORIENT FIRST. On the first turn, before doing any other tool action:
     2. Ask a cross-package question via Iris AI
        (e.g. "What are the recurring causal-link conventions?" — uses mcp__iris__ask).
 
-    3. Generate a new DoView outcomes-theory analysis on a topic the user describes,
-       grounded in this handbook, with an option to save it back into this set.
-       Path: iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')
-       → compose locally → optionally iris_save_doview_analysis. NOT mcp__iris__ask.
+    3. Generate a new DoView outcomes-theory analysis OR a new visual
+       DoView outcomes_map on a topic the user describes. → call
+       iris_create_diagram. The tool's own description carries the
+       full workflow (discover via list_notations / list_diagram_types,
+       fetch the creation prompt cascade via iris_get_response_prompt
+       with purpose='creation_format', run the guided conversation,
+       confirm destination using create_collection / create_set /
+       create_package as needed, save). Do not duplicate that
+       workflow here.
 
     4. Browse a particular chapter's diagrams in detail
        (iris_package_hierarchy filtered to a chapter, then mcp__iris__get_diagram on each).
 
 If the user's opening request explicitly asks for one option, briefly acknowledge it and present the menu of the other three so they can redirect.
 
-PATH DETAILS
-
-A. ANALYSIS (option 3 above) — written outcomes-theory analysis with embedded mermaid:
-   - Fetch rules: iris_get_response_prompt(notation='markdown', diagram_type='doview_analysis')
-   - Compose using mcp__iris__search + mcp__iris__get_diagram against this set
-   - After producing, offer BOTH save paths:
-       (i) iris_save_doview_analysis(set_id, name, content, parent_package_id?) —
-           auth required. BEFORE CALLING, ask the user WHERE to save:
-             • an existing set + parent package they name; OR
-             • a new set in an existing collection (call create_set first); OR
-             • a new collection + new set (call create_collection, then create_set); OR
-             • optionally also nest under a new package (call create_package).
-           Use AskUserQuestion when available; numbered list otherwise. Don't
-           pick a destination silently. The v5.16.0 entity-creation tools
-           (create_collection / create_set / create_package, ADR-161) cover
-           the new-container cases without leaving the conversation.
-           If the save fails with error="auth_required" (v5.15.0+, ADR-160),
-           follow the returned guidance: ask the user to visit
-           /settings/mcp-pairing, generate a pairing code, and paste it back.
-           Then call iris_authenticate(credential=<pasted code>) and retry the save.
-       (ii) Leave the markdown in chat for copy/paste — it IS the markdown.
-
-B. NEW VISUAL DOVIEW DIAGRAM (a notation=doview outcomes_map):
-   The guided creation flow (Stages 0-3, 13 drafting steps, balance checks) is best done in Iris's web UI:
-     https://iris-uat.chrisbarlow.nz/sets/33032180-d77a-4ce4-88cf-b49cd643e093
-   Open the set → New diagram → notation=DoView → diagram_type=outcomes_map. Recommend the web UI for this case.
-
 DISCOVERABILITY
 
-  list_response_format_types — what formats are available
+  list_response_format_types(purpose='response_format'|'creation_format') — what response formats / creation types are available
   iris_package_hierarchy(set_id=<this-set>) — chapter tree, single call
 ```
 
@@ -68,22 +46,22 @@ DISCOVERABILITY
 - **Orient lands on first turn whether Claude calls `search` or `get_set`** — v5.14.0 (ADR-159) extended search results for Set / Collection hits to include `mcp_system_context`. Claude's natural "search → return link" flow now also surfaces this content.
 - **The four options are mandatory and verbatim** — paraphrasing got Claude down to 2 options in v5.13.x. Explicit "all four, every time" + verbatim wording fixes that.
 - **AskUserQuestion is conditional** — Claude Code has it; Claude Desktop / claude.ai / generic MCP clients don't (yet). Numbered list is the fallback.
-- **Routing for "generate analysis" is explicit** — `iris_get_response_prompt`, NOT `mcp__iris__ask`. v5.13.x left this implicit and Claude defaulted to the wrong path.
+- **Workflow logic lives in the `create_diagram` tool description, not here.** v5.17.0 (ADR-162) moved the full creation flow (discover → fetch creation prompt → guided conversation → confirm destination → save) into the tool's description so it travels universally across every MCP client and every scope, not just this set. The scope context just points at the tool.
 
 ## Revision history
 
-- **v5.14.0 (this revision).** Trimmed from ~140 lines to ~50 (target was ~60). Same orient-first-with-four-option-menu intent, far less text. Surfaced through search results too (ADR-159) so the orient lands on first turn regardless of whether Claude calls `get_set` or just `search`.
+- **v5.17.0 (this revision).** Stripped the diagram-creation workflow entirely (paths A and B in v5.16.x) — that lives in `create_diagram`'s tool description now (ADR-162). The web-UI-handoff guidance for visual DoView creation is gone; the generic `create_diagram` flow covers both markdown DoView analyses and visual DoView outcomes_maps. ~30 lines shorter.
+- **v5.14.0.** Trimmed from ~140 lines to ~50 (target was ~60). Same orient-first-with-four-option-menu intent, far less text. Surfaced through search results too (ADR-159) so the orient lands on first turn regardless of whether Claude calls `get_set` or just `search`.
 - **v5.13.3.** Made the four-option menu mandatory and verbatim. Honest note about AskUserQuestion availability.
 - **v5.13.2.** Restored orient-first / offer-menu pattern; explicit analysis-vs-diagram routing; "DO NOT use mcp__iris__ask for analysis flow".
 - **v5.13.0.** Mention `iris_package_hierarchy` (ADR-158) as the preferred chapter-list call.
 - **v5.12.0.** Save-options offer added (Iris save + markdown artefact).
-
-The "offer both save paths" + "orient first" behaviours arguably belong in the `response-format-doview-analysis-v1` row's body so they apply universally, not just on this Set. Until that row is amended via `/admin/settings/ai`, this scope-specific doc is the single source of guidance.
 
 ## See also
 
 - [ADR-156](../adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for (per-scope context, data passthrough on `get_set` / `get_collection`).
 - [ADR-157](../adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — where the response_format rules live (universal layered prompts, admin-editable).
 - [ADR-159](../adrs/ADR-159-Scope-Context-In-Search-Results.md) — search results carry `mcp_system_context` so orient lands on first turn.
+- [ADR-162](../adrs/ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — generic `create_diagram` tool + workflow-in-tool-descriptions pattern.
 - [SPEC-157-A](../adrs/specs/SPEC-157-A-Response-Format-Prompts.md) — schema for the response_format mechanism.
 - [`doview-book-prompt-c-iris.md`](./doview-book-prompt-c-iris.md) — the source content from which the seeded response_format prompts were derived.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.16.0",
+	"version": "5.17.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/guide/collections-sets.md
+++ b/frontend/src/lib/guide/collections-sets.md
@@ -73,7 +73,7 @@ When you scope the app to a collection or set, that choice is **remembered in se
 - Or visit `/` without any URL parameters.
 - Or pick a different collection / set.
 
-The search bar is a deliberate exception to scope: it always runs globally on `/` (see ADR-121).
+The search bar is a deliberate exception to scope: it always runs globally on `/`.
 
 ## Next steps
 

--- a/frontend/src/lib/guide/dashboard.md
+++ b/frontend/src/lib/guide/dashboard.md
@@ -30,7 +30,7 @@ The graph has its own settings panel (top-right of the graph area) for spread, l
 
 ## Search
 
-The search bar sits beneath the graph. Unlike the counts panel, **the search bar is always global** — typing on `/` with no URL parameters searches every collection and every set. A remembered scope does not silently filter search (fixed in v4.1.3; see ADR-121).
+The search bar sits beneath the graph. Unlike the counts panel, **the search bar is always global** — typing on `/` with no URL parameters searches every collection and every set. A remembered scope does not silently filter search.
 
 Results appear inline with type badges; each result has a deep-link to the entity detail page plus an **Add to AI context** button — see [Search](search) and [Ask AI](ask-ai).
 

--- a/frontend/src/lib/guide/knowledge-graph.md
+++ b/frontend/src/lib/guide/knowledge-graph.md
@@ -22,7 +22,7 @@ Edge types:
 
 ## Hierarchy flow (radial force)
 
-Nodes are laid out in concentric bands around their governing collection centroid (ADR-120 / SPEC-120-A):
+Nodes are laid out in concentric bands around their governing collection centroid:
 
 1. **Collection** at the centre.
 2. **Sets** in a close ring.
@@ -74,7 +74,7 @@ A maximise icon sits in the top-right of the graph area. Click to expand the gra
 
 ## Performance notes
 
-Iris uses a custom radial-layer force (ADR-120) instead of raw d3-force's repulsion. This makes the layout deterministic enough for reliable screenshots and fast enough for sets with hundreds of members. For truly massive datasets (tens of thousands of elements), turn Elements off; the physics stays responsive.
+Iris uses a custom radial-layer force instead of raw d3-force's repulsion. This makes the layout deterministic enough for reliable screenshots and fast enough for sets with hundreds of members. For truly massive datasets (tens of thousands of elements), turn Elements off; the physics stays responsive.
 
 ## Next steps
 

--- a/frontend/src/lib/guide/search.md
+++ b/frontend/src/lib/guide/search.md
@@ -6,7 +6,7 @@ Iris indexes every entity name and description for full-text search. The dashboa
 
 ## Global vs scoped
 
-- **Dashboard search bar** is **always global.** Typing on `/` with no URL parameters returns results from every set and every collection. A remembered scope (for counts) does not silently filter search — see ADR-121.
+- **Dashboard search bar** is **always global.** Typing on `/` with no URL parameters returns results from every set and every collection. A remembered scope (for counts) does not silently filter search.
 - **List-page search boxes** (Collections, Sets, Diagrams, Elements) are scoped to that list. They don't filter by the dashboard's remembered scope; each list page has its own type-specific index.
 - **Deep-linked scoped search** — add `?set_id=<id>` or `?collection_id=<id>` to the dashboard URL and the search bar on that page scopes to it. Useful for URL-sharing narrow results.
 
@@ -32,7 +32,7 @@ Simple, prefix-matching:
 
 ## Indexing
 
-Whenever an entity is created, updated, or deleted, its search index entry is updated in-line (the entry is written in the same transaction as the entity's version row — see ADR-125). No manual re-index needed. If the search index ever gets out of sync, admins can force a full rebuild from **Admin → Settings → Rebuild Search Index** (available only in SQLite mode; Postgres has trigger-driven indices that don't need manual rebuild).
+Whenever an entity is created, updated, or deleted, its search index entry is updated in-line — written in the same transaction as the entity's version row. No manual re-index needed. If the search index ever gets out of sync, admins can force a full rebuild from **Admin → Settings → Rebuild Search Index** (available only in SQLite mode; Postgres has trigger-driven indices that don't need manual rebuild).
 
 ## Add to AI context
 

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -19,7 +19,16 @@ interface StoredAuth {
 function loadFromSession(): StoredAuth | null {
 	if (typeof sessionStorage === 'undefined') return null;
 	try {
-		const raw = sessionStorage.getItem(STORAGE_KEY);
+		// v5.17.0 (ADR-162): sessionStorage is per-tab. Fall back to
+		// localStorage if a sibling tab already saved auth there, then
+		// re-seed sessionStorage so this tab caches it going forward.
+		// Fixes "new tab opened from Claude's pairing link sees user as
+		// anonymous" symptom.
+		let raw = sessionStorage.getItem(STORAGE_KEY);
+		if (!raw && typeof localStorage !== 'undefined') {
+			raw = localStorage.getItem(STORAGE_KEY);
+			if (raw) sessionStorage.setItem(STORAGE_KEY, raw);
+		}
 		if (!raw) return null;
 		return JSON.parse(raw) as StoredAuth;
 	} catch {

--- a/frontend/src/routes/admin/settings/+page.svelte
+++ b/frontend/src/routes/admin/settings/+page.svelte
@@ -176,7 +176,7 @@
 		<div class="rounded border p-4" style="border-color: var(--color-border)">
 			<h2 class="text-lg font-medium" style="color: var(--color-fg)">System Notification Banner</h2>
 			<p class="mt-1 text-sm" style="color: var(--color-muted)">
-				Posts a message to every Iris user, including anonymous visitors. Shown at the top of every page until cleared. Empty to hide (ADR-124).
+				Posts a message to every Iris user, including anonymous visitors. Shown at the top of every page until cleared. Empty to hide.
 			</p>
 			<div class="mt-3">
 				<label for="notification-banner" class="text-sm" style="color: var(--color-fg)">

--- a/frontend/src/routes/admin/settings/ai/+page.svelte
+++ b/frontend/src/routes/admin/settings/ai/+page.svelte
@@ -16,7 +16,53 @@
 	};
 
 	type Notation = { id: string; name: string };
-	type DiagramType = { id: string; name: string };
+	// v5.17.0 (ADR-162): keep `notations` so the cascade helpers can
+	// filter diagram_types by their compatible notation_ids without a
+	// second fetch.
+	type NotationMapping = { notation_id: string; notation_name?: string; is_default?: boolean };
+	type DiagramType = { id: string; name: string; notations?: NotationMapping[] };
+
+	// ── Cascade helpers (v5.17.0 / ADR-162) ─────────────────────────────
+	// Notation-agnostic: works the same way for every notation/diagram_type.
+	// Powers the filter row, the create dialog, and the edit dialog.
+	function compatibleDiagramTypes(
+		notationId: string | null,
+		allDts: DiagramType[],
+	): DiagramType[] {
+		if (!notationId) return allDts;
+		return allDts.filter((dt) =>
+			(dt.notations ?? []).some((n) => n.notation_id === notationId),
+		);
+	}
+
+	function compatibleNotations(
+		dtId: string | null,
+		allDts: DiagramType[],
+		allNotations: Notation[],
+	): Notation[] {
+		if (!dtId) return allNotations;
+		const dt = allDts.find((d) => d.id === dtId);
+		if (!dt || !dt.notations || dt.notations.length === 0) return allNotations;
+		const validIds = new Set(dt.notations.map((n) => n.notation_id));
+		return allNotations.filter((n) => validIds.has(n.id));
+	}
+
+	// Inclusion predicate for the row table:
+	// (a) direct match on p.notation, OR
+	// (b) p.diagram_type maps to notationFilter via diagram_type_notations.
+	// Base-layer rows (notation=null, diagram_type=null) are excluded from
+	// notation-specific filters.
+	function isNotationScopeMatch(
+		p: { notation: string | null; diagram_type: string | null },
+		notationFilterValue: string,
+		allDts: DiagramType[],
+	): boolean {
+		if (!notationFilterValue) return true;
+		if ((p.notation ?? '') === notationFilterValue) return true;
+		if (!p.diagram_type) return false;
+		const dt = allDts.find((d) => d.id === p.diagram_type);
+		return !!(dt?.notations ?? []).some((n) => n.notation_id === notationFilterValue);
+	}
 
 	const PURPOSES = ['creation_format', 'response_format'] as const;
 	const LAYERS = ['base', 'notation', 'diagram_type', 'override'] as const;
@@ -321,7 +367,10 @@
 			.filter((p) => {
 				if (purposeFilter && (p.purpose ?? 'creation_format') !== purposeFilter) return false;
 				if (layerFilter && p.layer !== layerFilter) return false;
-				if (notationFilter && (p.notation ?? '') !== notationFilter) return false;
+				// v5.17.0 (ADR-162): notation filter matches direct OR via
+				// diagram_type_notations mapping. Fixes "doview shows only 1
+				// prompt" when diagram_type-layer rows have notation=null.
+				if (!isNotationScopeMatch(p, notationFilter, availableDiagramTypes)) return false;
 				if (diagramTypeFilter && (p.diagram_type ?? '') !== diagramTypeFilter) return false;
 				if (statusFilter === 'active' && !p.is_active) return false;
 				if (statusFilter === 'inactive' && p.is_active) return false;
@@ -787,7 +836,7 @@
 		<div>
 			<h2 class="text-xl font-bold" style="color: var(--color-fg)">AI Prompts</h2>
 			<p class="mt-1 text-sm" style="color: var(--color-muted)">
-				Layered prompts used for diagram creation (ADR-094-B / ADR-132) and response formatting (ADR-157). Filter, edit, enable/disable, add, and delete from this page. The cascade applies in order: override (replaces all) > base > notation > diagram_type.
+				Layered prompts used for diagram creation and response formatting. Filter, edit, enable/disable, add, and delete from this page. The cascade applies in order: override (replaces all) > base > notation > diagram_type.
 			</p>
 		</div>
 		<button
@@ -836,7 +885,7 @@
 			aria-label="Filter by notation"
 		>
 			<option value="">All notations</option>
-			{#each availableNotations as n (n.id)}
+			{#each compatibleNotations(diagramTypeFilter || null, availableDiagramTypes, availableNotations) as n (n.id)}
 				<option value={n.id}>{n.name}</option>
 			{/each}
 		</select>
@@ -847,7 +896,7 @@
 			aria-label="Filter by diagram type"
 		>
 			<option value="">All diagram types</option>
-			{#each availableDiagramTypes as d (d.id)}
+			{#each compatibleDiagramTypes(notationFilter || null, availableDiagramTypes) as d (d.id)}
 				<option value={d.id}>{d.name}</option>
 			{/each}
 		</select>
@@ -932,23 +981,25 @@
 					</select>
 				</label>
 				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
-					Notation (optional)
+					Notation {createForm.layer === 'base' ? '(disabled — base layer applies universally)' : '(optional)'}
 					<select bind:value={createForm.notation}
+						disabled={createForm.layer === 'base'}
 						class="rounded border px-2 py-1 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
 						<option value="">— none —</option>
-						{#each availableNotations as n (n.id)}
+						{#each compatibleNotations(createForm.diagram_type || null, availableDiagramTypes, availableNotations) as n (n.id)}
 							<option value={n.id}>{n.name}</option>
 						{/each}
 					</select>
 				</label>
 				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
-					Diagram type (optional)
+					Diagram type {createForm.layer === 'base' || createForm.layer === 'notation' ? '(disabled)' : '(optional)'}
 					<select bind:value={createForm.diagram_type}
+						disabled={createForm.layer === 'base' || createForm.layer === 'notation'}
 						class="rounded border px-2 py-1 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
 						<option value="">— none —</option>
-						{#each availableDiagramTypes as d (d.id)}
+						{#each compatibleDiagramTypes(createForm.notation || null, availableDiagramTypes) as d (d.id)}
 							<option value={d.id}>{d.name}</option>
 						{/each}
 					</select>
@@ -1080,23 +1131,25 @@
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" />
 				</label>
 				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
-					Notation
+					Notation {editingPrompt?.layer === 'base' ? '(disabled — base layer applies universally)' : ''}
 					<select bind:value={promptEditNotation}
+						disabled={editingPrompt?.layer === 'base'}
 						class="rounded border px-2 py-1 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
 						<option value="">— none —</option>
-						{#each availableNotations as n (n.id)}
+						{#each compatibleNotations(promptEditDiagramType || null, availableDiagramTypes, availableNotations) as n (n.id)}
 							<option value={n.id}>{n.name}</option>
 						{/each}
 					</select>
 				</label>
 				<label class="flex flex-col gap-1 text-sm" style="color: var(--color-fg)">
-					Diagram type
+					Diagram type {editingPrompt?.layer === 'base' || editingPrompt?.layer === 'notation' ? '(disabled)' : ''}
 					<select bind:value={promptEditDiagramType}
+						disabled={editingPrompt?.layer === 'base' || editingPrompt?.layer === 'notation'}
 						class="rounded border px-2 py-1 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)">
 						<option value="">— none —</option>
-						{#each availableDiagramTypes as d (d.id)}
+						{#each compatibleDiagramTypes(promptEditNotation || null, availableDiagramTypes) as d (d.id)}
 							<option value={d.id}>{d.name}</option>
 						{/each}
 					</select>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,11 +1,28 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { setAuth } from '$lib/stores/auth.svelte.js';
 	import { API_BASE_URL, DB_BACKEND } from '$lib/config.js';
 	import { supabase } from '$lib/supabase.js';
 	import type { AuthTokens, User } from '$lib/types/api.js';
 
 	const isSupabase = DB_BACKEND === 'supabase';
+
+	/** v5.17.0 (ADR-162): after a successful sign-in, return the user to
+	 * where they came from when a ?redirect= query param is present.
+	 * Only honoured for same-origin paths (must start with /, not //,
+	 * no ://, no whitespace) — external/protocol redirects are rejected
+	 * to /. Fixes "sign in from /settings/mcp-pairing bounces to dashboard".
+	 */
+	function safeRedirectTarget(): string {
+		const r = page.url.searchParams.get('redirect');
+		if (!r) return '/';
+		if (!r.startsWith('/')) return '/';
+		if (r.startsWith('//')) return '/';
+		if (r.includes('://')) return '/';
+		if (/\s/.test(r)) return '/';
+		return r;
+	}
 
 	let username = $state('');
 	let password = $state('');
@@ -108,7 +125,7 @@
 				{ access_token: data.session.access_token, refresh_token: data.session.refresh_token },
 				me,
 			);
-			await goto('/');
+			await goto(safeRedirectTarget());
 		} catch {
 			error = 'Unable to connect to server';
 		} finally {
@@ -150,7 +167,7 @@
 			};
 
 			setAuth(tokens, user);
-			await goto('/');
+			await goto(safeRedirectTarget());
 		} catch {
 			error = 'Unable to connect to server';
 		} finally {

--- a/frontend/src/routes/settings/mcp-pairing/+page.svelte
+++ b/frontend/src/routes/settings/mcp-pairing/+page.svelte
@@ -92,7 +92,8 @@
 {#if !isAuthenticated()}
 	<section class="mt-6 rounded border px-4 py-3 text-sm"
 		style="border-color: var(--color-border); color: var(--color-muted); background-color: var(--color-bg)">
-		Sign in first to generate a pairing code.
+		<a href="/login?redirect=/settings/mcp-pairing" style="color: var(--color-primary)">Sign in</a>
+		first to generate a pairing code.
 	</section>
 {:else}
 	<section class="mt-6">

--- a/frontend/tests/unit/adminPromptFilterCascade.test.ts
+++ b/frontend/tests/unit/adminPromptFilterCascade.test.ts
@@ -1,0 +1,91 @@
+/**
+ * v5.17.0 (ADR-162) — admin /admin/settings/ai filter dropdowns
+ * cascade so an admin can't pick incompatible (notation, diagram_type)
+ * combinations.
+ *
+ * Inline copies of the helpers; keep in sync with
+ * `frontend/src/routes/admin/settings/ai/+page.svelte`.
+ */
+import { describe, it, expect } from 'vitest';
+
+type NotationMapping = { notation_id: string; notation_name?: string; is_default?: boolean };
+type DiagramType = { id: string; name: string; notations?: NotationMapping[] };
+type Notation = { id: string; name: string };
+
+function compatibleDiagramTypes(
+	notationId: string | null,
+	allDts: DiagramType[],
+): DiagramType[] {
+	if (!notationId) return allDts;
+	return allDts.filter((dt) =>
+		(dt.notations ?? []).some((n) => n.notation_id === notationId),
+	);
+}
+
+function compatibleNotations(
+	dtId: string | null,
+	allDts: DiagramType[],
+	allNotations: Notation[],
+): Notation[] {
+	if (!dtId) return allNotations;
+	const dt = allDts.find((d) => d.id === dtId);
+	if (!dt || !dt.notations || dt.notations.length === 0) return allNotations;
+	const validIds = new Set(dt.notations.map((n) => n.notation_id));
+	return allNotations.filter((n) => validIds.has(n.id));
+}
+
+const NOTATIONS: Notation[] = [
+	{ id: 'simple', name: 'Simple' },
+	{ id: 'doview', name: 'DoView' },
+	{ id: 'c4', name: 'C4' },
+	{ id: 'markdown', name: 'Markdown' },
+];
+
+const DIAGRAM_TYPES: DiagramType[] = [
+	{ id: 'outcomes_map', name: 'Outcomes Map', notations: [{ notation_id: 'doview' }] },
+	{ id: 'overview', name: 'Overview', notations: [{ notation_id: 'doview' }] },
+	{ id: 'container', name: 'Container', notations: [{ notation_id: 'c4' }] },
+	{ id: 'doview_analysis', name: 'DoView Analysis', notations: [{ notation_id: 'markdown' }] },
+	{ id: 'component', name: 'Component', notations: [{ notation_id: 'simple' }, { notation_id: 'c4' }] },
+];
+
+describe('compatibleDiagramTypes — Notation → Diagram type cascade', () => {
+	it('returns every diagram_type when no notation filter is set', () => {
+		expect(compatibleDiagramTypes(null, DIAGRAM_TYPES)).toEqual(DIAGRAM_TYPES);
+	});
+
+	it('filters to doview-compatible types when notation=doview', () => {
+		const result = compatibleDiagramTypes('doview', DIAGRAM_TYPES);
+		expect(result.map((d) => d.id)).toEqual(['outcomes_map', 'overview']);
+	});
+
+	it('includes multi-notation types like component (simple + c4)', () => {
+		const c4 = compatibleDiagramTypes('c4', DIAGRAM_TYPES).map((d) => d.id);
+		expect(c4).toContain('container');
+		expect(c4).toContain('component');
+		const simple = compatibleDiagramTypes('simple', DIAGRAM_TYPES).map((d) => d.id);
+		expect(simple).toEqual(['component']);
+	});
+});
+
+describe('compatibleNotations — Diagram type → Notation cascade', () => {
+	it('returns every notation when no diagram_type filter is set', () => {
+		expect(compatibleNotations(null, DIAGRAM_TYPES, NOTATIONS)).toEqual(NOTATIONS);
+	});
+
+	it('filters to a diagram_types compatible notations', () => {
+		const r = compatibleNotations('outcomes_map', DIAGRAM_TYPES, NOTATIONS);
+		expect(r.map((n) => n.id)).toEqual(['doview']);
+	});
+
+	it('returns multi-notation set when diagram_type has multiple', () => {
+		const r = compatibleNotations('component', DIAGRAM_TYPES, NOTATIONS);
+		expect(r.map((n) => n.id).sort()).toEqual(['c4', 'simple']);
+	});
+
+	it('returns all when diagram_type has no notations field (defensive)', () => {
+		const dts: DiagramType[] = [{ id: 'lonely', name: 'Lonely' }];
+		const r = compatibleNotations('lonely', dts, NOTATIONS);
+		expect(r).toEqual(NOTATIONS);
+	});
+});

--- a/frontend/tests/unit/adminPromptFilterInclusion.test.ts
+++ b/frontend/tests/unit/adminPromptFilterInclusion.test.ts
@@ -1,0 +1,88 @@
+/**
+ * v5.17.0 (ADR-162) — `isNotationScopeMatch` lets the admin AI
+ * prompts table show diagram_type-layer rows whose `notation` is
+ * null but whose `diagram_type` maps to the selected notation via
+ * diagram_type_notations. Fixes "selecting doview shows only 1
+ * prompt" because the previous exact-match predicate excluded those
+ * indirect rows.
+ *
+ * Notation-agnostic: works the same way for every notation.
+ *
+ * Inline copy of the predicate; keep in sync with
+ * `frontend/src/routes/admin/settings/ai/+page.svelte`.
+ */
+import { describe, it, expect } from 'vitest';
+
+type NotationMapping = { notation_id: string };
+type DiagramType = { id: string; name: string; notations?: NotationMapping[] };
+
+function isNotationScopeMatch(
+	p: { notation: string | null; diagram_type: string | null },
+	notationFilterValue: string,
+	allDts: DiagramType[],
+): boolean {
+	if (!notationFilterValue) return true;
+	if ((p.notation ?? '') === notationFilterValue) return true;
+	if (!p.diagram_type) return false;
+	const dt = allDts.find((d) => d.id === p.diagram_type);
+	return !!(dt?.notations ?? []).some((n) => n.notation_id === notationFilterValue);
+}
+
+const DTS: DiagramType[] = [
+	{ id: 'outcomes_map', name: 'Outcomes Map', notations: [{ notation_id: 'doview' }] },
+	{ id: 'overview', name: 'Overview', notations: [{ notation_id: 'doview' }] },
+	{ id: 'doview_analysis', name: 'DoView Analysis', notations: [{ notation_id: 'markdown' }] },
+];
+
+describe('isNotationScopeMatch — admin AI prompts row inclusion', () => {
+	it('returns every row when filter is empty', () => {
+		const p = { notation: null, diagram_type: null };
+		expect(isNotationScopeMatch(p, '', DTS)).toBe(true);
+	});
+
+	it('matches direct notation (layer=notation, layer=override row)', () => {
+		// creation-doview-notation-v1: notation='doview', diagram_type=null
+		const p = { notation: 'doview', diagram_type: null };
+		expect(isNotationScopeMatch(p, 'doview', DTS)).toBe(true);
+	});
+
+	it('matches indirect via diagram_type_notations (layer=diagram_type row)', () => {
+		// creation-outcomes-map-v1: notation=null, diagram_type='outcomes_map'
+		// — outcomes_map maps to doview, so should appear under notation=doview.
+		const p = { notation: null, diagram_type: 'outcomes_map' };
+		expect(isNotationScopeMatch(p, 'doview', DTS)).toBe(true);
+	});
+
+	it('excludes base-layer rows from notation-specific filters', () => {
+		// creation-base-v1: notation=null, diagram_type=null
+		const p = { notation: null, diagram_type: null };
+		expect(isNotationScopeMatch(p, 'doview', DTS)).toBe(false);
+	});
+
+	it('excludes unrelated-notation rows', () => {
+		// A markdown notation-layer row should not appear under notation=doview.
+		const p = { notation: 'markdown', diagram_type: null };
+		expect(isNotationScopeMatch(p, 'doview', DTS)).toBe(false);
+	});
+
+	it('excludes diagram_types not mapped to the filter notation', () => {
+		// doview_analysis maps to markdown, not doview.
+		const p = { notation: null, diagram_type: 'doview_analysis' };
+		expect(isNotationScopeMatch(p, 'doview', DTS)).toBe(false);
+	});
+
+	it('reproduces the v5.17.0 fix-target: doview filter shows all 3 doview-relevant rows', () => {
+		// Three doview-relevant rows from v5.8.x+:
+		const rows = [
+			{ id: 'creation-doview-notation-v1', notation: 'doview', diagram_type: null },
+			{ id: 'creation-outcomes-map-v1', notation: null, diagram_type: 'outcomes_map' },
+			{ id: 'creation-doview-overview-v1', notation: null, diagram_type: 'overview' },
+		];
+		const matched = rows.filter((p) => isNotationScopeMatch(p, 'doview', DTS));
+		expect(matched.map((r) => r.id)).toEqual([
+			'creation-doview-notation-v1',
+			'creation-outcomes-map-v1',
+			'creation-doview-overview-v1',
+		]);
+	});
+});

--- a/frontend/tests/unit/authStoreLocalStorageFallback.test.ts
+++ b/frontend/tests/unit/authStoreLocalStorageFallback.test.ts
@@ -1,0 +1,94 @@
+/**
+ * v5.17.0 (ADR-162) — auth store falls back to localStorage when
+ * sessionStorage is empty, then re-seeds sessionStorage so the
+ * current tab caches the data going forward.
+ *
+ * Fixes the symptom where a new browser window opened from Claude's
+ * pairing-page link saw the user as anonymous even when sibling tabs
+ * had the auth state — sessionStorage is per-tab; localStorage is
+ * shared. The store wrote to BOTH on save but only read from sessionStorage.
+ *
+ * Tests are pure logic on the loadFromSession contract; we keep an
+ * inline copy of the helper to avoid pulling in the Svelte rune
+ * runtime for a unit test. Keep in sync with
+ * `frontend/src/lib/stores/auth.svelte.ts`.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+const STORAGE_KEY = 'iris_auth';
+
+interface StoredAuth {
+	accessToken: string;
+	refreshToken: string;
+	user: { id: string; username: string; role: string; is_active: boolean };
+}
+
+class MemoryStorage implements Storage {
+	private store = new Map<string, string>();
+	get length(): number { return this.store.size; }
+	clear(): void { this.store.clear(); }
+	getItem(k: string): string | null { return this.store.get(k) ?? null; }
+	key(i: number): string | null { return Array.from(this.store.keys())[i] ?? null; }
+	removeItem(k: string): void { this.store.delete(k); }
+	setItem(k: string, v: string): void { this.store.set(k, v); }
+}
+
+// Inline copy of loadFromSession with the v5.17.0 fallback behaviour.
+function loadFromSession(
+	sessionStorage: Storage,
+	localStorage: Storage,
+): StoredAuth | null {
+	try {
+		let raw = sessionStorage.getItem(STORAGE_KEY);
+		if (!raw) {
+			raw = localStorage.getItem(STORAGE_KEY);
+			if (raw) sessionStorage.setItem(STORAGE_KEY, raw);
+		}
+		if (!raw) return null;
+		return JSON.parse(raw) as StoredAuth;
+	} catch {
+		return null;
+	}
+}
+
+describe('loadFromSession — cross-tab localStorage fallback', () => {
+	let ss: MemoryStorage;
+	let ls: MemoryStorage;
+
+	beforeEach(() => {
+		ss = new MemoryStorage();
+		ls = new MemoryStorage();
+	});
+
+	const sample: StoredAuth = {
+		accessToken: 'tok',
+		refreshToken: 'ref',
+		user: { id: 'u1', username: 'admin', role: 'Architect', is_active: true },
+	};
+
+	it('reads sessionStorage when present (unchanged behaviour)', () => {
+		ss.setItem(STORAGE_KEY, JSON.stringify(sample));
+		expect(loadFromSession(ss, ls)).toEqual(sample);
+	});
+
+	it('falls back to localStorage when sessionStorage is empty', () => {
+		ls.setItem(STORAGE_KEY, JSON.stringify(sample));
+		const result = loadFromSession(ss, ls);
+		expect(result).toEqual(sample);
+	});
+
+	it('re-seeds sessionStorage on localStorage fallback', () => {
+		ls.setItem(STORAGE_KEY, JSON.stringify(sample));
+		loadFromSession(ss, ls);
+		expect(ss.getItem(STORAGE_KEY)).toBe(JSON.stringify(sample));
+	});
+
+	it('returns null when both stores are empty', () => {
+		expect(loadFromSession(ss, ls)).toBeNull();
+	});
+
+	it('returns null on corrupt JSON (and does not throw)', () => {
+		ls.setItem(STORAGE_KEY, 'not json');
+		expect(loadFromSession(ss, ls)).toBeNull();
+	});
+});

--- a/frontend/tests/unit/loginRedirectBack.test.ts
+++ b/frontend/tests/unit/loginRedirectBack.test.ts
@@ -1,0 +1,54 @@
+/**
+ * v5.17.0 (ADR-162) — /login honours a same-origin `?redirect=`
+ * query param after sign-in, so signing in from /settings/mcp-pairing
+ * returns the user there, not to the dashboard. Same-origin paths
+ * only — external/protocol redirects rejected to /.
+ *
+ * Inline copy of `safeRedirectTarget` so we can unit-test the
+ * validation without spinning up SvelteKit's $app/state. Keep in
+ * sync with `frontend/src/routes/login/+page.svelte`.
+ */
+import { describe, it, expect } from 'vitest';
+
+function safeRedirectTarget(redirect: string | null): string {
+	if (!redirect) return '/';
+	if (!redirect.startsWith('/')) return '/';
+	if (redirect.startsWith('//')) return '/';
+	if (redirect.includes('://')) return '/';
+	if (/\s/.test(redirect)) return '/';
+	return redirect;
+}
+
+describe('safeRedirectTarget — login redirect-back validation', () => {
+	it('returns / when no redirect provided', () => {
+		expect(safeRedirectTarget(null)).toBe('/');
+	});
+
+	it('honours a same-origin path', () => {
+		expect(safeRedirectTarget('/settings/mcp-pairing')).toBe('/settings/mcp-pairing');
+	});
+
+	it('honours a deeper same-origin path with query', () => {
+		expect(safeRedirectTarget('/admin/users?role=admin')).toBe('/admin/users?role=admin');
+	});
+
+	it('rejects protocol-relative URLs (//evil.example)', () => {
+		expect(safeRedirectTarget('//evil.example/path')).toBe('/');
+	});
+
+	it('rejects absolute URLs with scheme', () => {
+		expect(safeRedirectTarget('https://evil.example/path')).toBe('/');
+		expect(safeRedirectTarget('http://evil.example')).toBe('/');
+		expect(safeRedirectTarget('javascript://alert(1)')).toBe('/');
+	});
+
+	it('rejects paths not starting with /', () => {
+		expect(safeRedirectTarget('settings/mcp-pairing')).toBe('/');
+		expect(safeRedirectTarget('../etc/passwd')).toBe('/');
+	});
+
+	it('rejects paths containing whitespace', () => {
+		expect(safeRedirectTarget('/path with space')).toBe('/');
+		expect(safeRedirectTarget('/path\twith\ttab')).toBe('/');
+	});
+});

--- a/iris-client/src/iris_client/client.py
+++ b/iris-client/src/iris_client/client.py
@@ -466,19 +466,37 @@ class IrisClient:
 
     # --- Response-format prompts (ADR-157, v5.12.0) -------------------------
 
-    async def list_response_format_types(self) -> list["ResponseFormatType"]:
-        """List distinct (notation, diagram_type) pairs that have at least one
-        active response_format prompt. Anonymous-readable."""
-        response = await self._request("GET", "/api/ai/response-prompts/types")
+    async def list_response_format_types(
+        self, *, purpose: str = "response_format",
+    ) -> list["ResponseFormatType"]:
+        """List distinct (notation, diagram_type) pairs that have at least
+        one active prompt of the requested purpose. Anonymous-readable.
+
+        `purpose` defaults to ``response_format`` (backwards-compatible).
+        Pass ``creation_format`` to discover diagram-creation-capable
+        pairs (ADR-162, v5.17.0)."""
+        response = await self._request(
+            "GET", "/api/ai/response-prompts/types",
+            params={"purpose": purpose},
+        )
         return [ResponseFormatType.model_validate(r) for r in response.json()]
 
     async def get_response_prompt(
-        self, notation: str, diagram_type: str | None = None,
+        self,
+        notation: str,
+        diagram_type: str | None = None,
+        *,
+        purpose: str = "response_format",
     ) -> "ResponsePromptComposed":
-        """Fetch the composed response_format cascade for a (notation,
+        """Fetch the composed prompt cascade for a (notation,
         diagram_type) pair. Anonymous-readable. Returns the composed body
-        as the `body` field; empty string if no rows match."""
-        params: dict[str, str] = {"notation": notation}
+        as the `body` field; empty string if no rows match.
+
+        `purpose` defaults to ``response_format`` for backwards
+        compatibility. Pass ``creation_format`` to get the layered
+        creation cascade Iris AI uses when generating diagrams — used
+        by MCP clients to drive local-AI diagram creation (ADR-162)."""
+        params: dict[str, str] = {"notation": notation, "purpose": purpose}
         if diagram_type is not None:
             params["diagram_type"] = diagram_type
         response = await self._request(

--- a/iris-client/tests/test_creation_prompts.py
+++ b/iris-client/tests/test_creation_prompts.py
@@ -1,0 +1,77 @@
+"""iris-client purpose-aware prompt-fetch methods (ADR-162, SPEC-162-A).
+
+Verifies that `list_response_format_types` and `get_response_prompt`
+pass the new `purpose` kwarg through to the backend, defaulting to
+`response_format` for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from iris_client import IrisClient
+
+
+class TestListResponseFormatTypesPurpose:
+    @pytest.mark.asyncio
+    async def test_default_sends_purpose_response_format(
+        self, anon_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(
+            "http://iris.test/api/ai/response-prompts/types",
+        ).mock(return_value=httpx.Response(200, json=[]))
+        await anon_client.list_response_format_types()
+        url = route.calls.last.request.url
+        assert "purpose=response_format" in str(url)
+
+    @pytest.mark.asyncio
+    async def test_creation_format_passes_through(
+        self, anon_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(
+            "http://iris.test/api/ai/response-prompts/types",
+        ).mock(return_value=httpx.Response(200, json=[]))
+        await anon_client.list_response_format_types(purpose="creation_format")
+        url = route.calls.last.request.url
+        assert "purpose=creation_format" in str(url)
+
+
+class TestGetResponsePromptPurpose:
+    @pytest.mark.asyncio
+    async def test_default_sends_purpose_response_format(
+        self, anon_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(
+            "http://iris.test/api/ai/response-prompts/composed",
+        ).mock(return_value=httpx.Response(
+            200, json={"notation": "doview", "diagram_type": None, "body": ""},
+        ))
+        await anon_client.get_response_prompt("doview")
+        url = route.calls.last.request.url
+        assert "purpose=response_format" in str(url)
+        assert "notation=doview" in str(url)
+
+    @pytest.mark.asyncio
+    async def test_creation_format_with_diagram_type_passes_through(
+        self, anon_client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(
+            "http://iris.test/api/ai/response-prompts/composed",
+        ).mock(return_value=httpx.Response(
+            200,
+            json={
+                "notation": "doview",
+                "diagram_type": "outcomes_map",
+                "body": "Stage 0 — SETUP QUESTIONS...",
+            },
+        ))
+        resp = await anon_client.get_response_prompt(
+            "doview", "outcomes_map", purpose="creation_format",
+        )
+        url = route.calls.last.request.url
+        assert "purpose=creation_format" in str(url)
+        assert "notation=doview" in str(url)
+        assert "diagram_type=outcomes_map" in str(url)
+        assert resp.body.startswith("Stage 0")

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.16.0"
+version = "5.17.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -91,6 +91,30 @@ destination. Do not pick a destination silently.
 """.strip()
 
 
+_CREATION_FLOW_PREAMBLE = """
+Generic save for a new diagram of any (notation, diagram_type) pair.
+
+CREATION FLOW (recommended):
+  1. Discover: call list_notations / list_diagram_types if you don't
+     already know which (notation, diagram_type) the user wants.
+  2. Fetch the creation guidance: get_response_prompt(notation=...,
+     diagram_type=..., purpose='creation_format'). The body carries
+     the layered creation cascade (base + notation + diagram_type)
+     used by Iris AI when generating diagrams. For DoView it includes
+     the Stage 0 setup questions (Q1..Q6), the entity types, the
+     colour palette, and the outcomes_map layout rules.
+  3. Run the guided conversation IN CHAT with the user. Use
+     AskUserQuestion when supported; numbered list otherwise.
+  4. Compose the `data` JSON locally per the creation prompt's rules.
+     For visual diagrams (notation in doview / archimate / c4 / uml /
+     simple / bpmn), data is a Svelte-Flow-shaped {nodes, edges}
+     payload. For markdown diagrams, data is {"content": "<markdown>"}.
+  5. Confirm destination with the user (see destination preamble
+     below).
+  6. Call create_diagram with the composed data.
+""".strip()
+
+
 @dataclass(frozen=True)
 class Tool:
     name: str
@@ -223,18 +247,33 @@ async def _apply_diagram_creation(c: IrisClient, args: dict[str, Any]) -> str:
     return resp.model_dump_json()
 
 
-async def _list_response_format_types(c: IrisClient, _args: dict[str, Any]) -> str:
-    """ADR-157 (v5.12.0): list response-format types available."""
-    items = await c.list_response_format_types()
+async def _list_response_format_types(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-157 (v5.12.0): list response-format / creation-format types.
+
+    `purpose` defaults to `response_format` (existing behaviour);
+    `creation_format` lists the (notation, diagram_type) pairs that
+    have authored creation_format prompts so a local-AI MCP client
+    can pick a target for diagram drafting (ADR-162, v5.17.0).
+    """
+    items = await c.list_response_format_types(
+        purpose=args.get("purpose", "response_format"),
+    )
     return json.dumps([item.model_dump() for item in items])
 
 
 async def _get_response_prompt(c: IrisClient, args: dict[str, Any]) -> str:
-    """ADR-157 (v5.12.0): fetch the composed response_format prompt
-    cascade for a (notation, diagram_type) pair."""
+    """ADR-157 (v5.12.0); ADR-162 (v5.17.0): fetch the composed prompt
+    cascade for a (notation, diagram_type) pair.
+
+    `purpose='response_format'` (default) returns the output-shape
+    rules. `purpose='creation_format'` returns the layered creation
+    cascade — Iris AI uses this server-side when generating diagrams;
+    a local-AI MCP client uses it to drive `create_diagram`.
+    """
     resp = await c.get_response_prompt(
         args["notation"],
         diagram_type=args.get("diagram_type"),
+        purpose=args.get("purpose", "response_format"),
     )
     return resp.model_dump_json()
 
@@ -297,6 +336,47 @@ async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
     except IrisAuthError:
         return _auth_required_payload("Create package")
     return result.model_dump_json()
+
+
+async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-162 (v5.17.0): generic save for a new diagram of any
+    (notation, diagram_type) pair. The caller is expected to have
+    fetched the creation cascade for the chosen pair, run the guided
+    conversation with the user, composed the `data` payload locally,
+    and confirmed a destination. See the tool's description for the
+    full workflow."""
+    try:
+        diagram = await c.create_diagram(
+            diagram_type=args["diagram_type"],
+            notation=args.get("notation"),
+            name=args["name"],
+            data=args.get("data"),
+            set_id=args["set_id"],
+            parent_package_id=args.get("parent_package_id"),
+            description=args.get("description"),
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create diagram")
+    return diagram.model_dump_json()
+
+
+async def _list_notations(c: IrisClient, _args: dict[str, Any]) -> str:
+    """ADR-162 (v5.17.0): list the registered notations
+    (simple / uml / archimate / c4 / doview / markdown / bpmn) so a
+    local-AI MCP client can discover what's authorable. Wraps the
+    existing /api/registry/notations endpoint."""
+    response = await c._request("GET", "/api/registry/notations")
+    return json.dumps(response.json())
+
+
+async def _list_diagram_types(c: IrisClient, _args: dict[str, Any]) -> str:
+    """ADR-162 (v5.17.0): list the registered diagram_types with their
+    compatible notation_ids (from diagram_type_notations). Wraps the
+    existing /api/registry/diagram-types endpoint. The `notations`
+    field on each row tells callers which notations are compatible —
+    use this to filter the (notation, diagram_type) pair space."""
+    response = await c._request("GET", "/api/registry/diagram-types")
+    return json.dumps(response.json())
 
 
 async def _iris_authenticate(c: IrisClient, args: dict[str, Any]) -> str:
@@ -663,26 +743,46 @@ TOOLS: list[Tool] = [
     Tool(
         name="list_response_format_types",
         description=(
-            "List response-format types available — (notation, diagram_type) "
-            "pairs that have authored response_format prompts in Iris. Use "
-            "to discover which formats can be applied to your response "
-            "(e.g. notation='markdown' diagram_type='doview_analysis' for "
-            "the formal handbook-grounded outcomes-theory analysis shape)."
+            "List (notation, diagram_type) pairs that have authored prompts "
+            "in Iris (ADR-157, v5.12.0; ADR-162, v5.17.0). Default "
+            "purpose='response_format' returns output-shape pairs (e.g. "
+            "markdown/doview_analysis for formal outcomes-theory analyses). "
+            "Pass purpose='creation_format' to list pairs with authored "
+            "creation rules — pair with create_diagram for local-AI diagram "
+            "creation."
         ),
-        input_schema=_schema({}),
+        input_schema=_schema({
+            "purpose": (
+                {
+                    "type": "string",
+                    "enum": ["response_format", "creation_format"],
+                    "default": "response_format",
+                    "description": (
+                        "Which prompt purpose to list. 'response_format' "
+                        "(default) for output-shape rules; "
+                        "'creation_format' for the drafting/composition "
+                        "rules used when generating diagrams."
+                    ),
+                },
+                False,
+            ),
+        }),
         handler=_list_response_format_types,
     ),
     Tool(
         name="get_response_prompt",
         description=(
-            "Fetch the composed response_format prompt for a "
-            "(notation, diagram_type) pair (ADR-157). Returns the layered "
-            "cascade (base + notation + diagram_type) as `body`. Apply the "
-            "body as reference for shaping your response. Use this when "
-            "the user asks for a formal output style matching one of the "
-            "available types from `list_response_format_types` — for "
-            "DoView outcomes-theory analyses call with notation='markdown' "
-            "diagram_type='doview_analysis'."
+            "Fetch the composed prompt cascade for a (notation, "
+            "diagram_type) pair (ADR-157, v5.12.0; ADR-162, v5.17.0). "
+            "Returns the layered cascade (base + notation + diagram_type) "
+            "as `body`. Default purpose='response_format' returns the "
+            "output-shape rules; pass purpose='creation_format' to get the "
+            "drafting cascade Iris AI uses when generating a diagram — "
+            "use this to drive create_diagram from a local-AI MCP client. "
+            "Example: get_response_prompt(notation='doview', "
+            "diagram_type='outcomes_map', purpose='creation_format') "
+            "returns the Stage 0 setup questions + DoView methodology + "
+            "outcomes_map layout rules."
         ),
         input_schema=_schema({
             "notation": _str_arg(
@@ -693,6 +793,20 @@ TOOLS: list[Tool] = [
                 "Diagram type id, e.g. 'doview_analysis'. Optional — when "
                 "absent, returns the base + notation cascade only.",
                 required=False,
+            ),
+            "purpose": (
+                {
+                    "type": "string",
+                    "enum": ["response_format", "creation_format"],
+                    "default": "response_format",
+                    "description": (
+                        "Which prompt cascade to compose. "
+                        "'response_format' (default) for output-shape "
+                        "rules; 'creation_format' for the drafting / "
+                        "composition rules used when generating a diagram."
+                    ),
+                },
+                False,
             ),
         }),
         handler=_get_response_prompt,
@@ -722,10 +836,14 @@ TOOLS: list[Tool] = [
     Tool(
         name="save_doview_analysis",
         description=(
+            "[Deprecated since v5.17.0 (ADR-162): prefer create_diagram("
+            "notation='markdown', diagram_type='doview_analysis', "
+            "set_id=..., name=..., data={'content': '<markdown>'}, "
+            "parent_package_id=?). Will be removed in v6.0.0.]\n\n"
             "Persist a generated DoView analysis as a new doview_analysis "
-            "diagram in Iris (ADR-157, v5.12.0). Body is markdown text "
+            "diagram in Iris. Body is markdown text "
             "(with embedded mermaid blocks where applicable). Auth required "
-            "— use the iris_authenticate tool (ADR-160) if a previous call "
+            "— use the iris_authenticate tool if a previous call "
             "returned error=auth_required.\n\n"
             + _DESTINATION_PREAMBLE
         ),
@@ -854,6 +972,91 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_create_package,
+    ),
+    # ── Generic diagram creation (ADR-162, v5.17.0) ─────────────────────
+    Tool(
+        name="list_notations",
+        description=(
+            "List the diagram notations registered in Iris (simple, uml, "
+            "archimate, c4, doview, markdown, bpmn). Use to discover what "
+            "the user can pick as a `notation` argument when creating a "
+            "diagram via create_diagram (ADR-162, v5.17.0). Anonymous-"
+            "readable."
+        ),
+        input_schema=_schema({}),
+        handler=_list_notations,
+    ),
+    Tool(
+        name="list_diagram_types",
+        description=(
+            "List the diagram_types registered in Iris with their "
+            "compatible notations. Each entry's `notations` array tells "
+            "you which notation_ids the diagram_type can be authored "
+            "under (e.g. outcomes_map → doview). Use to discover what "
+            "(notation, diagram_type) pair to pass to create_diagram and "
+            "to get_response_prompt(purpose='creation_format') for "
+            "drafting guidance (ADR-162, v5.17.0). Anonymous-readable."
+        ),
+        input_schema=_schema({}),
+        handler=_list_diagram_types,
+    ),
+    Tool(
+        name="create_diagram",
+        description=(
+            _CREATION_FLOW_PREAMBLE
+            + "\n\n"
+            + _DESTINATION_PREAMBLE
+        ),
+        input_schema=_schema({
+            "set_id": _str_arg(
+                "set_id",
+                "Set to save the diagram under (use create_set first if "
+                "the user wants a new set)",
+            ),
+            "name": _str_arg(
+                "name",
+                "Display name for the new diagram (the user's chosen title)",
+            ),
+            "notation": _str_arg(
+                "notation",
+                "Notation id from list_notations (e.g. 'doview', "
+                "'markdown', 'archimate'). Optional but recommended for "
+                "non-trivial diagrams.",
+                required=False,
+            ),
+            "diagram_type": _str_arg(
+                "diagram_type",
+                "Diagram-type id from list_diagram_types compatible with "
+                "the chosen notation (e.g. 'outcomes_map' for doview, "
+                "'doview_analysis' for markdown).",
+            ),
+            "data": (
+                {
+                    "type": "object",
+                    "description": (
+                        "Diagram body. For visual diagrams "
+                        "(doview/archimate/c4/uml/simple/bpmn): "
+                        "Svelte-Flow-shaped {nodes, edges} payload "
+                        "matching the layout rules in the creation "
+                        "prompt. For markdown diagrams: "
+                        "{\"content\": \"<markdown>\"}."
+                    ),
+                    "additionalProperties": True,
+                },
+                False,
+            ),
+            "parent_package_id": _str_arg(
+                "parent_package_id",
+                "Optional package to nest the diagram inside within the set",
+                required=False,
+            ),
+            "description": _str_arg(
+                "description",
+                "Optional short description shown alongside the diagram",
+                required=False,
+            ),
+        }),
+        handler=_create_diagram,
     ),
 ]
 

--- a/mcp/tests/test_tools_authenticate.py
+++ b/mcp/tests/test_tools_authenticate.py
@@ -155,3 +155,82 @@ class TestPATPastePath:
         assert body["success"] is False
         assert body["error"] == "pat_invalid"
         assert token_store.load_token(BASE) is None
+
+
+class TestInSessionTokenPropagation:
+    """v5.17.0 (ADR-162) regression test for the v5.15.0 symptom the
+    user reported: `iris_authenticate` succeeded but the next write
+    tool still returned `auth_required`.
+
+    The mechanism (`IrisClient.set_token`) updates the long-lived
+    client's default Authorization header. This test verifies the
+    next outgoing request actually carries the new bearer — closing
+    the gap in v5.15.0's `test_happy_path_persists_and_updates_
+    in_process_token`, which only asserted `client.token == ...` but
+    didn't verify outgoing-header propagation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pairing_then_create_set_uses_new_pat_in_same_session(
+        self, home: Path, respx_mock: respx.Router,
+    ) -> None:
+        # Long-lived client starts anonymous (mirrors the real flow
+        # where __main__.py constructs the client with no IRIS_TOKEN
+        # and no persisted token).
+        async with IrisClient(url=BASE, token=None) as c:
+            # Mock the pairing exchange.
+            respx_mock.post(
+                f"{BASE}/api/auth/pairing-codes/IRIS-ABCD-EFGH/exchange",
+            ).mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "token": "iris_pat_freshly_minted",
+                        "prefix": "abcd1234",
+                        "expires_at": "2099-01-01T00:00:00+00:00",
+                        "mode": "pairing_code",
+                    },
+                ),
+            )
+
+            # Mock POST /api/sets — gated on the exchanged PAT.
+            def maybe_unauthorized(request: httpx.Request) -> httpx.Response:
+                auth = request.headers.get("authorization", "")
+                if auth == "Bearer iris_pat_freshly_minted":
+                    return httpx.Response(
+                        201,
+                        json={
+                            "id": "set-1",
+                            "name": "X",
+                            "description": None,
+                            "collection_id": None,
+                            "created_at": "2026-05-12T00:00:00+00:00",
+                            "updated_at": "2026-05-12T00:00:00+00:00",
+                        },
+                    )
+                return httpx.Response(401, json={"detail": "no auth"})
+
+            respx_mock.post(f"{BASE}/api/sets").mock(
+                side_effect=maybe_unauthorized,
+            )
+
+            # Step 1: dispatch iris_authenticate
+            r1 = await tools.dispatch(
+                "iris_authenticate", c, {"credential": "IRIS-ABCD-EFGH"},
+            )
+            r1_body = json.loads(r1[0].text)
+            assert r1_body["success"] is True
+            assert c.token == "iris_pat_freshly_minted"
+
+            # Step 2: dispatch create_set on the SAME long-lived client.
+            # The mock backend will return 401 unless the request carries
+            # the new bearer. If create_set succeeds (201), the in-process
+            # token propagation works end-to-end.
+            r2 = await tools.dispatch("create_set", c, {"name": "X"})
+            r2_body = json.loads(r2[0].text)
+            assert "auth_required" not in r2_body, (
+                "create_set received auth_required even though "
+                "iris_authenticate succeeded — set_token didn't "
+                "propagate to outgoing requests (v5.15.0 symptom)."
+            )
+            assert r2_body["id"] == "set-1"

--- a/mcp/tests/test_tools_create_diagram.py
+++ b/mcp/tests/test_tools_create_diagram.py
@@ -1,0 +1,210 @@
+"""create_diagram + list_notations + list_diagram_types tool tests
+(ADR-162, SPEC-162-A).
+
+Covers the generic create_diagram tool's happy paths for multiple
+notations + the auth_required mapping. Asserts the destination-
+confirmation preamble (v5.16.0) AND the creation-flow preamble (v5.17.0)
+both appear in the tool description. Also covers the new list_notations
+and list_diagram_types discoverability tools.
+
+Includes the assertion that save_doview_analysis's description carries
+the deprecation note pointing at create_diagram (v5.17.0 / ADR-162).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+def _diagram_payload(**overrides: object) -> dict[str, object]:
+    """Minimal payload satisfying the iris-client Diagram model."""
+    base = {
+        "id": "d-1",
+        "name": "X",
+        "description": None,
+        "diagram_type": "doview_analysis",
+        "notation": "markdown",
+        "current_version": 1,
+        "data": {"content": "# hi"},
+        "created_at": "2026-05-12T00:00:00+00:00",
+        "updated_at": "2026-05-12T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestInventoryAndDescriptions:
+    def test_three_new_tools_registered(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        assert {"create_diagram", "list_notations", "list_diagram_types"} <= names
+
+    def test_create_diagram_description_carries_both_preambles(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        desc = defs["create_diagram"].description
+        # Creation flow preamble (ADR-162)
+        assert "CREATION FLOW" in desc
+        assert "purpose='creation_format'" in desc
+        # Destination preamble (v5.16.0)
+        assert "BEFORE CALLING, confirm with the user" in desc
+
+    def test_save_doview_analysis_description_carries_deprecation_note(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        desc = defs["save_doview_analysis"].description
+        assert "Deprecated" in desc
+        assert "create_diagram" in desc
+
+    def test_get_response_prompt_accepts_purpose_argument(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        schema = defs["get_response_prompt"].inputSchema
+        assert "purpose" in schema["properties"]
+        assert (
+            schema["properties"]["purpose"]["enum"]
+            == ["response_format", "creation_format"]
+        )
+
+    def test_list_response_format_types_accepts_purpose_argument(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        schema = defs["list_response_format_types"].inputSchema
+        assert "purpose" in schema["properties"]
+
+
+class TestCreateDiagram:
+    @pytest.mark.asyncio
+    async def test_doview_outcomes_map_happy_path(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/diagrams").mock(
+            return_value=httpx.Response(
+                201,
+                json=_diagram_payload(
+                    id="d-doview-1",
+                    name="Climate 2030",
+                    diagram_type="outcomes_map",
+                    notation="doview",
+                    data={"nodes": [], "edges": []},
+                ),
+            ),
+        )
+        result = await tools.dispatch(
+            "create_diagram", client,
+            {
+                "set_id": "set-1",
+                "name": "Climate 2030",
+                "notation": "doview",
+                "diagram_type": "outcomes_map",
+                "data": {"nodes": [], "edges": []},
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "d-doview-1"
+        assert body["notation"] == "doview"
+
+    @pytest.mark.asyncio
+    async def test_markdown_doview_analysis_via_create_diagram(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        """The deprecated save_doview_analysis path is now reachable via
+        the generic create_diagram tool with the same semantics."""
+        respx_mock.post(f"{BASE}/api/diagrams").mock(
+            return_value=httpx.Response(
+                201,
+                json=_diagram_payload(
+                    id="d-md-1",
+                    name="Analysis of X",
+                    diagram_type="doview_analysis",
+                    notation="markdown",
+                    data={"content": "# analysis"},
+                ),
+            ),
+        )
+        result = await tools.dispatch(
+            "create_diagram", client,
+            {
+                "set_id": "set-1",
+                "name": "Analysis of X",
+                "notation": "markdown",
+                "diagram_type": "doview_analysis",
+                "data": {"content": "# analysis"},
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "d-md-1"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required_payload(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/diagrams").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "create_diagram", client,
+            {
+                "set_id": "set-1",
+                "name": "X",
+                "diagram_type": "outcomes_map",
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"
+        assert body["next_tool"] == "iris_authenticate"
+
+
+class TestListNotations:
+    @pytest.mark.asyncio
+    async def test_returns_registry_payload(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/registry/notations").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": "simple", "name": "Simple", "description": None,
+                     "display_order": 1, "is_active": True},
+                    {"id": "doview", "name": "DoView", "description": None,
+                     "display_order": 4, "is_active": True},
+                ],
+            ),
+        )
+        result = await tools.dispatch("list_notations", client, {})
+        body = json.loads(result[0].text)
+        assert isinstance(body, list)
+        assert {n["id"] for n in body} == {"simple", "doview"}
+
+
+class TestListDiagramTypes:
+    @pytest.mark.asyncio
+    async def test_returns_diagram_types_with_notations(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/registry/diagram-types").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "outcomes_map",
+                        "name": "Outcomes Map",
+                        "description": None,
+                        "display_order": 0,
+                        "is_active": True,
+                        "notations": [
+                            {"notation_id": "doview", "notation_name": "DoView", "is_default": True},
+                        ],
+                    },
+                ],
+            ),
+        )
+        result = await tools.dispatch("list_diagram_types", client, {})
+        body = json.loads(result[0].text)
+        assert body[0]["id"] == "outcomes_map"
+        assert body[0]["notations"][0]["notation_id"] == "doview"


### PR DESCRIPTION
## Summary

- **Generic MCP diagram-creation workflow.** Three new tools (`create_diagram`, `list_notations`, `list_diagram_types`) give Claude a notation-agnostic path for authoring any (notation, diagram_type) pair locally. The same workflow covers markdown analyses, visual DoView outcomes_maps, and every other registered diagram type — no web-UI handoff.
- **`get_response_prompt` / `list_response_format_types` gain `purpose` kwarg.** Default stays `response_format`; `purpose='creation_format'` returns the layered creation cascade Iris AI uses internally. Lets a local-AI MCP client pull the Stage 0 setup questions + entity types + layout rules and run the conversation in chat.
- **Workflow lives in the tool description**, not per-scope. The `create_diagram` description carries the universal flow (discover → fetch creation prompt → guided conversation → confirm destination → compose → save). `mcp_system_context` for the Outcomes Theory Book set is trimmed by ~30 lines.
- **`save_doview_analysis` deprecated** (two-stage retirement, removal in v6.0.0). Behaviour unchanged in v5.17.0; description carries the deprecation note pointing at `create_diagram`.
- **Bundled v5.16.0 follow-up fixes:**
  - Cross-tab auth lost between tabs → `loadFromSession` falls back to localStorage and re-seeds sessionStorage.
  - `/login` bounces to dashboard → `/login?redirect=<same-origin-path>` honoured with strict validation.
  - `/admin/settings/ai` filter dropdowns don't constrain each other → cascading via `DiagramTypeRegistry.notations`.
  - `/admin/settings/ai` "doview shows only 1 prompt" → notation-agnostic row-inclusion predicate covering both direct and diagram_type-mapped notation matches.
  - v5.15.0 in-session token-propagation regression test added (closes the test gap that allowed the user's symptom to ship undetected).
- **Housekeeping**: stripped 8 user-visible ADR references from the web UI.

## Test plan

- [x] Backend `tests/test_ai/test_response_prompts_purpose_query.py` — 8 cases (default + creation_format on both endpoints + invalid purpose + suppression-preamble dropped on HTTP path)
- [x] iris-client `tests/test_creation_prompts.py` — 4 cases (purpose passthrough on both methods)
- [x] MCP `tests/test_tools_create_diagram.py` — 10 cases (inventory; both preambles in description; create_diagram across 2 notations; auth_required; list_notations; list_diagram_types; deprecation note in save_doview_analysis)
- [x] MCP `tests/test_tools_authenticate.py` — +1 regression test exercising v5.15.0 symptom (pairing → create_set in one session)
- [x] Frontend 4 new test files — sessionStorage fallback (5), login redirect (7), cascade (7), inclusion (7) = 26 cases
- [x] Full suites still green: iris-client 57, MCP 123, frontend v5.15-v5.17 fixes 40, backend (excluding pre-existing failures) 450
- [ ] Apply trimmed `mcp_system_context` content to the Outcomes Theory Book set on UAT
- [ ] Manual end-to-end on UAT after deploy: visit `/settings/mcp-pairing` from a fresh tab while signed in elsewhere (should NOT show anonymous); sign-in flow returns to original page; `/admin/settings/ai` cascading dropdowns; doview filter shows all 3 doview-mapped rows; Claude Desktop end-to-end create-diagram flow

## Migration

- **No DB migration** this release.
- **Manual on UAT**: paste the trimmed canonical content from `docs/prompts/doview-book-mcp-system-context.md` into the Outcomes Theory Book set's `mcp_system_context` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)