### PR TITLE
fix(v6.0.4): wire MCP server instructions through HTTP transport (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.4] - 2026-05-13
+
+### Fixed
+
+- **MCP orient-first protocol over HTTP transport (issue #119, ADR-165).**
+  v5.18.0 (ADR-163) lifted the universal ORIENT-FIRST protocol into the
+  MCP `Server(instructions=...)` channel and wired it through the stdio
+  entry point. The parallel wiring for the HTTP transport
+  (`asgi.py:build_session_manager`, `http_main.py:create_app`) was
+  missed, so every claude.ai connection — which uses HTTP via the OAuth
+  connector introduced in v6.0.0 — received `InitializeResult` with no
+  `instructions` body. Without that directive in scope ("INVOKE the
+  structural-overview call... NOT as a follow-up 'want me to load it?'
+  prompt"), opening an authored set produced a paraphrased text menu
+  instead of the 5.x flow: auto-loaded TOC + four-option `AskUserQuestion`
+  widget.
+- `build_session_manager()` gains an `instructions: str | None = None`
+  keyword argument that forwards to `build_server(..., instructions=...)`.
+  `create_app()` builds the manager up front, then fetches the orient
+  body in the FastAPI lifespan startup and mutates
+  `session_manager.app.instructions` before the first request arrives.
+  Mutation is safe — the MCP SDK reads `Server.instructions` per request
+  when constructing the InitializeResult, not at server-construct time.
+- Fallback semantics are inherited from `fetch_server_instructions`:
+  any network error, HTTP error, malformed JSON, or empty body yields
+  the hardcoded baseline. The HTTP transport therefore never advertises
+  `instructions=None` in production.
+- Prior fixes (v6.0.1 m055, v6.0.2 m056, v6.0.3) targeted a separate
+  bug — the `iris_package_hierarchy` → `package_hierarchy` tool-name
+  substitution — which is unrelated and remains fixed.
+
+### Added
+
+- **Regression tests** (`test_server_instructions_wiring.py::TestBuildSessionManagerInstructionsWiring`,
+  `test_http_main.py::TestCreateAppFetchesInstructions`) pin the HTTP
+  transport's `instructions` wiring end-to-end. The wiring tests round-
+  trip an arbitrary body through `build_session_manager`; the http_main
+  tests verify the lifespan fetches `/api/ai/server-instructions` and
+  falls back gracefully on backend errors. Closes the test gap that let
+  the v5.18.0 regression land unnoticed.
+- `app.state.session_manager` exposed on the FastAPI app so regression
+  tests can introspect the wrapped MCP server's instructions without
+  walking private route internals.
+
+### Why this matters
+
+- claude.ai users opening any authored scope (e.g. the Outcomes Theory
+  Book set) now see the full ORIENT-FIRST flow: TOC auto-loaded,
+  four-option menu offered via `AskUserQuestion`, no "want me to load
+  it?" preamble. Matches the 5.x.previous flow captured in issue #119.
+
+### See also
+
+- [ADR-165](docs/adrs/ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md)
+- [SPEC-165-A](docs/adrs/specs/SPEC-165-A-MCP-Server-Instructions-Over-HTTP-Transport.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119)
+
 ## [6.0.3] - 2026-05-13
 
 ### Fixed

--- a/docs/adrs/ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md
+++ b/docs/adrs/ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md
@@ -1,0 +1,68 @@
+# ADR-165: Surface MCP server `instructions` over the HTTP transport
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md), [ADR-164](ADR-164-OAuth-2.1-for-MCP.md), [ADR-134](ADR-134-Standalone-MCP-HTTP-Service.md)
+
+## Context
+
+ADR-163 (v5.18.0) lifted the universal ORIENT-FIRST protocol out of every per-scope `mcp_system_context` into a server-wide channel — the MCP SDK's `Server(instructions=...)` field, returned in the `InitializeResult` to every connected MCP client. iris-mcp fetches the admin-editable body from the backend at startup and passes it to `build_server(client, instructions=...)`.
+
+The ADR-163 wiring landed in **`mcp/src/iris_mcp/__main__.py`** — the **stdio** entry point. It was not applied to **`mcp/src/iris_mcp/asgi.py:build_session_manager()`** — the **HTTP** entry point used by the standalone Render service (ADR-134) and consumed by claude.ai over OAuth (ADR-164).
+
+Concretely:
+
+```python
+# asgi.py:90
+server = build_server(_LazyClient())   # no instructions= kwarg → instructions=None
+```
+
+Effect: every HTTP MCP client (claude.ai web app, Claude Desktop's "Add custom connector", any future hosted-MCP client) connects to iris-mcp and receives an `InitializeResult` with **no `instructions` body**. The ORIENT-FIRST protocol — the imperative "INVOKE the structural-overview call... NOT as a follow-up 'want me to load it?' prompt" — never reaches the model.
+
+Issue [#119](https://github.com/cgbarlow/iris/issues/119) reports the user-visible regression: opening the Outcomes Theory Book in claude.ai shows the per-scope menu as plain text and asks the user *"Want me to load the package hierarchy?"* instead of auto-loading it and offering an `AskUserQuestion` widget. The 5.x behaviour worked because the orient protocol was embedded inline in `mcp_system_context` back then; v5.18.0's separation broke the HTTP path only.
+
+Prior fixes for the same issue (v6.0.1 m055, v6.0.2 m056, v6.0.3) targeted a related but distinct bug — the `iris_package_hierarchy` → `package_hierarchy` tool-name substitution. That path is fixed; the live `mcp_system_context` carries the correct name. But the imperative wrapper that says *"don't ask, just call it"* is still never delivered.
+
+The gap was uncovered because the v5.18.0 wiring test (`test_server_instructions_wiring.py`) only exercises `build_server()` in isolation; there is no test verifying that the **HTTP transport** end-to-end advertises the instructions on `InitializeResult`. The stdio path had the same test gap but the wiring happened to be correct there.
+
+## Decision
+
+Plumb `instructions=` through the HTTP transport so it matches the stdio behaviour.
+
+1. **`mcp/src/iris_mcp/asgi.py:build_session_manager()`** gains an `instructions: str | None = None` keyword argument and forwards it to `build_server(_LazyClient(), instructions=instructions)`. Default `None` keeps the function signature non-breaking for any external caller and matches `build_server()`'s own default.
+
+2. **`mcp/src/iris_mcp/http_main.py:create_app()`** calls `await fetch_server_instructions(iris_url)` once at app-construction time (inside an async helper invoked from the FastAPI lifespan startup) and passes the result to `build_session_manager(instructions=...)`. Same fallback semantics as stdio: if the backend is unreachable or returns an empty body, the hardcoded `_FALLBACK_INSTRUCTIONS` baseline ships.
+
+3. **Tests** — add three regression tests:
+   - `test_http_main.py`: `create_app()` builds an app whose session manager's wrapped server has `instructions` set to the value returned by `fetch_server_instructions` (mocked).
+   - `test_http_main.py`: when `fetch_server_instructions` falls back (mock the HTTP call to error), the server still has the fallback body — never `None`.
+   - `test_server_instructions_wiring.py`: `build_session_manager(instructions=...)` round-trips the value to the underlying server.
+
+Pin the contract: every transport iris-mcp ships must advertise `instructions`. No HTTP-vs-stdio drift.
+
+## Why fetch once at app construction (not per-request)
+
+- The `instructions` body is a singleton; admin edits via `/admin/settings/ai` are infrequent (typically once at deploy time, occasionally during prompt-engineering iteration).
+- claude.ai's MCP client caches `InitializeResult` for the session lifetime. Per-request fetches would not propagate edits any faster.
+- Fetch-on-startup matches the stdio model and keeps the request hot path free of backend round-trips.
+- Operationally consistent: admin updates the singleton → restarts iris-mcp → next session sees the new body. Documented in ADR-163.
+
+## Why not move the fetch into `build_session_manager()`
+
+- `build_session_manager()` is called from a sync context (`create_app()` returns a configured `FastAPI`); blocking on an async fetch there would require an `asyncio.run()` inside a function that may itself be called from inside an event loop in test fixtures.
+- Keeping the fetch in `create_app()` (which has an async lifespan available) preserves a clean separation: `build_session_manager` is pure wiring, `create_app` owns I/O.
+
+## Consequences
+
+- One added kwarg on `build_session_manager()`. Backwards-compatible default.
+- One added `await fetch_server_instructions(...)` call in `create_app()`. App startup gains one backend round-trip with a 5 s timeout and graceful fallback (already implemented in `server_instructions.py`).
+- Three new regression tests covering the HTTP path.
+- claude.ai users opening any authored scope now see the ORIENT-FIRST protocol in effect: TOC auto-loaded, menu via `AskUserQuestion` widget, no "want me to load it?" preamble.
+- Version bump v6.0.3 → v6.0.4. Patch-level (bug fix, no API surface change).
+
+## See also
+
+- [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md) — the original lift of orient-first to server-wide `instructions`.
+- [ADR-134](ADR-134-Standalone-MCP-HTTP-Service.md) — why iris-mcp ships as a separate HTTP service.
+- [ADR-164](ADR-164-OAuth-2.1-for-MCP.md) — the HTTP transport claude.ai uses to connect.
+- [SPEC-165-A](specs/SPEC-165-A-MCP-Server-Instructions-Over-HTTP-Transport.md) — wiring details and test plan.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — the regression report.

--- a/docs/adrs/specs/SPEC-165-A-MCP-Server-Instructions-Over-HTTP-Transport.md
+++ b/docs/adrs/specs/SPEC-165-A-MCP-Server-Instructions-Over-HTTP-Transport.md
@@ -1,0 +1,162 @@
+# SPEC-165-A: Surface MCP server `instructions` over the HTTP transport
+
+ADR: [ADR-165](../ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md)
+
+## Summary
+
+Plumb the `instructions` body fetched from the backend through the HTTP transport entry point so it reaches every claude.ai / Claude Desktop / hosted-MCP client. The wiring already exists for stdio (ADR-163); this spec mirrors it for HTTP.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/asgi.py`
+
+`build_session_manager()` accepts a new keyword-only `instructions` parameter and forwards it to `build_server`:
+
+```python
+def build_session_manager(
+    *,
+    instructions: str | None = None,
+) -> StreamableHTTPSessionManager:
+    """Build a stateless Streamable HTTP session manager.
+
+    `instructions` (ADR-165): forwarded to `build_server(...)` and
+    exposed on the MCP `InitializeResult.instructions` field returned
+    to every connected client. None disables the field.
+    """
+    server = build_server(_LazyClient(), instructions=instructions)
+    return StreamableHTTPSessionManager(
+        app=server, stateless=True, json_response=True,
+    )
+```
+
+Default `None` keeps backwards compatibility for any external test or harness that calls `build_session_manager()` directly.
+
+### `mcp/src/iris_mcp/http_main.py`
+
+`create_app()` builds the session manager up front with no instructions, then fetches the body in the lifespan startup and mutates `session_manager.app.instructions` before the first request arrives:
+
+```python
+from iris_mcp.server_instructions import fetch_server_instructions
+
+def create_app() -> FastAPI:
+    iris_url = os.environ.get("IRIS_API_URL")
+    if not iris_url:
+        raise RuntimeError(...)
+
+    session_manager = build_session_manager()
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        # ADR-165 (v6.0.4): mirror stdio wiring (ADR-163). The MCP SDK
+        # reads Server.instructions per request when constructing the
+        # InitializeResult, so post-construct mutation is safe.
+        session_manager.app.instructions = await fetch_server_instructions(
+            iris_url,
+        )
+        async with session_manager.run():
+            yield
+
+    app = FastAPI(..., lifespan=lifespan)
+    app.state.session_manager = session_manager   # for regression test introspection
+    ...
+```
+
+The fetch lives in the lifespan rather than directly in `create_app` for two reasons:
+
+1. `create_app` must remain sync-callable from any context. Async test cases (e.g. `test_oauth_resource.py::TestHttpMainEndpointMounted` and any future asgi-transport test) build the app from inside a running event loop; `asyncio.run()` inside `create_app` would raise `RuntimeError: asyncio.run() cannot be called from a running event loop`.
+2. uvicorn's lifespan protocol is the canonical place for startup I/O. The pattern matches how every other framework component (`StreamableHTTPSessionManager.run()`) is already wired here.
+
+Fallback semantics are inherited from `fetch_server_instructions`: any network error, HTTP error, malformed JSON, or empty body yields `_FALLBACK_INSTRUCTIONS` instead of raising or returning `None`. The HTTP transport therefore **never** advertises `instructions=None` in production — the worst case is the frozen baseline.
+
+## Tests
+
+### `mcp/tests/test_server_instructions_wiring.py`
+
+Add a class verifying `build_session_manager` forwards `instructions`:
+
+```python
+class TestBuildSessionManagerInstructionsWiring:
+    def test_instructions_passed_through(self) -> None:
+        sm = build_session_manager(instructions="HTTP HELLO")
+        assert sm.app.instructions == "HTTP HELLO"   # underlying server
+
+    def test_no_instructions_kwarg_yields_none(self) -> None:
+        sm = build_session_manager()
+        assert sm.app.instructions is None
+```
+
+The `StreamableHTTPSessionManager`'s `app` is the wrapped `Server`; `server.instructions` is the SDK-exposed attribute already used in the existing build-server wiring tests.
+
+### `mcp/tests/test_http_main.py`
+
+Add three tests covering the lifespan fetch + fallback paths. Each enters the lifespan via `TestClient(app)`'s context manager to trigger startup:
+
+```python
+class TestCreateAppFetchesInstructions:
+    def test_lifespan_fetches_and_wires_instructions(
+        self, respx_mock, monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": "ORIENT BODY"}),
+        )
+        app = create_app()
+        with TestClient(app):                     # triggers lifespan startup
+            sm = app.state.session_manager
+            assert sm.app.instructions == "ORIENT BODY"
+
+    def test_lifespan_falls_back_when_backend_unreachable(
+        self, respx_mock, monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            side_effect=httpx.ConnectError("nope"),
+        )
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions is not None  # fallback baseline
+            assert "ORIENT-FIRST PROTOCOL" in sm.app.instructions
+
+    def test_lifespan_falls_back_on_http_error(
+        self, respx_mock, monkeypatch,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            return_value=httpx.Response(500, json={"detail": "boom"}),
+        )
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions == _FALLBACK_INSTRUCTIONS
+```
+
+The `app_with_backend` fixture also gains a respx mock for `/api/ai/server-instructions` so unrelated tests (`/info`, favicon, root-mount) don't trigger a real network call during lifespan startup. The mock body for that fixture is arbitrary — those tests don't inspect `instructions`.
+
+### Existing tests preserved
+
+All three existing `TestBuildServerInstructionsWiring` cases stay green — they exercise `build_server` directly with no transport involvement. Pinning them in place guards against accidental regressions on the stdio path.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.3 → 6.0.4. Patch bump — wiring fix, no public API change. `frontend/package.json` follows the same v6.0.4 tag for release-tracking consistency with v6.0.x.
+
+## CHANGELOG
+
+```markdown
+## [6.0.4] - 2026-05-13
+
+### Fixed
+
+- **MCP orient-first protocol over HTTP transport (issue #119, ADR-165).** v5.18.0 (ADR-163) lifted the universal ORIENT-FIRST protocol into the MCP `Server(instructions=...)` channel and wired it for stdio. The parallel wiring for the HTTP transport (`asgi.py:build_session_manager`, `http_main.py:create_app`) was missed, so every claude.ai connection received `InitializeResult` with no `instructions` body. Model couldn't see the "INVOKE the structural-overview call... NOT as a follow-up 'want me to load it?' prompt" directive, so opening a scope produced a paraphrased text menu instead of the auto-loaded TOC + `AskUserQuestion` flow. Fix plumbs `instructions=` through `build_session_manager(instructions=...)` and fetches the body once at `create_app()`. Regression test `test_http_main.py::TestCreateAppFetchesInstructions` pins the wiring end-to-end.
+```
+
+## Acceptance criteria
+
+- [ ] `build_session_manager(instructions="X")` produces a session manager whose wrapped server has `instructions == "X"`.
+- [ ] `build_session_manager()` (no kwarg) produces a session manager whose wrapped server has `instructions is None` (backwards-compatible default).
+- [ ] `create_app()` fetches `/api/ai/server-instructions` from `IRIS_API_URL` and attaches the body to the session manager.
+- [ ] When the backend is unreachable, `create_app()` still produces a session manager with the fallback `instructions` body — never `None`.
+- [ ] Existing stdio wiring (`__main__.py`) is unchanged.
+- [ ] All existing `mcp/tests/` cases pass; three new regression tests pass.
+- [ ] Manual smoke-test: claude.ai connects to UAT iris-mcp via OAuth, opens the Outcomes Theory Book, sees the TOC auto-loaded and the four-option menu via `AskUserQuestion` widget (matching `5.x.previous.txt`).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.3",
+	"version": "6.0.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.3"
+version = "6.0.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/asgi.py
+++ b/mcp/src/iris_mcp/asgi.py
@@ -76,7 +76,10 @@ async def bind_client(client: "IrisClient") -> "AsyncIterator[None]":
         _current_client.reset(token)
 
 
-def build_session_manager() -> StreamableHTTPSessionManager:
+def build_session_manager(
+    *,
+    instructions: str | None = None,
+) -> StreamableHTTPSessionManager:
     """Build a stateless Streamable HTTP session manager.
 
     The wrapped MCP server reads its IrisClient from the ContextVar that
@@ -84,10 +87,20 @@ def build_session_manager() -> StreamableHTTPSessionManager:
     level session affinity — fine for our read-only + AI workload, and
     avoids the in-memory session table that would otherwise need
     eviction logic.
+
+    `instructions` (ADR-165, v6.0.4): forwarded to `build_server(...)`
+    and exposed on the MCP `InitializeResult.instructions` field
+    returned to every connected client. Mirrors the stdio wiring in
+    `__main__.py` so the orient-first protocol (ADR-163) reaches HTTP
+    clients too — without this kwarg, claude.ai connects and sees no
+    server-level instructions (issue #119).
     """
     # _LazyClientServer reads IrisClient from the ContextVar at dispatch
     # time, so we can build the server before any request arrives.
-    server = build_server(_LazyClient())  # type: ignore[arg-type]
+    server = build_server(
+        _LazyClient(),  # type: ignore[arg-type]
+        instructions=instructions,
+    )
     # json_response=True forces a single JSON response per request rather
     # than an open SSE stream — better for stateless mode and avoids
     # hung connections in clients that don't keep the SSE channel open.

--- a/mcp/src/iris_mcp/http_main.py
+++ b/mcp/src/iris_mcp/http_main.py
@@ -24,6 +24,7 @@ from iris_client import IrisClient
 from iris_mcp.asgi import bind_client, build_session_manager, extract_bearer
 from iris_mcp.branding import ICON_SVG
 from iris_mcp.oauth_resource import build_resource_metadata
+from iris_mcp.server_instructions import fetch_server_instructions
 
 
 def _pkg_version() -> str | None:
@@ -57,10 +58,27 @@ def create_app() -> FastAPI:
         )
         raise RuntimeError(msg)
 
+    # ADR-165 (v6.0.4): the orient-first protocol body (ADR-163) is
+    # fetched in the lifespan startup hook below, before the first
+    # request arrives. Build the session manager up front with no
+    # instructions; the lifespan mutates the wrapped server's
+    # `instructions` attribute once the body is in hand. Mutation is
+    # safe because the MCP SDK reads `Server.instructions` per request
+    # when constructing the InitializeResult — not at server-construct
+    # time. Doing the fetch in the lifespan keeps create_app() sync-
+    # callable from any context (including async test cases that build
+    # the app inside an existing event loop).
     session_manager = build_session_manager()
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        # Mirrors the stdio wiring in __main__.py (ADR-163). Falls back
+        # to the hardcoded baseline on any failure (see
+        # server_instructions.py) so the HTTP transport never advertises
+        # `instructions=None` in production.
+        session_manager.app.instructions = await fetch_server_instructions(
+            iris_url,
+        )
         # StreamableHTTPSessionManager.run() owns the anyio task group
         # the request handler depends on; entering it for the lifetime
         # of the app is the supported pattern.
@@ -72,6 +90,10 @@ def create_app() -> FastAPI:
         description="Standalone Streamable-HTTP MCP server for iris (ADR-131 / ADR-133 / ADR-134).",
         lifespan=lifespan,
     )
+    # Expose the session manager on app.state so the v6.0.4 regression
+    # tests (SPEC-165-A) can verify `instructions` reached the wrapped
+    # MCP server without walking private FastAPI route internals.
+    app.state.session_manager = session_manager
 
     # Favicons must be added before the root mount, otherwise the
     # /favicon.* paths get swallowed by the catch-all ASGI app.

--- a/mcp/tests/test_http_main.py
+++ b/mcp/tests/test_http_main.py
@@ -1,16 +1,30 @@
-"""Tests for the standalone iris-mcp HTTP service (SPEC-134-A)."""
+"""Tests for the standalone iris-mcp HTTP service (SPEC-134-A,
+SPEC-165-A)."""
 
 from __future__ import annotations
 
 from collections.abc import Iterator
 
+import httpx
 import pytest
+import respx
 from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def app_with_backend(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+def app_with_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    respx_mock: respx.Router,
+) -> Iterator[TestClient]:
+    # ADR-165 (v6.0.4): create_app() now fetches /api/ai/server-instructions
+    # at startup. Mock it so non-instruction tests don't depend on an
+    # unreachable backend (fall through is benign but slows the suite).
     monkeypatch.setenv("IRIS_API_URL", "http://iris-backend.test")
+    respx_mock.get(
+        "http://iris-backend.test/api/ai/server-instructions",
+    ).mock(
+        return_value=httpx.Response(200, json={"body": "TEST INSTRUCTIONS"}),
+    )
     from iris_mcp.http_main import create_app
 
     app = create_app()
@@ -95,3 +109,78 @@ class TestRootMount:
         # Response is a real MCP error/result, not a 405 from FastAPI —
         # confirms the ASGI mount is the one handling it.
         assert resp.status_code != 405
+
+
+class TestCreateAppFetchesInstructions:
+    """ADR-165 / issue #119: the HTTP transport must fetch the orient-
+    first protocol body in its startup lifespan and attach it to the
+    wrapped MCP server's `instructions` attribute. Without this wiring,
+    claude.ai connects and gets InitializeResult with no `instructions`
+    body — the model can't see the "INVOKE the structural-overview
+    call... NOT as a follow-up 'want me to load it?' prompt" directive,
+    and the user-visible flow regresses to a paraphrased text menu.
+
+    The fetch lives in the lifespan (not `create_app` directly) so the
+    factory stays sync-callable from async test contexts; tests enter
+    the lifespan via TestClient's context manager to trigger startup.
+    """
+
+    def test_lifespan_fetches_and_wires_instructions(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": "ORIENT BODY"}),
+        )
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        # SPEC-165-A: session_manager attached to app.state so the
+        # regression test can inspect the wrapped server's instructions
+        # without resorting to private FastAPI route walking.
+        with TestClient(app):
+            # Lifespan startup ran inside __enter__; instructions are now
+            # wired into the wrapped MCP server.
+            sm = app.state.session_manager
+            assert sm.app.instructions == "ORIENT BODY"
+
+    def test_lifespan_falls_back_when_backend_unreachable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            side_effect=httpx.ConnectError("connection refused"),
+        )
+        from iris_mcp.http_main import create_app
+        from iris_mcp.server_instructions import _FALLBACK_INSTRUCTIONS
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            # Never None in production — fall through always yields the
+            # hardcoded safe baseline. Pins the contract that the HTTP
+            # transport advertises *some* orient body even in degraded
+            # backend states.
+            assert sm.app.instructions == _FALLBACK_INSTRUCTIONS
+            assert "ORIENT-FIRST PROTOCOL" in sm.app.instructions
+
+    def test_lifespan_falls_back_on_http_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            return_value=httpx.Response(500, json={"detail": "boom"}),
+        )
+        from iris_mcp.http_main import create_app
+        from iris_mcp.server_instructions import _FALLBACK_INSTRUCTIONS
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions == _FALLBACK_INSTRUCTIONS

--- a/mcp/tests/test_server_instructions_wiring.py
+++ b/mcp/tests/test_server_instructions_wiring.py
@@ -1,8 +1,12 @@
-"""build_server `instructions` wiring tests (ADR-163, SPEC-163-A).
+"""build_server / build_session_manager `instructions` wiring tests
+(ADR-163, SPEC-163-A; ADR-165, SPEC-165-A).
 
 Verifies the MCP SDK's `Server(instructions=...)` constructor
 receives the value passed through `build_server(client, instructions=...)`
-and that omitting the kwarg yields `instructions=None`.
+(stdio path) AND through `build_session_manager(instructions=...)`
+(HTTP path). Both transports must advertise `instructions` on
+`InitializeResult` so the orient-first protocol reaches every
+connected MCP client. Issue #119 covers the HTTP-side regression.
 """
 
 from __future__ import annotations
@@ -10,6 +14,7 @@ from __future__ import annotations
 import pytest
 from iris_client import IrisClient
 
+from iris_mcp.asgi import build_session_manager
 from iris_mcp.server import build_server
 
 
@@ -40,3 +45,23 @@ class TestBuildServerInstructionsWiring:
     ) -> None:
         server = build_server(client, instructions=None)
         assert server.instructions is None
+
+
+class TestBuildSessionManagerInstructionsWiring:
+    """ADR-165 / issue #119: the HTTP transport must round-trip the
+    same `instructions` body the stdio transport already does."""
+
+    def test_instructions_passed_through(self) -> None:
+        sm = build_session_manager(instructions="HTTP HELLO")
+        # StreamableHTTPSessionManager.app is the wrapped MCP Server;
+        # `server.instructions` is what the SDK serialises into the
+        # InitializeResult that every MCP client reads on connect.
+        assert sm.app.instructions == "HTTP HELLO"
+
+    def test_no_instructions_kwarg_yields_none(self) -> None:
+        sm = build_session_manager()
+        assert sm.app.instructions is None
+
+    def test_explicit_none_yields_none(self) -> None:
+        sm = build_session_manager(instructions=None)
+        assert sm.app.instructions is None


### PR DESCRIPTION
## Summary

- v5.18.0 (ADR-163) lifted the universal ORIENT-FIRST protocol into the MCP `Server(instructions=...)` channel and wired it through the stdio entry point. The parallel wiring for the **HTTP transport** (`asgi.py:build_session_manager`, `http_main.py:create_app`) was missed, so every claude.ai connection received `InitializeResult` with no `instructions` body.
- Without that directive, opening an authored set produced a paraphrased text menu instead of the 5.x flow: auto-loaded TOC + four-option `AskUserQuestion` widget.
- Closes #119. ADR-165 / SPEC-165-A document the decision.

## Root cause

The diff for ADR-163 (commit `294dc25`) updated `__main__.py` (stdio) and `server.py` (`build_server` signature), but never touched `asgi.py:build_session_manager()` which is the HTTP transport's only entry point. claude.ai uses HTTP via the OAuth connector introduced in v6.0.0, so it never saw the orient-first protocol.

Prior fixes (v6.0.1 m055, v6.0.2 m056, v6.0.3) targeted a separate `iris_package_hierarchy` → `package_hierarchy` tool-name substitution and don't address this gap.

## Wiring

- `build_session_manager()` gains `instructions: str | None = None`, forwards to `build_server(...)`.
- `create_app()` builds the manager up front, then fetches the orient body in the FastAPI **lifespan startup** and mutates `session_manager.app.instructions` before the first request. The MCP SDK reads `Server.instructions` per request when constructing the InitializeResult, so post-construct mutation is safe.
- Fetch lives in the lifespan (not `create_app` directly) so the factory stays sync-callable from async test contexts.
- Fallback semantics inherited from `fetch_server_instructions`: HTTP transport never advertises `None` in production.

## Tests

- `test_server_instructions_wiring.py::TestBuildSessionManagerInstructionsWiring` — round-trips a body through `build_session_manager`.
- `test_http_main.py::TestCreateAppFetchesInstructions` — enters the lifespan via `TestClient` and verifies fetch + fallback paths end-to-end.
- `app.state.session_manager` exposed for introspection.
- Closes the test gap that let v5.18.0 ship with the regression.

All 129 MCP tests pass.

## Test plan

- [ ] CI green on the merge.
- [ ] Deploy iris-mcp v6.0.4 to UAT.
- [ ] In claude.ai, open the Outcomes Theory Book — confirm TOC auto-loads and the four-option menu appears via `AskUserQuestion` widget (matches the 5.x flow captured in #119).

## See also

- [ADR-165](https://github.com/cgbarlow/iris/blob/fix/issue-119-http-instructions-wiring/docs/adrs/ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md)
- [SPEC-165-A](https://github.com/cgbarlow/iris/blob/fix/issue-119-http-instructions-wiring/docs/adrs/specs/SPEC-165-A-MCP-Server-Instructions-Over-HTTP-Transport.md)
- Issue #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)