### PR TITLE
fix(v6.0.13): parameterise OAuth booleans for Postgres compatibility (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.13] - 2026-05-13
+
+### Fixed
+
+- **OAuth token exchange crashed on Postgres with a SQLite/Postgres
+  bool-vs-int type mismatch (ADR-173).** The connector dance reached
+  the final step in v6.0.12 — user signed in to Iris, tapped Allow on
+  consent, was redirected back to claude.ai with an authorization
+  code — and the token exchange at `POST /oauth/token` blew up with:
+
+  ```
+  asyncpg.exceptions.DatatypeMismatchError:
+    column "revoked" is of type boolean but expression is of type integer
+  ```
+
+  claude.ai surfaced the failure as `mcp_token_exchange_failed`. Live
+  Render logs pointed at `oauth/service.py:260` in
+  `create_refresh_token`.
+- Root cause: `oauth_refresh_tokens.revoked` is `BOOLEAN` on Postgres
+  (Supabase) but `INTEGER` on SQLite. Three call sites in
+  `app/oauth/service.py` used bare-int SQL literals (`VALUES (..., 0)`,
+  `SET revoked = 1`). SQLite accepts both, Postgres is strict. The
+  existing 40 OAuth tests all passed against SQLite, so the bug went
+  undetected from v6.0.0 until live production testing.
+- Fix: parameterise as Python `bool` so the DB adapter coerces to the
+  right SQL type on either backend.
+
+### Added
+
+- **Static regression guard** (`test_postgres_bool_int_compatibility.py`)
+  scans the OAuth service source for bare-int literals on boolean
+  columns. Catches future drift on SQLite-only test runs without
+  needing a Postgres test fixture. 4 new test cases.
+- 44/44 OAuth tests pass (40 existing + 4 new).
+
+### User-visible after deploy
+
+- claude.ai mobile → tap Sign in on Iris connector → consent page →
+  Allow → connector goes to "Connected" (no more
+  `mcp_token_exchange_failed`).
+- Write tools (`create_collection`, `create_set`, etc.) now succeed
+  with the issued bearer.
+
+### See also
+
+- [ADR-173](docs/adrs/ADR-173-OAuth-Boolean-Column-Parameterisation.md)
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — ten-
+  revision fix history.
+
 ## [6.0.12] - 2026-05-13
 
 ### Fixed

--- a/backend/app/oauth/service.py
+++ b/backend/app/oauth/service.py
@@ -257,12 +257,18 @@ async def create_refresh_token(
     family = family_id or str(uuid.uuid4())
     now_iso = _utcnow_iso()
     expires_at = (datetime.now(tz=UTC) + REFRESH_TOKEN_TTL).isoformat()
+    # v6.0.13 (ADR-173): `revoked` is BOOLEAN on Postgres (Supabase),
+    # INTEGER on SQLite. A bare `0` SQL literal is rejected by Postgres
+    # (`column "revoked" is of type boolean but expression is of type
+    # integer`) — the token endpoint crashed there during OAuth code
+    # exchange. Parameterise as a Python bool so the DB adapter coerces
+    # to the right type on either backend.
     await db.execute(
         "INSERT INTO oauth_refresh_tokens ("
         "  id, client_id, user_id, family_id,"
         "  expires_at, created_at, revoked"
-        ") VALUES (?, ?, ?, ?, ?, ?, 0)",
-        (token_value, client_id, user_id, family, expires_at, now_iso),
+        ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (token_value, client_id, user_id, family, expires_at, now_iso, False),
     )
     await db.commit()
     return token_value, family
@@ -306,10 +312,11 @@ async def rotate_refresh_token(
     # reserved for explicit revocation via /oauth/revoke or family
     # cascade) so this branch fires on every replay.
     if used_at is not None:
+        # v6.0.13 (ADR-173): parameterise the bool (see create_refresh_token).
         await db.execute(
-            "UPDATE oauth_refresh_tokens SET revoked = 1"
+            "UPDATE oauth_refresh_tokens SET revoked = ?"
             " WHERE family_id = ?",
-            (family_id,),
+            (True, family_id),
         )
         await db.commit()
         return None
@@ -344,10 +351,11 @@ async def revoke_refresh_token(
     to the client and was updated (idempotent on already-revoked tokens).
     RFC 7009 says revoke is always 200 OK regardless of success — the
     caller maps to that."""
+    # v6.0.13 (ADR-173): parameterise the bool (see create_refresh_token).
     cursor = await db.execute(
-        "UPDATE oauth_refresh_tokens SET revoked = 1"
+        "UPDATE oauth_refresh_tokens SET revoked = ?"
         " WHERE id = ? AND client_id = ?",
-        (token, client_id),
+        (True, token, client_id),
     )
     await db.commit()
     return cursor.rowcount > 0

--- a/backend/tests/test_oauth/test_postgres_bool_int_compatibility.py
+++ b/backend/tests/test_oauth/test_postgres_bool_int_compatibility.py
@@ -1,0 +1,92 @@
+"""v6.0.13 (ADR-173): bare 0/1 SQL literals for BOOLEAN columns crash
+on Postgres but pass on SQLite. Every OAuth-related boolean column
+must be set via a parameterised Python `bool`, not a bare int literal.
+
+The token-exchange path crashed in production with:
+
+    asyncpg.exceptions.DatatypeMismatchError:
+    column "revoked" is of type boolean but expression is of type integer
+
+at oauth/service.py:343 -> create_refresh_token's INSERT. The existing
+40 OAuth tests all passed on SQLite because SQLite stores booleans as
+integers and accepts both `0`/`1` and `False`/`True` interchangeably.
+The bug only surfaced on Supabase (Postgres) where the BOOLEAN type
+is strict.
+
+These tests scan the source of `app.oauth.service` for the antipattern
+so it can't drift back on SQLite-only test runs.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import app.oauth.service as oauth_service
+
+
+def _service_source() -> str:
+    return Path(oauth_service.__file__).read_text(encoding="utf-8")
+
+
+class TestNoBareBoolLiteralsInSQL:
+    def test_no_set_revoked_equals_bare_int(self) -> None:
+        """Reject `SET revoked = 0` and `SET revoked = 1`. The right
+        idiom is `SET revoked = ?` with True/False passed as a param."""
+        src = _service_source()
+        # Direct literal matches (whitespace-insensitive).
+        for needle in ("revoked = 0", "revoked = 1"):
+            assert needle not in src, (
+                f"bare-int literal `{needle}` in OAuth service SQL: "
+                f"BOOLEAN columns must be parameterised so the Postgres "
+                f"driver coerces correctly (v6.0.13 / ADR-173)."
+            )
+
+    def test_no_bare_int_trailing_in_oauth_refresh_insert(self) -> None:
+        """Reject INSERTs into oauth_refresh_tokens that end with a
+        bare 0/1 in the VALUES list (the position is `revoked`)."""
+        src = _service_source()
+        # Match `INSERT INTO oauth_refresh_tokens (...) VALUES (..., 0)`
+        # or `..., 1)` regardless of how many `?` placeholders precede.
+        pattern = re.compile(
+            r"INSERT\s+INTO\s+oauth_refresh_tokens\s*\([^)]*\)\s*"
+            r"VALUES\s*\([^)]*,\s*[01]\s*\)",
+            re.IGNORECASE | re.DOTALL,
+        )
+        match = pattern.search(src)
+        assert match is None, (
+            "INSERT INTO oauth_refresh_tokens has a bare int literal in "
+            f"its VALUES (...) — Postgres BOOLEAN rejects this:\n\n{match.group(0) if match else ''}"  # noqa: E501
+        )
+
+    def test_create_refresh_token_passes_bool_not_int(self) -> None:
+        """The INSERT in `create_refresh_token` must include a Python
+        bool in its params tuple. Static evidence: source contains
+        `, False)` (or `, False,`) somewhere inside the call site."""
+        src = _service_source()
+        # Locate the create_refresh_token function and grep its body.
+        marker = "async def create_refresh_token"
+        idx = src.index(marker)
+        # Function body ends at the next `async def` or end of file.
+        next_def = src.find("\nasync def ", idx + len(marker))
+        body = src[idx:next_def] if next_def != -1 else src[idx:]
+        assert ", False" in body, (
+            "create_refresh_token should pass `False` (Python bool) for "
+            "the `revoked` column, not a bare integer."
+        )
+
+    def test_rotate_and_revoke_pass_true_not_int(self) -> None:
+        """`rotate_refresh_token` (theft kill) and `revoke_refresh_token`
+        both set revoked=True. Pin that the params tuples contain a
+        Python True, not the int 1."""
+        src = _service_source()
+        for func in ("rotate_refresh_token", "revoke_refresh_token"):
+            marker = f"async def {func}"
+            assert marker in src, f"missing function {func}"
+            idx = src.index(marker)
+            next_def = src.find("\nasync def ", idx + len(marker))
+            body = src[idx:next_def] if next_def != -1 else src[idx:]
+            assert "True" in body, (
+                f"{func} should pass `True` (Python bool) for the "
+                f"`revoked` column, not a bare integer."
+            )

--- a/docs/adrs/ADR-173-OAuth-Boolean-Column-Parameterisation.md
+++ b/docs/adrs/ADR-173-OAuth-Boolean-Column-Parameterisation.md
@@ -1,0 +1,93 @@
+# ADR-173: Parameterise booleans for SQLite/Postgres portability in OAuth service
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-164](ADR-164-OAuth-2.1-for-MCP.md)
+
+## Context
+
+OAuth on the iris-mcp HTTP transport finally reached end-to-end token exchange in v6.0.12 (after the ADR-170/171/172 chain). The user signed in to Iris, tapped Allow on the consent screen, was redirected back to claude.ai with an authorization code — and the connector then displayed:
+
+> Authorization with the MCP server failed. ... `mcp_token_exchange_failed` ... `ofid_922f130efbf385c7`
+
+Live iris-api logs at the time of the failure:
+
+```
+File ".../backend/app/oauth/router.py", line 343, in token_endpoint
+  refresh_token, _ = await oauth_service.create_refresh_token(...)
+File ".../backend/app/oauth/service.py", line 260, in create_refresh_token
+asyncpg.exceptions.DatatypeMismatchError:
+  column "revoked" is of type boolean but expression is of type integer
+```
+
+The OAuth schema defines `oauth_refresh_tokens.revoked BOOLEAN NOT NULL DEFAULT FALSE` (per the Supabase migration `m058_oauth_tables.sql`). SQLite treats booleans as integers (0/1) and accepts both `0`/`1` and `False`/`True` interchangeably. Postgres has a strict BOOLEAN type — bare `0`/`1` SQL literals are rejected.
+
+Three call sites in `backend/app/oauth/service.py` used bare-int literals:
+
+| Location | Statement |
+|---|---|
+| `create_refresh_token` (line 264) | `VALUES (..., 0)` — INSERT |
+| `rotate_refresh_token` (line 310) | `SET revoked = 1` — theft kill |
+| `revoke_refresh_token` (line 348) | `SET revoked = 1` — explicit revoke |
+
+All three crash on Postgres. All three pass on SQLite. The existing 40 OAuth tests cover the full token-exchange + rotation + revoke paths, but they all run on SQLite, so the bug went undetected from v6.0.0 (when OAuth shipped) until live production testing now.
+
+## Decision
+
+Replace bare-int literals with parameterised Python `bool` values throughout the OAuth service:
+
+```python
+# Before (line 264):
+"VALUES (?, ?, ?, ?, ?, ?, 0)"
+(token_value, client_id, user_id, family, expires_at, now_iso),
+
+# After:
+"VALUES (?, ?, ?, ?, ?, ?, ?)"
+(token_value, client_id, user_id, family, expires_at, now_iso, False),
+```
+
+```python
+# Before (lines 310, 348):
+"UPDATE oauth_refresh_tokens SET revoked = 1 WHERE ..."
+
+# After:
+"UPDATE oauth_refresh_tokens SET revoked = ? WHERE ..."
+(True, ...)
+```
+
+The DB adapter coerces Python `bool` to the right SQL type on either backend (`INTEGER 0/1` on SQLite, `BOOLEAN false/true` on Postgres).
+
+## Add a static guard so this can't drift back
+
+The existing OAuth tests pass on SQLite by design; reading them won't catch a future bare-int regression. Add a focused regression test that **scans the OAuth service source** for the antipattern:
+
+- No `revoked = 0` or `revoked = 1` substrings (catches UPDATE statements).
+- No `INSERT INTO oauth_refresh_tokens ... VALUES (..., 0)` (regex match on the INSERT shape).
+- Positive assertions inside `create_refresh_token`, `rotate_refresh_token`, `revoke_refresh_token` that the param tuples include the Python `False` / `True` constants.
+
+This is a source-level check, fast, and runs on every test invocation regardless of DB backend.
+
+## Why source-scanning (not a real Postgres test)
+
+- Running the OAuth integration tests against a real Postgres in CI is a much bigger infrastructure lift (test containers, fixture management, parallel test isolation).
+- Source-scanning catches the specific antipattern that bit us; future strict-typing bugs of other kinds would need their own targeted guards.
+- The fix is one line per call site. The cost of the test is one file.
+
+If we eventually move test fixtures to Postgres for the OAuth path, the source-scan guard becomes redundant — but keeping it is cheap insurance.
+
+## Consequences
+
+- 3 lines changed in `app/oauth/service.py` (one INSERT + two UPDATE statements).
+- 4 new tests in `tests/test_oauth/test_postgres_bool_int_compatibility.py`.
+- 40 existing OAuth tests stay green.
+- 44/44 total OAuth tests pass.
+- Version bump v6.0.12 → v6.0.13. Patch-level (correctness fix, no schema or API surface change).
+
+## Verification
+
+- After deploy, claude.ai mobile → Sign in on Iris connector → consent page → Allow → connector status goes to "Connected" (no more `mcp_token_exchange_failed`). Write tools succeed.
+- Render API logs no longer show the `DatatypeMismatchError` traceback at `oauth/service.py:260`.
+
+## See also
+
+- [ADR-164](ADR-164-OAuth-2.1-for-MCP.md) — original OAuth 2.1 design (introduced the affected refresh_tokens table).
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — ten-revision fix history.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.12",
+	"version": "6.0.13",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.12"
+version = "6.0.13"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

OAuth token exchange crashed on Postgres with `asyncpg.exceptions.DatatypeMismatchError: column "revoked" is of type boolean but expression is of type integer`. The connector dance reached the final step in v6.0.12 — user signed in, tapped Allow, was redirected back with an auth code — and the token exchange at `POST /oauth/token` blew up. claude.ai surfaced this as `mcp_token_exchange_failed`.

Root cause: SQLite/Postgres bool-vs-int type difference. Three call sites in `oauth/service.py` used bare-int SQL literals for the BOOLEAN `revoked` column. SQLite accepts both 0/1 and True/False; Postgres is strict. All 40 existing OAuth tests pass on SQLite, so the bug shipped undetected from v6.0.0.

## Fix

Parameterise as Python `bool` at all three call sites:
- `create_refresh_token`: `VALUES (..., 0)` → `VALUES (..., ?)` + `False` param.
- `rotate_refresh_token`: `SET revoked = 1` → `SET revoked = ?` + `True` param.
- `revoke_refresh_token`: same shape as rotate.

## Tests

- New `test_postgres_bool_int_compatibility.py` — 4 static-source-scan cases that catch bare-int-on-bool antipatterns. Runs on SQLite-only test infra; cheap insurance.
- 44/44 OAuth tests pass (40 existing + 4 new).

## Test plan

- [ ] CI green.
- [ ] iris-api auto-redeploys on merge.
- [ ] claude.ai mobile → Sign in on Iris connector → consent page → Allow → connector goes "Connected" (no `mcp_token_exchange_failed`).
- [ ] Write tool succeeds: e.g. `create_collection` returns 200 with the new id.
- [ ] Render API logs no longer show the DatatypeMismatchError traceback at `oauth/service.py:260`.

## See also

- [ADR-173](https://github.com/cgbarlow/iris/blob/fix/v6.0.13-oauth-bool-int-postgres/docs/adrs/ADR-173-OAuth-Boolean-Column-Parameterisation.md)
- Issue #119 — ten-revision history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)