### PR TITLE
fix(v6.0.9): correct OAuth metadata URLs + intro/conclusion in TOC (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.9] - 2026-05-13
+
+### Fixed
+
+- **OAuth metadata pointed at the wrong host, silently breaking
+  claude.ai's auto-sign-in (ADR-169).** The Protected Resource metadata
+  at `iris-mcp.../.well-known/oauth-protected-resource` advertised
+  `https://iris-uat.chrisbarlow.nz` (the frontend host) as the
+  Authorization Server. The frontend is a SvelteKit SPA that returns
+  HTTP 200 with its `index.html` for any unknown path — including
+  `/.well-known/oauth-authorization-server` — so claude.ai's MCP
+  client couldn't parse OAuth metadata from the HTML body and fell
+  back to surfacing the tool-layer `auth_required` error. v6.0.0 →
+  v6.0.8 all shipped this bug.
+- v6.0.9 sources `authorization_server` from `IRIS_API_URL` (where the
+  RFC 8414 AS metadata document and `/oauth/{authorize,token,register,
+  revoke}` endpoints actually live). `resource` falls back to
+  `IRIS_API_URL` too when `IRIS_MCP_PUBLIC_URL` isn't set. `IRIS_WEB_URL`
+  is no longer read by the OAuth metadata path — its purpose is link
+  decoration only.
+- `render.yaml` for the `iris-mcp` service now sets
+  `IRIS_MCP_PUBLIC_URL = https://iris-mcp.onrender.com` so the live
+  deployment's `resource` field correctly identifies the iris-mcp
+  service (rather than falling back to the API host).
+- Tool-layer `auth_required` payload + canonical
+  `mcp_server_instructions` body refined: the previous wording
+  ("Configure → enable OAuth") assumed claude.ai's connector UI exposes
+  a manual OAuth toggle, but the actual flow auto-detects OAuth from
+  Protected Resource metadata and offers a "Sign in" button. The new
+  wording reflects that users do NOT enter `client_id` / `secret` and
+  that re-adding the connector forces metadata re-discovery if no
+  sign-in button appears.
+
+### Added
+
+- **Introduction and Conclusion in the Outcomes Theory Book TOC.** The
+  set has two root-level markdown diagrams (`parent_package_id=null`)
+  that bracket Part A through Part J; v6.0.7's `package_hierarchy` call
+  alone missed them. The canonical `doview-book-mcp-system-context.md`
+  paste-doc now names two structural-overview calls
+  (`package_hierarchy` + `list_diagrams` filtered to root) so the model
+  fetches both packages and root-level diagrams. The orient sheet
+  instructs the model to render Introduction first, the parts, then
+  Conclusion last.
+- Two new regression tests in `test_oauth_resource.py` pinning the
+  v6.0.9 metadata correctness: `authorization_server` points at
+  `IRIS_API_URL`; `resource` falls back to `IRIS_API_URL` (not
+  `IRIS_WEB_URL`) when `IRIS_MCP_PUBLIC_URL` is unset.
+- 164/164 MCP tests pass.
+
+### Admin action required after deploy
+
+After Render reports `6.0.9` on `/info`:
+
+1. **Re-paste** the v6.0.9 menu from
+   [`docs/prompts/doview-book-mcp-system-context.md`](docs/prompts/doview-book-mcp-system-context.md)
+   into the Outcomes Theory Book set's `mcp_system_context` field at
+   `/sets/33032180-d77a-4ce4-88cf-b49cd643e093`.
+2. **Re-paste** the v6.0.9 auth-recovery body from
+   [`docs/prompts/mcp-server-instructions.md`](docs/prompts/mcp-server-instructions.md)
+   into the `mcp_server_instructions` row at `/admin/settings/ai`.
+3. **Remove and re-add** the Iris connector in claude.ai so the MCP
+   client re-discovers the now-correct OAuth metadata. After that,
+   clicking "Sign in" on the connector should open a browser tab for
+   you to sign in to Iris (no `client_id` / `secret` entry).
+
+The v6.0.5 TTL refresh propagates both paste edits to claude.ai within
+60 seconds. No Render restart required for either.
+
+### See also
+
+- [ADR-169](docs/adrs/ADR-169-OAuth-Metadata-URL-Fix.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119)
+
 ## [6.0.8] - 2026-05-13
 
 ### Removed

--- a/docs/adrs/ADR-169-OAuth-Metadata-URL-Fix.md
+++ b/docs/adrs/ADR-169-OAuth-Metadata-URL-Fix.md
@@ -1,0 +1,89 @@
+# ADR-169: Fix Authorization Server URL in Protected Resource metadata
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-134](ADR-134-Standalone-MCP-HTTP-Service.md), [ADR-164](ADR-164-OAuth-2.1-for-MCP.md)
+
+## Context
+
+ADR-164 (v6.0.0) brought OAuth 2.1 to iris-mcp's HTTP transport: RFC 8414 Authorization Server metadata + RFC 9728 Protected Resource metadata + RFC 7591 Dynamic Client Registration + PKCE Authorization Code Flow. The intent was that any compliant MCP client (claude.ai, Claude Desktop, Claude Code, Cursor) could connect to iris-mcp and discover the OAuth endpoints automatically — no manual `client_id`/`secret` entry, no out-of-band configuration.
+
+Issue #119 testing post-v6.0.8 surfaced a concrete failure. A write tool call from claude.ai returned the `auth_required` tool error, and claude.ai never offered the user a sign-in popup. Investigating the metadata chain:
+
+```bash
+$ curl https://iris-mcp.onrender.com/.well-known/oauth-protected-resource
+{
+  "resource": "https://iris-uat.chrisbarlow.nz",
+  "authorization_servers": ["https://iris-uat.chrisbarlow.nz"],
+  ...
+}
+
+$ curl https://iris-uat.chrisbarlow.nz/.well-known/oauth-authorization-server
+HTTP 200
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    ...   # SvelteKit SPA index.html
+```
+
+The Protected Resource metadata advertises `https://iris-uat.chrisbarlow.nz` (the **frontend** host) as the Authorization Server. But the actual RFC 8414 AS metadata document and the `/oauth/{authorize,token,register,revoke}` endpoints live on the **API** host (`https://iris-api-gtb3.onrender.com`). The frontend host is a SvelteKit SPA configured with `adapter-static` + `fallback: 'index.html'`, so it returns HTTP 200 with the SPA index.html for any unknown path — including `/.well-known/oauth-authorization-server`.
+
+The OAuth discovery chain breaks silently at step 4 (AS metadata fetch). claude.ai's MCP client can't parse OAuth metadata out of an HTML body, and falls back to surfacing the tool-layer `auth_required` error to the model. The user sees the model's "obtuse" advisory message instead of a one-click sign-in popup.
+
+Root cause in `mcp/src/iris_mcp/http_main.py`:
+
+```python
+# v6.0.0 → v6.0.8 (BUGGY):
+web_url = os.environ.get("IRIS_WEB_URL", iris_url).rstrip("/")
+return build_resource_metadata(
+    resource=public_url or web_url,         # falls back to frontend
+    authorization_server=web_url,           # always uses frontend
+)
+```
+
+`IRIS_WEB_URL` is the **frontend** host, used elsewhere for entity `web_url` link decoration (so the model can quote real iris-uat URLs). That's the right purpose for those tool responses, but it's the wrong source for OAuth metadata.
+
+## Decision
+
+In the Protected Resource metadata endpoint at `/.well-known/oauth-protected-resource`:
+
+- `authorization_server` is sourced from **`IRIS_API_URL`** (the iris-backend host where the AS metadata document and `/oauth/*` endpoints live).
+- `resource` falls back to `IRIS_API_URL` when `IRIS_MCP_PUBLIC_URL` isn't set (same host as the AS — a sensible dev default). Operators set `IRIS_MCP_PUBLIC_URL` in production to the canonical iris-mcp public URL.
+- `IRIS_WEB_URL` is **no longer read** by the OAuth metadata path. Its purpose is link decoration only.
+
+Add `IRIS_MCP_PUBLIC_URL = https://iris-mcp.onrender.com` to `render.yaml` for the iris-mcp service so the live deployment advertises the correct canonical resource URL.
+
+Refine the tool-layer `auth_required` payload to give the user the right next-action wording. The previous "Configure → enable OAuth" framing assumed claude.ai's connector UI exposes a manual OAuth toggle; in the current flow the connector auto-detects OAuth from Protected Resource metadata and offers a "Sign in" button. The message now reflects that the user does **not** enter a `client_id` or `secret`, and that re-adding the connector forces metadata re-discovery if no sign-in button appears.
+
+Update the canonical `mcp_server_instructions` paste-doc (`docs/prompts/mcp-server-instructions.md`) to match. Admin pastes this on UAT; the v6.0.5 TTL refresh propagates the body to claude.ai within 60 seconds.
+
+## What changes for users
+
+- After v6.0.9 deploys, adding the Iris connector in claude.ai should automatically display a "Sign in" button. Clicking it opens a browser tab; the user signs in to Iris; consent screen; redirect; bearer token stored by claude.ai. No `client_id` / `secret` entry required (RFC 7591 DCR handles the registration silently).
+- Read tools (`search`, `get_*`, `list_*`, `package_hierarchy`) continue to work without sign-in. Only write tools (`create_*`, `update_*`) require it.
+- If a user already had the Iris connector added pre-v6.0.9 and never saw a sign-in flow, they should remove and re-add it once v6.0.9 is live so the connector re-discovers the now-correct OAuth metadata.
+
+## Why not also fix the upstream `oauth-authorization-server` proxy
+
+Considered: have the frontend (`iris-uat.chrisbarlow.nz`) proxy `/.well-known/oauth-authorization-server` requests to the API host. That would make either host work. Rejected:
+
+- Adds frontend complexity (SvelteKit `adapter-static` doesn't proxy; we'd need an explicit redirect or a non-static handler).
+- Doesn't fix the `resource` field — that's still wrong unless we also change `http_main.py`.
+- The simpler fix is to advertise the correct host in the first place.
+
+## Consequences
+
+- One `http_main.py` change (4 lines).
+- One `render.yaml` change (one new env var).
+- Three new test cases pinning the metadata correctness.
+- Auth-recovery wording updated in three places — the canonical paste-doc, the iris-mcp hardcoded fallback, the tool-layer error payload. The admin re-pastes the canonical doc into `/admin/settings/ai`; the TTL refresh propagates.
+- Version bump v6.0.8 → v6.0.9. Patch-level (config fix, no API surface change).
+
+## See also
+
+- [ADR-164](ADR-164-OAuth-2.1-for-MCP.md) — original OAuth 2.1 design that this fixes a deployment bug in.
+- [ADR-134](ADR-134-Standalone-MCP-HTTP-Service.md) — the standalone iris-mcp HTTP service where the metadata is served.
+- RFC 9728 — OAuth 2.0 Protected Resource Metadata.
+- RFC 8414 — OAuth 2.0 Authorization Server Metadata.
+- RFC 7591 — OAuth 2.0 Dynamic Client Registration.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — original regression that surfaced this and several other related issues.

--- a/docs/prompts/doview-book-mcp-system-context.md
+++ b/docs/prompts/doview-book-mcp-system-context.md
@@ -9,7 +9,11 @@ Canonical paste-ready content for the **MCP system context** field on the Outcom
 ```text
 This set is the visual companion to Dr Paul Duignan's outcomes-theory body of work and DoView outcomes-mapping methodology.
 
-Structural overview call: package_hierarchy(set_id=<this-set>) — lists Part A through Part J with one-line descriptions.
+Structural overview calls (make BOTH so the TOC is complete):
+  - package_hierarchy(set_id=<this-set>) — lists Part A through Part J packages.
+  - list_diagrams(set_id=<this-set>), then filter to entries with parent_package_id == null — these are the root-level Introduction and Conclusion markdown diagrams that bracket the parts.
+
+In the TOC you present, show Introduction first, then Part A through Part J, then Conclusion last. Render each entry as a clickable markdown link using its web_url.
 
 MENU (verbatim, all four):
   1. Pull up a specific chapter or diagram from the handbook (e.g. J06 — Mathematization of Outcomes Theory).
@@ -33,6 +37,7 @@ The menu above is the **v6.0.8** revision. If your live deployment is on the v5.
 
 ## Revision history
 
+- **v6.0.9.** Added Introduction + Conclusion to the TOC. The set has two root-level markdown diagrams (parent_package_id=null) that bracket Part A through Part J; v6.0.7's `package_hierarchy` call alone misses them. Orient sheet now names two structural-overview calls so the model fetches both packages and root-level diagrams.
 - **v6.0.8.** Dropped `mcp__iris__ask` reference (the `ask` tool was removed from MCP — ADR-168). Dropped the `→ call create_diagram` implementation tag from option 3. Broadened option 2 from "cross-package" to "cross-package, cross-set, or cross-collection".
 - **v5.18.0.** Stripped ORIENT-FIRST protocol and DISCOVERY catalogue — now in server-wide MCP instructions (ADR-163). Down from ~30 lines (v5.17.0) to ~12.
 - **v5.17.0.** Stripped diagram-creation workflow — now in `create_diagram`'s tool description (ADR-162).

--- a/docs/prompts/mcp-server-instructions.md
+++ b/docs/prompts/mcp-server-instructions.md
@@ -25,7 +25,7 @@ WORKFLOW GUIDANCE.
 Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow).
 
 AUTH RECOVERY.
-If a write tool returns error="auth_required" (HTTP transport), advise the user to configure OAuth in their MCP client's connector settings (e.g. claude.ai → Connectors → Iris → Configure → enable OAuth). The browser opens a consent screen, the user signs in to Iris, and writes work from then on. Don't call any auth-related tool yourself — the OAuth handshake is between the MCP client and Iris, not via tool calls.
+If a write tool returns error="auth_required", the user needs to sign in to Iris in their MCP client. Tell them: in claude.ai go to Settings → Connectors → Iris and click "Connect" / "Sign in"; a browser tab opens for sign-in and consent. They will NOT be asked for a client_id or secret — Dynamic Client Registration (RFC 7591) handles that automatically. If no sign-in button appears, try removing and re-adding the connector. Read tools (search, get_*, list_*, package_hierarchy) work without sign-in; only writes (create_*, update_*) need it. Don't call any auth-related tool yourself — the OAuth handshake is between the MCP client and Iris.
 ```
 
 ## Why this works

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.8",
+	"version": "6.0.9",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.8"
+version = "6.0.9"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/http_main.py
+++ b/mcp/src/iris_mcp/http_main.py
@@ -155,12 +155,25 @@ def create_app() -> FastAPI:
         Anonymous-readable. MCP clients fetch this on a 401 response's
         `WWW-Authenticate: Bearer resource_metadata="..."` hint and
         learn which Authorization Server to start an OAuth dance with.
+
+        v6.0.9 (ADR-169): `authorization_server` now points at the iris
+        API URL (`IRIS_API_URL`), not the frontend URL (`IRIS_WEB_URL`).
+        The RFC 8414 Authorization Server metadata document and the
+        `/oauth/{authorize,token,register,revoke}` endpoints all live
+        on the API host. The frontend host serves a SvelteKit SPA and
+        returns its index.html (HTTP 200) for unknown paths — including
+        `/.well-known/oauth-authorization-server` — which silently
+        broke the OAuth discovery chain. `resource` falls back to the
+        API URL too (instead of the frontend URL) so it stays on the
+        same host as the AS, matching the JWT `aud` semantics.
+        Operators set `IRIS_MCP_PUBLIC_URL` to override `resource` with
+        the canonical iris-mcp public URL when one exists.
         """
         public_url = os.environ.get("IRIS_MCP_PUBLIC_URL", "").rstrip("/")
-        web_url = os.environ.get("IRIS_WEB_URL", iris_url).rstrip("/")
+        as_url = iris_url.rstrip("/")
         return build_resource_metadata(
-            resource=public_url or web_url,
-            authorization_server=web_url,
+            resource=public_url or as_url,
+            authorization_server=as_url,
         )
 
     @app.get("/info", include_in_schema=False)

--- a/mcp/src/iris_mcp/server_instructions.py
+++ b/mcp/src/iris_mcp/server_instructions.py
@@ -39,7 +39,7 @@ WORKFLOW GUIDANCE.
 Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow).
 
 AUTH RECOVERY.
-If a write tool returns error="auth_required" (HTTP transport), advise the user to configure OAuth in their MCP client's connector settings (e.g. claude.ai → Connectors → Iris → Configure → enable OAuth). The browser opens a consent screen, the user signs in to Iris, and writes work from then on. Don't call any auth-related tool yourself — the OAuth handshake is between the MCP client and Iris, not via tool calls.
+If a write tool returns error="auth_required", the user needs to sign in to Iris in their MCP client. Tell them: in claude.ai go to Settings → Connectors → Iris and click "Connect" / "Sign in"; a browser tab opens for sign-in and consent. They will NOT be asked for a client_id or secret — Dynamic Client Registration (RFC 7591) handles that automatically. If no sign-in button appears, try removing and re-adding the connector. Read tools (search, get_*, list_*, package_hierarchy) work without sign-in; only writes (create_*, update_*) need it. Don't call any auth-related tool yourself — the OAuth handshake is between the MCP client and Iris.
 """
 
 

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -39,31 +39,42 @@ def _resource_metadata_url() -> str:
 
 
 def _auth_required_payload(action: str) -> str:
-    """ADR-164 / SPEC-164-A: shared 401 → OAuth-setup-guidance payload.
+    """ADR-164 / ADR-169: shared OAuth-setup-guidance payload.
 
-    Every write tool returns this exact shape on auth failure so the
-    model can extract the next step uniformly: advise the user to
-    configure OAuth in their MCP client's connector settings.
+    Every write tool returns this exact shape when iris-mcp gets a 401
+    from the backend, so the model can guide the user uniformly.
 
-    There is NO in-conversation auth dance — the OAuth handshake is
-    between the MCP client and Iris, not via tool calls.
+    The OAuth handshake is fully automatic in MCP — the client (e.g.
+    claude.ai) reads the RFC 9728 Protected Resource metadata at
+    `/.well-known/oauth-protected-resource`, performs RFC 7591 Dynamic
+    Client Registration with the Authorization Server, and pops a
+    browser window for the user to sign in. There is **no manual
+    client_id/secret entry** on the user's side. If the user is seeing
+    this message instead of an automatic sign-in popup, the client
+    hasn't initiated the OAuth flow yet — usually a one-click "Connect"
+    button in the client's connector UI triggers it.
     """
     return json.dumps({
         "success": False,
         "error": "auth_required",
         "message": (
-            f"{action} failed — this MCP connector isn't"
-            " authenticated.\n\n"
-            "Advise the user to configure OAuth in their MCP client's"
-            " connector settings (e.g. claude.ai → Connectors →"
-            " Iris → Configure → enable OAuth). The browser will open"
-            " a consent screen, the user signs in to Iris, and writes"
-            " work from then on.\n\n"
-            "Do NOT call any auth-related tool yourself — the OAuth"
-            " handshake is between the MCP client and Iris, not via"
-            " tool calls."
+            f"{action} requires that you (the user) sign in to Iris.\n\n"
+            "Tell the user: in your MCP client's connector list, find "
+            "the Iris connector and click \"Connect\" / \"Sign in\" "
+            "(in claude.ai: Settings → Connectors → Iris). A browser "
+            "tab will open for you to sign in to Iris and approve "
+            "access. You will NOT be asked for a client_id or secret "
+            "— the MCP client registers itself automatically via "
+            "Dynamic Client Registration (RFC 7591).\n\n"
+            "If no sign-in button appears, try removing and re-adding "
+            "the connector to force re-discovery of the OAuth metadata.\n\n"
+            "Do NOT call any auth-related tool yourself — the OAuth "
+            "handshake is between the MCP client and Iris, not via "
+            "tool calls. Read tools (search, get_*, list_*, "
+            "package_hierarchy) work without sign-in; only writes "
+            "(create_*, update_*) need it."
         ),
-        "next_step": "configure_oauth_in_connector_settings",
+        "next_step": "user_signs_in_via_mcp_client_connector_ui",
         "oauth_resource_metadata_url": _resource_metadata_url(),
     })
 

--- a/mcp/tests/test_oauth_resource.py
+++ b/mcp/tests/test_oauth_resource.py
@@ -73,6 +73,10 @@ class TestHttpMainEndpointMounted:
         from iris_mcp.http_main import create_app
         monkeypatch.setenv("IRIS_API_URL", "https://iris-backend.example.com")
         monkeypatch.setenv("IRIS_MCP_PUBLIC_URL", "https://iris-mcp.example.com")
+        # ADR-169 (v6.0.9): IRIS_WEB_URL must NOT appear in the OAuth
+        # metadata. Set it to a known wrong value so the test would fail
+        # if the v6.0.0–v6.0.8 buggy behaviour re-emerged.
+        monkeypatch.setenv("IRIS_WEB_URL", "https://wrong-host.example.com")
         app = create_app()
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
@@ -80,4 +84,37 @@ class TestHttpMainEndpointMounted:
         assert resp.status_code == 200
         body = resp.json()
         assert body["resource"] == "https://iris-mcp.example.com"
-        assert body["authorization_servers"] == ["https://iris-backend.example.com"]
+        # ADR-169 (v6.0.9): the Authorization Server URL must point at
+        # the API (where /oauth/* and /.well-known/oauth-authorization-server
+        # actually live), NOT at the frontend (which serves a SvelteKit
+        # SPA and returns index.html for unknown paths — silently breaking
+        # the OAuth discovery chain).
+        assert body["authorization_servers"] == [
+            "https://iris-backend.example.com",
+        ]
+        assert "wrong-host" not in body["authorization_servers"][0]
+        assert "wrong-host" not in body["resource"]
+
+    @pytest.mark.asyncio
+    async def test_metadata_falls_back_to_api_url_without_public_url(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """ADR-169: without `IRIS_MCP_PUBLIC_URL`, both `resource` and
+        `authorization_server` fall back to `IRIS_API_URL` (same host,
+        consistent with the AS-and-resource-co-located dev setup). The
+        v6.0.0–v6.0.8 buggy fallback used `IRIS_WEB_URL` for both,
+        which broke OAuth discovery."""
+        import httpx
+        from iris_mcp.http_main import create_app
+        monkeypatch.setenv("IRIS_API_URL", "https://iris-backend.example.com")
+        monkeypatch.delenv("IRIS_MCP_PUBLIC_URL", raising=False)
+        monkeypatch.setenv("IRIS_WEB_URL", "https://wrong-host.example.com")
+        app = create_app()
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+            resp = await c.get("/.well-known/oauth-protected-resource")
+        body = resp.json()
+        assert body["resource"] == "https://iris-backend.example.com"
+        assert body["authorization_servers"] == [
+            "https://iris-backend.example.com",
+        ]

--- a/mcp/tests/test_tools_create.py
+++ b/mcp/tests/test_tools_create.py
@@ -95,7 +95,7 @@ class TestCreateCollection:
         assert body["error"] == "auth_required"
         # v6.0.0 (ADR-164): OAuth-setup-guidance payload — no more
         # next_tool/pairing_url; instead next_step + oauth_resource_metadata_url.
-        assert body["next_step"] == "configure_oauth_in_connector_settings"
+        assert body["next_step"] == "user_signs_in_via_mcp_client_connector_ui"
         assert "/.well-known/oauth-protected-resource" in body["oauth_resource_metadata_url"]
 
 

--- a/mcp/tests/test_tools_create_diagram.py
+++ b/mcp/tests/test_tools_create_diagram.py
@@ -159,7 +159,7 @@ class TestCreateDiagram:
         assert body["error"] == "auth_required"
         # v6.0.0 (ADR-164): OAuth-setup-guidance — no more next_tool/pairing_url;
         # instead next_step + oauth_resource_metadata_url.
-        assert body["next_step"] == "configure_oauth_in_connector_settings"
+        assert body["next_step"] == "user_signs_in_via_mcp_client_connector_ui"
         assert "/.well-known/oauth-protected-resource" in body["oauth_resource_metadata_url"]
 
 

--- a/render.yaml
+++ b/render.yaml
@@ -104,3 +104,11 @@ services:
         # instead of guessing the host. Optional — when unset the MCP
         # omits `web_url` from tool responses.
         value: https://iris-uat.chrisbarlow.nz
+      - key: IRIS_MCP_PUBLIC_URL
+        # v6.0.9 (ADR-169): canonical iris-mcp public URL. Used as the
+        # `resource` field in the RFC 9728 Protected Resource metadata
+        # document at /.well-known/oauth-protected-resource. MCP clients
+        # use this to identify the resource server when starting an
+        # OAuth dance. Without this env var, `resource` falls back to
+        # IRIS_API_URL, which works but isn't the actual MCP endpoint.
+        value: https://iris-mcp.onrender.com


### PR DESCRIPTION
## Summary

Two issues from v6.0.8 testing:

1. **OAuth auto-sign-in never triggers in claude.ai** — Protected Resource metadata advertised the frontend host as the Authorization Server, but `/oauth/*` and `/.well-known/oauth-authorization-server` live on the API host. The frontend SPA returns its `index.html` HTML for `/.well-known/...`, breaking metadata discovery silently. claude.ai's MCP client can't parse OAuth from HTML and falls back to surfacing the tool-layer `auth_required` to the model.
2. **TOC misses Introduction + Conclusion** — root-level markdown diagrams (`parent_package_id=null`) that v6.0.7's `package_hierarchy` call alone doesn't return.

## Fix

**OAuth metadata (ADR-169)**:
- `mcp/src/iris_mcp/http_main.py`: source `authorization_server` from `IRIS_API_URL` (not `IRIS_WEB_URL`). `resource` falls back to `IRIS_API_URL` too. `IRIS_WEB_URL` is no longer read by the OAuth path — its purpose is link decoration only.
- `render.yaml`: set `IRIS_MCP_PUBLIC_URL=https://iris-mcp.onrender.com` so the live `resource` field correctly identifies iris-mcp.
- Per RFC 7591 DCR, users do NOT enter a `client_id` or `secret` — once metadata is correct, claude.ai auto-registers and presents a one-click sign-in popup. The `auth_required` tool error + canonical `mcp_server_instructions` reworded to reflect this.

**Intro/conclusion**:
- Canonical `doview-book-mcp-system-context.md` paste-doc now names two structural-overview calls: `package_hierarchy(set_id=...)` + `list_diagrams(set_id=...)` filtered to `parent_package_id == null`. Orient sheet instructs render order: Introduction → parts → Conclusion.

## Tests

164/164 MCP tests pass. Two new regression cases in `test_oauth_resource.py` pin the metadata correctness; existing `auth_required` tests updated for the new `next_step` value.

## Admin action after deploy

After Render reports `6.0.9` on `/info`:

1. **Re-paste** the v6.0.9 menu from `docs/prompts/doview-book-mcp-system-context.md` into the Outcomes Theory Book's `mcp_system_context` field at `/sets/33032180-d77a-4ce4-88cf-b49cd643e093`.
2. **Re-paste** the v6.0.9 auth-recovery body from `docs/prompts/mcp-server-instructions.md` into the `mcp_server_instructions` row at `/admin/settings/ai`.
3. **Remove + re-add** the Iris connector in claude.ai so it re-discovers the now-correct OAuth metadata. Then click "Sign in" on the connector → browser tab opens for sign-in to Iris → done. No `client_id`/`secret` entry.

The v6.0.5 TTL refresh propagates both paste edits within 60s; no Render restart needed.

## See also

- [ADR-169](https://github.com/cgbarlow/iris/blob/fix/v6.0.9-oauth-metadata-and-intro-conclusion/docs/adrs/ADR-169-OAuth-Metadata-URL-Fix.md)
- Issue #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)