### PR TITLE
fix(v6.0.11): point OAuth authorization_endpoint at frontend (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.11] - 2026-05-13
+
+### Fixed
+
+- **OAuth `authorization_endpoint` pointed at the wrong host, 404'ing
+  the consent flow (ADR-171).** v6.0.10 unblocked claude.ai's OAuth
+  trigger — tapping "Sign in" on the Iris connector finally initiated
+  the flow. But the browser then redirected to the AS-metadata-
+  advertised `authorization_endpoint` and landed on a hard
+  `{"detail":"Not Found"}` 404. The metadata advertised the API host:
+
+  ```
+  authorization_endpoint: https://iris-api-gtb3.onrender.com/oauth/authorize
+  ```
+
+  But iris-api has no GET handler at `/oauth/authorize`. The user-
+  facing consent screen is a SvelteKit page on the frontend at
+  `https://iris-uat.chrisbarlow.nz/oauth/authorize`. The OAuth 2.1
+  authorization endpoint is a **browser** endpoint — its job is to
+  show login + consent UI and redirect back to the client's
+  redirect_uri with an authorization code. v6.0.0 → v6.0.10 advertised
+  the wrong host for that endpoint.
+- v6.0.11 sources `authorization_endpoint` from `IRIS_WEB_URL` (the
+  frontend host) in `app.oauth.router.authorization_server_metadata`.
+  Token / registration / revocation endpoints stay on the API host —
+  those are machine-to-machine endpoints (no browser involved).
+  `render.yaml` adds `IRIS_WEB_URL=https://iris-uat.chrisbarlow.nz` to
+  the iris-api service so the live deployment knows where the
+  frontend lives.
+- Falls back to the API host when `IRIS_WEB_URL` is unset (dev
+  convenience — the metadata is well-formed, even though the URL
+  won't actually serve a consent page).
+
+### Added
+
+- 3 new regression tests in `backend/tests/test_oauth/test_metadata.py`:
+  - `authorization_endpoint` uses `IRIS_WEB_URL` when set.
+  - Trailing slashes on `IRIS_WEB_URL` are stripped (no double-slash
+    in the URL).
+  - Falls back to issuer when `IRIS_WEB_URL` is unset.
+  - Token / registration / revocation endpoints stay on the API host
+    regardless.
+- 36/36 backend OAuth tests pass.
+
+### User-visible after deploy
+
+- `https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server`
+  now reports
+  `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize`.
+- claude.ai → tap Sign in on Iris connector → browser opens the
+  SvelteKit consent page (not a 404) → user signs in to Iris if not
+  already signed in → consent screen → tap Allow → redirected back to
+  claude.ai with an auth code → bearer issued → write tools work.
+
+### See also
+
+- [ADR-171](docs/adrs/ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — eight-
+  revision fix history.
+
 ## [6.0.10] - 2026-05-13
 
 ### Fixed

--- a/backend/app/oauth/router.py
+++ b/backend/app/oauth/router.py
@@ -15,6 +15,7 @@ helpers:
 
 from __future__ import annotations
 
+import os
 from typing import Any
 from urllib.parse import urlencode
 
@@ -40,6 +41,32 @@ def _issuer(request: Request) -> str:
     return f"{request.url.scheme}://{request.url.netloc}"
 
 
+def _authorization_endpoint(api_base: str) -> str:
+    """Build the user-facing authorization-endpoint URL.
+
+    The OAuth 2.1 authorization endpoint is a **browser** endpoint —
+    the OAuth client redirects the user's browser there, the user is
+    shown a login + consent screen, and the page redirects back to
+    the client's `redirect_uri` with an authorization code.
+
+    In Iris's split-service deployment the user-facing UI lives on the
+    SvelteKit frontend (`IRIS_WEB_URL`), NOT on the FastAPI backend.
+    The backend has `/api/oauth/authorize/{prepare,decision}` JSON
+    endpoints that the frontend page calls — but the *browser* should
+    only ever hit the frontend page at `<IRIS_WEB_URL>/oauth/authorize`.
+
+    v6.0.0 → v6.0.10 advertised this endpoint on the API host, causing
+    a hard `{"detail":"Not Found"}` 404 when claude.ai redirected the
+    user's browser there (FastAPI has no GET `/oauth/authorize`).
+    v6.0.11 (ADR-171) reads `IRIS_WEB_URL` and points the metadata at
+    the SvelteKit page. Falls back to the API host so dev environments
+    where the frontend isn't separately running still load *something*
+    (a 404, but the metadata is at least well-formed).
+    """
+    web_url = os.environ.get("IRIS_WEB_URL", "").rstrip("/")
+    return f"{web_url or api_base}/oauth/authorize"
+
+
 @router.get(
     "/.well-known/oauth-authorization-server",
     response_model=AuthorizationServerMetadata,
@@ -51,11 +78,17 @@ async def authorization_server_metadata(
 
     Anonymous-readable. iris-mcp's protected-resource metadata points
     here so MCP clients can discover the AS.
+
+    v6.0.11 (ADR-171): `authorization_endpoint` is sourced from
+    `IRIS_WEB_URL` (the SvelteKit frontend host) because that's where
+    the user-facing consent screen actually lives. The token /
+    registration / revocation endpoints stay on the API host — those
+    are machine endpoints, not browser endpoints.
     """
     base = _issuer(request)
     return AuthorizationServerMetadata(
         issuer=base,
-        authorization_endpoint=f"{base}/oauth/authorize",
+        authorization_endpoint=_authorization_endpoint(base),
         token_endpoint=f"{base}/oauth/token",
         registration_endpoint=f"{base}/oauth/register",
         revocation_endpoint=f"{base}/oauth/revoke",

--- a/backend/tests/test_oauth/test_metadata.py
+++ b/backend/tests/test_oauth/test_metadata.py
@@ -93,3 +93,55 @@ class TestAuthorizationServerMetadata:
         # No Authorization header.
         resp = await client.get("/.well-known/oauth-authorization-server")
         assert resp.status_code == 200
+
+
+class TestAuthorizationEndpointFromIrisWebUrl:
+    """v6.0.11 (ADR-171): the `authorization_endpoint` must point at the
+    SvelteKit frontend page (where the consent screen lives), NOT at the
+    API host. The token / registration / revocation endpoints stay on
+    the API host."""
+
+    async def test_authorization_endpoint_uses_iris_web_url(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("IRIS_WEB_URL", "https://web.example.com")
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        assert meta["authorization_endpoint"] == (
+            "https://web.example.com/oauth/authorize"
+        )
+        # Machine endpoints stay on the API host (the issuer).
+        issuer = meta["issuer"]
+        assert meta["token_endpoint"] == f"{issuer}/oauth/token"
+        assert meta["registration_endpoint"] == f"{issuer}/oauth/register"
+        assert meta["revocation_endpoint"] == f"{issuer}/oauth/revoke"
+
+    async def test_authorization_endpoint_strips_trailing_slash(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("IRIS_WEB_URL", "https://web.example.com/")
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        # No double-slash even when operator's env var has a trailing slash.
+        assert meta["authorization_endpoint"] == (
+            "https://web.example.com/oauth/authorize"
+        )
+
+    async def test_authorization_endpoint_falls_back_to_api_when_unset(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dev environments without a separately-running frontend get
+        the API host fallback — produces a 404 if the user actually
+        clicks through, but the metadata document is at least
+        well-formed."""
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        issuer = meta["issuer"]
+        assert meta["authorization_endpoint"] == f"{issuer}/oauth/authorize"

--- a/docs/adrs/ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md
+++ b/docs/adrs/ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md
@@ -1,0 +1,74 @@
+# ADR-171: AS `authorization_endpoint` must point at the frontend, not the API
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-164](ADR-164-OAuth-2.1-for-MCP.md), [ADR-170](ADR-170-Require-Bearer-On-MCP-HTTP-Endpoint.md)
+
+## Context
+
+ADR-170 (v6.0.10) added the missing spec-required 401 + WWW-Authenticate trigger so claude.ai's MCP client now correctly initiates the OAuth flow. Live testing immediately surfaced the next break: when the user tapped "Sign in" on the Iris connector in claude.ai mobile, the browser redirected to the Authorization Server's `authorization_endpoint` and landed on a hard `{"detail":"Not Found"}` 404.
+
+Root cause: the RFC 8414 AS metadata published at `/.well-known/oauth-authorization-server` advertises:
+
+```json
+{
+  "authorization_endpoint": "https://iris-api-gtb3.onrender.com/oauth/authorize",
+  ...
+}
+```
+
+But the iris-api FastAPI app has **no** GET handler for `/oauth/authorize`. The authorization endpoint is a *browser* endpoint — the OAuth client redirects the user's browser there, the user sees a login + consent screen, the page redirects back to the client's `redirect_uri` with an authorization code. In Iris's split-service deployment that screen lives on the **SvelteKit frontend** at `frontend/src/routes/oauth/authorize/+page.svelte`, served at `https://iris-uat.chrisbarlow.nz/oauth/authorize`. The frontend page reads the query params, POSTs them to the API's `/api/oauth/authorize/prepare` to validate, renders the consent UI, and on Allow POSTs `/api/oauth/authorize/decision` for the redirect-with-code.
+
+The backend has only the JSON helpers (`prepare`, `decision`, `token`, `register`, `revoke`) — no user-facing GET at `/oauth/authorize`. v6.0.0 → v6.0.10 advertised the wrong host for the user-facing endpoint, so every OAuth attempt 404'd as soon as it redirected.
+
+## Decision
+
+In `backend/app/oauth/router.py:authorization_server_metadata`, source the `authorization_endpoint` URL from the `IRIS_WEB_URL` environment variable (the frontend host) and fall back to the API issuer URL only when the env var is unset (dev convenience):
+
+```python
+def _authorization_endpoint(api_base: str) -> str:
+    web_url = os.environ.get("IRIS_WEB_URL", "").rstrip("/")
+    return f"{web_url or api_base}/oauth/authorize"
+```
+
+The token / registration / revocation endpoints stay on the API host — those are machine-to-machine endpoints (no browser involved).
+
+Add `IRIS_WEB_URL = https://iris-uat.chrisbarlow.nz` to the iris-api service's env vars in `render.yaml`. (iris-mcp already had it for entity-link decoration since v5.6.1.)
+
+## Why not redirect on the API side
+
+Considered: catch GET `/oauth/authorize` on the API host and redirect to the frontend. Rejected:
+
+- AS metadata still needs to be correct for spec compliance — clients SHOULD treat the metadata's `authorization_endpoint` as canonical and ignore servers that redirect away from it.
+- A redirect adds a hop (latency, more failure modes) on every sign-in.
+- The fix at the metadata level is one line.
+
+## Why not move the page to the API
+
+The consent UI is user-facing UI, with the same look/feel as the rest of iris-uat: shared layout, theming, login redirect, DOMPurify sanitisation of DCR-supplied `client_name`. Hoisting it into the FastAPI codebase would duplicate all that. The SPA boundary is the right place for the UI.
+
+## Why `IRIS_WEB_URL` (the same env var already used elsewhere)
+
+- iris-mcp already reads `IRIS_WEB_URL` for entity-link decoration (`web_url` fields on tool responses, since v5.6.1).
+- One env var = one source of truth for "where the frontend lives".
+- The fallback (`api_base`) gives developers a meaningful response when running iris-api alone without a frontend — the metadata is well-formed even though the URL won't actually serve a consent page.
+
+## Consequences
+
+- One backend code change (`_authorization_endpoint` helper) and one `os` import.
+- One `render.yaml` env var addition for the iris-api service.
+- Three new regression tests pin: `authorization_endpoint` uses `IRIS_WEB_URL`; trailing slashes are stripped; fallback to issuer when unset. The other endpoints (token/register/revoke) keep using the API host — pinned by the test.
+- Version bump v6.0.10 → v6.0.11. Patch-level (config fix, no API surface change).
+
+## Verification
+
+- All `backend/tests/test_oauth/` cases pass (36/36).
+- Post-deploy: `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` shows `"authorization_endpoint": "https://iris-uat.chrisbarlow.nz/oauth/authorize"`.
+- claude.ai → tap Sign in on Iris connector → browser opens to the frontend page → consent screen renders → user clicks Allow → redirected back to claude.ai with auth code → bearer issued → write tools work.
+
+## See also
+
+- [ADR-164](ADR-164-OAuth-2.1-for-MCP.md) — original OAuth 2.1 design.
+- [ADR-169](ADR-169-OAuth-Metadata-URL-Fix.md) — fixed Protected Resource metadata URLs (AS-side counterpart).
+- [ADR-170](ADR-170-Require-Bearer-On-MCP-HTTP-Endpoint.md) — added the 401 trigger that surfaced this bug.
+- RFC 8414 §2 — AS metadata `authorization_endpoint` definition.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — eight-revision fix history culminating here.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.10",
+	"version": "6.0.11",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.10"
+version = "6.0.11"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/render.yaml
+++ b/render.yaml
@@ -74,6 +74,13 @@ services:
         sync: false
       - key: IRIS_DEBUG
         value: "false"
+      - key: IRIS_WEB_URL
+        # v6.0.11 (ADR-171): sourced for the OAuth `authorization_endpoint`
+        # in the RFC 8414 AS metadata. The user-facing consent screen
+        # is a SvelteKit page at <IRIS_WEB_URL>/oauth/authorize, NOT a
+        # FastAPI route on the API host. Without this, claude.ai
+        # redirected user browsers to the API host and got HTTP 404.
+        value: https://iris-uat.chrisbarlow.nz
       # v5.5.7 (issue #55 follow-up): GitHub PAT used by
       # POST /api/extensions/{id}/check-update to query releases.
       # Without it, requests are unauthenticated (60/hr per IP) and


### PR DESCRIPTION
## Summary

v6.0.10 unblocked the OAuth trigger; tapping Sign in on the Iris connector now initiates the flow. But the browser redirected to the AS-metadata-advertised `authorization_endpoint` and landed on a hard 404. The metadata advertised `https://iris-api-gtb3.onrender.com/oauth/authorize` — but iris-api has no GET handler there. The user-facing consent screen is a **SvelteKit page on the frontend** at `https://iris-uat.chrisbarlow.nz/oauth/authorize`.

v6.0.11 sources `authorization_endpoint` from `IRIS_WEB_URL`. Token / registration / revocation endpoints stay on the API host (those are machine endpoints).

## Fix

- `backend/app/oauth/router.py`: new `_authorization_endpoint(api_base)` helper reads `IRIS_WEB_URL`. Falls back to the API host when unset (dev convenience).
- `render.yaml`: add `IRIS_WEB_URL=https://iris-uat.chrisbarlow.nz` to the iris-api service.

## Tests

- 3 new cases in `test_oauth/test_metadata.py`:
  - `authorization_endpoint` uses `IRIS_WEB_URL` when set.
  - Trailing slashes stripped.
  - Falls back to issuer when `IRIS_WEB_URL` unset.
  - Token / registration / revocation endpoints stay on the API host.
- 36/36 backend OAuth tests pass.

## Test plan

- [ ] CI green.
- [ ] Render auto-deploys iris-api with the new env var. `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` reports `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize`.
- [ ] In claude.ai: tap Sign in on the Iris connector → browser opens the SvelteKit consent page (no 404) → sign in if not already → tap Allow → redirected back → claude.ai shows the connector connected → write tools work.

## See also

- [ADR-171](https://github.com/cgbarlow/iris/blob/fix/v6.0.11-authorize-endpoint-frontend/docs/adrs/ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md)
- Issue #119 — eight-revision history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)