### PR TITLE
fix(v6.0.2): per-scope mcp_system_context tool name (issue #115 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.2] - 2026-05-13
+
+### Fixed
+
+- **Per-scope `mcp_system_context` still carried `iris_package_hierarchy`**
+  (issue #115 follow-up). v6.0.1's m055/m059 fixed the server-wide
+  `mcp_server_instructions` singleton row, but the **per-scope
+  content** on `sets.mcp_system_context` (and `collections.mcp_system_context`)
+  was pasted during v5.18.0 / v6.0.0 admin setup with the wrong tool
+  name. Live-data testing confirmed: search results for the Outcomes
+  Theory Book still surfaced `iris_package_hierarchy(set_id=)` in
+  the scope content, defeating v6.0.1's protocol fix.
+- **m056 (SQLite) + m060 (Supabase)** surgically REPLACE() the wrong
+  substring in `sets.mcp_system_context` AND `collections.mcp_system_context`
+  for every row that's non-NULL. Admin customisations elsewhere in
+  each body are preserved. Idempotent.
+
+### Migration
+
+- **SQLite m056** runs automatically on next boot. No manual paste.
+- **Supabase m060**: apply once via `./scripts/supabase-migrate.sh`.
+
+### Tests
+
+- 4 new migration-parser tests (REPLACE shape on both tables, guards,
+  NULL-skip, Supabase mirror). End-to-end smoke against an in-memory
+  SQLite fixture confirms the REPLACE fixes stale rows and is
+  idempotent.
+
 ## [6.0.1] - 2026-05-13
 
 ### Fixed

--- a/backend/app/migrations/m056_fix_scope_context_tool_name.py
+++ b/backend/app/migrations/m056_fix_scope_context_tool_name.py
@@ -1,0 +1,60 @@
+"""Migration 056: fix the orient-protocol tool name in per-scope
+`mcp_system_context` fields on sets and collections (issue #115
+follow-up, v6.0.2).
+
+v6.0.1 (m055/m059) fixed the server-wide `mcp_server_instructions`
+singleton, but the per-scope `mcp_system_context` on the Outcomes
+Theory Book set (and any other authored scope) was pasted in the
+v5.18.0 / v6.0.0 era when the canonical doc still said
+`iris_package_hierarchy`. The live scope content remained stale —
+search results still surface the wrong tool name to MCP clients,
+and Claude can't load the structural-overview tool with that name.
+
+This migration is surgical: REPLACE() the wrong substring with the
+right one in `sets.mcp_system_context` AND `collections.mcp_system_context`
+wherever it appears. Admin customisations elsewhere in the body
+are preserved (REPLACE is a no-op when the substring isn't present).
+
+Idempotent — running twice yields the same result.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m056_fix_scope_context_tool_name"
+
+
+async def _fix(db: aiosqlite.Connection, table: str) -> None:
+    """REPLACE the wrong tool name in `<table>.mcp_system_context`
+    rows. No-op if the table or column doesn't exist (test-fixture
+    isolation)."""
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name = ?",
+        (table,),
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    cursor = await db.execute(f"PRAGMA table_info({table})")
+    columns = {row[1] for row in await cursor.fetchall()}
+    if "mcp_system_context" not in columns:
+        return
+
+    await db.execute(
+        f"UPDATE {table}"
+        " SET mcp_system_context = REPLACE(mcp_system_context,"
+        "                                  'iris_package_hierarchy',"
+        "                                  'package_hierarchy')"
+        " WHERE mcp_system_context IS NOT NULL",
+    )
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up — idempotent surgical REPLACE on both tables."""
+    await _fix(db, "sets")
+    await _fix(db, "collections")
+    await db.commit()

--- a/backend/app/migrations/supabase/m060_fix_scope_context_tool_name.sql
+++ b/backend/app/migrations/supabase/m060_fix_scope_context_tool_name.sql
@@ -1,0 +1,20 @@
+-- Migration 060: fix the orient-protocol tool name in per-scope
+-- `mcp_system_context` fields on sets and collections (issue #115
+-- follow-up, v6.0.2).
+--
+-- Mirrors SQLite m056. Surgical REPLACE() preserves any admin
+-- customisations elsewhere in the body.
+--
+-- Idempotent — running twice yields the same result.
+
+UPDATE public.sets
+SET mcp_system_context = REPLACE(mcp_system_context,
+                                 'iris_package_hierarchy',
+                                 'package_hierarchy')
+WHERE mcp_system_context IS NOT NULL;
+
+UPDATE public.collections
+SET mcp_system_context = REPLACE(mcp_system_context,
+                                 'iris_package_hierarchy',
+                                 'package_hierarchy')
+WHERE mcp_system_context IS NOT NULL;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -59,6 +59,7 @@ from app.migrations.m051_response_format_prompts import up as m051_up
 from app.migrations.m053_mcp_server_instructions_seed import up as m053_up
 from app.migrations.m054_oauth_tables import up as m054_up
 from app.migrations.m055_fix_orient_protocol_tool_name import up as m055_up
+from app.migrations.m056_fix_scope_context_tool_name import up as m056_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -144,7 +145,8 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     # m052 (pairing_codes) superseded by m054 (drops the table) — ADR-164, v6.0.0.
     await m053_up(main)
     await m054_up(main)
-    await m055_up(main)  # issue #115, v6.0.1: fix iris_package_hierarchy → package_hierarchy
+    await m055_up(main)  # issue #115, v6.0.1: fix iris_package_hierarchy → package_hierarchy (server-wide)
+    await m056_up(main)  # issue #115, v6.0.2: same fix for per-scope mcp_system_context
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_migrations/test_scope_context_tool_name_fix.py
+++ b/backend/tests/test_migrations/test_scope_context_tool_name_fix.py
@@ -1,0 +1,51 @@
+"""v6.0.2 (issue #115 follow-up): SQLite m056 + Supabase m060 — fix the
+orient-protocol tool name in per-scope `mcp_system_context` fields.
+
+v6.0.1's m055/m059 corrected the server-wide singleton; m056/m060
+correct the per-scope content on `sets` and `collections`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_sqlite_m056_replaces_in_sets_and_collections() -> None:
+    py = _read("app/migrations/m056_fix_scope_context_tool_name.py")
+    assert "REPLACE(mcp_system_context" in py
+    assert "'iris_package_hierarchy'" in py
+    assert "'package_hierarchy'" in py
+    # Both tables targeted.
+    assert '_fix(db, "sets")' in py
+    assert '_fix(db, "collections")' in py
+
+
+def test_sqlite_m056_table_and_column_guards() -> None:
+    py = _read("app/migrations/m056_fix_scope_context_tool_name.py")
+    # Guards so the migration no-ops on isolated test fixtures.
+    assert "type='table'" in py
+    assert "PRAGMA table_info" in py
+    assert '"mcp_system_context" not in columns' in py
+
+
+def test_sqlite_m056_skips_null_rows() -> None:
+    py = _read("app/migrations/m056_fix_scope_context_tool_name.py")
+    # WHERE clause avoids updating rows with NULL mcp_system_context.
+    assert "WHERE mcp_system_context IS NOT NULL" in py
+
+
+def test_supabase_m060_mirrors_sqlite() -> None:
+    sql = _read("app/migrations/supabase/m060_fix_scope_context_tool_name.sql")
+    assert "UPDATE public.sets" in sql
+    assert "UPDATE public.collections" in sql
+    assert "REPLACE(mcp_system_context" in sql
+    assert "'iris_package_hierarchy'" in sql
+    assert "'package_hierarchy'" in sql
+    # Both UPDATEs scope to non-null rows.
+    assert sql.count("WHERE mcp_system_context IS NOT NULL") == 2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.1",
+	"version": "6.0.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.1"
+version = "6.0.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

v6.0.1 fixed the **server-wide** `mcp_server_instructions` singleton row. But live testing on UAT showed the search result for the Outcomes Theory Book still surfacing:

```
"mcp_system_context": "...Structural overview call: iris_package_hierarchy(set_id=) — lists Part A through Part J..."
```

That's the **per-scope** `mcp_system_context` field on `sets.mcp_system_context` — separate from the server-wide singleton. The admin pasted the v5.18.0-era canonical content (with the wrong tool name) into the field during v6.0.0 setup; v6.0.1's fix didn't touch it.

## Fix

`m056` (SQLite) + `m060` (Supabase) surgically `REPLACE()` `iris_package_hierarchy` → `package_hierarchy` in `sets.mcp_system_context` AND `collections.mcp_system_context` for every non-NULL row. Preserves admin customisations elsewhere in each body. Idempotent.

## Test plan

- [x] 4 new migration-parser tests
- [x] End-to-end smoke against in-memory SQLite fixture with a stale row → migration fixes it, idempotent on re-run
- [x] Backend migration sweep 89 pass
- [ ] Apply Supabase m060 to UAT
- [ ] Re-test on UAT: open the Outcomes Theory Book via claude.ai connector; confirm the search result's `mcp_system_context` no longer contains `iris_package_hierarchy`, and Claude now invokes `package_hierarchy` as part of the orient instead of offering it as a follow-up

## Migration

- **SQLite m056** runs automatically on next boot. No manual paste needed.
- **Supabase m060**: apply via `./scripts/supabase-migrate.sh`. Note: it's the **`.sql`** file, not the `.py` file — same source-of-truth caveat as v6.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)