### PR TITLE
release(v5.18.0): centralised admin-editable MCP server instructions (ADR-163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.18.0] - 2026-05-13
+
+### Added
+
+- **Centralised, admin-editable MCP server instructions**
+  (ADR-163, SPEC-163-A). The universal ORIENT-FIRST protocol and
+  DISCOVERY catalogue that v5.13.x → v5.17.x had embedded in every
+  authored scope's `mcp_system_context` are lifted into a single
+  server-wide channel: the MCP spec's `Server(instructions=...)`
+  field, returned in the InitializeResult to every connected MCP
+  client. Universal across every scope. Three clean layers now:
+  per-tool workflow (in tool descriptions), server-wide orient
+  (this), scope-specific menu (per-scope `mcp_system_context`).
+- **New `purpose='mcp_server_instructions'`** on
+  `ai_creation_prompts`. Singleton row at layer=base, seeded by
+  m053 (SQLite) + m057 (Supabase). Admin-editable from
+  `/admin/settings/ai` filtering by the new purpose value —
+  consistent with creation_format and response_format prompts.
+- **New backend endpoint `GET /api/ai/server-instructions`**
+  (anonymous-readable). Returns the singleton row body.
+- **New iris-mcp module `iris_mcp/server_instructions.py`** with
+  `fetch_server_instructions(iris_url)` + a hardcoded fallback
+  baseline. iris-mcp fetches once at startup and passes the body
+  through `build_server(client, instructions=...)` to the MCP SDK.
+  Falls back gracefully if the backend is unreachable / errors /
+  returns empty.
+- **Frontend admin polish.** `PURPOSES` const extended; new
+  `appliesToLabel()` branch renders the singleton row as
+  "Server-wide (MCP instructions)" in the row table and live
+  preview.
+
+### Changed
+
+- **Canonical `doview-book-mcp-system-context.md` trimmed again**
+  to ~12 lines (was ~30 in v5.17.0, ~50 in v5.14.0, ~140 in v5.13.x).
+  The orient-first protocol and discovery catalogue moved to the
+  new server-wide channel. The scope content now carries only
+  what's actually scope-specific: a one-sentence description, the
+  structural-overview call name, and the menu options verbatim.
+  Admin must paste the new shorter content into the Outcomes
+  Theory Book set's `mcp_system_context` field on UAT.
+- **New `docs/prompts/mcp-server-instructions.md`** as the
+  canonical paste-ready content for the new singleton row.
+
+### Migration
+
+- **SQLite**: m053_mcp_server_instructions_seed.py runs
+  automatically on next boot (idempotent INSERT OR IGNORE).
+- **Supabase**: apply `m057_mcp_server_instructions_seed.sql`
+  once. Command: `./scripts/supabase-migrate.sh "$SUPABASE_URL"`.
+- **Manual**: paste the trimmed canonical content from
+  `docs/prompts/doview-book-mcp-system-context.md` into the
+  Outcomes Theory Book set's `mcp_system_context` field on UAT.
+
+### Tests
+
+- ~18 net new tests: 10 backend (endpoint + migration parser +
+  Pydantic Literal extension), 11 MCP (fetch happy path + 6
+  failure-mode fallbacks + 3 wiring), 7 frontend (PURPOSES + 5
+  appliesToLabel branches). Combined MCP suite now 134 (was 123).
+
 ## [5.17.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -314,7 +314,17 @@ for the generic local-AI diagram-creation workflow from v5.17.0).
 The legacy `save_doview_analysis` tool is deprecated in v5.17.0
 (prefer `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`)
 and will be removed in v6.0.0. Plus `iris://` resource URIs for
-JSON export bundles. When `IRIS_WEB_URL` is set, every tool
+JSON export bundles.
+
+**Server-wide orient-first protocol** (v5.18.0 / ADR-163). On every
+session, iris-mcp surfaces an admin-editable orient-first protocol
++ discovery catalogue via the MCP `instructions` channel (returned
+in the InitializeResult to every connected MCP client). Admins
+edit the body at `/admin/settings/ai` filtering by
+`purpose=mcp_server_instructions`; the next MCP session picks up
+the change. iris-mcp falls back to a hardcoded baseline if the
+Iris backend is unreachable at startup, so write tools stay
+usable in degraded states. When `IRIS_WEB_URL` is set, every tool
 response that carries an entity id also carries a resolved front-end
 URL so MCP-using LLMs link back to the live UI without guessing
 hosts. See [`mcp/README.md`](mcp/README.md) and

--- a/backend/app/ai/models.py
+++ b/backend/app/ai/models.py
@@ -197,7 +197,9 @@ class CreationPromptCreate(BaseModel):
 
     name: str = Field(min_length=1, max_length=255)
     description: str | None = None
-    purpose: Literal["creation_format", "response_format"] = "creation_format"
+    purpose: Literal[
+        "creation_format", "response_format", "mcp_server_instructions",
+    ] = "creation_format"
     layer: Literal["base", "notation", "diagram_type", "override"]
     notation: str | None = None
     diagram_type: str | None = None
@@ -239,6 +241,17 @@ class ResponsePromptComposed(BaseModel):
     notation: str
     diagram_type: str | None = None
     body: str  # composed cascade body — may be empty if no rows match
+
+
+class ServerInstructionsResponse(BaseModel):
+    """Singleton MCP-server-instructions body (ADR-163, v5.18.0).
+
+    Returned by `GET /api/ai/server-instructions`. iris-mcp fetches
+    this at startup and passes it to the MCP SDK `Server(instructions=…)`
+    constructor so every MCP client receives it in the InitializeResult.
+    """
+
+    body: str  # may be empty if no active singleton row exists
 
 
 class ResponseFormatType(BaseModel):

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -58,6 +58,7 @@ from app.ai.models import (
     QAResponse,
     ResponseFormatType,
     ResponsePromptComposed,
+    ServerInstructionsResponse,
 )
 from app.auth.dependencies import get_current_user, get_optional_user
 
@@ -873,7 +874,7 @@ async def list_creation_prompts(
 # ---------------------------------------------------------------------------
 
 
-_VALID_PURPOSES = ("response_format", "creation_format")
+_VALID_PURPOSES = ("response_format", "creation_format", "mcp_server_instructions")
 
 
 @router.get("/response-prompts/types", response_model=list[ResponseFormatType])
@@ -991,6 +992,32 @@ async def get_response_prompt_composed(
         diagram_type=diagram_type,
         body=body,
     )
+
+
+@router.get("/server-instructions", response_model=ServerInstructionsResponse)
+async def get_mcp_server_instructions(
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ServerInstructionsResponse:
+    """Return the singleton mcp_server_instructions row body (ADR-163,
+    v5.18.0). Anonymous-readable; iris-mcp fetches at startup to
+    populate the MCP server `instructions` field surfaced to every
+    connected MCP client.
+
+    Empty body if no active row exists — iris-mcp falls back to its
+    hardcoded baseline in that case.
+    """
+    db = request.app.state.db_manager.main_db
+    cursor = await db.execute(
+        "SELECT prompt_text FROM ai_creation_prompts"
+        " WHERE purpose = 'mcp_server_instructions'"
+        "   AND is_active = 1"
+        " ORDER BY display_order ASC, id ASC LIMIT 1",
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return ServerInstructionsResponse(body="")
+    return ServerInstructionsResponse(body=row[0])
 
 
 @router.put("/creation-prompts/{prompt_id}", response_model=CreationPromptResponse)

--- a/backend/app/migrations/m053_mcp_server_instructions_seed.py
+++ b/backend/app/migrations/m053_mcp_server_instructions_seed.py
@@ -1,0 +1,81 @@
+"""Migration 053: seed the MCP server-instructions singleton row
+(ADR-163, SPEC-163-A, v5.18.0).
+
+Inserts one row into `ai_creation_prompts` with the new
+`purpose='mcp_server_instructions'` discriminator value. iris-mcp
+fetches this row's body at startup via `GET /api/ai/server-instructions`
+and passes it to the MCP SDK `Server(instructions=...)` constructor.
+Loaded by every connected MCP client (Claude Desktop, Claude Code,
+Cursor, …) on every session.
+
+Singleton at `layer='base'`, `notation=NULL`, `diagram_type=NULL`.
+Idempotent (INSERT OR IGNORE on id).
+
+The body is the canonical orient-first protocol + discovery catalogue
++ workflow pointers + auth recovery. Source: docs/prompts/mcp-server-instructions.md
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m053_mcp_server_instructions_seed"
+
+
+_SEED_BODY = """\
+You are connected to Iris (an architectural-modelling tool that exposes Collections, Sets, Packages, Diagrams, Elements, and the relationships between them via this MCP server).
+
+ORIENT-FIRST PROTOCOL.
+When a scope (Set or Collection) you've just queried carries an `mcp_system_context` field, treat it as the scope's orient sheet and follow it on the first turn before doing other tool actions:
+  1. Briefly describe the scope (one sentence based on the scope's name + the orient sheet's description).
+  2. If the orient sheet names a structural-overview call (e.g. iris_package_hierarchy for a Set with packages), make that call and surface the contents.
+  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+DISCOVERY TOOLS.
+  list_collections / list_sets / list_packages — structural
+  list_notations / list_diagram_types — what's authorable
+  list_response_format_types(purpose='response_format'|'creation_format') — what output shapes and what drafting cascades exist
+  iris_package_hierarchy(set_id=...) — full tree in one call
+
+WORKFLOW GUIDANCE.
+Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow). For authentication, see `iris_authenticate`.
+
+AUTH RECOVERY.
+Write tools that return error="auth_required" can be unblocked by the iris_authenticate flow — never tell the user to restart their MCP client.
+"""
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    # The `ai_creation_prompts` table is created by m028 / m040; if it
+    # doesn't exist yet (test fixture isolation), skip — the seed makes
+    # no sense without the table.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='ai_creation_prompts'",
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    await db.execute(
+        "INSERT OR IGNORE INTO ai_creation_prompts "
+        "(id, name, description, purpose, layer, notation, diagram_type, "
+        "prompt_text, display_order, is_active) "
+        "VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, 0, 1)",
+        (
+            "mcp-server-instructions-v1",
+            "MCP Server Instructions",
+            (
+                "Universal orient-first protocol + discovery catalogue "
+                "surfaced by iris-mcp via the MCP server `instructions` "
+                "field (ADR-163, v5.18.0). One singleton row at layer=base."
+            ),
+            "mcp_server_instructions",
+            "base",
+            _SEED_BODY,
+        ),
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m057_mcp_server_instructions_seed.sql
+++ b/backend/app/migrations/supabase/m057_mcp_server_instructions_seed.sql
@@ -1,0 +1,44 @@
+-- Migration 057: seed the MCP server-instructions singleton row
+-- (ADR-163, SPEC-163-A, v5.18.0).
+--
+-- Mirrors SQLite m053. One row in `ai_creation_prompts` with the new
+-- `purpose='mcp_server_instructions'` discriminator value. iris-mcp
+-- fetches this at startup via GET /api/ai/server-instructions and
+-- passes the body to the MCP SDK Server(instructions=...) constructor.
+--
+-- Idempotent (ON CONFLICT DO NOTHING on id).
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'mcp-server-instructions-v1',
+    'MCP Server Instructions',
+    'Universal orient-first protocol + discovery catalogue surfaced by iris-mcp via the MCP server `instructions` field (ADR-163, v5.18.0). One singleton row at layer=base.',
+    'mcp_server_instructions',
+    'base',
+    NULL,
+    NULL,
+    $body$You are connected to Iris (an architectural-modelling tool that exposes Collections, Sets, Packages, Diagrams, Elements, and the relationships between them via this MCP server).
+
+ORIENT-FIRST PROTOCOL.
+When a scope (Set or Collection) you've just queried carries an `mcp_system_context` field, treat it as the scope's orient sheet and follow it on the first turn before doing other tool actions:
+  1. Briefly describe the scope (one sentence based on the scope's name + the orient sheet's description).
+  2. If the orient sheet names a structural-overview call (e.g. iris_package_hierarchy for a Set with packages), make that call and surface the contents.
+  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+DISCOVERY TOOLS.
+  list_collections / list_sets / list_packages — structural
+  list_notations / list_diagram_types — what's authorable
+  list_response_format_types(purpose='response_format'|'creation_format') — what output shapes and what drafting cascades exist
+  iris_package_hierarchy(set_id=...) — full tree in one call
+
+WORKFLOW GUIDANCE.
+Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow). For authentication, see `iris_authenticate`.
+
+AUTH RECOVERY.
+Write tools that return error="auth_required" can be unblocked by the iris_authenticate flow — never tell the user to restart their MCP client.
+$body$,
+    0,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -57,6 +57,7 @@ from app.migrations.m049_mcp_prompt_column import up as m049_up
 from app.migrations.m050_rename_mcp_prompt_to_mcp_system_context import up as m050_up
 from app.migrations.m051_response_format_prompts import up as m051_up
 from app.migrations.m052_mcp_pairing_codes import up as m052_up
+from app.migrations.m053_mcp_server_instructions_seed import up as m053_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -140,6 +141,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m050_up(main)
     await m051_up(main)
     await m052_up(main)
+    await m053_up(main)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_ai/test_server_instructions_endpoint.py
+++ b/backend/tests/test_ai/test_server_instructions_endpoint.py
@@ -1,0 +1,157 @@
+"""v5.18.0 (ADR-163, SPEC-163-A): GET /api/ai/server-instructions
+returns the singleton mcp_server_instructions row body. iris-mcp
+fetches this at startup to populate the MCP `Server.instructions`
+field surfaced to every connected MCP client.
+
+Anonymous-readable. Empty body when no active row exists (iris-mcp
+falls back to its hardcoded baseline in that case).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+        rate_limit_general=1000,
+        rate_limit_pat=1000,
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+class TestServerInstructionsEndpoint:
+    async def test_returns_seeded_body(self, client: httpx.AsyncClient) -> None:
+        resp = await client.get("/api/ai/server-instructions")
+        assert resp.status_code == 200
+        body = resp.json()["body"]
+        # The seeded body always contains the orient-first protocol marker.
+        assert "ORIENT-FIRST PROTOCOL" in body
+        assert "DISCOVERY TOOLS" in body
+        assert "AUTH RECOVERY" in body
+
+    async def test_anonymous_readable(self, client: httpx.AsyncClient) -> None:
+        # No Authorization header.
+        resp = await client.get("/api/ai/server-instructions")
+        assert resp.status_code == 200
+
+    async def test_empty_body_when_row_deactivated(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        # Deactivate the singleton row directly via SQL.
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[attr-defined]
+        await db.execute(
+            "UPDATE ai_creation_prompts SET is_active = 0"
+            " WHERE purpose = 'mcp_server_instructions'",
+        )
+        await db.commit()
+        resp = await client.get("/api/ai/server-instructions")
+        assert resp.status_code == 200
+        assert resp.json()["body"] == ""
+
+    async def test_returns_most_recent_when_multiple_rows_exist(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        # The singleton seed is row-1. Add a second active row with a
+        # later id; the endpoint should still return the seeded one
+        # (order by display_order ASC, id ASC LIMIT 1).
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[attr-defined]
+        await db.execute(
+            "INSERT INTO ai_creation_prompts "
+            "(id, name, description, purpose, layer, notation, diagram_type, "
+            " prompt_text, display_order, is_active) "
+            "VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, 1, 1)",
+            (
+                "mcp-server-instructions-v2-experimental",
+                "Experimental v2",
+                "test row",
+                "mcp_server_instructions",
+                "base",
+                "OVERRIDDEN BODY",
+            ),
+        )
+        await db.commit()
+        resp = await client.get("/api/ai/server-instructions")
+        body = resp.json()["body"]
+        # display_order=0 (the seed) wins over display_order=1.
+        assert "ORIENT-FIRST PROTOCOL" in body
+        assert "OVERRIDDEN BODY" not in body
+
+
+class TestPurposeAcceptedByCreationPromptPydantic:
+    """Adding `mcp_server_instructions` to the Pydantic Literal means
+    POST /api/ai/creation-prompts no longer rejects it.
+
+    (Adding NEW server-instructions rows via the CRUD is an admin
+    affordance; the seed migration handles day-one.)"""
+
+    async def test_post_with_new_purpose_value_does_not_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        # Create an admin so we can hit the auth-required CRUD endpoint.
+        await client.post(
+            "/api/auth/setup",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        login = await client.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        token = login.json()["access_token"]
+
+        resp = await client.post(
+            "/api/ai/creation-prompts",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "name": "Test mcp_server_instructions extra",
+                "description": "test",
+                "purpose": "mcp_server_instructions",
+                "layer": "base",
+                "notation": None,
+                "diagram_type": None,
+                "prompt_text": "test body",
+                "display_order": 99,
+                "is_active": False,
+            },
+        )
+        # Either 201 (accepted) or 409 (conflict with existing active
+        # singleton) is fine — both prove the Pydantic Literal accepts
+        # the new value. 422 would indicate the Literal rejected it.
+        assert resp.status_code in (201, 409), (
+            f"expected 201 or 409, got {resp.status_code}: {resp.text}"
+        )

--- a/backend/tests/test_migrations/test_mcp_server_instructions_seed.py
+++ b/backend/tests/test_migrations/test_mcp_server_instructions_seed.py
@@ -1,0 +1,64 @@
+"""v5.18.0 (ADR-163, SPEC-163-A): static-parser test for the SQLite
+m053 + Supabase m057 seed migrations that insert the singleton
+`mcp_server_instructions` row into `ai_creation_prompts`.
+
+Verifies:
+- both migrations exist
+- both reference the new purpose value
+- both insert at layer=base with notation/diagram_type NULL
+- both are idempotent (INSERT OR IGNORE / ON CONFLICT DO NOTHING)
+- the seeded body contains the orient-first protocol + discovery markers
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_sqlite_m053_inserts_singleton_row() -> None:
+    py = _read("app/migrations/m053_mcp_server_instructions_seed.py")
+    assert "INSERT OR IGNORE INTO ai_creation_prompts" in py
+    assert "mcp-server-instructions-v1" in py
+    assert "mcp_server_instructions" in py
+    # NULL for notation and diagram_type — singleton row.
+    assert "VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, 0, 1)" in py
+
+
+def test_sqlite_m053_seed_body_contains_protocol_markers() -> None:
+    py = _read("app/migrations/m053_mcp_server_instructions_seed.py")
+    assert "ORIENT-FIRST PROTOCOL" in py
+    assert "DISCOVERY TOOLS" in py
+    assert "WORKFLOW GUIDANCE" in py
+    assert "AUTH RECOVERY" in py
+
+
+def test_sqlite_m053_is_idempotent() -> None:
+    py = _read("app/migrations/m053_mcp_server_instructions_seed.py")
+    # Idempotency guards: INSERT OR IGNORE on the unique id, plus a
+    # table-existence check that no-ops on isolated test fixtures.
+    assert "INSERT OR IGNORE" in py
+    assert "ai_creation_prompts" in py
+
+
+def test_supabase_m057_inserts_singleton_row() -> None:
+    sql = _read("app/migrations/supabase/m057_mcp_server_instructions_seed.sql")
+    assert "INSERT INTO public.ai_creation_prompts" in sql
+    assert "'mcp-server-instructions-v1'" in sql
+    assert "'mcp_server_instructions'" in sql
+    assert "'base'" in sql
+    assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
+def test_supabase_m057_seed_body_matches_sqlite() -> None:
+    sql = _read("app/migrations/supabase/m057_mcp_server_instructions_seed.sql")
+    # Same canonical body markers as the SQLite seed.
+    assert "ORIENT-FIRST PROTOCOL" in sql
+    assert "DISCOVERY TOOLS" in sql
+    assert "WORKFLOW GUIDANCE" in sql
+    assert "AUTH RECOVERY" in sql

--- a/docs/adrs/ADR-163-Centralised-MCP-Server-Instructions.md
+++ b/docs/adrs/ADR-163-Centralised-MCP-Server-Instructions.md
@@ -1,0 +1,86 @@
+# ADR-163: Centralised, admin-editable MCP server instructions
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md), [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md), [ADR-162](ADR-162-Generic-MCP-Diagram-Creation-Workflow.md)
+
+## Context
+
+v5.17.0 (ADR-162) moved diagram-creation workflow logic out of per-scope `mcp_system_context` into the `create_diagram` tool's description. Good progress, but the canonical content for the Outcomes Theory Book set still embedded two universal mechanisms that any authored scope would duplicate:
+
+- **ORIENT-FIRST protocol** — "describe the scope, call the structural-overview command, present the menu verbatim, AskUserQuestion or numbered list". Identical for every scope; only the menu differs.
+- **DISCOVERY catalogue** — the list of universal tools (`list_response_format_types`, `iris_package_hierarchy`, etc.). Not scope-specific at all.
+
+Real testing of v5.17.0 surfaced the question: can the universal mechanism be lifted out so that authoring a new scope just means writing the scope-specific menu + a one-sentence description, not re-pasting the protocol boilerplate?
+
+The MCP spec has the exact channel for this: `Server(name, instructions=...)`. The instructions are returned in the InitializeResult and loaded by every compliant MCP client (Claude Desktop / Claude Code / Cursor) on every session. Universal across every scope, every tool call.
+
+The same testing surfaced a corollary requirement: the content must be **admin-editable from `/admin/settings/ai`**, consistent with every other prompt-shape concern in Iris (creation_format prompts, response_format prompts, per-scope `mcp_system_context`). Hardcoding the instructions in iris-mcp Python code would be the lone exception, and would create a friction every time the protocol needs to evolve.
+
+## Decision
+
+Introduce a third `purpose` value on `ai_creation_prompts`: `mcp_server_instructions`. Singleton row at `layer='base'`, `notation=NULL`, `diagram_type=NULL`. Seeded in v5.18.0 with the orient-first protocol + discovery catalogue + auth-recovery + workflow-pointers text.
+
+Backend exposes the row body via `GET /api/ai/server-instructions` (anonymous-readable; no auth required because the instructions describe how to use the MCP server, not its data).
+
+iris-mcp fetches the body once at startup and passes it to `Server(name=..., instructions=...)`. The MCP SDK already accepts the `instructions` constructor parameter (verified via signature inspection); the InitializeResult surfaces it on every session.
+
+`/admin/settings/ai` surfaces the new purpose in its existing filter/edit machinery — extend the `PURPOSES` Svelte const and the `appliesToLabel()` helper. No new UI components.
+
+iris-mcp keeps a **hardcoded fallback baseline** in `iris_mcp/server_instructions.py`. The fallback fires only when the backend is unreachable at startup, so iris-mcp stays functional in degraded states. The fallback text matches the seeded body on day one (acceptable DRY trade-off — the fallback is a frozen safe baseline, not a live mirror).
+
+## Three layers of prompt content (after v5.18.0)
+
+| Layer | Where | Edit cadence | Scope |
+|---|---|---|---|
+| Per-tool workflow guidance | MCP tool descriptions (code constants) | code change + release | per tool, universal |
+| Server-wide orient + discovery | `ai_creation_prompts` singleton, surfaced via MCP `instructions` | edit in `/admin/settings/ai`; next session sees it | server, universal |
+| Scope-specific menu | per-scope `mcp_system_context` on Set/Collection | edit per scope | per scope |
+
+The canonical Outcomes Theory Book `mcp_system_context` drops from ~30 lines (v5.17.0) to ~12 lines (v5.18.0). New scopes only need to author the scope-specific menu + a description + a structural-overview-call name.
+
+## Why store as a singleton in `ai_creation_prompts` (not a new table)
+
+- Same shape as creation_format and response_format prompts: a single text body, admin-editable, version-comparable via the existing prompts machinery.
+- `purpose` discriminator already exists; adding a third value is a one-line Pydantic Literal extension + one-line `_VALID_PURPOSES` tuple extension.
+- The admin UI's existing filter/edit dialog handles the new row without changes — `layer='base'` already disables notation/diagram_type pickers (v5.17.0 Fix #3).
+- Audit, deactivate, edit-history all come for free via the existing CRUD.
+
+## Why a dedicated `GET /api/ai/server-instructions` endpoint (not reusing `/response-prompts/composed?purpose=mcp_server_instructions`)
+
+- The composed endpoint requires `notation=` and `diagram_type=` query parameters (cascade-shaped). `mcp_server_instructions` is a singleton — those parameters have no meaning.
+- A dedicated endpoint reads cleaner from the iris-mcp side and from the OpenAPI surface.
+- 25 LOC vs. the alternative's "special-case purpose value in two cascade endpoints". Worth the focused endpoint.
+
+## Why anonymous-readable
+
+- iris-mcp fetches at startup with no token. Adding auth would force every iris-mcp install to be authenticated before any MCP client could use it.
+- The body describes mechanism, not data. Same posture as the existing `/response-prompts/composed` endpoint (also anonymous-readable).
+- Self-hosting users who don't want this exposed can revoke anonymous access to the endpoint via existing CSP / proxy controls.
+
+## Consequences
+
+- One new purpose value in `_VALID_PURPOSES` and the Pydantic Literal.
+- One new endpoint `GET /api/ai/server-instructions`.
+- One new SQLite migration (m053) + one Supabase migration (m057) seeding the singleton row.
+- New iris-mcp `server_instructions.py` module (~40 LOC) with fetch helper + hardcoded fallback.
+- `build_server()` gains an `instructions: str | None = None` argument forwarded to `Server(...)`.
+- `__main__.py:run()` fetches instructions before constructing the server.
+- Frontend `PURPOSES` const gains one entry; `appliesToLabel()` gains one branch.
+- Canonical `doview-book-mcp-system-context.md` trimmed to ~12 lines. Admin must paste the trimmed content into the set's `mcp_system_context` field on UAT.
+- Three copies of the same body on day one (seeded row, hardcoded fallback, canonical doc). Acceptable; see SPEC for rationale.
+- ~13 new tests across backend, MCP, frontend, migrations.
+
+## Out of scope (deferred)
+
+- Reading the canonical doc text at migration / fallback time to deduplicate the three copies — defer to v6.0.0.
+- Versioning the instructions ("this body is older than the iris-mcp build expects") — no real case yet.
+- Cascading multiple `mcp_server_instructions` rows (e.g. base + scope-override). Singleton works; revisit if multi-tenancy or per-deployment-fork needs surface.
+- Renaming `ai_creation_prompts` to `ai_prompts` — cosmetic; v6.0.0.
+- Admin-UI authoring metadata for the singleton row ("loaded by iris-mcp at startup; restart your MCP client to see changes"). UX polish; v5.19+.
+
+## See also
+
+- [ADR-156](ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for (per-scope data passthrough; now narrower).
+- [ADR-157](ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — the `purpose` discriminator on `ai_creation_prompts` this ADR extends.
+- [ADR-162](ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — generic create_diagram + the workflow-in-tool-descriptions principle this ADR generalises.
+- [SPEC-163-A](specs/SPEC-163-A-Centralised-MCP-Server-Instructions.md) — schema extension, endpoint shape, MCP wiring, admin UI changes, test plan.

--- a/docs/adrs/specs/SPEC-163-A-Centralised-MCP-Server-Instructions.md
+++ b/docs/adrs/specs/SPEC-163-A-Centralised-MCP-Server-Instructions.md
@@ -1,0 +1,265 @@
+# SPEC-163-A: Centralised, admin-editable MCP server instructions
+
+ADR: [ADR-163](../ADR-163-Centralised-MCP-Server-Instructions.md)
+
+## Database
+
+**No schema changes.** One singleton row added to `ai_creation_prompts` with the new `purpose='mcp_server_instructions'` discriminator value.
+
+### SQLite seed migration `m053_mcp_server_instructions_seed.py`
+
+```python
+MIGRATION_ID = "m053_mcp_server_instructions_seed"
+
+_SEED_BODY = """<canonical seeded body — see docs/prompts/mcp-server-instructions.md>""".strip()
+
+async def up(db: aiosqlite.Connection) -> None:
+    await db.execute(
+        "INSERT OR IGNORE INTO ai_creation_prompts ("
+        "  id, name, description, purpose, layer,"
+        "  notation, diagram_type, prompt_text, display_order, is_active"
+        ") VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, 0, 1)",
+        (
+            "mcp-server-instructions-v1",
+            "MCP Server Instructions",
+            "Universal orient-first protocol + discovery catalogue surfaced by iris-mcp via the MCP server `instructions` field (ADR-163, v5.18.0). One singleton row at layer=base.",
+            "mcp_server_instructions",
+            "base",
+            _SEED_BODY,
+        ),
+    )
+    await db.commit()
+```
+
+### Supabase mirror `m057_mcp_server_instructions_seed.sql`
+
+```sql
+INSERT INTO public.ai_creation_prompts (
+    id, name, description, purpose, layer,
+    notation, diagram_type, prompt_text, display_order, is_active
+) VALUES (
+    'mcp-server-instructions-v1',
+    'MCP Server Instructions',
+    'Universal orient-first protocol + discovery catalogue surfaced by iris-mcp via the MCP server `instructions` field (ADR-163, v5.18.0). One singleton row at layer=base.',
+    'mcp_server_instructions',
+    'base',
+    NULL,
+    NULL,
+    $body$<canonical seeded body>$body$,
+    0,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;
+```
+
+Idempotent on both backends.
+
+## Backend
+
+### `backend/app/ai/models.py`
+
+Extend `CreationPromptCreate.purpose`:
+
+```python
+purpose: Literal[
+    "creation_format",
+    "response_format",
+    "mcp_server_instructions",
+] = "creation_format"
+```
+
+Add response model `ServerInstructionsResponse`:
+
+```python
+class ServerInstructionsResponse(BaseModel):
+    body: str
+```
+
+### `backend/app/ai/router.py`
+
+Extend `_VALID_PURPOSES`:
+
+```python
+_VALID_PURPOSES = ("response_format", "creation_format", "mcp_server_instructions")
+```
+
+Add endpoint:
+
+```python
+@router.get("/server-instructions", response_model=ServerInstructionsResponse)
+async def get_mcp_server_instructions(
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),
+) -> ServerInstructionsResponse:
+    """Return the singleton mcp_server_instructions row body (ADR-163,
+    v5.18.0). Anonymous-readable; iris-mcp fetches at startup to
+    populate the MCP server `instructions` field."""
+    db = request.app.state.db_manager.main_db
+    cursor = await db.execute(
+        "SELECT prompt_text FROM ai_creation_prompts"
+        " WHERE purpose = 'mcp_server_instructions'"
+        "   AND is_active = 1"
+        " ORDER BY display_order ASC, id ASC LIMIT 1",
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return ServerInstructionsResponse(body="")
+    return ServerInstructionsResponse(body=row[0])
+```
+
+### Backend tests
+
+`backend/tests/test_ai/test_server_instructions_endpoint.py`:
+
+- 200 OK returns the seeded body.
+- Empty body when no active row of that purpose exists.
+- Anonymous-readable (no Authorization header required).
+- Returns the most-recently-seeded body when multiple rows exist (display_order then id).
+
+`backend/tests/test_migrations/test_mcp_server_instructions_seed.py`:
+
+- m053 inserts a row with the expected id, purpose, layer, prompt_text non-empty.
+- m057 mirrors with the same constraints (static-parser test on the SQL).
+
+## iris-mcp
+
+### `mcp/src/iris_mcp/server_instructions.py`
+
+```python
+"""Fetch the MCP server `instructions` text at startup (ADR-163,
+v5.18.0). Falls back to a hardcoded baseline if the backend is
+unreachable so the MCP server stays functional in degraded states."""
+
+from __future__ import annotations
+
+import httpx
+
+_FALLBACK_INSTRUCTIONS = """<copy of the seeded body>""".strip()
+
+
+async def fetch_server_instructions(iris_url: str) -> str:
+    try:
+        async with httpx.AsyncClient(base_url=iris_url, timeout=5.0) as c:
+            response = await c.get("/api/ai/server-instructions")
+            response.raise_for_status()
+            body = response.json().get("body") or ""
+            return body if body.strip() else _FALLBACK_INSTRUCTIONS
+    except (httpx.HTTPError, ValueError):
+        return _FALLBACK_INSTRUCTIONS
+```
+
+### `mcp/src/iris_mcp/server.py:build_server()`
+
+```python
+def build_server(
+    client: IrisClient,
+    *,
+    instructions: str | None = None,
+) -> Server:
+    server: Server = Server(
+        "iris-mcp",
+        version=_package_version(),
+        instructions=instructions,  # ADR-163, v5.18.0
+        website_url="https://github.com/cgbarlow/iris",
+        icons=[iris_icon()],
+    )
+    ...
+```
+
+### `mcp/src/iris_mcp/__main__.py:run()`
+
+```python
+async def run() -> None:
+    config = load()
+    token, source = _resolve_token(config.token, config.url)
+    print(f"iris-mcp: using {source}", file=sys.stderr)
+    instructions = await fetch_server_instructions(config.url)
+    async with IrisClient(url=config.url, token=token) as client:
+        server = build_server(client, instructions=instructions)
+        ...
+```
+
+### MCP tests
+
+`mcp/tests/test_server_instructions.py`:
+
+- Happy fetch returns the body.
+- Network error (`httpx.RequestError`) falls back.
+- HTTP error (404, 500) falls back.
+- 200 OK with empty body falls back to the hardcoded baseline.
+- Bad JSON / non-JSON response falls back.
+
+`mcp/tests/test_server_instructions_wiring.py`:
+
+- `build_server(client, instructions="hello")` produces a `Server` whose `instructions` attribute is `"hello"`.
+- `build_server(client)` (no kwarg) produces a `Server` with `instructions=None`.
+
+## Frontend
+
+### `frontend/src/routes/admin/settings/ai/+page.svelte`
+
+Extend `PURPOSES`:
+
+```ts
+const PURPOSES = [
+    'creation_format',
+    'response_format',
+    'mcp_server_instructions',
+] as const;
+```
+
+Extend `appliesToLabel()` to special-case the new purpose:
+
+```ts
+if (p.purpose === 'mcp_server_instructions') return 'Server-wide (MCP instructions)';
+```
+
+(Branch checked before the existing `layer` branches so it wins for `layer=base, purpose=mcp_server_instructions`.)
+
+### Frontend test
+
+`frontend/tests/unit/adminPromptPurposeEnum.test.ts`:
+
+- `PURPOSES` includes `mcp_server_instructions`.
+- `appliesToLabel({ purpose: 'mcp_server_instructions', layer: 'base', notation: null, diagram_type: null })` returns "Server-wide (MCP instructions)".
+
+## Canonical doc + per-scope trimming
+
+### New `docs/prompts/mcp-server-instructions.md`
+
+Canonical paste-ready content. Mirrors the seeded body. Provides admins a place to copy from if they edit and need to revert. Same pattern as `docs/prompts/doview-book-mcp-system-context.md`.
+
+### Trim `docs/prompts/doview-book-mcp-system-context.md`
+
+Strip ORIENT-FIRST wrapper (now in server instructions) and DISCOVERABILITY catalogue (also moved). Keep: one-sentence description, structural-overview call name, the menu options verbatim. ~12 lines (was ~30 in v5.17.0).
+
+## End-to-end verification
+
+After UAT deploy:
+
+1. Visit `/admin/settings/ai`. Filter `purpose=mcp_server_instructions`. One row appears with the seeded body. Click edit, change a single word, save.
+2. Restart Claude Desktop. The new session sees the updated instructions (visible indirectly through Claude's orient behaviour).
+3. Stop the backend / point iris-mcp at a dead URL. Restart Claude Desktop. iris-mcp still starts and uses the hardcoded fallback.
+4. Open the Outcomes Theory Book set fresh in Claude. Orient-first protocol fires (describe scope, call structural overview, present menu verbatim) even though the scope context no longer contains the protocol — proving the centralisation.
+5. Author a fresh test set with a minimal `mcp_system_context` (just description + structural call + 2-option menu). Open it via Claude. The protocol still fires. Centralisation works for any scope.
+
+## Manual UAT step
+
+Apply m057 Supabase migration via `./scripts/supabase-migrate.sh`. Then paste the trimmed `docs/prompts/doview-book-mcp-system-context.md` content into the Outcomes Theory Book set's `mcp_system_context` field.
+
+## Test counts target
+
+- Backend: ~6 (endpoint happy / empty row / anonymous / multiple rows / Pydantic literal accept / migration static-parser)
+- MCP: ~7 (5 fetch cases + 2 wiring cases)
+- Frontend: ~2 (PURPOSES + appliesToLabel)
+- iris-client: 0
+- **Total**: ~15 new tests for v5.18.0
+- **Combined suite**: ~548+ tests passing
+
+## Out of scope (deferred)
+
+- Deduplicating the three text copies (seed body / hardcoded fallback / canonical doc) — v6.0.0.
+- Instructions versioning — no current need.
+- Cascading multiple instructions rows — singleton is sufficient.
+- Renaming `ai_creation_prompts` table — cosmetic; v6.0.0.
+- Admin UI authoring-metadata for the singleton — UX polish; v5.19+.

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -1,67 +1,43 @@
 # DoView / Outcomes-Theory Set — `mcp_system_context` content
 
-Canonical paste-ready content for the **MCP system context** field on the Outcomes Theory Set (`/sets/33032180-d77a-4ce4-88cf-b49cd643e093`, previously named "DoView Book"). The same content flows through both `get_set` and (since v5.14.0 / ADR-159) `search` results, so an MCP client model sees the orient guidance the moment the set is matched — no follow-up `get_set` call required.
+Canonical paste-ready content for the **MCP system context** field on the Outcomes Theory Set (`/sets/33032180-d77a-4ce4-88cf-b49cd643e093`, previously named "DoView Book"). The same content flows through both `get_set` and (since v5.14.0 / ADR-159) `search` results, so an MCP client model sees this orient sheet the moment the set is matched.
+
+**Scope only.** The generic ORIENT-FIRST protocol and DISCOVERY catalogue have moved to the server-wide MCP `instructions` field (v5.18.0 / ADR-163); this scope content only carries what's specific to the DoView handbook.
 
 ## Content (paste this into the field on UAT)
 
 ```text
 This set is the visual companion to Dr Paul Duignan's outcomes-theory body of work and DoView outcomes-mapping methodology.
 
-ORIENT FIRST. On the first turn, before doing any other tool action:
-  1. Briefly describe the set (one sentence).
-  2. Call iris_package_hierarchy(set_id=<this-set>) — NOT list_packages — and list the chapters (Part A through Part J) with one-line descriptions.
-  3. Offer ALL FOUR options below. Use a structured multi-choice UI if your client has one (Claude Code: AskUserQuestion). Otherwise present as a numbered list (1./2./3./4.), one option per line.
+Structural overview call: iris_package_hierarchy(set_id=<this-set>) — lists Part A through Part J with one-line descriptions.
 
-  THE FOUR OPTIONS — verbatim, all four, every time:
-
-    1. Pull up a specific chapter or diagram from the handbook
-       (e.g. J06 — Mathematization of Outcomes Theory).
-
-    2. Ask a cross-package question via Iris AI
-       (e.g. "What are the recurring causal-link conventions?" — uses mcp__iris__ask).
-
-    3. Generate a new DoView outcomes-theory analysis OR a new visual
-       DoView outcomes_map on a topic the user describes. → call
-       iris_create_diagram. The tool's own description carries the
-       full workflow (discover via list_notations / list_diagram_types,
-       fetch the creation prompt cascade via iris_get_response_prompt
-       with purpose='creation_format', run the guided conversation,
-       confirm destination using create_collection / create_set /
-       create_package as needed, save). Do not duplicate that
-       workflow here.
-
-    4. Browse a particular chapter's diagrams in detail
-       (iris_package_hierarchy filtered to a chapter, then mcp__iris__get_diagram on each).
-
-If the user's opening request explicitly asks for one option, briefly acknowledge it and present the menu of the other three so they can redirect.
-
-DISCOVERABILITY
-
-  list_response_format_types(purpose='response_format'|'creation_format') — what response formats / creation types are available
-  iris_package_hierarchy(set_id=<this-set>) — chapter tree, single call
+MENU (verbatim, all four):
+  1. Pull up a specific chapter or diagram from the handbook (e.g. J06 — Mathematization of Outcomes Theory).
+  2. Ask a cross-package question via Iris AI (e.g. "What are the recurring causal-link conventions?" — uses mcp__iris__ask).
+  3. Generate a new DoView outcomes-theory analysis OR a new visual DoView outcomes_map → call create_diagram.
+  4. Browse a particular chapter's diagrams in detail.
 ```
 
 ## Why this works
 
-- **Orient lands on first turn whether Claude calls `search` or `get_set`** — v5.14.0 (ADR-159) extended search results for Set / Collection hits to include `mcp_system_context`. Claude's natural "search → return link" flow now also surfaces this content.
-- **The four options are mandatory and verbatim** — paraphrasing got Claude down to 2 options in v5.13.x. Explicit "all four, every time" + verbatim wording fixes that.
-- **AskUserQuestion is conditional** — Claude Code has it; Claude Desktop / claude.ai / generic MCP clients don't (yet). Numbered list is the fallback.
-- **Workflow logic lives in the `create_diagram` tool description, not here.** v5.17.0 (ADR-162) moved the full creation flow (discover → fetch creation prompt → guided conversation → confirm destination → save) into the tool's description so it travels universally across every MCP client and every scope, not just this set. The scope context just points at the tool.
+- **The orient-first protocol is universal, not scope-specific.** v5.18.0 (ADR-163) lifted it into the MCP server `instructions` field — see [`mcp-server-instructions.md`](./mcp-server-instructions.md). Every authored scope automatically gets the "describe, call structural overview, present menu verbatim" behaviour. This scope content just supplies the specifics.
+- **DISCOVERY catalogue is universal too.** Also lifted to server instructions.
+- **Diagram-creation workflow lives in the `create_diagram` tool description.** v5.17.0 (ADR-162). Not duplicated here.
 
 ## Revision history
 
-- **v5.17.0 (this revision).** Stripped the diagram-creation workflow entirely (paths A and B in v5.16.x) — that lives in `create_diagram`'s tool description now (ADR-162). The web-UI-handoff guidance for visual DoView creation is gone; the generic `create_diagram` flow covers both markdown DoView analyses and visual DoView outcomes_maps. ~30 lines shorter.
-- **v5.14.0.** Trimmed from ~140 lines to ~50 (target was ~60). Same orient-first-with-four-option-menu intent, far less text. Surfaced through search results too (ADR-159) so the orient lands on first turn regardless of whether Claude calls `get_set` or just `search`.
-- **v5.13.3.** Made the four-option menu mandatory and verbatim. Honest note about AskUserQuestion availability.
-- **v5.13.2.** Restored orient-first / offer-menu pattern; explicit analysis-vs-diagram routing; "DO NOT use mcp__iris__ask for analysis flow".
-- **v5.13.0.** Mention `iris_package_hierarchy` (ADR-158) as the preferred chapter-list call.
-- **v5.12.0.** Save-options offer added (Iris save + markdown artefact).
+- **v5.18.0 (this revision).** Stripped ORIENT-FIRST protocol and DISCOVERY catalogue — now in server-wide MCP instructions (ADR-163). Down from ~30 lines (v5.17.0) to ~12.
+- **v5.17.0.** Stripped diagram-creation workflow — now in `create_diagram`'s tool description (ADR-162).
+- **v5.14.0.** Trimmed from ~140 lines to ~50. Surfaced through search results too (ADR-159).
+- **v5.13.3.** Made the four-option menu mandatory and verbatim.
+- **v5.13.2.** Restored orient-first / offer-menu pattern.
+- **v5.13.0.** Mention `iris_package_hierarchy` (ADR-158).
+- **v5.12.0.** Save-options offer added.
 
 ## See also
 
-- [ADR-156](../adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for (per-scope context, data passthrough on `get_set` / `get_collection`).
-- [ADR-157](../adrs/ADR-157-Response-Format-Prompts-and-DoView-Analysis-Artefact.md) — where the response_format rules live (universal layered prompts, admin-editable).
-- [ADR-159](../adrs/ADR-159-Scope-Context-In-Search-Results.md) — search results carry `mcp_system_context` so orient lands on first turn.
-- [ADR-162](../adrs/ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — generic `create_diagram` tool + workflow-in-tool-descriptions pattern.
-- [SPEC-157-A](../adrs/specs/SPEC-157-A-Response-Format-Prompts.md) — schema for the response_format mechanism.
-- [`doview-book-prompt-c-iris.md`](./doview-book-prompt-c-iris.md) — the source content from which the seeded response_format prompts were derived.
+- [`mcp-server-instructions.md`](./mcp-server-instructions.md) — the universal orient-first protocol + discovery catalogue (v5.18.0).
+- [ADR-156](../adrs/ADR-156-MCP-System-Context-Data-Passthrough.md) — what `mcp_system_context` is for.
+- [ADR-159](../adrs/ADR-159-Scope-Context-In-Search-Results.md) — search results carry `mcp_system_context`.
+- [ADR-162](../adrs/ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — generic `create_diagram` + workflow-in-tool-descriptions.
+- [ADR-163](../adrs/ADR-163-Centralised-MCP-Server-Instructions.md) — server-wide instructions channel.

--- a/docs/prompts/mcp-server-instructions.md
+++ b/docs/prompts/mcp-server-instructions.md
@@ -1,0 +1,45 @@
+# MCP server `instructions` — canonical paste-ready content
+
+Canonical paste-ready content for the **MCP Server Instructions** row at `/admin/settings/ai` (filter `purpose=mcp_server_instructions`). This text is surfaced to every connected MCP client (Claude Desktop / Claude Code / Cursor) via the MCP server `instructions` field on every session (ADR-163, v5.18.0).
+
+The seed migration (m053 SQLite + m057 Supabase) writes this text on first install. Admins edit the body in-app; iris-mcp re-fetches on its next startup. If an admin breaks the content, re-paste from this doc to recover.
+
+## Content (paste this into the row's `prompt_text` field)
+
+```text
+You are connected to Iris (an architectural-modelling tool that exposes Collections, Sets, Packages, Diagrams, Elements, and the relationships between them via this MCP server).
+
+ORIENT-FIRST PROTOCOL.
+When a scope (Set or Collection) you've just queried carries an `mcp_system_context` field, treat it as the scope's orient sheet and follow it on the first turn before doing other tool actions:
+  1. Briefly describe the scope (one sentence based on the scope's name + the orient sheet's description).
+  2. If the orient sheet names a structural-overview call (e.g. iris_package_hierarchy for a Set with packages), make that call and surface the contents.
+  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+DISCOVERY TOOLS.
+  list_collections / list_sets / list_packages — structural
+  list_notations / list_diagram_types — what's authorable
+  list_response_format_types(purpose='response_format'|'creation_format') — what output shapes and what drafting cascades exist
+  iris_package_hierarchy(set_id=...) — full tree in one call
+
+WORKFLOW GUIDANCE.
+Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow). For authentication, see `iris_authenticate`.
+
+AUTH RECOVERY.
+Write tools that return error="auth_required" can be unblocked by the iris_authenticate flow — never tell the user to restart their MCP client.
+```
+
+## Why this works
+
+- **Universal across every scope and every session.** The MCP spec's `Server.instructions` field is loaded on every InitializeResult; every compliant MCP client (Claude Desktop, Claude Code, Cursor) sees it without per-scope authoring.
+- **Admin-editable from `/admin/settings/ai`** filtering `purpose=mcp_server_instructions`. Edits take effect on the next iris-mcp session (the MCP server is short-lived — one process per Claude Desktop launch — so "next session" is the next time the client restarts).
+- **Falls back gracefully.** iris-mcp ships a hardcoded baseline (`mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS`) that mirrors this content on day one. If the backend is unreachable at startup, iris-mcp uses the baseline so write tools still work.
+
+## Revision history
+
+- **v5.18.0 (this revision).** Introduced. Centralises the ORIENT-FIRST protocol and DISCOVERY catalogue out of per-scope `mcp_system_context` into the server-wide MCP `instructions` channel (ADR-163).
+
+## See also
+
+- [ADR-163](../adrs/ADR-163-Centralised-MCP-Server-Instructions.md) — design rationale and three-layer separation.
+- [SPEC-163-A](../adrs/specs/SPEC-163-A-Centralised-MCP-Server-Instructions.md) — schema, endpoint, MCP wiring, test plan.
+- [`doview-book-mcp-system-context.md`](./doview-book-mcp-system-context.md) — example of the now-narrower per-scope content (just description + structural call + menu).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "5.17.0",
+	"version": "5.18.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/admin/settings/ai/+page.svelte
+++ b/frontend/src/routes/admin/settings/ai/+page.svelte
@@ -64,10 +64,17 @@
 		return !!(dt?.notations ?? []).some((n) => n.notation_id === notationFilterValue);
 	}
 
-	const PURPOSES = ['creation_format', 'response_format'] as const;
+	// v5.18.0 (ADR-163): added `mcp_server_instructions` — singleton row
+	// loaded by iris-mcp at startup and surfaced via the MCP server
+	// `instructions` field to every connected MCP client.
+	const PURPOSES = ['creation_format', 'response_format', 'mcp_server_instructions'] as const;
 	const LAYERS = ['base', 'notation', 'diagram_type', 'override'] as const;
 
-	function appliesToLabel(p: { layer: string; notation: string | null; diagram_type: string | null }): string {
+	function appliesToLabel(p: { purpose?: string; layer: string; notation: string | null; diagram_type: string | null }): string {
+		// v5.18.0 (ADR-163): mcp_server_instructions is a server-wide
+		// singleton (layer=base, no notation, no diagram_type). Surface
+		// that explicitly so admins know what they're editing.
+		if (p.purpose === 'mcp_server_instructions') return 'Server-wide (MCP instructions)';
 		// ADR-158 (v5.13.0): make the cascade behaviour visible — addresses the
 		// "ArchiMate Process Layout has no notation" confusion. Coerce empty
 		// strings to null so the live-preview hint in the create form works
@@ -1012,7 +1019,7 @@
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg); resize: vertical"></textarea>
 			</label>
 			<p class="mt-2 text-xs" style="color: var(--color-muted)">
-				Will apply to: <strong>{appliesToLabel({ layer: createForm.layer, notation: createForm.notation || null, diagram_type: createForm.diagram_type || null })}</strong>
+				Will apply to: <strong>{appliesToLabel({ purpose: createForm.purpose, layer: createForm.layer, notation: createForm.notation || null, diagram_type: createForm.diagram_type || null })}</strong>
 			</p>
 			{#if createConflict}
 				<p class="mt-2 text-xs" style="color: var(--color-danger)">
@@ -1167,7 +1174,7 @@
 			</label>
 
 			<p class="mt-2 text-xs" style="color: var(--color-muted)">
-				Will apply to: <strong>{appliesToLabel({ layer: editingPrompt.layer, notation: promptEditNotation || null, diagram_type: promptEditDiagramType || null })}</strong>
+				Will apply to: <strong>{appliesToLabel({ purpose: editingPrompt.purpose, layer: editingPrompt.layer, notation: promptEditNotation || null, diagram_type: promptEditDiagramType || null })}</strong>
 			</p>
 
 			<div class="mt-4 flex justify-end gap-3">

--- a/frontend/tests/unit/adminPromptPurposeEnum.test.ts
+++ b/frontend/tests/unit/adminPromptPurposeEnum.test.ts
@@ -1,0 +1,94 @@
+/**
+ * v5.18.0 (ADR-163, SPEC-163-A) — `PURPOSES` enum extended with
+ * `mcp_server_instructions` and `appliesToLabel` shows "Server-wide
+ * (MCP instructions)" for the new purpose.
+ *
+ * Inline copies of helpers; keep in sync with
+ * `frontend/src/routes/admin/settings/ai/+page.svelte`.
+ */
+import { describe, it, expect } from 'vitest';
+
+const PURPOSES = ['creation_format', 'response_format', 'mcp_server_instructions'] as const;
+
+function appliesToLabel(p: { purpose?: string; layer: string; notation: string | null; diagram_type: string | null }): string {
+	if (p.purpose === 'mcp_server_instructions') return 'Server-wide (MCP instructions)';
+	const n = p.notation || null;
+	const d = p.diagram_type || null;
+	if (p.layer === 'base') return 'Any notation × Any diagram type';
+	if (p.layer === 'override') return n ? `Override: ${n} (replaces all layers)` : 'Override (no notation set — invalid)';
+	if (p.layer === 'notation') return n ? `${n} × any diagram type` : 'Notation layer (no notation set — invalid)';
+	const notationPart = n ?? 'Any notation';
+	const dtPart = d ?? '?';
+	return `${notationPart} × ${dtPart} diagrams`;
+}
+
+describe('PURPOSES enum', () => {
+	it('contains creation_format, response_format, mcp_server_instructions', () => {
+		expect(PURPOSES).toContain('creation_format');
+		expect(PURPOSES).toContain('response_format');
+		expect(PURPOSES).toContain('mcp_server_instructions');
+	});
+
+	it('has exactly 3 values (v5.18.0)', () => {
+		expect(PURPOSES.length).toBe(3);
+	});
+});
+
+describe('appliesToLabel — mcp_server_instructions branch', () => {
+	it('returns "Server-wide (MCP instructions)" for the new purpose', () => {
+		expect(
+			appliesToLabel({
+				purpose: 'mcp_server_instructions',
+				layer: 'base',
+				notation: null,
+				diagram_type: null,
+			}),
+		).toBe('Server-wide (MCP instructions)');
+	});
+
+	it('wins over the layer=base default label', () => {
+		// Without the purpose branch, this would return
+		// "Any notation × Any diagram type". The new branch must short-circuit.
+		const label = appliesToLabel({
+			purpose: 'mcp_server_instructions',
+			layer: 'base',
+			notation: null,
+			diagram_type: null,
+		});
+		expect(label).not.toBe('Any notation × Any diagram type');
+	});
+
+	it('does not affect creation_format rows', () => {
+		expect(
+			appliesToLabel({
+				purpose: 'creation_format',
+				layer: 'notation',
+				notation: 'doview',
+				diagram_type: null,
+			}),
+		).toBe('doview × any diagram type');
+	});
+
+	it('does not affect response_format rows', () => {
+		expect(
+			appliesToLabel({
+				purpose: 'response_format',
+				layer: 'diagram_type',
+				notation: 'markdown',
+				diagram_type: 'doview_analysis',
+			}),
+		).toBe('markdown × doview_analysis diagrams');
+	});
+
+	it('omitting purpose still works for legacy rows', () => {
+		// Pre-v5.18.0 rows might be rendered without `purpose` — the
+		// helper must not crash and must fall through to layer logic.
+		expect(
+			appliesToLabel({
+				layer: 'base',
+				notation: null,
+				diagram_type: null,
+			}),
+		).toBe('Any notation × Any diagram type');
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "5.17.0"
+version = "5.18.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/__main__.py
+++ b/mcp/src/iris_mcp/__main__.py
@@ -12,6 +12,7 @@ from mcp.server.stdio import stdio_server
 
 from iris_mcp.config import load
 from iris_mcp.server import build_server
+from iris_mcp.server_instructions import fetch_server_instructions
 from iris_mcp.token_store import load_token
 
 
@@ -35,8 +36,13 @@ async def run() -> None:
     config = load()
     token, source = _resolve_token(config.token, config.url)
     print(f"iris-mcp: using {source}", file=sys.stderr)
+    # ADR-163 (v5.18.0): fetch the admin-editable orient-first
+    # protocol from Iris and pass it through to the MCP server's
+    # `instructions` field. Falls back to a hardcoded baseline if
+    # the backend is unreachable.
+    instructions = await fetch_server_instructions(config.url)
     async with IrisClient(url=config.url, token=token) as client:
-        server = build_server(client)
+        server = build_server(client, instructions=instructions)
         async with stdio_server() as (read, write):
             await server.run(
                 read,

--- a/mcp/src/iris_mcp/server.py
+++ b/mcp/src/iris_mcp/server.py
@@ -28,10 +28,23 @@ def _package_version() -> str | None:
         return None
 
 
-def build_server(client: IrisClient) -> Server:
+def build_server(
+    client: IrisClient,
+    *,
+    instructions: str | None = None,
+) -> Server:
+    """Build the iris-mcp MCP server.
+
+    `instructions` (ADR-163, v5.18.0): the server-wide MCP
+    `instructions` text returned in the InitializeResult to every
+    connected MCP client. Typically the body fetched from the Iris
+    backend's `GET /api/ai/server-instructions`. None disables the
+    field (clients see no server-level instructions).
+    """
     server: Server = Server(
         "iris-mcp",
         version=_package_version(),
+        instructions=instructions,
         website_url="https://github.com/cgbarlow/iris",
         icons=[iris_icon()],
     )

--- a/mcp/src/iris_mcp/server_instructions.py
+++ b/mcp/src/iris_mcp/server_instructions.py
@@ -1,0 +1,62 @@
+"""Fetch the MCP server `instructions` text at startup (ADR-163,
+v5.18.0).
+
+The Iris backend stores the orient-first protocol + discovery
+catalogue + workflow pointers + auth-recovery guidance as a
+singleton row in `ai_creation_prompts` with
+`purpose='mcp_server_instructions'`. This module fetches that body
+once at startup and returns it to be passed to the MCP SDK
+`Server(name=..., instructions=...)` constructor.
+
+Falls back to a hardcoded baseline if the backend is unreachable,
+returns an HTTP error, or yields an empty body — so iris-mcp stays
+functional in degraded states. The fallback text mirrors the seed
+body on day one; admins who later edit the seed body will diverge
+from the fallback intentionally (the fallback is "last known safe
+baseline shipped with this iris-mcp version", not "current state").
+"""
+
+from __future__ import annotations
+
+import httpx
+
+_FALLBACK_INSTRUCTIONS = """\
+You are connected to Iris (an architectural-modelling tool that exposes Collections, Sets, Packages, Diagrams, Elements, and the relationships between them via this MCP server).
+
+ORIENT-FIRST PROTOCOL.
+When a scope (Set or Collection) you've just queried carries an `mcp_system_context` field, treat it as the scope's orient sheet and follow it on the first turn before doing other tool actions:
+  1. Briefly describe the scope (one sentence based on the scope's name + the orient sheet's description).
+  2. If the orient sheet names a structural-overview call (e.g. iris_package_hierarchy for a Set with packages), make that call and surface the contents.
+  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+DISCOVERY TOOLS.
+  list_collections / list_sets / list_packages — structural
+  list_notations / list_diagram_types — what's authorable
+  list_response_format_types(purpose='response_format'|'creation_format') — what output shapes and what drafting cascades exist
+  iris_package_hierarchy(set_id=...) — full tree in one call
+
+WORKFLOW GUIDANCE.
+Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow). For authentication, see `iris_authenticate`.
+
+AUTH RECOVERY.
+Write tools that return error="auth_required" can be unblocked by the iris_authenticate flow — never tell the user to restart their MCP client.
+"""
+
+
+async def fetch_server_instructions(iris_url: str) -> str:
+    """GET /api/ai/server-instructions and return its body.
+
+    Falls back to `_FALLBACK_INSTRUCTIONS` on any network error,
+    HTTP error, malformed JSON, or empty body. Never raises.
+    """
+    try:
+        async with httpx.AsyncClient(base_url=iris_url, timeout=5.0) as c:
+            response = await c.get("/api/ai/server-instructions")
+            response.raise_for_status()
+            payload = response.json()
+            body = payload.get("body") if isinstance(payload, dict) else None
+            if isinstance(body, str) and body.strip():
+                return body
+            return _FALLBACK_INSTRUCTIONS
+    except (httpx.HTTPError, ValueError):
+        return _FALLBACK_INSTRUCTIONS

--- a/mcp/tests/test_server_instructions.py
+++ b/mcp/tests/test_server_instructions.py
@@ -1,0 +1,106 @@
+"""server_instructions tests (ADR-163, SPEC-163-A).
+
+Verifies `fetch_server_instructions` returns the backend body on a
+happy fetch and falls back to the hardcoded baseline on any failure
+mode (network error, HTTP error, malformed JSON, empty body).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from iris_mcp.server_instructions import (
+    _FALLBACK_INSTRUCTIONS,
+    fetch_server_instructions,
+)
+
+BASE = "http://iris.test"
+
+
+class TestFetchServerInstructions:
+    @pytest.mark.asyncio
+    async def test_happy_fetch_returns_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(
+                200, json={"body": "ADMIN-EDITED INSTRUCTIONS"},
+            ),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == "ADMIN-EDITED INSTRUCTIONS"
+
+    @pytest.mark.asyncio
+    async def test_empty_body_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": ""}),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_whitespace_body_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": "   \n   "}),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_http_error_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(500, json={"detail": "boom"}),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_404_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(404, json={"detail": "not found"}),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_network_error_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            side_effect=httpx.ConnectError("connection refused"),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_falls_back(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(
+                200,
+                text="not json",
+                headers={"content-type": "application/json"},
+            ),
+        )
+        result = await fetch_server_instructions(BASE)
+        assert result == _FALLBACK_INSTRUCTIONS
+
+    @pytest.mark.asyncio
+    async def test_fallback_contains_protocol_markers(self) -> None:
+        # Fallback must mirror the seeded body for landing-safety
+        # when the backend is unreachable.
+        assert "ORIENT-FIRST PROTOCOL" in _FALLBACK_INSTRUCTIONS
+        assert "DISCOVERY TOOLS" in _FALLBACK_INSTRUCTIONS
+        assert "WORKFLOW GUIDANCE" in _FALLBACK_INSTRUCTIONS
+        assert "AUTH RECOVERY" in _FALLBACK_INSTRUCTIONS

--- a/mcp/tests/test_server_instructions_wiring.py
+++ b/mcp/tests/test_server_instructions_wiring.py
@@ -1,0 +1,42 @@
+"""build_server `instructions` wiring tests (ADR-163, SPEC-163-A).
+
+Verifies the MCP SDK's `Server(instructions=...)` constructor
+receives the value passed through `build_server(client, instructions=...)`
+and that omitting the kwarg yields `instructions=None`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from iris_client import IrisClient
+
+from iris_mcp.server import build_server
+
+
+@pytest.fixture
+async def client() -> IrisClient:
+    async with IrisClient(url="http://iris.test", token=None) as c:
+        yield c
+
+
+class TestBuildServerInstructionsWiring:
+    @pytest.mark.asyncio
+    async def test_instructions_passed_through(
+        self, client: IrisClient,
+    ) -> None:
+        server = build_server(client, instructions="HELLO INSTRUCTIONS")
+        assert server.instructions == "HELLO INSTRUCTIONS"
+
+    @pytest.mark.asyncio
+    async def test_no_instructions_kwarg_yields_none(
+        self, client: IrisClient,
+    ) -> None:
+        server = build_server(client)
+        assert server.instructions is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_none_yields_none(
+        self, client: IrisClient,
+    ) -> None:
+        server = build_server(client, instructions=None)
+        assert server.instructions is None


### PR DESCRIPTION
## Summary

- **Centralised, admin-editable MCP server instructions.** The ORIENT-FIRST protocol and DISCOVERY catalogue lift out of per-scope `mcp_system_context` into a server-wide channel — the MCP SDK's `Server(instructions=...)` field, returned in the InitializeResult to every connected MCP client.
- **Stored as a singleton row** in `ai_creation_prompts` with new `purpose='mcp_server_instructions'`. Admin-editable from `/admin/settings/ai`. Consistent with creation_format + response_format prompts; no special-case admin UI.
- **iris-mcp fetches once at startup** via `GET /api/ai/server-instructions` (anonymous-readable) and passes through `build_server(client, instructions=...)`. Falls back to a hardcoded baseline if the backend is unreachable / errors / empty.
- **Canonical scope context shrinks again.** Outcomes Theory Book `mcp_system_context` trimmed from ~30 lines (v5.17.0) to ~12. The universal mechanism is no longer duplicated per-scope.

Three clean layers now:
- per-tool workflow → MCP tool descriptions (code constants)
- server-wide orient + discovery → singleton DB row, admin-editable
- scope-specific menu → per-scope `mcp_system_context`

## Test plan

- [x] Backend `tests/test_ai/test_server_instructions_endpoint.py` — 5 cases (seeded body returned; anonymous-readable; empty when deactivated; display_order ordering; Pydantic Literal accepts new purpose value)
- [x] Backend `tests/test_migrations/test_mcp_server_instructions_seed.py` — 5 cases (SQLite + Supabase singleton inserts; idempotency; canonical body markers present)
- [x] MCP `tests/test_server_instructions.py` — 8 cases (happy fetch; empty body falls back; whitespace falls back; HTTP error falls back; 404 falls back; network error falls back; malformed JSON falls back; fallback contains protocol markers)
- [x] MCP `tests/test_server_instructions_wiring.py` — 3 cases (`build_server(client, instructions=X)` propagates to `Server.instructions`; omitting kwarg yields None; explicit None yields None)
- [x] Frontend `tests/unit/adminPromptPurposeEnum.test.ts` — 7 cases (PURPOSES contains the new value; appliesToLabel branch wins; doesn't affect creation/response_format rows; legacy rows without purpose still work)
- [x] Full suites green: iris-client 57, MCP 134, backend (relevant subsets) 460, frontend (v5.15-v5.18 fixes) 47.
- [ ] Apply Supabase migration m057 to UAT
- [ ] Paste trimmed `docs/prompts/doview-book-mcp-system-context.md` into the Outcomes Theory Book set's mcp_system_context field
- [ ] Manual end-to-end on UAT after deploy: edit the singleton row in /admin/settings/ai; restart Claude Desktop; verify orient-first protocol still fires on the Outcomes Theory Book set; verify it ALSO fires on a fresh test set with just description + structural-call + 2-option menu in its scope context (proving the universal centralisation works)

## Migration

- **SQLite m053** runs automatically on next boot (idempotent INSERT OR IGNORE).
- **Supabase m057**: apply once via `./scripts/supabase-migrate.sh "$SUPABASE_URL"`.
- **Manual**: paste the trimmed Outcomes Theory Book scope content into the set's `mcp_system_context` field on UAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)