### PR TITLE
fix(v6.0.5): TTL refresh for MCP server instructions (issue #119 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.5] - 2026-05-13
+
+### Fixed
+
+- **MCP server instructions now refresh from the backend on a TTL —
+  admin edits propagate without a Render redeploy (issue #119 final
+  follow-up, ADR-166).** v6.0.4 (ADR-165) wired the orient-first
+  protocol body through the HTTP transport at lifespan startup, but
+  iris-mcp continued serving the body it fetched at boot for the
+  entire lifetime of the process. Admins editing the
+  `mcp_server_instructions` row in `/admin/settings/ai` had to wait
+  for a manual Render "Manual Deploy" before the new body reached
+  claude.ai. That defeated the "admin-editable" promise of ADR-163.
+- The HTTP-transport lifespan now spawns an `asyncio` background task
+  that re-fetches `/api/ai/server-instructions` every
+  `IRIS_MCP_INSTRUCTIONS_REFRESH_S` seconds (default **60**) and
+  updates `session_manager.app.instructions` if the body has changed.
+  The MCP SDK reads `Server.instructions` per request, so the next
+  claude.ai session that connects after the tick sees the fresh body.
+- **Transient backend failures preserve the last good value.** A new
+  helper `try_fetch_server_instructions(iris_url) -> str | None`
+  returns `None` on every failure mode `fetch_server_instructions`
+  falls back from (network error, HTTP error, malformed JSON, empty
+  body). The refresh loop only writes when it gets a fresh real body,
+  so a 30-second backend hiccup doesn't silently revert admin
+  customisations to the hardcoded fallback. The startup fetch still
+  uses `fetch_server_instructions` so the first request never sees
+  `instructions=None`.
+- **Background task is cancelled cleanly on lifespan shutdown.** No
+  hung tasks, no leaked exceptions when iris-mcp restarts.
+
+### Added
+
+- New env var `IRIS_MCP_INSTRUCTIONS_REFRESH_S` (default 60, set 0 to
+  disable the loop). Tunable for prompt-engineering iteration (shorter
+  interval) or quiet production (longer interval / disabled).
+- 7 new regression tests:
+  - `test_server_instructions.py::TestTryFetchServerInstructions` (7
+    cases) — `try_fetch` returns body on happy path; `None` on every
+    failure mode the canonical variant falls back from.
+  - `test_http_main.py::TestRefreshLoop` (3 cases) — refresh picks up
+    an updated body within the TTL window; preserves last-good body
+    on transient failure; disabled when interval is 0.
+
+### Why this matters
+
+- Admins iterating on the orient protocol from `/admin/settings/ai`
+  now see edits propagate to claude.ai within ≤ 60 seconds (default).
+  No Render dashboard required, no commit-and-deploy cycle. This is
+  what ADR-163's "admin-editable" promise has meant all along; v6.0.5
+  is the last gap closed.
+
+### See also
+
+- [ADR-166](docs/adrs/ADR-166-MCP-Server-Instructions-TTL-Refresh.md)
+- [SPEC-166-A](docs/adrs/specs/SPEC-166-A-MCP-Server-Instructions-TTL-Refresh.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119)
+
 ## [6.0.4] - 2026-05-13
 
 ### Fixed

--- a/docs/adrs/ADR-166-MCP-Server-Instructions-TTL-Refresh.md
+++ b/docs/adrs/ADR-166-MCP-Server-Instructions-TTL-Refresh.md
@@ -1,0 +1,68 @@
+# ADR-166: TTL background refresh for MCP server instructions
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md), [ADR-165](ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md)
+
+## Context
+
+ADR-163 made the MCP `Server.instructions` body admin-editable from `/admin/settings/ai`. ADR-165 wired that body through the HTTP transport so claude.ai actually receives it. Issue #119 testing surfaced a third gap: **admin edits don't take effect until the iris-mcp service is manually redeployed.**
+
+The iris-mcp HTTP service fetches the body once in its FastAPI lifespan startup hook (`http_main.py:create_app`). After that, the fetched value is held in `session_manager.app.instructions` for the lifetime of the process. Subsequent admin edits to the `/api/ai/server-instructions` row do update the backend response immediately, but iris-mcp keeps serving its stale copy until Render restarts the container.
+
+Observed during issue #119 debugging:
+
+1. Admin paste the canonical strong-wording body into `/admin/settings/ai`.
+2. `curl /api/ai/server-instructions` confirms the new body is live on iris-api.
+3. `curl iris-mcp.../` (MCP `initialize`) still returns the **old weak body** that iris-mcp cached at boot.
+4. claude.ai keeps following the weak body until Render redeploys iris-mcp.
+
+That breaks the "admin-editable" promise of ADR-163. Every iteration of prompt-engineering on the orient protocol currently requires a manual Render redeploy.
+
+## Decision
+
+Add a TTL background-refresh loop to the HTTP-transport lifespan.
+
+- The lifespan startup hook still does the initial blocking fetch (so the very first request never sees `instructions=None`).
+- After that, an `asyncio` background task re-fetches `/api/ai/server-instructions` every `IRIS_MCP_INSTRUCTIONS_REFRESH_S` seconds (default **60**) and mutates `session_manager.app.instructions` if the new body differs from the current one.
+- If the backend is transiently unavailable mid-loop, **keep the last good value** rather than overwriting with the fallback baseline. Avoids "admin body briefly disappears during a backend hiccup". A new helper `try_fetch_server_instructions(iris_url) -> str | None` returns `None` on any failure (network, HTTP, malformed body, empty body); the loop only writes if the result is `not None` and `!= current`.
+- On lifespan shutdown, cancel the background task and swallow `CancelledError` cleanly.
+- Refresh interval is **configurable** via `IRIS_MCP_INSTRUCTIONS_REFRESH_S`. Set to `0` to disable refresh entirely (e.g. for tests; the lifespan still does the initial fetch). Set to a small value for prompt-engineering iteration.
+
+The MCP SDK reads `Server.instructions` per request when constructing `InitializeResult`, so post-startup mutation is observed by every new claude.ai session without per-request fetch overhead.
+
+## Why TTL (not per-init fetch)
+
+- Per-init fetch couples MCP-init latency to backend availability and adds a backend round-trip on every claude.ai session start. With claude.ai's stateless-mode connections (ADR-134, `stateless=True`), that's potentially every conversation turn — far more pressure than admin edit cadence justifies.
+- A 60-second TTL means admin edits propagate to claude.ai within a minute. The orient protocol is not a hot-iteration knob; minute-scale propagation matches the workflow.
+- Per-init fetch would also need to deal with the "backend unavailable on init" case identically to lifespan startup (keep advertising last good value), so the implementation overhead isn't materially smaller.
+
+## Why an env-var-tunable interval
+
+- The default 60 s is a guess at "fast enough for prompt-engineering, slow enough to not hammer the backend". Self-hosters with different cadences (e.g. long-stable production deployment vs. active development) should be able to tune without rebuilding.
+- `0` disables refresh — useful in tests that want deterministic instructions (the test injects whatever body it wants via `respx_mock` once, doesn't want the loop racing the assertion).
+
+## Why mutate `session_manager.app.instructions` directly
+
+- The MCP SDK exposes `instructions` as a public `__init__` attribute, read per request. Mutation is supported by the contract.
+- Wrapping the Server to add a callable `instructions_provider()` hook would be cleaner architecturally but is much more code for a single concern. The session manager's `app` is already the Server instance; one attribute write is the simplest path.
+
+## Consequences
+
+- One new helper `try_fetch_server_instructions(iris_url) -> str | None` in `server_instructions.py`.
+- `http_main.py` lifespan gains a background task with start + cancel-on-shutdown.
+- New env var `IRIS_MCP_INSTRUCTIONS_REFRESH_S` (default 60, set 0 to disable).
+- Render `render.yaml` left unchanged — default 60s applies via the implicit default.
+- 4 new regression tests:
+  - `try_fetch_server_instructions` returns the body on success.
+  - `try_fetch_server_instructions` returns `None` on every failure mode that `fetch_server_instructions` falls back from.
+  - The lifespan refresh loop picks up an updated body within the TTL window.
+  - The lifespan refresh loop preserves the last good body when the backend transiently fails.
+- Documentation update — `docs/prompts/mcp-server-instructions.md` "Why this works" section gains a note about minute-scale propagation.
+- Version bump v6.0.4 → v6.0.5. Patch-level (operator-experience fix, no API surface change).
+
+## See also
+
+- [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md) — original admin-editable instructions design.
+- [ADR-165](ADR-165-MCP-Server-Instructions-Over-HTTP-Transport.md) — wiring fix that made the issue visible.
+- [SPEC-166-A](specs/SPEC-166-A-MCP-Server-Instructions-TTL-Refresh.md) — implementation details.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — original regression report.

--- a/docs/adrs/specs/SPEC-166-A-MCP-Server-Instructions-TTL-Refresh.md
+++ b/docs/adrs/specs/SPEC-166-A-MCP-Server-Instructions-TTL-Refresh.md
@@ -1,0 +1,216 @@
+# SPEC-166-A: TTL background refresh for MCP server instructions
+
+ADR: [ADR-166](../ADR-166-MCP-Server-Instructions-TTL-Refresh.md)
+
+## Summary
+
+Add an `asyncio` background task to the HTTP-transport lifespan that re-fetches `/api/ai/server-instructions` every `IRIS_MCP_INSTRUCTIONS_REFRESH_S` seconds (default 60) and updates `session_manager.app.instructions` if the body has changed. Preserve last-good-value on transient backend failures.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/server_instructions.py`
+
+Add a new helper that returns `None` instead of falling back, so the refresh loop can distinguish "real new body" from "backend unavailable":
+
+```python
+async def try_fetch_server_instructions(iris_url: str) -> str | None:
+    """Like `fetch_server_instructions` but returns None on any failure
+    instead of the hardcoded fallback. Use in the refresh loop where
+    we want to preserve the previously-fetched body if the backend is
+    transiently unavailable; the initial startup fetch still uses
+    `fetch_server_instructions` so the very first request never sees
+    `instructions=None`.
+    """
+    try:
+        async with httpx.AsyncClient(base_url=iris_url, timeout=5.0) as c:
+            response = await c.get("/api/ai/server-instructions")
+            response.raise_for_status()
+            payload = response.json()
+            body = payload.get("body") if isinstance(payload, dict) else None
+            if isinstance(body, str) and body.strip():
+                return body
+            return None
+    except (httpx.HTTPError, ValueError):
+        return None
+```
+
+The existing `fetch_server_instructions` is kept unchanged for the startup-fetch path (where the hardcoded fallback is the right answer to avoid `None` on the first request).
+
+### `mcp/src/iris_mcp/http_main.py`
+
+Update the lifespan:
+
+```python
+import asyncio
+
+REFRESH_DEFAULT_S = 60.0
+
+def create_app() -> FastAPI:
+    iris_url = os.environ.get("IRIS_API_URL")
+    if not iris_url:
+        raise RuntimeError(...)
+
+    session_manager = build_session_manager()
+
+    refresh_interval = float(
+        os.environ.get("IRIS_MCP_INSTRUCTIONS_REFRESH_S", REFRESH_DEFAULT_S),
+    )
+
+    async def _refresh_loop() -> None:
+        # Periodic background refresh. Preserves last-good on transient
+        # backend failures (try_fetch returns None instead of fallback).
+        while True:
+            await asyncio.sleep(refresh_interval)
+            fresh = await try_fetch_server_instructions(iris_url)
+            if fresh is not None and fresh != session_manager.app.instructions:
+                session_manager.app.instructions = fresh
+                logger.info("iris-mcp: refreshed server instructions body")
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        # Initial blocking fetch — never let the first request see None.
+        session_manager.app.instructions = await fetch_server_instructions(
+            iris_url,
+        )
+
+        refresh_task: asyncio.Task[None] | None = None
+        if refresh_interval > 0:
+            refresh_task = asyncio.create_task(_refresh_loop())
+
+        try:
+            async with session_manager.run():
+                yield
+        finally:
+            if refresh_task is not None:
+                refresh_task.cancel()
+                try:
+                    await refresh_task
+                except asyncio.CancelledError:
+                    pass
+
+    app = FastAPI(..., lifespan=lifespan)
+    app.state.session_manager = session_manager
+    ...
+```
+
+`IRIS_MCP_INSTRUCTIONS_REFRESH_S=0` disables the loop entirely (useful for deterministic tests).
+
+## Tests
+
+### `mcp/tests/test_server_instructions.py`
+
+Add a `TestTryFetchServerInstructions` class mirroring `TestFetchServerInstructions` but asserting `None` on failure modes instead of the fallback constant:
+
+- Happy path returns body.
+- Empty body → None.
+- Whitespace body → None.
+- 500 → None.
+- 404 → None.
+- Network error → None.
+- Malformed JSON → None.
+
+### `mcp/tests/test_http_main.py`
+
+Add a `TestRefreshLoop` class:
+
+```python
+class TestRefreshLoop:
+    def test_lifespan_picks_up_updated_body(
+        self, monkeypatch, respx_mock,
+    ) -> None:
+        """Refresh loop updates `instructions` when the backend body
+        changes."""
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0.05")
+        route = respx_mock.get(
+            "http://iris.test/api/ai/server-instructions",
+        )
+        # First call returns the boot body, subsequent calls return the
+        # updated body — simulating an admin edit landing mid-session.
+        route.mock(side_effect=[
+            httpx.Response(200, json={"body": "BOOT BODY"}),
+            httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+            httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+        ])
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            # Initial fetch happens in lifespan startup.
+            assert sm.app.instructions == "BOOT BODY"
+            # Wait long enough for one refresh tick.
+            for _ in range(20):
+                time.sleep(0.05)
+                if sm.app.instructions == "ADMIN-EDITED BODY":
+                    break
+            assert sm.app.instructions == "ADMIN-EDITED BODY"
+
+    def test_lifespan_preserves_body_on_transient_failure(
+        self, monkeypatch, respx_mock,
+    ) -> None:
+        """When the backend fails mid-loop, the previously-fetched body
+        is preserved rather than overwritten with the fallback."""
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0.05")
+        respx_mock.get(
+            "http://iris.test/api/ai/server-instructions",
+        ).mock(side_effect=[
+            httpx.Response(200, json={"body": "GOOD BODY"}),
+            httpx.ConnectError("backend down"),
+            httpx.ConnectError("backend still down"),
+        ])
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions == "GOOD BODY"
+            # Wait long enough for at least one failed refresh tick.
+            time.sleep(0.2)
+            # The good body is still there — the failed refreshes didn't
+            # clobber it with the fallback.
+            assert sm.app.instructions == "GOOD BODY"
+
+    def test_refresh_disabled_when_interval_zero(
+        self, monkeypatch, respx_mock,
+    ) -> None:
+        """Setting IRIS_MCP_INSTRUCTIONS_REFRESH_S=0 disables the loop —
+        only the initial startup fetch runs."""
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0")
+        route = respx_mock.get(
+            "http://iris.test/api/ai/server-instructions",
+        ).mock(
+            return_value=httpx.Response(200, json={"body": "ONCE"}),
+        )
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            time.sleep(0.2)
+            sm = app.state.session_manager
+            assert sm.app.instructions == "ONCE"
+            # Only the lifespan startup fetch ran.
+            assert route.call_count == 1
+```
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.4 → 6.0.5. Patch bump — operator-experience fix, no public API change.
+`frontend/package.json`: matched 6.0.5.
+
+## CHANGELOG
+
+Add a `[6.0.5]` entry documenting the TTL refresh, the new env var, and the issue #119 closing context (this is the last gap that prevented admin edits from reaching claude.ai in real time).
+
+## Acceptance criteria
+
+- [ ] `try_fetch_server_instructions` returns body on success, `None` on every failure path that `fetch_server_instructions` falls back from.
+- [ ] iris-mcp lifespan startup still does an immediate blocking fetch — no regression on the v6.0.4 wiring.
+- [ ] Refresh loop picks up an admin edit within `IRIS_MCP_INSTRUCTIONS_REFRESH_S` seconds.
+- [ ] Refresh loop preserves last-good body when the backend fails transiently.
+- [ ] Setting `IRIS_MCP_INSTRUCTIONS_REFRESH_S=0` disables the loop.
+- [ ] Cancellation on lifespan shutdown is clean (no hung tasks, no leaked exceptions).
+- [ ] All v6.0.4 regression tests still pass.
+- [ ] Manual smoke after deploy: admin edits the `mcp_server_instructions` body, waits ≤ 60 s, fresh claude.ai chat sees the new body in `InitializeResult` without a Render redeploy.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.4",
+	"version": "6.0.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.4"
+version = "6.0.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/http_main.py
+++ b/mcp/src/iris_mcp/http_main.py
@@ -11,6 +11,7 @@ Run: `uvicorn iris_mcp.http_main:create_app --factory --host 0.0.0.0`.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -24,7 +25,14 @@ from iris_client import IrisClient
 from iris_mcp.asgi import bind_client, build_session_manager, extract_bearer
 from iris_mcp.branding import ICON_SVG
 from iris_mcp.oauth_resource import build_resource_metadata
-from iris_mcp.server_instructions import fetch_server_instructions
+from iris_mcp.server_instructions import (
+    fetch_server_instructions,
+    try_fetch_server_instructions,
+)
+
+# ADR-166 (v6.0.5): default 60s between refresh ticks. Tunable via
+# IRIS_MCP_INSTRUCTIONS_REFRESH_S; set to 0 to disable the loop entirely.
+REFRESH_DEFAULT_S = 60.0
 
 
 def _pkg_version() -> str | None:
@@ -70,6 +78,31 @@ def create_app() -> FastAPI:
     # the app inside an existing event loop).
     session_manager = build_session_manager()
 
+    # ADR-166 (v6.0.5): how often the background refresh loop re-fetches
+    # `/api/ai/server-instructions` so admin edits propagate without a
+    # Render redeploy. 0 disables the loop.
+    refresh_interval = float(
+        os.environ.get(
+            "IRIS_MCP_INSTRUCTIONS_REFRESH_S",
+            str(REFRESH_DEFAULT_S),
+        ),
+    )
+
+    async def _refresh_loop() -> None:
+        """Periodic refresh. Preserves last-good on transient backend
+        failures — `try_fetch_server_instructions` returns None instead
+        of the fallback baseline, so we only write when we got a fresh
+        real body."""
+        while True:
+            await asyncio.sleep(refresh_interval)
+            fresh = await try_fetch_server_instructions(iris_url)
+            if (
+                fresh is not None
+                and fresh != session_manager.app.instructions
+            ):
+                session_manager.app.instructions = fresh
+                logger.info("iris-mcp: refreshed server instructions body")
+
     @asynccontextmanager
     async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         # Mirrors the stdio wiring in __main__.py (ADR-163). Falls back
@@ -79,11 +112,24 @@ def create_app() -> FastAPI:
         session_manager.app.instructions = await fetch_server_instructions(
             iris_url,
         )
-        # StreamableHTTPSessionManager.run() owns the anyio task group
-        # the request handler depends on; entering it for the lifetime
-        # of the app is the supported pattern.
-        async with session_manager.run():
-            yield
+
+        refresh_task: asyncio.Task[None] | None = None
+        if refresh_interval > 0:
+            refresh_task = asyncio.create_task(_refresh_loop())
+
+        try:
+            # StreamableHTTPSessionManager.run() owns the anyio task
+            # group the request handler depends on; entering it for the
+            # lifetime of the app is the supported pattern.
+            async with session_manager.run():
+                yield
+        finally:
+            if refresh_task is not None:
+                refresh_task.cancel()
+                try:
+                    await refresh_task
+                except asyncio.CancelledError:
+                    pass
 
     app = FastAPI(
         title="iris-mcp",

--- a/mcp/src/iris_mcp/server_instructions.py
+++ b/mcp/src/iris_mcp/server_instructions.py
@@ -48,6 +48,30 @@ async def fetch_server_instructions(iris_url: str) -> str:
 
     Falls back to `_FALLBACK_INSTRUCTIONS` on any network error,
     HTTP error, malformed JSON, or empty body. Never raises.
+
+    Used by the lifespan startup fetch — the caller wants a usable
+    body in hand before serving the first request, so falling back to
+    the hardcoded baseline is the right behaviour. The refresh-loop
+    variant `try_fetch_server_instructions` returns `None` instead, so
+    a transient backend failure mid-loop doesn't clobber a previously-
+    fetched admin-edited body with the baseline (ADR-166, v6.0.5).
+    """
+    body = await try_fetch_server_instructions(iris_url)
+    return body if body is not None else _FALLBACK_INSTRUCTIONS
+
+
+async def try_fetch_server_instructions(iris_url: str) -> str | None:
+    """GET /api/ai/server-instructions and return its body, or None.
+
+    Returns `None` on any failure mode that `fetch_server_instructions`
+    falls back from — network error, HTTP error, malformed JSON, empty
+    body, whitespace-only body. Never raises.
+
+    Used by the v6.0.5 refresh loop (ADR-166): if the backend is
+    transiently unavailable mid-loop, the caller preserves the last
+    good body rather than overwriting it with the hardcoded fallback.
+    The lifespan startup path uses `fetch_server_instructions` so the
+    very first request still sees a non-`None` body.
     """
     try:
         async with httpx.AsyncClient(base_url=iris_url, timeout=5.0) as c:
@@ -57,6 +81,6 @@ async def fetch_server_instructions(iris_url: str) -> str:
             body = payload.get("body") if isinstance(payload, dict) else None
             if isinstance(body, str) and body.strip():
                 return body
-            return _FALLBACK_INSTRUCTIONS
+            return None
     except (httpx.HTTPError, ValueError):
-        return _FALLBACK_INSTRUCTIONS
+        return None

--- a/mcp/tests/test_http_main.py
+++ b/mcp/tests/test_http_main.py
@@ -1,8 +1,9 @@
 """Tests for the standalone iris-mcp HTTP service (SPEC-134-A,
-SPEC-165-A)."""
+SPEC-165-A, SPEC-166-A)."""
 
 from __future__ import annotations
 
+import time
 from collections.abc import Iterator
 
 import httpx
@@ -19,7 +20,10 @@ def app_with_backend(
     # ADR-165 (v6.0.4): create_app() now fetches /api/ai/server-instructions
     # at startup. Mock it so non-instruction tests don't depend on an
     # unreachable backend (fall through is benign but slows the suite).
+    # ADR-166 (v6.0.5): disable the refresh loop for unrelated tests so
+    # the background task doesn't race other assertions.
     monkeypatch.setenv("IRIS_API_URL", "http://iris-backend.test")
+    monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0")
     respx_mock.get(
         "http://iris-backend.test/api/ai/server-instructions",
     ).mock(
@@ -174,6 +178,7 @@ class TestCreateAppFetchesInstructions:
         respx_mock: respx.Router,
     ) -> None:
         monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0")
         respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
             return_value=httpx.Response(500, json={"detail": "boom"}),
         )
@@ -184,3 +189,107 @@ class TestCreateAppFetchesInstructions:
         with TestClient(app):
             sm = app.state.session_manager
             assert sm.app.instructions == _FALLBACK_INSTRUCTIONS
+
+
+class TestRefreshLoop:
+    """ADR-166 / SPEC-166-A: TTL background refresh so admin edits to
+    `mcp_server_instructions` propagate to claude.ai without requiring
+    a Render redeploy. Tests use a short refresh interval so the loop
+    runs multiple times during the test window.
+    """
+
+    def test_lifespan_picks_up_updated_body(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        # 50ms refresh — fast enough to land within the test window,
+        # slow enough that the initial startup fetch settles before the
+        # first refresh tick (avoids racy "did the loop run yet?" reads).
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0.05")
+        # First call: lifespan startup. Subsequent: refresh ticks see
+        # the new body — simulating an admin edit landing mid-session.
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            side_effect=[
+                httpx.Response(200, json={"body": "BOOT BODY"}),
+                httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+                httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+                httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+                httpx.Response(200, json={"body": "ADMIN-EDITED BODY"}),
+            ],
+        )
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions == "BOOT BODY"
+            # Poll for the refresh — up to 1 second.
+            for _ in range(20):
+                if sm.app.instructions == "ADMIN-EDITED BODY":
+                    break
+                time.sleep(0.05)
+            assert sm.app.instructions == "ADMIN-EDITED BODY"
+
+    def test_lifespan_preserves_body_on_transient_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        """Failed refreshes must NOT clobber the previously-fetched body
+        with the fallback baseline — that would silently revert admin
+        customisations any time the backend hiccups for >REFRESH_S."""
+        from iris_mcp.server_instructions import _FALLBACK_INSTRUCTIONS
+
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0.05")
+        call_count = [0]
+
+        def _side_effect(request: httpx.Request) -> httpx.Response:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return httpx.Response(200, json={"body": "GOOD BODY"})
+            # Every subsequent call simulates a transient backend
+            # failure — refresh loop should preserve the boot body.
+            raise httpx.ConnectError("backend down")
+
+        respx_mock.get("http://iris.test/api/ai/server-instructions").mock(
+            side_effect=_side_effect,
+        )
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            sm = app.state.session_manager
+            assert sm.app.instructions == "GOOD BODY"
+            # Wait long enough for several failed refresh ticks.
+            time.sleep(0.3)
+            assert sm.app.instructions == "GOOD BODY"
+            # Specifically, never clobbered with the hardcoded fallback.
+            assert sm.app.instructions != _FALLBACK_INSTRUCTIONS
+            # Sanity: the refresh loop actually fired more than once.
+            assert call_count[0] >= 2
+
+    def test_refresh_disabled_when_interval_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        respx_mock: respx.Router,
+    ) -> None:
+        """`IRIS_MCP_INSTRUCTIONS_REFRESH_S=0` short-circuits the loop —
+        only the startup fetch runs. Useful for deterministic tests and
+        for ops who don't want background traffic to their backend."""
+        monkeypatch.setenv("IRIS_API_URL", "http://iris.test")
+        monkeypatch.setenv("IRIS_MCP_INSTRUCTIONS_REFRESH_S", "0")
+        route = respx_mock.get(
+            "http://iris.test/api/ai/server-instructions",
+        ).mock(return_value=httpx.Response(200, json={"body": "ONCE"}))
+        from iris_mcp.http_main import create_app
+
+        app = create_app()
+        with TestClient(app):
+            time.sleep(0.2)
+            sm = app.state.session_manager
+            assert sm.app.instructions == "ONCE"
+            # Only the lifespan startup fetch ran — no refresh ticks.
+            assert route.call_count == 1

--- a/mcp/tests/test_server_instructions.py
+++ b/mcp/tests/test_server_instructions.py
@@ -14,6 +14,7 @@ import respx
 from iris_mcp.server_instructions import (
     _FALLBACK_INSTRUCTIONS,
     fetch_server_instructions,
+    try_fetch_server_instructions,
 )
 
 BASE = "http://iris.test"
@@ -104,3 +105,89 @@ class TestFetchServerInstructions:
         assert "DISCOVERY TOOLS" in _FALLBACK_INSTRUCTIONS
         assert "WORKFLOW GUIDANCE" in _FALLBACK_INSTRUCTIONS
         assert "AUTH RECOVERY" in _FALLBACK_INSTRUCTIONS
+
+
+class TestTryFetchServerInstructions:
+    """ADR-166 / SPEC-166-A: `try_fetch_server_instructions` is the
+    refresh-loop variant of `fetch_server_instructions` — returns
+    `None` on every failure mode the canonical variant falls back from,
+    so the refresh loop can distinguish "real new body" from "backend
+    transiently unavailable" and preserve the last good value rather
+    than clobber it with the fallback baseline.
+    """
+
+    @pytest.mark.asyncio
+    async def test_happy_fetch_returns_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(
+                200, json={"body": "ADMIN-EDITED INSTRUCTIONS"},
+            ),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result == "ADMIN-EDITED INSTRUCTIONS"
+
+    @pytest.mark.asyncio
+    async def test_empty_body_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": ""}),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_whitespace_body_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(200, json={"body": "   \n   "}),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_http_error_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(500, json={"detail": "boom"}),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_404_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(404, json={"detail": "not found"}),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_network_error_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            side_effect=httpx.ConnectError("connection refused"),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_returns_none(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/ai/server-instructions").mock(
+            return_value=httpx.Response(
+                200,
+                text="not json",
+                headers={"content-type": "application/json"},
+            ),
+        )
+        result = await try_fetch_server_instructions(BASE)
+        assert result is None


### PR DESCRIPTION
## Summary

- v6.0.4 (ADR-165) wired `instructions` through HTTP at lifespan startup — but iris-mcp held the fetched body for the lifetime of the process. Admin edits to `mcp_server_instructions` didn't reach claude.ai until a manual Render redeploy, defeating ADR-163's "admin-editable" promise.
- v6.0.5 adds a TTL background-refresh loop (default 60 s, env-tunable) so admin edits propagate without a redeploy. Closes the last gap from issue #119.

## Wiring

- Lifespan still does the initial blocking fetch (first request never sees `instructions=None`).
- Background `asyncio.Task` re-fetches every `IRIS_MCP_INSTRUCTIONS_REFRESH_S` seconds (default 60) and updates `session_manager.app.instructions` when the body changes. MCP SDK reads `Server.instructions` per request, so next claude.ai session picks up the new body.
- New helper `try_fetch_server_instructions(iris_url) -> str | None` returns `None` on every failure path that the canonical fetcher falls back from. Refresh loop only writes on `not None and != current` — transient backend failures preserve the last good body rather than clobbering it with the hardcoded fallback.
- Background task cancelled cleanly on lifespan shutdown.
- `IRIS_MCP_INSTRUCTIONS_REFRESH_S=0` disables the loop.

## Tests

- `test_server_instructions.py::TestTryFetchServerInstructions` — 7 cases mirroring the canonical fetcher's failure paths, asserting `None` instead of the fallback.
- `test_http_main.py::TestRefreshLoop` — 3 cases: refresh picks up an updated body within the TTL; preserves last-good body on transient failure; disabled when interval is 0.
- 139/139 MCP tests pass.

## Test plan

- [ ] CI green.
- [ ] Render auto-deploys iris-mcp from `main`. After deploy, `/info` reports `6.0.5`.
- [ ] In `/admin/settings/ai`, edit the `mcp_server_instructions` body. Wait ≤ 60 s. `curl -X POST iris-mcp.../` with an MCP `initialize` returns the new body. No Render restart required.
- [ ] Fresh claude.ai chat: open the Outcomes Theory Book, confirm TOC auto-loads and four-option `AskUserQuestion` widget appears (5.x flow restored).

## See also

- [ADR-166](https://github.com/cgbarlow/iris/blob/fix/v6.0.5-instructions-ttl-refresh/docs/adrs/ADR-166-MCP-Server-Instructions-TTL-Refresh.md)
- [SPEC-166-A](https://github.com/cgbarlow/iris/blob/fix/v6.0.5-instructions-ttl-refresh/docs/adrs/specs/SPEC-166-A-MCP-Server-Instructions-TTL-Refresh.md)
- Issue #119
- PR #120 (v6.0.4 — wiring; this PR closes the cache-staleness gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)