### PR TITLE
fix(v6.0.7): TOC as bullet-list with links + verbatim menu (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.7] - 2026-05-13
+
+### Fixed
+
+- **TOC now renders as a markdown bullet list with clickable links per
+  Part / chapter (issue #119 polish).** v6.0.6 got claude.ai to invoke
+  `package_hierarchy` and present the parts, but the model rendered the
+  result as a wall of text without links. Two underlying causes:
+  - `package_hierarchy` tool output was not decorated with `web_url`
+    fields (`with_web_urls_list` only walks the top level; the nested
+    `children` arrays were left bare).
+  - The orient wrapper said only "Surface the resulting tree" — no
+    formatting prescription, so the model defaulted to a paragraph.
+- New `decorate_tree(nodes, kind, base)` walks a homogeneous tree
+  recursively and attaches `web_url` at every depth. `_package_hierarchy`
+  now wraps its output with `with_web_urls_tree`. Every Part and chapter
+  in the response carries `web_url`, so the model can render `[name](url)`
+  markdown links directly.
+- Orient wrapper now spells out the TOC format explicitly: "render the
+  result as a markdown bullet list, ONE ENTRY PER LINE, with each entry
+  as a clickable markdown link using the node's `web_url` field". Includes
+  a concrete two-line example so the model has a pattern to mimic.
+
+- **Menu options now stay verbatim (issue #119 polish).** v6.0.6 said
+  "do not paraphrase" but the model still dropped parenthetical examples
+  ("(e.g. J06 — Mathematization of Outcomes Theory)"), tool references
+  ("uses mcp__iris__ask"), and "→ call create_diagram" — and even reworded
+  "outcomes-theory analysis" to "outcomes map".
+- Orient wrapper now demands "CHARACTER-BY-CHARACTER" copying with explicit
+  negations: "Do NOT summarise. Do NOT shorten. Do NOT drop parenthetical
+  examples like '(e.g. J06 — Mathematization of Outcomes Theory)' or tool
+  references like 'uses mcp__iris__ask'. ... Long options are intentional."
+
+### Added
+
+- New `decorate_tree` and `with_web_urls_tree` helpers in `links.py`.
+  Exported from `__all__`.
+- 5 new regression tests (`TestPackageHierarchyTreeDecoration`,
+  `TestOrientWrapperFormattingDirectives`) pinning the recursive
+  decoration and the strengthened wrapper wording.
+
+### Why this matters
+
+- Users opening an authored scope now see the TOC as a navigable list
+  with one-click access to each Part / chapter — restoring the click-to-
+  open affordance the 5.x UI had via the dashboard. Matches the user's
+  visual request in issue #119 follow-up.
+- The four menu options match the admin-authored body exactly. Admins
+  iterating on the menu copy in `/admin/settings/ai` see their edits
+  reach claude.ai unmodified.
+
+### See also
+
+- ADR-167 — Orient directive in tool response (updated to cover the
+  TOC formatting + character-by-character menu wording).
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — five-revision
+  fix history: v6.0.4 (wire), v6.0.5 (refresh), v6.0.6 (embed), v6.0.7
+  (TOC format + verbatim menu).
+
 ## [6.0.6] - 2026-05-13
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.6",
+	"version": "6.0.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.6"
+version = "6.0.7"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/links.py
+++ b/mcp/src/iris_mcp/links.py
@@ -79,18 +79,39 @@ def _orient_wrapper(kind: str, entity_id: str) -> str:
         f"This scope is a {kind} ({id_kw}). The orient sheet below names a "
         f"structural-overview call AND a numbered menu. Before responding "
         f"to the user, you MUST, in order:\n"
+        f"\n"
         f"  1. Briefly describe the scope (one sentence based on its name "
         f"and description).\n"
+        f"\n"
         f"  2. INVOKE the structural-overview call named below, passing "
         f"this scope's {id_kw}. The TOC is mandatory, not optional. If the "
         f"named tool is not currently in your toolset, request a tool-load "
         f"first — do NOT skip this step.\n"
-        f"  3. Offer the menu options below via AskUserQuestion (if your "
-        f"client supports it) or a numbered list, IN ORDER, VERBATIM. "
-        f"Do not paraphrase, do not silently drop options.\n"
+        f"     FORMAT: render the result as a markdown bullet list, ONE "
+        f"ENTRY PER LINE, with each entry as a clickable markdown link "
+        f"using the node's `web_url` field as the target. Example: \n"
+        f"       - [Part A — DoView Planning Fundamentals (5 chapters)]"
+        f"(https://iris-uat.chrisbarlow.nz/packages/abc...)\n"
+        f"       - [Part B — DoView Drawing and Strategy Principles "
+        f"(25 chapters)](https://iris-uat.chrisbarlow.nz/packages/def...)\n"
+        f"     Show the URL as the link target only — do NOT also print "
+        f"the bare URL alongside. Each node has `name`, `web_url`, and "
+        f"`children` fields; the chapter count is `len(children)`.\n"
+        f"\n"
+        f"  3. Offer the menu options below to the user. The four options "
+        f"are LITERAL TEXT — copy each one CHARACTER-BY-CHARACTER from the "
+        f"orient sheet's MENU section into your response. Do NOT summarise. "
+        f"Do NOT shorten. Do NOT drop parenthetical examples like "
+        f"\"(e.g. J06 — Mathematization of Outcomes Theory)\" or tool "
+        f"references like \"uses mcp__iris__ask\". If an option says "
+        f"\"Generate a new DoView outcomes-theory analysis OR a new visual "
+        f"DoView outcomes_map → call create_diagram\", the user must see "
+        f"EXACTLY that text — every word, including OR / →. Long options "
+        f"are intentional.\n"
         f"\n"
         f"Do NOT ask \"want me to load the table of contents?\" — load it "
-        f"yourself. Do NOT respond with just the menu and skip the TOC.\n"
+        f"yourself. Do NOT respond with just the menu and skip the TOC. "
+        f"Do NOT respond with just the TOC and skip the menu.\n"
         f"\n"
         f"---\n"
         f"\n"
@@ -176,6 +197,31 @@ def decorate_list(items: list[Any], kind: str, base: str | None = None) -> None:
         return
     for item in items:
         decorate_item(item, kind, resolved_base)
+
+
+def decorate_tree(
+    nodes: list[Any], kind: str, base: str | None = None,
+) -> None:
+    """v6.0.7: in-place recursive web_url decoration for tree-shaped
+    responses (e.g. `package_hierarchy`).
+
+    `decorate_list` only walks the top level; package_hierarchy returns
+    nested `children` arrays that also need web_urls so the model can
+    render each Part / chapter as a clickable markdown link. Same kind
+    applies at every depth — package_hierarchy is homogeneously packages
+    all the way down.
+    """
+    if not isinstance(nodes, list):
+        return
+    resolved_base = base if base is not None else web_base()
+    if not resolved_base:
+        return
+    for node in nodes:
+        decorate_item(node, kind, resolved_base)
+        if isinstance(node, dict):
+            children = node.get("children")
+            if isinstance(children, list):
+                decorate_tree(children, kind, resolved_base)
 
 
 def decorate_search(payload: dict[str, Any], base: str | None = None) -> None:
@@ -277,10 +323,31 @@ __all__ = [
     "decorate_item",
     "decorate_list",
     "decorate_search",
+    "decorate_tree",
     "web_base",
     "web_url_for",
     "with_web_url",
     "with_web_urls_list",
     "with_web_urls_search",
+    "with_web_urls_tree",
     "wrap_orient",
 ]
+
+
+def with_web_urls_tree(payload: str, kind: str) -> str:
+    """v6.0.7: decorate a JSON-serialised tree response (e.g.
+    `package_hierarchy`) recursively, so every node at every depth
+    carries a `web_url`. Strips sensitive keys at the top level only
+    (children inherit the homogeneous kind, no per-level scrub needed
+    for the current schema). No-ops on invalid JSON.
+    """
+    try:
+        data = json.loads(payload)
+    except (json.JSONDecodeError, TypeError):
+        return payload
+    if isinstance(data, list):
+        _strip_sensitive_keys_list(data)
+    base = web_base()
+    if base:
+        decorate_tree(data, kind, base)
+    return json.dumps(data)

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -22,6 +22,7 @@ from iris_mcp.links import (
     with_web_url,
     with_web_urls_list,
     with_web_urls_search,
+    with_web_urls_tree,
 )
 def _resource_metadata_url() -> str:
     """Return the iris-mcp Protected Resource metadata URL.
@@ -189,12 +190,20 @@ async def _list_packages(c: IrisClient, args: dict[str, Any]) -> str:
 
 async def _package_hierarchy(c: IrisClient, args: dict[str, Any]) -> str:
     """ADR-158 (v5.13.0): return the complete package tree in one call.
-    Prefer this over `list_packages` for structural overview."""
+    Prefer this over `list_packages` for structural overview.
+
+    v6.0.7: each node (and every child recursively) is decorated with
+    `web_url` via `with_web_urls_tree` so the model can render each
+    Part / chapter as a clickable markdown link.
+    """
     nodes = await c.package_hierarchy(
         set_id=args.get("set_id"),
         root_id=args.get("root_id"),
     )
-    return json.dumps([node.model_dump() for node in nodes])
+    return with_web_urls_tree(
+        json.dumps([node.model_dump() for node in nodes]),
+        "package",
+    )
 
 
 async def _list_sets(c: IrisClient, args: dict[str, Any]) -> str:

--- a/mcp/tests/test_links_orient_wrapper.py
+++ b/mcp/tests/test_links_orient_wrapper.py
@@ -23,14 +23,126 @@ from __future__ import annotations
 import json
 
 from iris_mcp.links import (
+    decorate_tree,
     with_web_url,
     with_web_urls_list,
     with_web_urls_search,
+    with_web_urls_tree,
     wrap_orient,
 )
 
 WEB = "https://iris-uat.chrisbarlow.nz"
 _MARKER = "[ORIENT"
+
+
+class TestPackageHierarchyTreeDecoration:
+    """v6.0.7: package_hierarchy returns a nested tree; every node at
+    every depth must get a `web_url` so the model can render the TOC as
+    clickable markdown links. `decorate_list` only walks the top level —
+    `decorate_tree` recurses through children."""
+
+    def test_decorate_tree_attaches_web_url_at_root(
+        self, monkeypatch,
+    ) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        nodes = [
+            {"id": "part-a", "name": "Part A", "children": []},
+            {"id": "part-b", "name": "Part B", "children": []},
+        ]
+        decorate_tree(nodes, "package")
+        assert nodes[0]["web_url"] == f"{WEB}/packages/part-a"
+        assert nodes[1]["web_url"] == f"{WEB}/packages/part-b"
+
+    def test_decorate_tree_recurses_into_children(
+        self, monkeypatch,
+    ) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        nodes = [{
+            "id": "part-a", "name": "Part A",
+            "children": [
+                {"id": "chap-1", "name": "A01", "children": []},
+                {"id": "chap-2", "name": "A02", "children": []},
+            ],
+        }]
+        decorate_tree(nodes, "package")
+        assert nodes[0]["web_url"] == f"{WEB}/packages/part-a"
+        children = nodes[0]["children"]
+        assert children[0]["web_url"] == f"{WEB}/packages/chap-1"
+        assert children[1]["web_url"] == f"{WEB}/packages/chap-2"
+
+    def test_decorate_tree_handles_arbitrary_depth(
+        self, monkeypatch,
+    ) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        nodes = [{
+            "id": "a", "name": "A", "children": [{
+                "id": "a1", "name": "A1", "children": [{
+                    "id": "a1.1", "name": "A1.1", "children": [],
+                }],
+            }],
+        }]
+        decorate_tree(nodes, "package")
+        assert nodes[0]["web_url"] == f"{WEB}/packages/a"
+        assert nodes[0]["children"][0]["web_url"] == f"{WEB}/packages/a1"
+        assert nodes[0]["children"][0]["children"][0]["web_url"] == (
+            f"{WEB}/packages/a1.1"
+        )
+
+    def test_decorate_tree_noop_without_iris_web_url(
+        self, monkeypatch,
+    ) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        nodes = [{"id": "a", "name": "A", "children": []}]
+        decorate_tree(nodes, "package")
+        assert "web_url" not in nodes[0]
+
+    def test_with_web_urls_tree_round_trips_json(
+        self, monkeypatch,
+    ) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("IRIS_WEB_URL", WEB)
+        payload = json.dumps([
+            {"id": "p1", "name": "P1", "children": [
+                {"id": "p1.1", "name": "P1.1", "children": []},
+            ]},
+        ])
+        out = json.loads(with_web_urls_tree(payload, "package"))
+        assert out[0]["web_url"] == f"{WEB}/packages/p1"
+        assert out[0]["children"][0]["web_url"] == f"{WEB}/packages/p1.1"
+
+
+class TestOrientWrapperFormattingDirectives:
+    """v6.0.7: the wrapper must spell out TOC formatting and menu
+    verbatim copying explicitly — the v6.0.6 wording was too soft and
+    the model kept paraphrasing both."""
+
+    def test_wrapper_names_markdown_link_format_for_toc(self) -> None:
+        item = {
+            "id": "s1",
+            "mcp_system_context": "original",
+        }
+        wrap_orient(item, "set")
+        ctx = item["mcp_system_context"]
+        # Explicit instruction on TOC presentation shape.
+        assert "markdown bullet list" in ctx
+        assert "ONE ENTRY PER LINE" in ctx
+        assert "clickable markdown link" in ctx
+        assert "web_url" in ctx
+        # Example present so the model has a concrete pattern.
+        assert "Part A" in ctx
+        assert "https://iris-uat.chrisbarlow.nz/packages/" in ctx
+
+    def test_wrapper_demands_character_by_character_menu_copy(self) -> None:
+        item = {"id": "s1", "mcp_system_context": "x"}
+        wrap_orient(item, "set")
+        ctx = item["mcp_system_context"]
+        assert "CHARACTER-BY-CHARACTER" in ctx
+        assert "Do NOT summarise" in ctx
+        assert "Do NOT shorten" in ctx
+        # Negate the specific paraphrasing failures observed in the
+        # v6.0.6 trace.
+        assert "parenthetical examples" in ctx
+        assert "mcp__iris__ask" in ctx
+        assert "create_diagram" in ctx
 
 
 class TestWrapOrient:
@@ -55,7 +167,7 @@ class TestWrapOrient:
         # The strong directives are present.
         assert "INVOKE" in ctx
         assert "TOC is mandatory" in ctx
-        assert "Do not paraphrase" in ctx
+        assert "CHARACTER-BY-CHARACTER" in ctx  # v6.0.7 strengthened
         assert "want me to load" in ctx  # explicit anti-pattern call-out
 
     def test_wraps_collection_with_collection_id_kw(self) -> None:


### PR DESCRIPTION
## Summary

Two polish issues after v6.0.6:

1. **TOC was a paragraph, not a navigable list, and had no links per Part / chapter.**
   - `package_hierarchy` tool output wasn't decorated with `web_url` (`with_web_urls_list` only walks the top level; nested `children` arrays were bare).
   - Orient wrapper said only "Surface the resulting tree" — no formatting prescription, so the model defaulted to a paragraph.

2. **Menu options paraphrased again** — model dropped parenthetical examples and tool references and reworded "outcomes-theory analysis" to "outcomes map".

## Fix

- New `decorate_tree(nodes, kind, base)` walks a homogeneous tree recursively, attaching `web_url` at every depth.
- New `with_web_urls_tree(payload, kind)` is the public JSON wrapper. `_package_hierarchy` uses it — every Part and chapter now carries `web_url`.
- Orient wrapper now prescribes the TOC format explicitly: "render the result as a markdown bullet list, ONE ENTRY PER LINE, with each entry as a clickable markdown link using the node's `web_url` field". Includes a concrete two-line example.
- Orient wrapper now demands "CHARACTER-BY-CHARACTER" menu copying: "Do NOT summarise. Do NOT shorten. Do NOT drop parenthetical examples ... Long options are intentional."

## Tests

- 5 new (`TestPackageHierarchyTreeDecoration`, `TestOrientWrapperFormattingDirectives`).
- 1 existing assertion updated to match the strengthened wording.
- 161/161 MCP tests pass.

## Test plan

- [ ] CI green.
- [ ] Render auto-deploys; `/info` reports `6.0.7`.
- [ ] Smoke: fresh claude.ai chat → "open up outcomes theory book in iris" → TOC renders as a bullet list with one Part per line, each a clickable markdown link; menu reproduces the admin-authored options exactly including parentheticals and tool references.

## See also

- ADR-167 (covers v6.0.6 + v6.0.7 wrapper iterations)
- Issue #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)