### PR TITLE
fix(v6.0.14): accept iris-OAuth JWTs in Supabase mode (issue #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,85 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.14] - 2026-05-13
+
+### Fixed
+
+- **OAuth-issued JWTs now validate in Supabase deployment mode
+  (ADR-174).** v6.0.13 got the connector to "Connected" — token
+  exchange returned 200 — but the very first authenticated API call
+  the connector made got 401, and every subsequent write call too.
+  Root cause: `_get_current_user_supabase` only validates JWTs with
+  the **Supabase** signing key (ES256 via JWKS or HS256 with
+  `SUPABASE_JWT_SECRET`). iris-OAuth tokens are signed by
+  `app.oauth.service.issue_access_token` with the **iris** JWT secret
+  via `config.auth.jwt_secret`. Two different keys → signature
+  validation always fails → 401.
+- The bug existed from v6.0.0 (when OAuth shipped) but was hidden
+  because the existing OAuth tests run in SQLite mode, where
+  `_get_current_user_sqlite` validates with the iris JWT secret and
+  everything works.
+- Fix: hybrid validation in `_get_current_user_supabase`. JWTs with
+  `aud="iris-mcp"` (the canonical OAuth audience) route through the
+  iris HS256 validator using `config.auth.jwt_secret`; everything
+  else stays on the Supabase validation path. Audience-claim routing
+  with strict per-issuer signature validation — no fall-through (a
+  token claiming `aud="iris-mcp"` with the wrong signature gets 401,
+  not a second chance with the Supabase secret).
+- Profile lookup unchanged: both paths use the same
+  `get_profile(db, user_id)` because the OAuth `sub` claim IS the
+  Supabase auth.users UUID (consent screen captured it from this
+  same function pre-issue).
+
+### Security
+
+- **`IRIS_JWT_SECRET` is now required in production.** The dev
+  default in `config.py` is a hardcoded string in the public repo
+  — anyone reading the repo can forge OAuth-issued JWTs against any
+  deployment that hasn't overridden the secret. v6.0.14 adds
+  `IRIS_JWT_SECRET` to `render.yaml` with `sync: false`; the
+  operator generates a per-deployment secret
+  (`openssl rand -hex 32`) and pastes it into the Render dashboard
+  for the `iris-api` service. **This does NOT auto-apply** (Render
+  Blueprint-sync limitation — same gotcha as `IRIS_MCP_PUBLIC_URL`
+  in v6.0.9 and `IRIS_WEB_URL` in v6.0.11). Operator action
+  required.
+
+### Added
+
+- 3 new regression tests in `tests/test_auth/test_supabase_mode_oauth_token.py`:
+  - iris-OAuth token (correct signature) validates via iris path →
+    returns user dict.
+  - iris-OAuth token with wrong signature → 401 (no fall-through to
+    Supabase validation).
+  - Supabase-shaped token (no `aud="iris-mcp"`) routes through
+    Supabase path → returns user dict.
+- 120/120 OAuth + auth tests pass.
+
+### Operator action required after deploy
+
+1. **Set `IRIS_JWT_SECRET` on the iris-api service in the Render
+   dashboard.** Generate the value with `openssl rand -hex 32`. Save;
+   the service restarts.
+2. **Disconnect + reconnect the Iris connector in claude.ai.** Old
+   bearers signed with the dev-default secret will no longer
+   validate; a fresh OAuth flow will mint bearers with the new
+   secret.
+
+### User-visible after that
+
+- claude.ai → Sign in on Iris connector → consent → Allow → connector
+  goes to **Connected** → write tools (`create_collection`,
+  `create_set`, etc.) succeed.
+
+### See also
+
+- [ADR-174](docs/adrs/ADR-174-Hybrid-JWT-Validation-In-Supabase-Mode.md)
+- [ADR-164](docs/adrs/ADR-164-OAuth-2.1-for-MCP.md) — original OAuth
+  design that introduced the dual-key situation.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — eleven-
+  revision fix history (v6.0.4 → v6.0.14).
+
 ## [6.0.13] - 2026-05-13
 
 ### Fixed

--- a/backend/app/auth/dependencies.py
+++ b/backend/app/auth/dependencies.py
@@ -107,22 +107,64 @@ async def _get_current_user_supabase(
     request: Request,
     token: str,
 ) -> dict[str, Any]:
-    """Validate Supabase JWT and check profiles table (Supabase mode)."""
+    """Validate JWT and check profiles table (Supabase deployment mode).
+
+    Two JWT issuers are accepted on the same header:
+
+    1. **iris-OAuth tokens** — signed by our `/oauth/token` endpoint with
+       `IRIS_JWT_SECRET` (HS256). Identified by `aud="iris-mcp"` claim.
+       v6.0.14 (ADR-174). Without this branch, every OAuth-issued
+       bearer 401'd in production because Supabase's JWT secret never
+       matches the iris JWT secret, so the signature validation failed.
+    2. **Supabase-issued tokens** — signed by Supabase itself (ES256 via
+       JWKS or HS256 with `SUPABASE_JWT_SECRET`). The standard
+       login-via-Supabase path.
+
+    Both resolve through the same `profiles` table lookup — the `sub`
+    claim is the Supabase auth.users UUID in either case, and the OAuth
+    consent screen captures `current_user["id"]` (which already came
+    from this same function before re-validation), so the `sub` in our
+    OAuth-issued token IS the profile id.
+    """
+    from app.auth.service import decode_access_token  # noqa: PLC0415
     from app.auth.supabase_service import (  # noqa: PLC0415
         decode_supabase_jwt,
         fetch_jwks,
         get_profile,
     )
+    from jose import jwt as _jose_jwt  # noqa: PLC0415
 
     config = request.app.state.config
     if config.supabase is None:
         raise HTTPException(status_code=500, detail="Supabase not configured")
 
+    payload: dict[str, Any] | None = None
+
+    # 1. Route iris-OAuth tokens via the iris JWT secret. Peek at the
+    #    unverified `aud` claim first — that's safe because we still
+    #    validate the signature below before trusting any other claim.
     try:
-        jwks = await fetch_jwks(config.supabase.url)
-        payload = decode_supabase_jwt(token, config.supabase.jwt_secret, jwks)
+        unverified = _jose_jwt.get_unverified_claims(token)
     except JWTError:
-        raise HTTPException(status_code=401, detail="Invalid token")  # noqa: B904
+        unverified = {}
+    if unverified.get("aud") == "iris-mcp":
+        try:
+            payload = decode_access_token(token, config.auth)
+        except JWTError as e:
+            raise HTTPException(  # noqa: B904
+                status_code=401,
+                detail="Invalid iris-OAuth token",
+            ) from e
+
+    # 2. Fall through to Supabase validation for everything else.
+    if payload is None:
+        try:
+            jwks = await fetch_jwks(config.supabase.url)
+            payload = decode_supabase_jwt(
+                token, config.supabase.jwt_secret, jwks,
+            )
+        except JWTError:
+            raise HTTPException(status_code=401, detail="Invalid token")  # noqa: B904
 
     user_id = payload.get("sub")
     if not user_id:

--- a/backend/tests/test_auth/test_supabase_mode_oauth_token.py
+++ b/backend/tests/test_auth/test_supabase_mode_oauth_token.py
@@ -1,0 +1,181 @@
+"""v6.0.14 (ADR-174): in Supabase deployment mode, `get_current_user`
+must accept iris-OAuth-issued tokens (signed with IRIS_JWT_SECRET,
+`aud="iris-mcp"`) in addition to Supabase-issued tokens. Without this
+hybrid validation, every OAuth bearer 401'd in production because
+Supabase JWKS / SUPABASE_JWT_SECRET never matches the iris JWT secret.
+
+These tests pin the routing: tokens with `aud="iris-mcp"` go through
+iris's HS256 validator using `config.auth.jwt_secret`; everything else
+goes through `decode_supabase_jwt`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from jose import jwt
+
+from app.auth.dependencies import _get_current_user_supabase
+from app.config import AppConfig, AuthConfig, DatabaseConfig, SupabaseConfig
+
+
+def _make_iris_oauth_token(jwt_secret: str, user_id: str = "user-abc") -> str:
+    """Mint an iris-OAuth-shaped JWT for testing.
+
+    Mirrors the claim set produced by `oauth_service.issue_access_token`.
+    """
+    payload = {
+        "sub": user_id,
+        "role": "viewer",
+        "aud": "iris-mcp",
+        "azp": "iris-mcp-test-client",
+        "scope": "iris",
+        "jti": "test-jti-12345",
+    }
+    return jwt.encode(payload, jwt_secret, algorithm="HS256")
+
+
+def _make_supabase_shaped_token(
+    jwt_secret: str, user_id: str = "user-xyz",
+) -> str:
+    """Mint a Supabase-shaped JWT (no aud=iris-mcp; signed with the
+    Supabase jwt_secret in this test). The hybrid validator should
+    treat this as a Supabase token."""
+    payload = {
+        "sub": user_id,
+        "aud": "authenticated",
+        "role": "authenticated",
+    }
+    return jwt.encode(payload, jwt_secret, algorithm="HS256")
+
+
+def _fake_request(config: AppConfig) -> Any:
+    """Build a minimal Request stand-in carrying the app state."""
+    class _State:
+        pass
+
+    class _AppState:
+        def __init__(self) -> None:
+            self.config = config
+            self.db_manager = _DBManager()
+
+    class _DBManager:
+        def __init__(self) -> None:
+            self.main_db = None  # get_profile mocked
+
+    class _Req:
+        def __init__(self) -> None:
+            self.app = type("App", (), {"state": _AppState()})()
+
+    return _Req()
+
+
+@pytest.fixture
+def supabase_config(tmp_path) -> AppConfig:  # type: ignore[no-untyped-def]
+    return AppConfig(
+        debug=True,
+        cors_origins=["https://iris-uat.test"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="iris-jwt-secret-32-bytes-long-for-hs256-ok",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+        supabase=SupabaseConfig(
+            url="https://supabase.example.com",
+            anon_key="anon",
+            service_role_key="srv",
+            db_url="postgres://example",
+            jwt_secret="SUPABASE-DIFFERENT-secret-also-32-bytes-or-more",
+        ),
+        rate_limit_general=1000,
+        rate_limit_pat=1000,
+    )
+
+
+@pytest.mark.asyncio
+class TestHybridIrisOAuthInSupabaseMode:
+    """Iris-OAuth tokens (aud='iris-mcp', signed with IRIS_JWT_SECRET)
+    must validate in Supabase mode via the iris JWT decoder."""
+
+    async def test_iris_oauth_token_validates_via_iris_secret(
+        self, supabase_config: AppConfig,
+    ) -> None:
+        token = _make_iris_oauth_token(
+            supabase_config.auth.jwt_secret, user_id="user-iris-oauth",
+        )
+        req = _fake_request(supabase_config)
+
+        # Mock get_profile to return a populated profile.
+        profile = {
+            "id": "user-iris-oauth",
+            "username": "iris-user",
+            "role": "viewer",
+            "is_active": True,
+        }
+        with patch(
+            "app.auth.supabase_service.get_profile",
+            new=AsyncMock(return_value=profile),
+        ):
+            result = await _get_current_user_supabase(req, token)
+
+        assert result["id"] == "user-iris-oauth"
+        assert result["username"] == "iris-user"
+        assert result["role"] == "viewer"
+        assert result["jti"] == "test-jti-12345"
+
+    async def test_iris_oauth_token_with_wrong_signature_401(
+        self, supabase_config: AppConfig,
+    ) -> None:
+        """A token claiming aud='iris-mcp' but signed with the WRONG
+        secret must be rejected — the hybrid path doesn't fall through
+        to the Supabase decoder for aud='iris-mcp' tokens (would let
+        any Supabase-signed token forge an iris-OAuth identity)."""
+        # Sign with a totally unrelated secret.
+        bad_token = _make_iris_oauth_token(
+            "wrong-secret-32-bytes-long-not-iris-jwt-secret",
+            user_id="forged-user",
+        )
+        req = _fake_request(supabase_config)
+        with pytest.raises(HTTPException) as exc:
+            await _get_current_user_supabase(req, bad_token)
+        assert exc.value.status_code == 401
+
+    async def test_supabase_token_still_validates_via_supabase_path(
+        self, supabase_config: AppConfig,
+    ) -> None:
+        """Tokens without aud='iris-mcp' must go through the Supabase
+        decoder, not the iris path. Round-trip a Supabase-shaped token
+        signed with SUPABASE_JWT_SECRET and confirm it routes there."""
+        token = _make_supabase_shaped_token(
+            supabase_config.supabase.jwt_secret, user_id="user-supabase",
+        )
+        req = _fake_request(supabase_config)
+
+        profile = {
+            "id": "user-supabase",
+            "username": "sb-user",
+            "role": "editor",
+            "is_active": True,
+        }
+
+        # Mock JWKS fetch (returns no keys → falls to HS256 path inside
+        # decode_supabase_jwt with the Supabase secret).
+        with (
+            patch(
+                "app.auth.supabase_service.fetch_jwks",
+                new=AsyncMock(return_value={"keys": []}),
+            ),
+            patch(
+                "app.auth.supabase_service.get_profile",
+                new=AsyncMock(return_value=profile),
+            ),
+        ):
+            result = await _get_current_user_supabase(req, token)
+
+        assert result["id"] == "user-supabase"
+        assert result["role"] == "editor"

--- a/docs/adrs/ADR-174-Hybrid-JWT-Validation-In-Supabase-Mode.md
+++ b/docs/adrs/ADR-174-Hybrid-JWT-Validation-In-Supabase-Mode.md
@@ -1,0 +1,86 @@
+# ADR-174: Accept iris-OAuth JWTs in Supabase deployment mode
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-164](ADR-164-OAuth-2.1-for-MCP.md), [ADR-173](ADR-173-OAuth-Boolean-Column-Parameterisation.md)
+
+## Context
+
+v6.0.13 fixed the Postgres bool-vs-int crash in `create_refresh_token` and the user successfully exchanged an authorization code for an access token (`POST /oauth/token` → HTTP 200 with bearer). The connector showed as connected. But the very next write call from claude.ai surfaced:
+
+> Iris is asking you to sign in before it'll let me create anything.
+
+Live iris-api logs confirmed the bearer was being rejected with HTTP 401 on every authenticated route the connector tried:
+
+```
+20:13:18  POST /oauth/token            200 OK    ← token issued
+20:13:27  GET  /api/prompts/scope-index 401 ✗   ← bearer rejected
+20:14:51  POST /api/sets                401 ✗
+```
+
+Root cause: in Supabase deployment mode, `_get_current_user_supabase` validates the JWT using **Supabase's** signing key (ES256 via JWKS, or HS256 with `SUPABASE_JWT_SECRET`). But iris-OAuth tokens are signed with **iris's** JWT secret via `app.oauth.service.issue_access_token`:
+
+```python
+return jwt.encode(payload, config.jwt_secret, algorithm=config.jwt_algorithm)
+#                          └── from IRIS_JWT_SECRET, NOT SUPABASE_JWT_SECRET
+```
+
+The two signing keys are different. The signature validation in `decode_supabase_jwt` always fails → 401. This regressed silently from v6.0.0 (when OAuth shipped) because the deployment ran SQLite mode in testing — only `_get_current_user_sqlite` validates with the iris JWT secret, so the bug only surfaces on Postgres-backed (Supabase) deployments. The end-to-end OAuth tests pass on SQLite and the bug stayed hidden.
+
+A second, related issue surfaced in the same diagnostic: **`IRIS_JWT_SECRET` is not set in production** (no env var on the iris-api Render service). The code falls back to the dev default literal in `config.py` — which is a string in the public repo (`"dev-secret-change-in-production-must-be-at-least-32-bytes-long"`). Anyone reading the repo can forge OAuth-issued JWTs against the live deployment until this is fixed.
+
+## Decision
+
+Two changes:
+
+### 1. Hybrid JWT validation in Supabase mode
+
+`_get_current_user_supabase` now accepts two JWT issuers on the same `Authorization: Bearer` header:
+
+- **iris-OAuth tokens** — identified by `aud="iris-mcp"` (the canonical OAuth audience set by `issue_access_token`). Signature validated with `config.auth.jwt_secret` via the existing `decode_access_token` helper. Pure iris HS256.
+- **Supabase-issued tokens** — everything else. Routed through the existing `decode_supabase_jwt` path (ES256 via JWKS, HS256 fallback with `SUPABASE_JWT_SECRET`). Standard Supabase login bearer.
+
+The branch happens at the *audience-claim* level, NOT at the signature-validation level — both paths still validate the signature against their own key. We don't fall through from one validator to the other on signature failure, so a token claiming `aud="iris-mcp"` with the wrong signature stays 401'd (would otherwise let any Supabase-signed token forge an iris-OAuth identity).
+
+Profile lookup is unchanged: both paths use the same `get_profile(db, user_id)` because the `sub` claim is the Supabase auth.users UUID in either case (the OAuth consent screen captures `current_user["id"]`, which came from this same function pre-OAuth, so the `sub` in the issued OAuth token IS the profile id).
+
+### 2. Add `IRIS_JWT_SECRET` to `render.yaml`
+
+Add the env var with `sync: false` so the operator generates a per-deployment secret (`openssl rand -hex 32`) and pastes it into the Render dashboard. The fallback dev string stays in `config.py` so local development keeps working; the comment explains the production requirement.
+
+This doesn't auto-apply to the running iris-api (Render Blueprint sync limitation — same gotcha as `IRIS_MCP_PUBLIC_URL` in v6.0.9 and `IRIS_WEB_URL` in v6.0.11). The operator must add it manually in the dashboard for an existing service.
+
+## Why hybrid validation, not "OAuth tokens use SUPABASE_JWT_SECRET"
+
+Considered: have `issue_access_token` sign with `SUPABASE_JWT_SECRET` in Supabase mode. Then `_get_current_user_supabase` already validates them.
+
+Rejected because:
+
+- It couples our OAuth token issuance to Supabase's signing key. Rotating SUPABASE_JWT_SECRET (which Supabase recommends periodically) would invalidate every outstanding iris-OAuth bearer. Bad operational coupling.
+- iris-OAuth tokens then look like Supabase-issued tokens but with custom claims (`aud="iris-mcp"`, `azp`, `scope`). They aren't real Supabase tokens — they'd never validate against Supabase's own `/auth/v1/*` endpoints — but they share the same signing trust. Confusing security boundary.
+- The hybrid approach makes the issuer/validator pair symmetric: iris signs → iris validates. Supabase signs → Supabase validates. Clean separation.
+
+## Why not fall through from iris validation to Supabase validation on signature failure
+
+If a token with `aud="iris-mcp"` fails the iris-signature check, **return 401 immediately**. Don't try Supabase validation. Otherwise an attacker who possesses a valid Supabase-signed token could attach `aud="iris-mcp"` to it (no, they couldn't actually — the `aud` is part of the signed payload — but the broader principle holds): the iris-OAuth identity should require an iris-OAuth-signed token. Audience is a routing claim, signature is the security boundary.
+
+## Consequences
+
+- ~40 LOC added to `_get_current_user_supabase` for the hybrid branch.
+- 3 new regression tests in `tests/test_auth/test_supabase_mode_oauth_token.py`:
+  - iris-OAuth token (correct signature) validates via iris path → returns user dict.
+  - iris-OAuth token with wrong signature → 401, no Supabase fall-through.
+  - Supabase-shaped token (no `aud="iris-mcp"`) routes through Supabase path → returns user dict.
+- 120/120 OAuth + auth tests pass.
+- `render.yaml` updated with `IRIS_JWT_SECRET` env var; operator must set the value in the dashboard (sync: false).
+- Version bump v6.0.13 → v6.0.14. Patch-level (auth-correctness fix).
+
+## Verification
+
+- After deploy + operator sets `IRIS_JWT_SECRET` in the dashboard, claude.ai retries the OAuth flow → sign in → consent → Allow → connector status goes to **Connected** → `create_collection` returns 200 with the new id (no more `auth_required` from iris-mcp).
+- Render API logs show successful 200s on `/api/sets`, `/api/collections`, etc.
+
+## See also
+
+- [ADR-164](ADR-164-OAuth-2.1-for-MCP.md) — original OAuth 2.1 design that introduced the dual-key situation.
+- [ADR-173](ADR-173-OAuth-Boolean-Column-Parameterisation.md) — the previous step on this critical-path chain.
+- Issue [#119](https://github.com/cgbarlow/iris/issues/119) — eleven-revision fix history.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.13",
+	"version": "6.0.14",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.13"
+version = "6.0.14"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/render.yaml
+++ b/render.yaml
@@ -70,6 +70,15 @@ services:
         sync: false
       - key: SUPABASE_JWT_SECRET
         sync: false
+      - key: IRIS_JWT_SECRET
+        # v6.0.14 (ADR-174): HS256 signing secret for iris-issued JWTs.
+        # The /oauth/token endpoint mints OAuth bearers signed with this
+        # secret; _get_current_user_supabase validates them using the
+        # same. Without this set, the code falls back to a dev default
+        # string baked into config.py — which is in the public repo and
+        # would let anyone with the iris-api URL forge tokens.
+        # Generate with: openssl rand -hex 32
+        sync: false
       - key: IRIS_CORS_ORIGINS
         sync: false
       - key: IRIS_DEBUG


### PR DESCRIPTION
## Summary

v6.0.13 got the connector to "Connected" — token exchange returned 200 — but the very first authenticated API call got 401, and every subsequent write too. Live iris-api logs:

```
20:13:18  POST /oauth/token             200 OK   ← token issued
20:13:27  GET  /api/prompts/scope-index 401 ✗    ← bearer rejected
20:14:51  POST /api/sets                401 ✗
```

Root cause: in Supabase deployment mode, `_get_current_user_supabase` only validates JWTs with the **Supabase** signing key (ES256 via JWKS or HS256 with `SUPABASE_JWT_SECRET`). But iris-OAuth tokens are signed by `oauth_service.issue_access_token` with the **iris** JWT secret. Different keys → signature always fails → 401.

The bug existed from v6.0.0 but was hidden because the existing OAuth tests run in SQLite mode where `_get_current_user_sqlite` validates with the iris JWT secret.

## Fix

Hybrid validation in `_get_current_user_supabase`:
- JWTs with `aud="iris-mcp"` → iris HS256 validator using `config.auth.jwt_secret`.
- Everything else → existing Supabase validator.
- Per-issuer signature validation, no fall-through (wrong signature on aud=iris-mcp ⇒ 401, not retry against Supabase secret).

## Security

`IRIS_JWT_SECRET` is now required in production. The dev default in `config.py` is a hardcoded string in the public repo — token-forgery risk on any deployment that hasn't overridden it. `render.yaml` now lists `IRIS_JWT_SECRET` with `sync: false`; operator generates with `openssl rand -hex 32` and pastes into the Render dashboard for `iris-api`.

(Render Blueprint sync doesn't auto-apply env-var additions to existing services — same gotcha as `IRIS_MCP_PUBLIC_URL`/`IRIS_WEB_URL`. Operator action required.)

## Tests

3 new in `test_auth/test_supabase_mode_oauth_token.py`. 120/120 OAuth + auth tests pass.

## Test plan

- [ ] CI green.
- [ ] iris-api auto-redeploys on merge.
- [ ] **Operator sets `IRIS_JWT_SECRET`** in Render dashboard for iris-api.
- [ ] Disconnect + reconnect Iris connector in claude.ai.
- [ ] Sign in → Allow → connector goes "Connected".
- [ ] Ask Claude to create a test collection → 200 with new id.

## See also

- [ADR-174](https://github.com/cgbarlow/iris/blob/fix/v6.0.14-supabase-mode-oauth-jwt-validation/docs/adrs/ADR-174-Hybrid-JWT-Validation-In-Supabase-Mode.md)
- Issue #119 — eleven-revision history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)