### PR TITLE
docs: backfill SPEC-168 through SPEC-174 + README OAuth audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,19 +278,44 @@ command emits machine-parsable output. See
 uv tool install --from ./mcp iris-mcp
 ```
 
-Two transports, two auth paths (ADR-164, v6.0.0):
+Two transports, two auth paths:
 
 **HTTP transport (claude.ai connectors, claude.ai-style hosted MCP)** —
-iris-mcp implements OAuth 2.1 (RFC 8414 + RFC 9728 + RFC 7591 + PKCE).
-The user adds iris-mcp's URL as a connector; the MCP client performs
-DCR + OAuth handshake automatically; the user signs in to Iris on a
-consent screen; the MCP client stores the bearer and includes it on
-every subsequent request. There is no `IRIS_TOKEN` or `iris_authenticate`
-ceremony — the OAuth handshake is the auth path.
+iris-mcp implements OAuth 2.1 (RFC 8414 + RFC 9728 + RFC 7591 + PKCE)
+per ADR-164 (v6.0.0), with the discovery chain hardened across
+ADR-169 → ADR-174 (v6.0.9–v6.0.14). The user adds iris-mcp's URL as
+a connector; iris-mcp's first 401 + `WWW-Authenticate: Bearer
+resource_metadata="..."` (ADR-170) triggers the MCP client's OAuth
+flow; the client performs Dynamic Client Registration; the user signs
+in to Iris on the SvelteKit consent screen (ADR-171); the bearer is
+exchanged via `/oauth/token` and stored by the client for every
+subsequent request. There is no `IRIS_TOKEN` ceremony — the OAuth
+handshake IS the auth path. **All HTTP-transport MCP requests require
+a bearer** (anonymous read access via HTTP was removed in v6.0.10 to
+make the OAuth-discovery trigger spec-compliant).
+
+For a self-hosted production iris-api the operator must set:
+- `IRIS_WEB_URL=https://<frontend-host>` — where the OAuth consent
+  page lives (ADR-171). Falls back to a CORS-derived value when
+  unset (ADR-172) but explicit is cleaner.
+- `IRIS_JWT_SECRET` — HS256 signing key for iris-issued OAuth bearers
+  (ADR-174). Generate with `openssl rand -hex 32` and paste into the
+  deploy environment without echoing the value back into chats or
+  commits. The `config.py` dev default is a public-repo string and
+  must never be used in production.
+
+For iris-mcp:
+- `IRIS_API_URL=https://<api-host>` — backend URL (required).
+- `IRIS_MCP_PUBLIC_URL=https://<mcp-host>` — canonical iris-mcp URL,
+  used as `resource` in the Protected Resource metadata (ADR-169 /
+  ADR-172).
+- `IRIS_WEB_URL` — entity-link decoration; optional.
 
 **Stdio transport (Claude Desktop with the local iris-mcp binary)** —
 operators set `IRIS_TOKEN` env var to a Personal Access Token issued
-from `/settings/tokens` in the web UI.
+from `/settings/tokens` in the web UI. Anonymous-read use is
+supported on stdio (omit `IRIS_TOKEN`) because the trigger-on-401
+behaviour only applies to the HTTP transport.
 
 ```json
 {
@@ -308,31 +333,45 @@ from `/settings/tokens` in the web UI.
 }
 ```
 
-`IRIS_TOKEN` is optional. Read-only tools work anonymously; for
-write-capable tools, either configure OAuth (HTTP transport) or set
-`IRIS_TOKEN` (stdio transport).
+Exposes ~27 tools (search, list/get for every entity, export,
+conversations, plus `create_collection` / `create_set` /
+`create_package` for organising destinations, `create_diagram` /
+`apply_diagram_creation` / `list_notations` / `list_diagram_types`
+for the generic local-AI diagram-creation workflow). Plus `iris://`
+resource URIs for JSON export bundles.
 
-Exposes ~28 tools (search, list/get for every entity, export, ask-AI,
-apply-diagram-creation, conversations, plus `create_collection` /
-`create_set` / `create_package` for organising destinations,
-`create_diagram` / `list_notations` / `list_diagram_types` for the
-generic local-AI diagram-creation workflow). Plus `iris://` resource
-URIs for JSON export bundles. **Removed in v6.0.0** (ADR-164):
-`iris_authenticate` (replaced by OAuth handshake), `save_doview_analysis`
-(use `create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`).
+**Removed in v6.0.0** (ADR-164): `iris_authenticate` (replaced by OAuth
+handshake), `save_doview_analysis` (use
+`create_diagram(notation='markdown', diagram_type='doview_analysis', ...)`).
+**Removed in v6.0.8** (ADR-168): `ask` (the server-side AI question
+tool) — cross-package, cross-set, and cross-collection questions are
+fulfilled by the local AI walking the read-only MCP tools (`search`,
+`get_*`, `list_*`, `package_hierarchy`) and reasoning over the data
+in its own voice. `iris-client.IrisClient.ask(...)` SDK method is
+kept for non-MCP consumers.
 
-**Server-wide orient-first protocol** (v5.18.0 / ADR-163). On every
-session, iris-mcp surfaces an admin-editable orient-first protocol
-+ discovery catalogue via the MCP `instructions` channel (returned
-in the InitializeResult to every connected MCP client). Admins
-edit the body at `/admin/settings/ai` filtering by
-`purpose=mcp_server_instructions`; the next MCP session picks up
-the change. iris-mcp falls back to a hardcoded baseline if the
-Iris backend is unreachable at startup, so write tools stay
-usable in degraded states. When `IRIS_WEB_URL` is set, every tool
-response that carries an entity id also carries a resolved front-end
-URL so MCP-using LLMs link back to the live UI without guessing
-hosts. See [`mcp/README.md`](mcp/README.md) and
+**Server-wide orient-first protocol** (v5.18.0 / ADR-163, refined
+through v6.0.4–v6.0.7). Two delivery channels for the orient-first
+protocol:
+
+- MCP `Server(instructions=...)` field, returned in the
+  InitializeResult to every connected client. The body is
+  admin-editable at `/admin/settings/ai` filtering by
+  `purpose=mcp_server_instructions`; iris-mcp re-fetches every 60s
+  (ADR-166) so admin edits propagate without a redeploy.
+- A per-scope orient wrapper prepended to `mcp_system_context` in
+  every search/list/get response containing a Set or Collection
+  (ADR-167). claude.ai's hosted MCP integration doesn't reliably
+  surface `Server.instructions` to the model; the tool-response
+  wrapper is belt-and-suspenders.
+
+When `IRIS_WEB_URL` is set, every tool response that carries an
+entity id also carries a resolved front-end URL so MCP-using LLMs
+link back to the live UI without guessing hosts. `package_hierarchy`
+responses are decorated recursively (ADR-167 / v6.0.7) so each Part
+and chapter renders as a clickable markdown link.
+
+See [`mcp/README.md`](mcp/README.md) and
 [ADR-131](docs/adrs/ADR-131-MCP-Server-Architecture.md).
 
 Also surfaces the spec-defined MCP **prompts** capability: every

--- a/docs/adrs/specs/SPEC-168-A-Remove-Ask-Tool-From-MCP-Surface.md
+++ b/docs/adrs/specs/SPEC-168-A-Remove-Ask-Tool-From-MCP-Surface.md
@@ -1,0 +1,71 @@
+# SPEC-168-A: Remove the `ask` tool from the MCP surface
+
+ADR: [ADR-168](../ADR-168-Remove-Ask-Tool-From-MCP-Surface.md)
+
+## Summary
+
+Drop the `ask` MCP tool definition and dispatch handler from iris-mcp. Keep `iris_client.IrisClient.ask(...)` intact (used outside MCP). Strengthen the orient wrapper in `links.py` to steer the model to do analysis + cross-scope question-answering itself via the read-only MCP tools, rather than looking for a delegated AI tool. Update the canonical paste-doc for the Outcomes Theory Book menu to drop the obsolete `mcp__iris__ask` reference and the `→ call create_diagram` implementation tag.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/tools.py`
+
+Remove the `Tool(name="ask", ...)` entry from `tool_definitions()` (the v6.0.0 entry that exposed `c.ask(...)`). Remove the `_ask(c, args)` handler function. Replace the deleted block with a comment explaining the removal so future readers don't reintroduce it.
+
+Rewrite the description of the adjacent `apply_diagram_creation` tool — the v6.0.0 wording referenced "Use after calling `ask` with mode='creation'". The new description reflects the local-AI-as-author model:
+
+> "Apply a local-AI-generated diagram bundle to a set. The client drafts the diagrams JSON (one entry per diagram, matching the creation_format cascade returned by `get_response_prompt(purpose='creation_format', notation=..., diagram_type=...)`) and posts it here for persistence. Prefer `create_diagram` for single-diagram creation; this tool is for batch saves."
+
+### `mcp/src/iris_mcp/links.py`
+
+Append two paragraphs to the orient-wrapper text inside `_orient_wrapper`, after the existing "step 3" menu-verbatim guidance:
+
+1. "Cross-package, cross-set, or cross-collection questions are answered by YOUR reasoning over data you read via the read-only MCP tools (search, get_diagram, get_element, get_package, get_set, get_collection, list_*, package_hierarchy). There is no 'ask Iris AI' tool — it has been removed (v6.0.8). Walk the data yourself."
+2. "DoView outcomes-theory analyses and visual outcomes_map diagrams are drafted by YOU using your own reasoning, following the creation cascade from `get_response_prompt(purpose='creation_format', notation=..., diagram_type=...)`. Persist the result by calling `create_diagram` (single) or `apply_diagram_creation` (batch). Do NOT look for a separate AI-analysis tool — none exists."
+
+### `docs/prompts/doview-book-mcp-system-context.md`
+
+Update the paste-ready menu:
+
+| Before (v6.0.7) | After (v6.0.8) |
+|---|---|
+| Option 2: "Ask a cross-package question via Iris AI (e.g. ... — uses mcp__iris__ask)." | Option 2: "Ask a cross-package, cross-set, or cross-collection question about the material (e.g. ...)." |
+| Option 3: "Generate ... outcomes_map → call create_diagram." | Option 3: "Generate a new DoView outcomes-theory analysis or a new visual DoView outcomes_map." |
+
+Add a "v6.0.8 menu changes (paste required)" subsection explaining that admins must re-paste from the doc into the set's `mcp_system_context` field. TTL refresh (v6.0.5) propagates to claude.ai within 60 s.
+
+## Tests
+
+### `mcp/tests/test_tools.py`
+
+Replace the v5.x `TestAsk` class with `TestAskRemoved` (2 cases):
+
+```python
+class TestAskRemoved:
+    def test_ask_not_in_tool_definitions(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        assert "ask" not in names
+
+    async def test_ask_dispatch_returns_unknown_tool_error(
+        self, client: IrisClient,
+    ) -> None:
+        result = await tools.dispatch("ask", client, {"question": "?"})
+        assert result[0].text.startswith("ERROR: unknown tool")
+```
+
+### `mcp/tests/test_links_orient_wrapper.py`
+
+Update the existing `test_wrapper_demands_character_by_character_menu_copy` to assert `mcp__iris__ask` is **not** in the wrapper text. Add `test_wrapper_steers_analysis_to_local_ai` asserting "YOU do the work, not a separate AI", "drafted by YOU using your own reasoning", "creation_format", and "Do NOT look for a separate AI-analysis tool".
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.7 → 6.0.8. Patch — tool surface shrinks but every previous caller of `ask` is steered to a working substitute (local reasoning + read-only tools). `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] `ask` is not in `tools.tool_definitions()`. Dispatching to `"ask"` returns the standard unknown-tool error.
+- [ ] `apply_diagram_creation` description no longer references `ask`.
+- [ ] Orient wrapper output contains the two new "YOU do the work" paragraphs.
+- [ ] Canonical `doview-book-mcp-system-context.md` reflects the v6.0.8 menu wording.
+- [ ] 163/163 MCP tests pass.
+- [ ] After deploy + admin paste: claude.ai → open the Outcomes Theory Book → menu reads the new wording, no `mcp__iris__ask` / `→ call create_diagram`. Pick option 3 ("Generate analysis") — local model drafts the analysis itself, never calls a separate AI tool.

--- a/docs/adrs/specs/SPEC-169-A-OAuth-Metadata-URL-Fix.md
+++ b/docs/adrs/specs/SPEC-169-A-OAuth-Metadata-URL-Fix.md
@@ -1,0 +1,86 @@
+# SPEC-169-A: Fix Authorization Server URL in Protected Resource metadata
+
+ADR: [ADR-169](../ADR-169-OAuth-Metadata-URL-Fix.md)
+
+## Summary
+
+In iris-mcp's RFC 9728 Protected Resource metadata at `/.well-known/oauth-protected-resource`, source `authorization_server` from `IRIS_API_URL` (where the RFC 8414 AS metadata document and `/oauth/*` endpoints actually live), not from `IRIS_WEB_URL` (the frontend, which is a SvelteKit SPA that returns its `index.html` for unknown `/.well-known/*` paths). The `resource` field falls back to `IRIS_API_URL` too when `IRIS_MCP_PUBLIC_URL` isn't set. Add `IRIS_MCP_PUBLIC_URL=https://iris-mcp.onrender.com` to `render.yaml` so the live deployment correctly identifies the iris-mcp service in the `resource` field.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/http_main.py:_protected_resource_metadata`
+
+Replace the v6.0.0 → v6.0.8 logic that sourced both fields from `IRIS_WEB_URL`:
+
+```python
+# Before (BUGGY):
+public_url = os.environ.get("IRIS_MCP_PUBLIC_URL", "").rstrip("/")
+web_url = os.environ.get("IRIS_WEB_URL", iris_url).rstrip("/")
+return build_resource_metadata(
+    resource=public_url or web_url,
+    authorization_server=web_url,                # ← broke OAuth discovery
+)
+```
+
+with `IRIS_API_URL`-based sourcing:
+
+```python
+# After:
+public_url = os.environ.get("IRIS_MCP_PUBLIC_URL", "").rstrip("/")
+as_url = iris_url.rstrip("/")                    # iris_url == IRIS_API_URL
+return build_resource_metadata(
+    resource=public_url or as_url,
+    authorization_server=as_url,
+)
+```
+
+`IRIS_WEB_URL` is **no longer read** by the OAuth-metadata code path. Its purpose remains link decoration only (`web_url` fields on tool responses, since v5.6.1).
+
+### Auth-required tool error wording
+
+`mcp/src/iris_mcp/tools.py:_auth_required_payload`: rewrite the message to reflect the correct claude.ai UX flow. Old wording assumed claude.ai's connector UI had a manual OAuth toggle ("Configure → enable OAuth") — the actual flow auto-detects OAuth from Protected Resource metadata and surfaces a "Sign in" button. New wording:
+
+- Explains the user does NOT enter `client_id` / `secret` (Dynamic Client Registration handles it).
+- Tells the model to direct the user to "find the Iris connector and click 'Connect' / 'Sign in'".
+- Advises re-adding the connector if no Sign-in button appears (forces OAuth re-discovery).
+- `next_step` field changes from `configure_oauth_in_connector_settings` → `user_signs_in_via_mcp_client_connector_ui`.
+
+Mirror the same wording in `mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS` (AUTH RECOVERY section) and in the canonical `docs/prompts/mcp-server-instructions.md`. Operator pastes the canonical body into `/admin/settings/ai` to override the seeded text.
+
+### `render.yaml` for the iris-mcp service
+
+Add `IRIS_MCP_PUBLIC_URL=https://iris-mcp.onrender.com` to the `envVars` list. Operator must add this manually in the Render dashboard for the existing service — Render Blueprint sync doesn't auto-apply env-var additions to running services (same gotcha hit again in v6.0.11 / v6.0.12). The code's fallback to `IRIS_API_URL` keeps the deployment functional until the env var is set; the `resource` field is then cosmetically `iris-api...` instead of `iris-mcp.onrender.com`.
+
+## Tests
+
+### `mcp/tests/test_oauth_resource.py`
+
+Strengthen the existing `TestHttpMainEndpointMounted.test_metadata_endpoint_returns_200` to set `IRIS_WEB_URL` to a known wrong value and assert it does NOT leak into either `resource` or `authorization_servers`:
+
+```python
+monkeypatch.setenv("IRIS_WEB_URL", "https://wrong-host.example.com")
+# ...
+assert body["resource"] == "https://iris-mcp.example.com"
+assert body["authorization_servers"] == ["https://iris-backend.example.com"]
+assert "wrong-host" not in body["resource"]
+assert "wrong-host" not in body["authorization_servers"][0]
+```
+
+Add a fallback-shape test: without `IRIS_MCP_PUBLIC_URL`, both `resource` and `authorization_server` fall back to `IRIS_API_URL`.
+
+### Existing tests
+
+The `next_step` rename (`configure_oauth_in_connector_settings` → `user_signs_in_via_mcp_client_connector_ui`) breaks two existing test cases in `test_tools_create.py` and `test_tools_create_diagram.py`. Sed-replace to the new value.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.8 → 6.0.9. `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] `curl https://iris-mcp.onrender.com/.well-known/oauth-protected-resource` returns `authorization_servers: ["https://iris-api-gtb3.onrender.com"]`.
+- [ ] After operator adds `IRIS_MCP_PUBLIC_URL` in the Render dashboard for iris-mcp: `resource` reads `https://iris-mcp.onrender.com`. Without it, `resource` falls back to the API host (functional but cosmetically wrong).
+- [ ] `IRIS_WEB_URL` does not appear in the OAuth metadata output for any combination of env settings.
+- [ ] `auth_required` tool payload renders the v6.0.9 wording (no "Configure → enable OAuth"; explicit "no client_id/secret").
+- [ ] 164/164 MCP tests pass.
+- [ ] claude.ai → tap Sign in on Iris connector → browser opens to a host that returns OAuth metadata JSON (no SPA HTML). Without v6.0.10's 401 trigger this won't actually start the OAuth dance yet — that's the next ADR's spec.

--- a/docs/adrs/specs/SPEC-170-A-Require-Bearer-On-MCP-HTTP-Endpoint.md
+++ b/docs/adrs/specs/SPEC-170-A-Require-Bearer-On-MCP-HTTP-Endpoint.md
@@ -1,0 +1,98 @@
+# SPEC-170-A: Return 401 + WWW-Authenticate on unauthenticated MCP requests
+
+ADR: [ADR-170](../ADR-170-Require-Bearer-On-MCP-HTTP-Endpoint.md)
+
+## Summary
+
+Short-circuit `POST /` on iris-mcp's HTTP transport at the ASGI layer when no bearer token is present. Return HTTP 401 with `WWW-Authenticate: Bearer resource_metadata="..."`. That response is the canonical OAuth Discovery trigger per MCP 2025-06-18 + RFC 9728 — claude.ai's MCP client uses it to start the OAuth dance (fetch metadata, DCR, redirect-to-sign-in, exchange code for bearer, retry). Static / health endpoints stay anonymous.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/http_main.py:mcp_asgi`
+
+Before dispatching to the MCP SDK's `session_manager.handle_request`, extract the bearer from the request's `Authorization` header. If absent, emit a 401 response with the WWW-Authenticate header and return without touching the MCP layer:
+
+```python
+async def mcp_asgi(scope, receive, send):
+    if scope["type"] != "http":
+        return
+    token = extract_bearer(scope.get("headers") or [])
+
+    if not token:
+        metadata_url = (
+            os.environ.get("IRIS_MCP_PUBLIC_URL", iris_url).rstrip("/")
+            + "/.well-known/oauth-protected-resource"
+        )
+        # Header value is latin-1 only — keep the prose ASCII.
+        header = (
+            f'Bearer resource_metadata="{metadata_url}", '
+            'error="invalid_token", '
+            'error_description="MCP requests require an OAuth 2.1 '
+            'access token. Sign in to Iris via your MCP client\'s '
+            'connector UI; Dynamic Client Registration (RFC 7591) '
+            'handles client setup automatically (no client_id or '
+            'client_secret required)."'
+        )
+        await send({
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"www-authenticate", header.encode("latin-1")),
+            ],
+        })
+        await send({
+            "type": "http.response.body",
+            "body": (
+                b'{"error":"unauthorized",'
+                b'"error_description":"Sign in to Iris via your '
+                b'MCP client connector to use this resource."}'
+            ),
+        })
+        return
+
+    async with IrisClient(url=iris_url, token=token) as client, bind_client(client):
+        await session_manager.handle_request(scope, receive, send)
+```
+
+The `metadata_url` reads `IRIS_MCP_PUBLIC_URL` (per ADR-169) so the resource_metadata pointer matches what the Protected Resource metadata document advertises.
+
+### Endpoints that stay anonymous
+
+The 401 gate is on the **ASGI mount at `/`** (the MCP JSON-RPC endpoint). FastAPI routes that are mounted *before* the catch-all stay anonymous because they handle the request without ever reaching `mcp_asgi`:
+
+- `GET /info` — service identity / health.
+- `GET /favicon.{ico,svg}` — branding asset.
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata. Must be anonymous so the OAuth client can fetch it after seeing the 401.
+
+## Removed
+
+Anonymous HTTP read access via iris-mcp. CLI scripts that need anonymous reads should use the **stdio transport** (`iris-mcp` binary with `IRIS_TOKEN`) or talk to iris-api directly via the SDK. Frontend + iris-client public endpoints are unaffected. This trade-off is what unlocks claude.ai's OAuth flow — every working production hosted-MCP server requires auth uniformly.
+
+## Tool-layer payload preserved
+
+The `_auth_required_payload` JSON in `tools.py` remains as a defensive backstop for the "bearer is present but invalid/expired" case (a 401 from iris-api downstream). v6.0.10's 401 only fires when no bearer at all. The two paths cover the two states.
+
+## Tests
+
+### `mcp/tests/test_http_main.py`
+
+New `TestAuthChallenge` class with 4 cases:
+
+1. `test_post_root_without_bearer_returns_401` — bare POST / with no auth header → HTTP 401.
+2. `test_401_includes_www_authenticate_with_resource_metadata` — header is `Bearer resource_metadata="<url ending in /.well-known/oauth-protected-resource>"`.
+3. `test_401_resource_metadata_url_uses_public_url_when_set` — with `IRIS_MCP_PUBLIC_URL=https://iris-mcp.example.com`, the `resource_metadata` value matches.
+4. `test_post_root_with_bogus_bearer_passes_through_to_mcp_layer` — bearer present (even invalid) → not 401 at the transport layer. MCP layer handles the invalid bearer via the iris-api 401 → tool-payload path.
+
+The existing `test_post_root_does_not_307` is updated to acknowledge the v6.0.10 401 (asserts `!= 307` and `!= 405` — both still hold).
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.9 → 6.0.10. `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] `curl -i -X POST https://iris-mcp.onrender.com/` returns HTTP 401 + `WWW-Authenticate: Bearer resource_metadata="..."` with `error="invalid_token"` and a user-facing `error_description`.
+- [ ] GET `/info`, `/favicon.*`, `/.well-known/oauth-protected-resource` continue to return 200 anonymously.
+- [ ] claude.ai's MCP client now recognises the connector as OAuth-required and surfaces a "Sign in" button on the connector card. (Direct verification: a call from claude.ai now returns the OAuth re-authorization prompt rather than the tool-error string.)
+- [ ] 168/168 MCP tests pass.

--- a/docs/adrs/specs/SPEC-171-A-OAuth-Authorization-Endpoint-Points-At-Frontend.md
+++ b/docs/adrs/specs/SPEC-171-A-OAuth-Authorization-Endpoint-Points-At-Frontend.md
@@ -1,0 +1,81 @@
+# SPEC-171-A: Point AS `authorization_endpoint` at the frontend, not the API
+
+ADR: [ADR-171](../ADR-171-OAuth-Authorization-Endpoint-Points-At-Frontend.md)
+
+## Summary
+
+iris-api's RFC 8414 metadata at `/.well-known/oauth-authorization-server` advertised `authorization_endpoint: https://iris-api-gtb3.onrender.com/oauth/authorize`. iris-api has no GET handler at `/oauth/authorize` — the user-facing consent screen is a SvelteKit page on the **frontend** at `https://iris-uat.chrisbarlow.nz/oauth/authorize`. Sign-in attempts landed on a hard `{"detail":"Not Found"}` 404.
+
+Fix: source `authorization_endpoint` from `IRIS_WEB_URL`. Token / registration / revocation endpoints stay on the API host — those are machine-to-machine endpoints with no browser involved.
+
+## Backend changes
+
+### `backend/app/oauth/router.py`
+
+Add a helper that builds the authorization_endpoint URL, reading `IRIS_WEB_URL` with fallback to the API issuer (dev-environment convenience):
+
+```python
+import os
+
+def _authorization_endpoint(api_base: str) -> str:
+    """Build the user-facing authorization-endpoint URL.
+
+    The OAuth 2.1 authorization endpoint is a BROWSER endpoint — the
+    OAuth client redirects the user's browser there, the user sees a
+    login + consent screen, and the page redirects back to the
+    client's redirect_uri with an authorization code.
+
+    In Iris's split-service deployment the user-facing UI lives on the
+    SvelteKit frontend (IRIS_WEB_URL), NOT on the FastAPI backend.
+    """
+    web_url = os.environ.get("IRIS_WEB_URL", "").rstrip("/")
+    return f"{web_url or api_base}/oauth/authorize"
+```
+
+Wire it into `authorization_server_metadata`:
+
+```python
+return AuthorizationServerMetadata(
+    issuer=base,
+    authorization_endpoint=_authorization_endpoint(base),   # ← frontend
+    token_endpoint=f"{base}/oauth/token",                    # API host
+    registration_endpoint=f"{base}/oauth/register",          # API host
+    revocation_endpoint=f"{base}/oauth/revoke",              # API host
+    ...
+)
+```
+
+### `render.yaml` for the iris-api service
+
+Add `IRIS_WEB_URL=https://iris-uat.chrisbarlow.nz` to the iris-api `envVars` list. iris-mcp already has this set for entity-link decoration (v5.6.1). The Render Blueprint-sync gotcha applies: existing services don't auto-pick up env-var additions; the operator may need to add it manually in the dashboard for the existing iris-api service. v6.0.12 (ADR-172) addresses this with an auto-derived fallback so the manual step becomes optional.
+
+### Frontend (no change)
+
+The frontend's `oauth/authorize/+page.svelte` already exists and correctly handles the OAuth flow:
+- Reads query params from the request URL.
+- POSTs them to iris-api's `/api/oauth/authorize/prepare` (with the user's session bearer) to validate.
+- Renders the consent screen with the returned `request_id`.
+- On Allow, POSTs `/api/oauth/authorize/decision` and `window.location.href = result.redirect_to`.
+
+If the user isn't signed in, the page bounces through `/login?redirect=...` first.
+
+## Tests
+
+### `backend/tests/test_oauth/test_metadata.py`
+
+New `TestAuthorizationEndpointFromIrisWebUrl` class (3 cases):
+
+1. `test_authorization_endpoint_uses_iris_web_url` — with `IRIS_WEB_URL=https://web.example.com` set, `authorization_endpoint` is `https://web.example.com/oauth/authorize`. Token/register/revoke endpoints stay on the API issuer.
+2. `test_authorization_endpoint_strips_trailing_slash` — `IRIS_WEB_URL=https://web.example.com/` (with slash) produces a clean `https://web.example.com/oauth/authorize` (no double-slash).
+3. `test_authorization_endpoint_falls_back_to_api_when_unset` — without `IRIS_WEB_URL`, falls back to the API issuer. Metadata is well-formed (404 if clicked, but won't break tests / dev environments).
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.10 → 6.0.11. `frontend/package.json` matched. (Backend `pyproject.toml` version stays at 1.2.0 — historically unchanged across the v6.0.x line.)
+
+## Acceptance criteria
+
+- [ ] `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` reports `authorization_endpoint: https://iris-uat.chrisbarlow.nz/oauth/authorize`.
+- [ ] Token / registration / revocation endpoints in the same payload stay on `iris-api-gtb3.onrender.com`.
+- [ ] claude.ai → tap Sign in on Iris connector → browser opens the SvelteKit consent page (not a 404). Sign in if needed → consent screen → tap Allow → redirected back to claude.ai with auth code.
+- [ ] 39/39 backend OAuth tests pass (36 existing + 3 new).

--- a/docs/adrs/specs/SPEC-172-A-Derive-Frontend-URL-From-CORS-Origins.md
+++ b/docs/adrs/specs/SPEC-172-A-Derive-Frontend-URL-From-CORS-Origins.md
@@ -1,0 +1,69 @@
+# SPEC-172-A: Derive OAuth `authorization_endpoint` frontend URL from CORS origins
+
+ADR: [ADR-172](../ADR-172-Derive-Frontend-URL-From-CORS-Origins.md)
+
+## Summary
+
+Make the AS `authorization_endpoint` derivation robust to `IRIS_WEB_URL` not being set. Fall through to the first non-localhost entry in `IRIS_CORS_ORIGINS`, which has been set since v6.0.0 and is guaranteed to contain the public frontend URL (the frontend can't call iris-api without being in the CORS allow-list). Render Blueprint sync doesn't auto-apply env-var additions to existing services — this fallback eliminates the env-var dependency for the common case.
+
+## Backend changes
+
+### `backend/app/oauth/router.py`
+
+Extend `_authorization_endpoint` with a CORS-origins fallback. Resolution order:
+
+1. `IRIS_WEB_URL` env var — explicit, operator-controlled.
+2. First non-localhost entry in `IRIS_CORS_ORIGINS` — auto-derived.
+3. `api_base` (the issuer URL) — last-resort dev fallback.
+
+```python
+def _authorization_endpoint(api_base: str) -> str:
+    web_url = os.environ.get("IRIS_WEB_URL", "").rstrip("/")
+    if not web_url:
+        web_url = _frontend_from_cors_origins()
+    return f"{web_url or api_base}/oauth/authorize"
+
+
+def _frontend_from_cors_origins() -> str:
+    """Return the first non-localhost entry in IRIS_CORS_ORIGINS,
+    rstrip-ed of trailing slashes. Empty string when none found.
+    Skips http://localhost:* and http://127.0.0.1:* — those are
+    dev-only allow-listed origins that don't reflect the public
+    frontend URL.
+    """
+    raw = os.environ.get("IRIS_CORS_ORIGINS", "")
+    for origin in (s.strip() for s in raw.split(",")):
+        if not origin:
+            continue
+        if origin.startswith(("http://localhost", "http://127.0.0.1")):
+            continue
+        return origin.rstrip("/")
+    return ""
+```
+
+### Why skip localhost
+
+`IRIS_CORS_ORIGINS` in development typically contains both `http://localhost:5173` (dev frontend) and the production frontend URL. The metadata document is served to remote MCP clients, which can't reach `localhost`. If a localhost entry leaked into `authorization_endpoint`, every OAuth flow from external clients would break.
+
+## Tests
+
+### `backend/tests/test_oauth/test_metadata.py`
+
+New `TestAuthorizationEndpointFromCorsOrigins` class (4 cases):
+
+1. `test_uses_first_non_localhost_cors_origin` — with `IRIS_WEB_URL` unset and `IRIS_CORS_ORIGINS="http://localhost:5173,https://iris-uat.chrisbarlow.nz"`, `authorization_endpoint` is `https://iris-uat.chrisbarlow.nz/oauth/authorize`.
+2. `test_iris_web_url_wins_over_cors` — both env vars set with different hostnames; `IRIS_WEB_URL` wins.
+3. `test_skips_localhost_127_0_0_1` — `127.0.0.1` entries are skipped just like `localhost`.
+4. `test_strips_trailing_slash_from_cors_entry` — trailing-slash hygiene matches the IRIS_WEB_URL path.
+
+Existing `test_authorization_endpoint_falls_back_to_api_when_unset` is updated to set `IRIS_CORS_ORIGINS` to localhost-only so the API fallback path actually exercises (otherwise the CORS auto-derive would catch it first).
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.11 → 6.0.12. `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] `curl https://iris-api-gtb3.onrender.com/.well-known/oauth-authorization-server` reports a frontend URL as `authorization_endpoint`, even if `IRIS_WEB_URL` is not set on iris-api in Render. (The fallback derives it from `IRIS_CORS_ORIGINS`.)
+- [ ] If `IRIS_CORS_ORIGINS` contains the Render-internal URL first (`https://iris-frontend-xwzi.onrender.com,https://iris-uat.chrisbarlow.nz`), the metadata uses that — explicit `IRIS_WEB_URL` is the way to force the custom domain.
+- [ ] 40/40 backend OAuth tests pass (36 existing + 4 new).

--- a/docs/adrs/specs/SPEC-173-A-OAuth-Boolean-Column-Parameterisation.md
+++ b/docs/adrs/specs/SPEC-173-A-OAuth-Boolean-Column-Parameterisation.md
@@ -1,0 +1,44 @@
+# SPEC-173-A: Parameterise booleans for SQLite/Postgres portability in OAuth service
+
+ADR: [ADR-173](../ADR-173-OAuth-Boolean-Column-Parameterisation.md)
+
+## Summary
+
+`oauth_refresh_tokens.revoked` is `BOOLEAN` on Postgres (Supabase), `INTEGER` on SQLite. Three SQL statements in `backend/app/oauth/service.py` used bare-int literals (`0`/`1`). SQLite accepts both; Postgres rejects with `DatatypeMismatchError`. Replace with parameterised Python `bool` so the DB adapter coerces correctly on either backend. Add a source-scan regression test so the antipattern can't drift back.
+
+## Backend changes
+
+### `backend/app/oauth/service.py`
+
+Three call sites:
+
+| Function | Before | After |
+|---|---|---|
+| `create_refresh_token` (INSERT) | `VALUES (?, ?, ?, ?, ?, ?, 0)` with 6 params | `VALUES (?, ?, ?, ?, ?, ?, ?)` with 7 params, last is `False` |
+| `rotate_refresh_token` (theft kill) | `"UPDATE oauth_refresh_tokens SET revoked = 1 WHERE family_id = ?", (family_id,)` | `"UPDATE oauth_refresh_tokens SET revoked = ? WHERE family_id = ?", (True, family_id)` |
+| `revoke_refresh_token` | `"UPDATE oauth_refresh_tokens SET revoked = 1 WHERE id = ? AND client_id = ?", (token, client_id)` | `"UPDATE oauth_refresh_tokens SET revoked = ? WHERE id = ? AND client_id = ?", (True, token, client_id)` |
+
+Add a short v6.0.13 comment at each site referencing ADR-173 so future readers know why the boolean is parameterised rather than literal.
+
+## Tests
+
+### `backend/tests/test_oauth/test_postgres_bool_int_compatibility.py` (new)
+
+4 source-scan cases. Faster than spinning up a Postgres test container, catches the specific antipattern that bit us:
+
+1. `test_no_set_revoked_equals_bare_int` — `"revoked = 0"` and `"revoked = 1"` substrings absent from `app.oauth.service` source.
+2. `test_no_bare_int_trailing_in_oauth_refresh_insert` — regex `INSERT INTO oauth_refresh_tokens (...) VALUES (..., [01])` not found.
+3. `test_create_refresh_token_passes_bool_not_int` — the `create_refresh_token` function body contains `, False`.
+4. `test_rotate_and_revoke_pass_true_not_int` — `rotate_refresh_token` and `revoke_refresh_token` bodies contain `True`.
+
+If the test setup ever moves to a real Postgres fixture, the source-scan guards become redundant — but they're cheap insurance to keep on SQLite-only CI.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.12 → 6.0.13. `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] Render API logs no longer show `asyncpg.exceptions.DatatypeMismatchError` from `oauth/service.py:260` during token exchange.
+- [ ] claude.ai → Sign in → Allow → connector goes to "Connected" (no `mcp_token_exchange_failed`).
+- [ ] 44/44 backend OAuth tests pass (40 existing + 4 new source-scan).

--- a/docs/adrs/specs/SPEC-174-A-Hybrid-JWT-Validation-In-Supabase-Mode.md
+++ b/docs/adrs/specs/SPEC-174-A-Hybrid-JWT-Validation-In-Supabase-Mode.md
@@ -1,0 +1,108 @@
+# SPEC-174-A: Accept iris-OAuth JWTs in Supabase deployment mode
+
+ADR: [ADR-174](../ADR-174-Hybrid-JWT-Validation-In-Supabase-Mode.md)
+
+## Summary
+
+In Supabase deployment mode, `_get_current_user_supabase` only validated JWTs with Supabase's signing key. iris-OAuth tokens are signed with `IRIS_JWT_SECRET` — different key, signature always fails, 401 on every bearer. Add a hybrid path: tokens with `aud="iris-mcp"` route through iris's HS256 validator using `config.auth.jwt_secret`; everything else stays on the Supabase path. Also require `IRIS_JWT_SECRET` in production (current dev default is a hardcoded string in the public repo).
+
+## Backend changes
+
+### `backend/app/auth/dependencies.py:_get_current_user_supabase`
+
+Insert a branch before the existing Supabase JWT validation:
+
+```python
+async def _get_current_user_supabase(request, token):
+    from app.auth.service import decode_access_token
+    from app.auth.supabase_service import (
+        decode_supabase_jwt, fetch_jwks, get_profile,
+    )
+    from jose import jwt as _jose_jwt
+
+    config = request.app.state.config
+    if config.supabase is None:
+        raise HTTPException(status_code=500, detail="Supabase not configured")
+
+    payload: dict[str, Any] | None = None
+
+    # 1. iris-OAuth tokens (aud="iris-mcp") → validate with iris JWT secret.
+    try:
+        unverified = _jose_jwt.get_unverified_claims(token)
+    except JWTError:
+        unverified = {}
+    if unverified.get("aud") == "iris-mcp":
+        try:
+            payload = decode_access_token(token, config.auth)
+        except JWTError as e:
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid iris-OAuth token",
+            ) from e
+
+    # 2. Everything else → existing Supabase validation.
+    if payload is None:
+        try:
+            jwks = await fetch_jwks(config.supabase.url)
+            payload = decode_supabase_jwt(
+                token, config.supabase.jwt_secret, jwks,
+            )
+        except JWTError:
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    # Profile lookup unchanged: same get_profile call for both paths.
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token claims")
+
+    db = request.app.state.db_manager.main_db
+    profile = await get_profile(db, str(user_id))
+    if profile is None or not profile["is_active"]:
+        raise HTTPException(status_code=401, detail="User not found or inactive")
+
+    return {
+        "id": profile["id"],
+        "username": profile["username"],
+        "role": profile["role"],
+        "jti": payload.get("jti"),
+    }
+```
+
+### Critical: no fall-through on signature failure
+
+If a token claims `aud="iris-mcp"` but its signature doesn't validate against the iris JWT secret, return **401**. Do **not** try Supabase validation as a fallback. Audience is a routing claim, signature is the security boundary — letting a Supabase-signed token forge an iris-OAuth identity by adding `aud="iris-mcp"` to its (signed) payload is the failure mode this guards against (an attacker can't actually re-sign the payload, but the principle keeps the trust domains separate).
+
+### `render.yaml` for the iris-api service
+
+Add `IRIS_JWT_SECRET` with `sync: false` so the operator generates a per-deployment secret and pastes it into the Render dashboard. **Operator must add it manually** to existing services (Render Blueprint-sync limitation).
+
+The fallback dev string in `config.py` keeps local development working without an env var; the comment in `render.yaml` explains the production requirement.
+
+## Tests
+
+### `backend/tests/test_auth/test_supabase_mode_oauth_token.py` (new)
+
+3 cases using mock for `get_profile`:
+
+1. `test_iris_oauth_token_validates_via_iris_secret` — iris-OAuth-shaped token signed with `config.auth.jwt_secret` → routes through iris validator → returns the user dict.
+2. `test_iris_oauth_token_with_wrong_signature_401` — same `aud="iris-mcp"` but signed with the wrong secret → 401 (no fall-through to Supabase decoder).
+3. `test_supabase_token_still_validates_via_supabase_path` — Supabase-shaped token (no `aud="iris-mcp"`, signed with `config.supabase.jwt_secret`) → routes through Supabase decoder → returns the user dict.
+
+The tests construct an `AppConfig` with separate iris + Supabase JWT secrets so the routing is testable without a real Supabase JWKS endpoint.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.13 → 6.0.14. `frontend/package.json` matched.
+
+## Operator action required after deploy
+
+1. **Set `IRIS_JWT_SECRET` on iris-api** in the Render dashboard. Generate locally: `openssl rand -hex 32`. Paste the value into Environment → Add Environment Variable. Save → iris-api restarts. **Do not generate the secret on the agent's side** (per the secret-handling memory note — the secret would leak through chat output / tool capture).
+2. **Disconnect + reconnect Iris connector in claude.ai.** Bearers signed with the previous dev-default secret won't validate against the new one. A fresh OAuth flow mints fresh bearers.
+
+## Acceptance criteria
+
+- [ ] `IRIS_JWT_SECRET` is set as an env var on the iris-api Render service (verifiable via `curl /v1/services/.../env-vars` → key present, value hidden as expected).
+- [ ] claude.ai → Sign in → Allow → connector goes to "Connected" → `create_collection` returns 200 with the new id.
+- [ ] Render API logs show 200s on `/api/sets`, `/api/collections`, etc. — no 401s after the bearer is issued.
+- [ ] 120/120 OAuth + auth tests pass (117 existing + 3 new).
+- [ ] An attacker can't forge a bearer using the public-repo dev default — `IRIS_JWT_SECRET` is operator-set and unique per deployment.


### PR DESCRIPTION
## Summary

Protocol audit cleanup for the v6.0.4–v6.0.14 OAuth-fix cycle. No code changes, no version bump, no release — pure docs.

## Compliance gaps closed

**SPECs (Protocol §2: every ADR with impl details needs a SPEC)** — 168 → 174 were missing. Backfilled all 7. v6.0.7's bundled change ("recursive `web_url` decoration + stronger orient-wrapper wording") stays covered by ADR-167's extension wording, per your call.

| ADR | New SPEC |
|---|---|
| 168 — Remove `ask` tool | SPEC-168-A |
| 169 — Fix AS URL in PR metadata | SPEC-169-A |
| 170 — Require bearer on MCP HTTP endpoint | SPEC-170-A |
| 171 — Point `authorization_endpoint` at frontend | SPEC-171-A |
| 172 — Derive frontend URL from CORS_ORIGINS | SPEC-172-A |
| 173 — Parameterise OAuth booleans | SPEC-173-A |
| 174 — Hybrid JWT validation in Supabase mode | SPEC-174-A |

**README (Protocol §12: must reflect implementation)** — corrected the MCP/OAuth section to match v6.0.14 reality:
- HTTP-transport: all requests now require a bearer (anonymous-read access removed in v6.0.10).
- `IRIS_JWT_SECRET` added to required production env vars, with the openssl-rand hint (and the secret-handling caveat: generate locally, never echo into chat).
- `IRIS_WEB_URL` and `IRIS_MCP_PUBLIC_URL` added to the env-var list with the relevant ADR refs.
- Tool count corrected (~28 → ~27) and `ask` removed from the inline tool list.
- `apply_diagram_creation` description updated to reflect the local-AI-as-author model.
- Server-wide orient-first paragraph rewritten — two delivery channels (Server.instructions + per-scope wrapper), TTL refresh, recursive `web_url` on `package_hierarchy`.

## What stays in the ADRs vs. moves into SPECs

The ADRs keep the "why" and "decision" — they're now lean decision-records as protocol §1 intends. The SPECs carry the "how" — file paths, function signatures, code blocks, test plans, acceptance criteria. A reader scanning the ADR knows the trade-off; a reader implementing or reviewing the change goes to the SPEC.

## Test plan

No code change, but:
- [ ] All SPEC files render correctly on GitHub (just markdown).
- [ ] README OAuth/MCP section reads accurately end-to-end.
- [ ] No broken intra-doc links (the new SPECs reference their ADRs; the README references the ADRs by number).

🤖 Generated with [Claude Code](https://claude.com/claude-code)