### PR TITLE
fix(v6.0.15): decorate create_* tool responses with web_url (ADR-175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.15] - 2026-05-13
+
+### Fixed
+
+- **`create_*` MCP tool responses now include `web_url` so the model
+  can link the user straight to the new entity (ADR-175).** Pre-
+  v6.0.15, every read tool was decorated with `web_url` via
+  `links.with_web_url(...)`, but the create_* tools returned a bare
+  `model_dump_json()`. The model had no link to surface and had to
+  guess the host. Concrete v6.0.14 failure:
+  ```
+  User: link me to it
+  Claude: https://iris.chrisbarlow.nz/sets/df7aa9df-...   ← wrong host
+  ```
+  v6.0.15 wraps the return of `_create_collection`, `_create_set`,
+  `_create_package`, and `_create_diagram` with
+  `with_web_url(result.model_dump_json(), "<kind>")`. The model now
+  surfaces the real frontend URL.
+- `apply_diagram_creation` is unchanged — its batch response shape
+  (`{diagram_ids: [...], primary_diagram_id: ...}`) of bare id
+  strings needs a different decoration approach; deferred.
+
+### Added
+
+- 5 regression tests in `tests/test_create_tools_web_url_decoration.py`:
+  - Each create_* tool's response includes a correctly-shaped
+    `web_url` when `IRIS_WEB_URL` is set.
+  - Absent `IRIS_WEB_URL` → response passes through unchanged (no
+    `web_url` key), behaviour parity with read tools.
+- 173/173 MCP tests pass.
+
+### See also
+
+- [ADR-175](docs/adrs/ADR-175-Web-URL-Decoration-On-Create-Tools.md)
+- [SPEC-175-A](docs/adrs/specs/SPEC-175-A-Web-URL-Decoration-On-Create-Tools.md)
+
 ## [6.0.14] - 2026-05-13
 
 ### Fixed

--- a/docs/adrs/ADR-175-Web-URL-Decoration-On-Create-Tools.md
+++ b/docs/adrs/ADR-175-Web-URL-Decoration-On-Create-Tools.md
@@ -1,0 +1,67 @@
+# ADR-175: Decorate create_* tool responses with `web_url`
+
+Status: Accepted (2026-05-13)
+Extends: [ADR-126](ADR-126-Web-URL-Link-Decoration.md) (the v5.6.1 entity-link-decoration design), [ADR-161](ADR-161-MCP-Entity-Creation-and-Destination-Flow.md)
+
+## Context
+
+`iris-mcp`'s read tools (`get_set`, `get_collection`, `get_diagram`, `list_*`, `search`, `package_hierarchy`) all decorate their responses with a `web_url` field that resolves the entity to a clickable URL on the iris frontend. The decoration is centralised in `mcp/src/iris_mcp/links.py` (`with_web_url` / `with_web_urls_list` / `with_web_urls_search` / `with_web_urls_tree`) and triggered when `IRIS_WEB_URL` is configured.
+
+The **create_*** tools — `create_collection`, `create_set`, `create_package`, `create_diagram` — return the new entity's full dict from iris-api but **skip the decoration**. The model gets back an id and a name but no link.
+
+User-visible failure during v6.0.14 end-of-issue-#119 testing:
+
+> User: `make a new set in iris called 'claude test'`
+> Claude: *creates the set, returns the id*
+> User: `link me to it`
+> Claude: `https://iris.chrisbarlow.nz/sets/df7aa9df-…` ← **wrong host** (should be `iris-uat.chrisbarlow.nz`)
+
+The model had to guess the host (and got the subdomain wrong). The right answer was already known to iris-mcp via the `IRIS_WEB_URL` env var — the create_* handlers just weren't using it.
+
+## Decision
+
+Wrap each create_* handler's return value with `with_web_url(json, kind)` so the response shape matches the corresponding `get_*` tool. Four handlers in `mcp/src/iris_mcp/tools.py`:
+
+```python
+# Before:
+return result.model_dump_json()
+
+# After:
+return with_web_url(result.model_dump_json(), "<kind>")
+```
+
+| Handler | `<kind>` |
+|---|---|
+| `_create_collection` | `"collection"` |
+| `_create_set` | `"set"` |
+| `_create_package` | `"package"` |
+| `_create_diagram` | `"diagram"` |
+
+`with_web_url` already does the right thing for write-tool responses: it adds `web_url` when `IRIS_WEB_URL` is set, strips `system_prompt` per ADR-151 (sensitive-key strip), and is a no-op when the entity has no `id` or the env var is unset. It also runs `wrap_orient` — a no-op on freshly-created entities because they have no `mcp_system_context` content yet, but the safety still applies.
+
+`apply_diagram_creation` is **not** changed in this ADR. Its response shape is a batched `{diagram_ids: [...], primary_diagram_id: ...}` of bare id strings, not entity dicts — decoration would need a different shape (e.g. `{diagram_ids: [...], web_urls: [...]}`) and a per-entity batch helper. Out of scope; defer to a follow-up.
+
+## Why not also resolve `iris://` deep-links in the response
+
+Considered: turn the entity's `iris://` URI (used inside markdown bodies) into a frontend URL in the response. Rejected as a separate concern — `iris://` is for the markdown rendering path and the existing `with_web_url` covers the explicit `web_url` field, which is what the model uses to link.
+
+## Consequences
+
+- 4 one-line changes to `tools.py` (`_create_collection`, `_create_set`, `_create_package`, `_create_diagram` now wrap their returns).
+- 5 new regression tests in `tests/test_create_tools_web_url_decoration.py`:
+  - Each create_* tool's response includes a correctly-shaped `web_url`.
+  - When `IRIS_WEB_URL` is unset (dev), responses pass through unchanged (no `web_url` key) — behaviour parity with the read tools.
+- The existing 19 `test_tools_create.py` cases stay green — they don't assert on `web_url` absence, so adding it doesn't break them.
+- Version bump v6.0.14 → v6.0.15. Patch-level — UX fix, no API surface change.
+
+## Verification
+
+- After deploy, `create_set` from claude.ai → response includes `web_url`. The model surfaces the real frontend URL when the user asks "link me to it"; no more host-guessing.
+- 173/173 MCP tests pass.
+
+## See also
+
+- [ADR-126](ADR-126-Web-URL-Link-Decoration.md) — v5.6.1 origin of the link-decoration pattern.
+- [ADR-161](ADR-161-MCP-Entity-Creation-and-Destination-Flow.md) — the v5.16.0 introduction of these create_* tools.
+- [ADR-167](ADR-167-Orient-Directive-In-Tool-Response.md) — the v6.0.6/7 orient wrapper that piggybacks on the same `with_web_url` helper.
+- [SPEC-175-A](specs/SPEC-175-A-Web-URL-Decoration-On-Create-Tools.md).

--- a/docs/adrs/specs/SPEC-175-A-Web-URL-Decoration-On-Create-Tools.md
+++ b/docs/adrs/specs/SPEC-175-A-Web-URL-Decoration-On-Create-Tools.md
@@ -1,0 +1,86 @@
+# SPEC-175-A: Decorate create_* tool responses with `web_url`
+
+ADR: [ADR-175](../ADR-175-Web-URL-Decoration-On-Create-Tools.md)
+
+## Summary
+
+Wrap each create_* MCP handler's return value with `links.with_web_url(json, kind)` so the response shape matches the corresponding `get_*` tool — `web_url` populated when `IRIS_WEB_URL` is set, absent otherwise.
+
+## MCP changes
+
+### `mcp/src/iris_mcp/tools.py`
+
+Four one-line wrappers:
+
+```python
+async def _create_collection(c, args):
+    try:
+        result = await c.create_collection(...)
+    except IrisAuthError:
+        return _auth_required_payload("Create collection")
+    return with_web_url(result.model_dump_json(), "collection")
+
+async def _create_set(c, args):
+    try:
+        result = await c.create_set(...)
+    except IrisAuthError:
+        return _auth_required_payload("Create set")
+    return with_web_url(result.model_dump_json(), "set")
+
+async def _create_package(c, args):
+    try:
+        result = await c.create_package(...)
+    except IrisAuthError:
+        return _auth_required_payload("Create package")
+    return with_web_url(result.model_dump_json(), "package")
+
+async def _create_diagram(c, args):
+    try:
+        diagram = await c.create_diagram(...)
+    except IrisAuthError:
+        return _auth_required_payload("Create diagram")
+    return with_web_url(diagram.model_dump_json(), "diagram")
+```
+
+`with_web_url` is already imported at the top of `tools.py`; no new imports needed.
+
+### Behaviour map (`with_web_url(payload, kind)` recap)
+
+- Parses payload as JSON; no-op on parse failure.
+- Strips `system_prompt` per ADR-151 (sensitive-key strip).
+- Runs `wrap_orient(item, kind)` — no-op on freshly-created entities (no `mcp_system_context`).
+- If `IRIS_WEB_URL` is set and `kind` is in the known-kinds map, adds `web_url` = `<IRIS_WEB_URL>/<path>/<id>`.
+- Returns JSON string.
+
+### Out of scope
+
+`apply_diagram_creation` returns `{diagram_ids: [str], primary_diagram_id: str}` — bare id strings, not entity dicts. Decoration would need a separate shape (e.g. `web_urls: list[str]`) and a per-entity batch helper. Defer to follow-up.
+
+## Tests
+
+### `mcp/tests/test_create_tools_web_url_decoration.py` (new)
+
+5 cases, each using `respx` to mock the iris-api response and `tools.dispatch` to exercise the full handler chain:
+
+1. `TestCreateCollectionWebUrl::test_response_includes_web_url` — response body has `web_url == "https://iris-uat.chrisbarlow.nz/collections/<id>"`.
+2. `TestCreateSetWebUrl::test_response_includes_web_url` — same for sets; explicit assert that `chrisbarlow.nz` is in the URL (regression on the host-guessing bug).
+3. `TestCreatePackageWebUrl::test_response_includes_web_url` — same for packages.
+4. `TestCreateDiagramWebUrl::test_response_includes_web_url` — same for diagrams; URL uses the `views` path.
+5. `TestNoIrisWebUrlNoDecoration::test_create_set_without_iris_web_url` — when `IRIS_WEB_URL` is unset, response has no `web_url` key; other fields unchanged.
+
+The Package test fixture must include `current_version` (required by the Pydantic Package model).
+
+### Existing tests
+
+`test_tools_create.py` (19 cases) and `test_tools_create_diagram.py` stay green — they don't assert on `web_url` absence, so adding it doesn't break them.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.0.14 → 6.0.15. Patch — UX fix, no API surface change. `frontend/package.json` matched.
+
+## Acceptance criteria
+
+- [ ] After deploy, claude.ai → `create_set` → response includes `web_url`. The model uses it when the user asks "link me to it" instead of host-guessing.
+- [ ] All four create_* tools have `web_url` in the response when `IRIS_WEB_URL` is set.
+- [ ] No regression on the existing create_* tool tests.
+- [ ] 173/173 MCP tests pass.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.14",
+	"version": "6.0.15",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.14"
+version = "6.0.15"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -291,7 +291,13 @@ async def _get_response_prompt(c: IrisClient, args: dict[str, Any]) -> str:
 
 
 async def _create_collection(c: IrisClient, args: dict[str, Any]) -> str:
-    """ADR-161 (v5.16.0): create a new Collection."""
+    """ADR-161 (v5.16.0): create a new Collection.
+
+    v6.0.15 (ADR-175): response decorated with `web_url` via
+    `with_web_url` so the model can link the user straight to the new
+    entity in the Iris UI. Previously, the create_* tools returned the
+    bare entity dict and the model had to guess the host.
+    """
     try:
         result = await c.create_collection(
             name=args["name"],
@@ -299,11 +305,13 @@ async def _create_collection(c: IrisClient, args: dict[str, Any]) -> str:
         )
     except IrisAuthError:
         return _auth_required_payload("Create collection")
-    return result.model_dump_json()
+    return with_web_url(result.model_dump_json(), "collection")
 
 
 async def _create_set(c: IrisClient, args: dict[str, Any]) -> str:
-    """ADR-161 (v5.16.0): create a new Set."""
+    """ADR-161 (v5.16.0): create a new Set.
+
+    v6.0.15 (ADR-175): response decorated with `web_url`."""
     try:
         result = await c.create_set(
             name=args["name"],
@@ -312,11 +320,13 @@ async def _create_set(c: IrisClient, args: dict[str, Any]) -> str:
         )
     except IrisAuthError:
         return _auth_required_payload("Create set")
-    return result.model_dump_json()
+    return with_web_url(result.model_dump_json(), "set")
 
 
 async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
-    """ADR-161 (v5.16.0): create a new Package."""
+    """ADR-161 (v5.16.0): create a new Package.
+
+    v6.0.15 (ADR-175): response decorated with `web_url`."""
     try:
         result = await c.create_package(
             name=args["name"],
@@ -327,7 +337,7 @@ async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
         )
     except IrisAuthError:
         return _auth_required_payload("Create package")
-    return result.model_dump_json()
+    return with_web_url(result.model_dump_json(), "package")
 
 
 async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
@@ -336,7 +346,9 @@ async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
     fetched the creation cascade for the chosen pair, run the guided
     conversation with the user, composed the `data` payload locally,
     and confirmed a destination. See the tool's description for the
-    full workflow."""
+    full workflow.
+
+    v6.0.15 (ADR-175): response decorated with `web_url`."""
     try:
         diagram = await c.create_diagram(
             diagram_type=args["diagram_type"],
@@ -349,7 +361,7 @@ async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
         )
     except IrisAuthError:
         return _auth_required_payload("Create diagram")
-    return diagram.model_dump_json()
+    return with_web_url(diagram.model_dump_json(), "diagram")
 
 
 async def _list_notations(c: IrisClient, _args: dict[str, Any]) -> str:

--- a/mcp/tests/test_create_tools_web_url_decoration.py
+++ b/mcp/tests/test_create_tools_web_url_decoration.py
@@ -1,0 +1,195 @@
+"""v6.0.15 (ADR-175): the create_* tools must return responses with
+`web_url` populated so the model can link the user straight to the new
+entity in the Iris UI.
+
+Pre-v6.0.15, every read tool was decorated with `web_url` via
+`links.with_web_url(...)` but the create_* tools returned a bare
+`model_dump_json()`. The model had to guess the host — and when the
+user asked "link me to it" after a successful create_set, it produced
+a wrong URL (e.g. `iris.chrisbarlow.nz` instead of
+`iris-uat.chrisbarlow.nz`).
+
+These tests pin the decoration on each create_* tool. They use
+`respx` to mock iris-api responses, dispatch the MCP tool, and assert
+that the resulting JSON contains a correctly-shaped `web_url` field.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+WEB = "https://iris-uat.chrisbarlow.nz"
+
+
+@pytest.fixture
+def patched_web_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set IRIS_WEB_URL so the decoration produces a populated URL."""
+    monkeypatch.setenv("IRIS_WEB_URL", WEB)
+
+
+class TestCreateCollectionWebUrl:
+    @pytest.mark.asyncio
+    async def test_response_includes_web_url(
+        self,
+        patched_web_url: None,
+        client: IrisClient,
+        respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/collections").mock(
+            return_value=httpx.Response(201, json={
+                "id": "col-abc",
+                "name": "Test Collection",
+                "description": None,
+                "created_at": "2026-05-13T22:45:57.278151+00:00",
+                "updated_at": "2026-05-13T22:45:57.278151+00:00",
+                "created_by": "user-1",
+                "is_deleted": False,
+            }),
+        )
+        result = await tools.dispatch(
+            "create_collection", client, {"name": "Test Collection"},
+        )
+        body = json.loads(result[0].text)
+        assert body["web_url"] == f"{WEB}/collections/col-abc"
+
+
+class TestCreateSetWebUrl:
+    @pytest.mark.asyncio
+    async def test_response_includes_web_url(
+        self,
+        patched_web_url: None,
+        client: IrisClient,
+        respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/sets").mock(
+            return_value=httpx.Response(201, json={
+                "id": "set-xyz",
+                "name": "claude test",
+                "description": None,
+                "collection_id": None,
+                "created_at": "2026-05-13T22:45:57.278151+00:00",
+                "updated_at": "2026-05-13T22:45:57.278151+00:00",
+                "created_by": "user-1",
+                "is_deleted": False,
+            }),
+        )
+        result = await tools.dispatch(
+            "create_set", client, {"name": "claude test"},
+        )
+        body = json.loads(result[0].text)
+        assert body["web_url"] == f"{WEB}/sets/set-xyz"
+        # Regression on the original symptom: this is exactly the URL
+        # the model would have guessed wrong in v6.0.14 (e.g.
+        # `iris.chrisbarlow.nz/sets/...` instead of iris-uat).
+        assert "chrisbarlow.nz" in body["web_url"]
+
+
+class TestCreatePackageWebUrl:
+    @pytest.mark.asyncio
+    async def test_response_includes_web_url(
+        self,
+        patched_web_url: None,
+        client: IrisClient,
+        respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(201, json={
+                "id": "pkg-123",
+                "name": "Test Package",
+                "description": None,
+                "set_id": "set-xyz",
+                "parent_package_id": None,
+                "current_version": 1,
+                "created_at": "2026-05-13T22:45:57.278151+00:00",
+                "updated_at": "2026-05-13T22:45:57.278151+00:00",
+                "is_deleted": False,
+            }),
+        )
+        result = await tools.dispatch(
+            "create_package", client,
+            {"name": "Test Package", "set_id": "set-xyz"},
+        )
+        body = json.loads(result[0].text)
+        assert body["web_url"] == f"{WEB}/packages/pkg-123"
+
+
+class TestCreateDiagramWebUrl:
+    @pytest.mark.asyncio
+    async def test_response_includes_web_url(
+        self,
+        patched_web_url: None,
+        client: IrisClient,
+        respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/diagrams").mock(
+            return_value=httpx.Response(201, json={
+                "id": "dia-789",
+                "name": "Test Diagram",
+                "diagram_type": "doview_analysis",
+                "notation": "markdown",
+                "description": None,
+                "set_id": "set-xyz",
+                "parent_package_id": None,
+                "data": {"content": "# test"},
+                "created_at": "2026-05-13T22:45:57.278151+00:00",
+                "updated_at": "2026-05-13T22:45:57.278151+00:00",
+                "is_deleted": False,
+                "tags": [],
+                "current_version": 1,
+                "set_name": "claude test",
+            }),
+        )
+        result = await tools.dispatch(
+            "create_diagram", client,
+            {
+                "name": "Test Diagram",
+                "diagram_type": "doview_analysis",
+                "notation": "markdown",
+                "set_id": "set-xyz",
+                "data": {"content": "# test"},
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["web_url"] == f"{WEB}/views/dia-789"
+
+
+class TestNoIrisWebUrlNoDecoration:
+    """When IRIS_WEB_URL isn't configured (dev), the create_* tools
+    return the entity dict unchanged (no `web_url` key). The model
+    still gets a usable response; just no link to surface."""
+
+    @pytest.mark.asyncio
+    async def test_create_set_without_iris_web_url(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        client: IrisClient,
+        respx_mock: respx.Router,
+    ) -> None:
+        monkeypatch.delenv("IRIS_WEB_URL", raising=False)
+        respx_mock.post(f"{BASE}/api/sets").mock(
+            return_value=httpx.Response(201, json={
+                "id": "set-dev",
+                "name": "dev set",
+                "description": None,
+                "collection_id": None,
+                "created_at": "2026-05-13T22:45:57.278151+00:00",
+                "updated_at": "2026-05-13T22:45:57.278151+00:00",
+                "created_by": "user-1",
+                "is_deleted": False,
+            }),
+        )
+        result = await tools.dispatch(
+            "create_set", client, {"name": "dev set"},
+        )
+        body = json.loads(result[0].text)
+        assert "web_url" not in body
+        # Other fields untouched.
+        assert body["id"] == "set-dev"


### PR DESCRIPTION
## Summary

Read tools (get_*, list_*, search, package_hierarchy) get the `web_url` decoration. Create tools didn't — model had to guess the host. v6.0.14 testing surfaced the failure: after a successful `create_set`, the user asked "link me to it" and got `https://iris.chrisbarlow.nz/sets/...` (wrong subdomain; should be `iris-uat...`).

v6.0.15 wraps each create_* handler's return with `with_web_url(json, kind)` so the response shape matches the corresponding `get_*` tool.

## Changes

- `_create_collection` → wraps with kind `"collection"`
- `_create_set` → wraps with kind `"set"`
- `_create_package` → wraps with kind `"package"`
- `_create_diagram` → wraps with kind `"diagram"`

`apply_diagram_creation` is out of scope (its batch response is bare id strings, needs different decoration shape — deferred).

## Tests

5 new in `test_create_tools_web_url_decoration.py`. 173/173 MCP tests pass.

## Test plan

- [ ] CI green.
- [ ] iris-mcp auto-redeploys.
- [ ] In claude.ai: ask Claude to create a test set → response now contains a real `web_url`. Ask "link me to it" → model surfaces the correct URL (no host-guessing).

## See also

- [ADR-175](https://github.com/cgbarlow/iris/blob/fix/v6.0.15-create-tool-web-url-decoration/docs/adrs/ADR-175-Web-URL-Decoration-On-Create-Tools.md)
- [SPEC-175-A](https://github.com/cgbarlow/iris/blob/fix/v6.0.15-create-tool-web-url-decoration/docs/adrs/specs/SPEC-175-A-Web-URL-Decoration-On-Create-Tools.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)