### PR TITLE
fix(v6.0.12): derive OAuth frontend URL from CORS_ORIGINS as fallback (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.12] - 2026-05-13
+
+### Fixed
+
+- **OAuth `authorization_endpoint` now derives from `IRIS_CORS_ORIGINS`
+  when `IRIS_WEB_URL` isn't set (ADR-172).** v6.0.11 wired the endpoint
+  through `IRIS_WEB_URL` and added the env var to `render.yaml`. Render
+  Blueprint-sync gotcha: env-var additions in `render.yaml` don't
+  auto-apply to existing services — they only take effect on initial
+  service creation or via manual Blueprint re-sync. The same issue hit
+  `IRIS_MCP_PUBLIC_URL` on iris-mcp in v6.0.9. Live iris-api still
+  served the API host as `authorization_endpoint` post-v6.0.11 deploy
+  because the new env var didn't propagate.
+- v6.0.12 makes the code robust to that: if `IRIS_WEB_URL` is unset, it
+  derives the frontend URL from the first non-localhost entry in
+  `IRIS_CORS_ORIGINS` (which has been set since v6.0.0 and is
+  guaranteed to be present — the frontend can't call iris-api without
+  it). Resolution order: `IRIS_WEB_URL` → `IRIS_CORS_ORIGINS` (first
+  non-localhost) → API issuer URL.
+
+### Added
+
+- 4 new regression tests in `backend/tests/test_oauth/test_metadata.py`:
+  - Uses first non-localhost CORS origin when `IRIS_WEB_URL` is unset.
+  - `IRIS_WEB_URL` wins over the CORS-origin fallback.
+  - Skips `http://localhost:*` and `http://127.0.0.1:*` entries.
+  - Strips trailing slashes.
+- 40/40 backend OAuth tests pass.
+
+### User-visible after deploy
+
+- `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server`
+  now reports
+  `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize`
+  even if the new env var was never synced — auto-derived from the
+  long-existing `IRIS_CORS_ORIGINS`.
+- The OAuth flow continues from claude.ai → SvelteKit consent page →
+  Allow → redirect with code → token → bearer → write tools succeed.
+
+### See also
+
+- [ADR-172](docs/adrs/ADR-172-Derive-Frontend-URL-From-CORS-Origins.md)
+- [ADR-171](docs/adrs/ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — nine-
+  revision fix history.
+
 ## [6.0.11] - 2026-05-13
 
 ### Fixed

--- a/backend/app/oauth/router.py
+++ b/backend/app/oauth/router.py
@@ -50,21 +50,51 @@ def _authorization_endpoint(api_base: str) -> str:
     the client's `redirect_uri` with an authorization code.
 
     In Iris's split-service deployment the user-facing UI lives on the
-    SvelteKit frontend (`IRIS_WEB_URL`), NOT on the FastAPI backend.
-    The backend has `/api/oauth/authorize/{prepare,decision}` JSON
-    endpoints that the frontend page calls — but the *browser* should
-    only ever hit the frontend page at `<IRIS_WEB_URL>/oauth/authorize`.
+    SvelteKit frontend, NOT on the FastAPI backend. The backend has
+    `/api/oauth/authorize/{prepare,decision}` JSON endpoints that the
+    frontend page calls — but the *browser* should only ever hit the
+    frontend page at `<frontend>/oauth/authorize`.
 
-    v6.0.0 → v6.0.10 advertised this endpoint on the API host, causing
-    a hard `{"detail":"Not Found"}` 404 when claude.ai redirected the
-    user's browser there (FastAPI has no GET `/oauth/authorize`).
-    v6.0.11 (ADR-171) reads `IRIS_WEB_URL` and points the metadata at
-    the SvelteKit page. Falls back to the API host so dev environments
-    where the frontend isn't separately running still load *something*
-    (a 404, but the metadata is at least well-formed).
+    Resolution order (v6.0.12, ADR-172 refines ADR-171):
+
+    1. `IRIS_WEB_URL` env var — explicit, operator-controlled.
+    2. First non-localhost entry in `IRIS_CORS_ORIGINS` — auto-derived
+       fallback. The frontend host MUST be in CORS_ORIGINS because the
+       frontend talks to this API, so it's a reliable proxy for "where
+       the frontend lives". This eliminates the env-var-sync gotcha:
+       on Render, env-var additions in `render.yaml` don't auto-apply
+       to existing services. The IRIS_CORS_ORIGINS env var was set in
+       v6.0.0 (or earlier) and is guaranteed to be present.
+    3. `api_base` — last-resort fallback for dev environments running
+       iris-api alone. Produces a 404 if the user actually clicks
+       through, but the metadata document is at least well-formed.
+
+    v6.0.0 → v6.0.10 advertised the endpoint on the API host directly,
+    causing a hard `{"detail":"Not Found"}` 404 when claude.ai
+    redirected user browsers there (FastAPI has no GET `/oauth/authorize`).
     """
     web_url = os.environ.get("IRIS_WEB_URL", "").rstrip("/")
+    if not web_url:
+        web_url = _frontend_from_cors_origins()
     return f"{web_url or api_base}/oauth/authorize"
+
+
+def _frontend_from_cors_origins() -> str:
+    """Return the first non-localhost entry in `IRIS_CORS_ORIGINS`,
+    rstrip-ed of trailing slashes. Empty string when none found.
+
+    CORS origins are comma-separated. Localhost entries (`http://localhost:*`,
+    `http://127.0.0.1:*`) are skipped — those are dev-only fallbacks that
+    don't reflect the public frontend URL.
+    """
+    raw = os.environ.get("IRIS_CORS_ORIGINS", "")
+    for origin in (s.strip() for s in raw.split(",")):
+        if not origin:
+            continue
+        if origin.startswith(("http://localhost", "http://127.0.0.1")):
+            continue
+        return origin.rstrip("/")
+    return ""
 
 
 @router.get(

--- a/backend/tests/test_oauth/test_metadata.py
+++ b/backend/tests/test_oauth/test_metadata.py
@@ -131,17 +131,94 @@ class TestAuthorizationEndpointFromIrisWebUrl:
             "https://web.example.com/oauth/authorize"
         )
 
-    async def test_authorization_endpoint_falls_back_to_api_when_unset(
+    async def test_authorization_endpoint_falls_back_to_api_when_all_unset(
         self,
         client: httpx.AsyncClient,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Dev environments without a separately-running frontend get
-        the API host fallback — produces a 404 if the user actually
-        clicks through, but the metadata document is at least
-        well-formed."""
+        """Last-resort fallback: dev environments with neither
+        IRIS_WEB_URL nor a non-localhost CORS_ORIGINS entry get the
+        API host. The metadata is well-formed even though the URL
+        won't actually serve a consent page."""
         monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        monkeypatch.setenv(
+            "IRIS_CORS_ORIGINS", "http://localhost:5173,http://127.0.0.1:3000",
+        )
         resp = await client.get("/.well-known/oauth-authorization-server")
         meta = resp.json()
         issuer = meta["issuer"]
         assert meta["authorization_endpoint"] == f"{issuer}/oauth/authorize"
+
+
+class TestAuthorizationEndpointFromCorsOrigins:
+    """v6.0.12 (ADR-172): `IRIS_CORS_ORIGINS` first non-localhost entry
+    is the auto-derived fallback when `IRIS_WEB_URL` isn't set. This
+    sidesteps Render's Blueprint-sync gotcha: env-var additions in
+    `render.yaml` don't auto-apply to existing services, but
+    `IRIS_CORS_ORIGINS` has been set since v6.0.0 (or earlier) and is
+    guaranteed to contain the public frontend URL — the frontend
+    couldn't call iris-api otherwise.
+    """
+
+    async def test_uses_first_non_localhost_cors_origin(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        monkeypatch.setenv(
+            "IRIS_CORS_ORIGINS",
+            "http://localhost:5173,https://iris-uat.chrisbarlow.nz",
+        )
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        assert meta["authorization_endpoint"] == (
+            "https://iris-uat.chrisbarlow.nz/oauth/authorize"
+        )
+
+    async def test_iris_web_url_wins_over_cors(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit env var wins over the auto-derived fallback."""
+        monkeypatch.setenv("IRIS_WEB_URL", "https://explicit.example.com")
+        monkeypatch.setenv(
+            "IRIS_CORS_ORIGINS", "https://cors.example.com",
+        )
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        assert meta["authorization_endpoint"] == (
+            "https://explicit.example.com/oauth/authorize"
+        )
+
+    async def test_skips_localhost_127_0_0_1(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        monkeypatch.setenv(
+            "IRIS_CORS_ORIGINS",
+            "http://127.0.0.1:5173,https://prod.example.com",
+        )
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        assert meta["authorization_endpoint"] == (
+            "https://prod.example.com/oauth/authorize"
+        )
+
+    async def test_strips_trailing_slash_from_cors_entry(
+        self,
+        client: httpx.AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        monkeypatch.setenv(
+            "IRIS_CORS_ORIGINS", "https://web.example.com/",
+        )
+        resp = await client.get("/.well-known/oauth-authorization-server")
+        meta = resp.json()
+        assert meta["authorization_endpoint"] == (
+            "https://web.example.com/oauth/authorize"
+        )

--- a/docs/adrs/ADR-172-Derive-Frontend-URL-From-CORS-Origins.md
+++ b/docs/adrs/ADR-172-Derive-Frontend-URL-From-CORS-Origins.md
@@ -1,0 +1,75 @@
+# ADR-172: Derive OAuth authorization_endpoint frontend URL from CORS origins
+
+Status: Accepted (2026-05-13)
+Refines: [ADR-171](ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md)
+
+## Context
+
+ADR-171 (v6.0.11) made iris-api's `authorization_endpoint` in the RFC 8414 metadata source from `IRIS_WEB_URL`. The env var was added to `render.yaml` for the iris-api service. But after deploying v6.0.11, the live metadata still advertised the API host:
+
+```bash
+$ curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server
+{"authorization_endpoint": "https://iris-api-gtb3.onrender.com/oauth/authorize", ...}
+```
+
+Root cause: **Render Blueprint-sync gotcha.** Env-var additions in `render.yaml` don't auto-apply to existing services — they only take effect on initial service creation or via a manual Blueprint re-sync. The same issue hit `IRIS_MCP_PUBLIC_URL` on iris-mcp in v6.0.9 testing; the user had to add it manually in the Render dashboard.
+
+Two paths to fix per service:
+
+1. Manually add the env var in the Render dashboard (operator action per service).
+2. Make the code robust to the env var being unset.
+
+For long-term reliability, (2) is better. Operators forget to sync env vars; "wired to the env var" is one more thing that can drift.
+
+## Decision
+
+When `IRIS_WEB_URL` is unset, derive the frontend URL from `IRIS_CORS_ORIGINS`. The first non-localhost entry (skipping `http://localhost:*` and `http://127.0.0.1:*`) is the frontend host. This works because:
+
+- iris-api requires CORS origins to be configured for the frontend to call it (browser-side `fetch`).
+- `IRIS_CORS_ORIGINS` has been set since v6.0.0 (or earlier) and is guaranteed to be present on any deployed iris-api.
+- The first non-localhost entry is the public frontend URL by construction.
+
+Resolution order in `_authorization_endpoint`:
+
+1. `IRIS_WEB_URL` env var — explicit, operator-controlled.
+2. First non-localhost entry in `IRIS_CORS_ORIGINS` — auto-derived fallback.
+3. `api_base` (the issuer URL) — last-resort fallback for dev environments running iris-api alone.
+
+## Why not just always use CORS_ORIGINS
+
+`IRIS_WEB_URL` stays as the primary because:
+
+- Explicit > implicit. An operator who wants to override the frontend URL (e.g. for a multi-domain deployment with a separate OAuth-only frontend) should be able to set the env var.
+- Backwards compatibility with v6.0.11.
+- Documenting the relationship as "we use the frontend URL, fall back to CORS_ORIGINS first non-localhost, fall back to the issuer" is clearer than just "we use CORS_ORIGINS".
+
+## Why skip localhost
+
+`IRIS_CORS_ORIGINS` in development typically contains both `http://localhost:5173` (dev frontend) and the production frontend URL. The localhost entries shouldn't be picked when deciding the OAuth `authorization_endpoint`, because:
+
+- The metadata is served to remote MCP clients (claude.ai etc.), which can't reach `localhost`.
+- If localhost slips into the metadata, every OAuth flow from external clients breaks.
+
+Skipping `localhost` and `127.0.0.1` covers the standard dev origins. Other dev-only hostnames (e.g. `dev.local`) would need explicit `IRIS_WEB_URL` to override — acceptable edge case.
+
+## Consequences
+
+- One new helper (`_frontend_from_cors_origins`) in `app.oauth.router`.
+- `_authorization_endpoint` resolution order extended from 2 levels to 3.
+- 4 new regression tests:
+  - Uses first non-localhost CORS origin when `IRIS_WEB_URL` is unset.
+  - `IRIS_WEB_URL` wins over the CORS-origin fallback.
+  - Skips `localhost` and `127.0.0.1` entries.
+  - Strips trailing slashes.
+- One existing test (`test_authorization_endpoint_falls_back_to_api_when_unset`) updated: the test now needs to clear both `IRIS_WEB_URL` AND set `IRIS_CORS_ORIGINS` to localhost-only to exercise the API-host fallback path.
+- Version bump v6.0.11 → v6.0.12. Patch-level (config robustness, no API surface change).
+
+## Verification
+
+- 40/40 backend OAuth tests pass.
+- Post-deploy: `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` reports `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize` regardless of whether `IRIS_WEB_URL` is set on the service — auto-derived from the existing `IRIS_CORS_ORIGINS`.
+
+## See also
+
+- [ADR-171](ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md) — the v6.0.11 fix this refines.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — nine-revision fix history.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.11",
+	"version": "6.0.12",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.11"
+version = "6.0.12"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

v6.0.11 wired `authorization_endpoint` through `IRIS_WEB_URL` and added the env var to `render.yaml`. But Render's Blueprint-sync doesn't auto-apply env-var additions to existing services (same gotcha that hit `IRIS_MCP_PUBLIC_URL` on iris-mcp in v6.0.9). Live iris-api kept serving the API host as `authorization_endpoint` even after v6.0.11 deployed.

v6.0.12 makes the code robust to env-var drift by deriving the frontend URL from `IRIS_CORS_ORIGINS` (first non-localhost entry) when `IRIS_WEB_URL` is unset. `CORS_ORIGINS` has been set since v6.0.0 and is guaranteed to contain the public frontend URL — the frontend can't call iris-api without it.

## Resolution order

1. `IRIS_WEB_URL` env var (explicit, operator-controlled).
2. First non-localhost entry in `IRIS_CORS_ORIGINS` (auto-derived).
3. API issuer URL (last-resort dev fallback).

## Tests

- 4 new in `test_oauth/test_metadata.py`.
- 1 existing test updated to set `IRIS_CORS_ORIGINS` to localhost-only when exercising the API-host fallback path.
- 40/40 backend OAuth tests pass.

## Test plan

- [ ] CI green.
- [ ] iris-api auto-redeploys on merge to main.
- [ ] `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` reports `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize` (auto-derived from CORS_ORIGINS, no env-var dance needed).
- [ ] claude.ai → Sign in on Iris connector → consent page loads (not 404) → Allow → write tools work.

## See also

- [ADR-172](https://github.com/cgbarlow/iris/blob/fix/v6.0.12-derive-web-url-from-cors/docs/adrs/ADR-172-Derive-Frontend-URL-From-CORS-Origins.md)
- Issue #119 — nine-revision history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)