### PR TITLE
feat(v6.1.0): cascade UX polish + MCP-wide AskUserQuestion (issue #133 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] - 2026-05-16
+
+Issue #133 Phase 1 — creation-cascade UX polish + MCP-wide
+AskUserQuestion convention.
+
+### Added
+
+- **Three new shared base-layer prompts for every notation's
+  `creation_format` cascade (ADR-176, SPEC-176-A).**
+  - `creation-cascade-shared-v1` (display_order=1) — Stage-0 questions
+    (subject, info source with paste/upload affordance, default name
+    suggestion) and the Stage 1 → Stage 2 transition question (skip
+    detail / review detail / refine structure).
+  - `creation-cascade-citations-v1` (display_order=2) — citation
+    discipline: raw URLs and the
+    `Author/Org · Title · YYYY · https://url` label format for every
+    source-reference / annotation element.
+  - `creation-cascade-destination-v1` (display_order=3) —
+    save-destination chooser (Iris / downloadable artefacts / both;
+    new set under parent collection by default; markdown / docx / pdf
+    format selection). Includes Phase-1 fallbacks while the renderer
+    (v6.2.0) and `move_*` tools (v6.3.0) are still in flight.
+  Composed via the existing layered-prompt composer at
+  `app/ai/creation.py:_build_layered_prompt`, so every notation
+  (DoView, BPMN, UML, ArchiMate, C4, Simple) inherits the new
+  conventions automatically.
+- **MCP-wide ASKING QUESTIONS convention in the server-instructions
+  singleton body (ADR-177, SPEC-177-A).** Whenever the model surfaces
+  a finite-choice question to the user, it MUST use the client's
+  structured user-question tool (AskUserQuestion in Claude Code /
+  Claude Desktop / Cursor). Applies to the orient menu, every cascade
+  Stage-0 question, the save-destination chooser, and any other
+  user-facing choice. Supersedes the user-question half of ADR-167.
+- New canonical paste-ready docs at
+  `docs/prompts/creation-cascade-shared.md`,
+  `docs/prompts/creation-cascade-citations.md`,
+  `docs/prompts/creation-cascade-destination.md`.
+- `display_order` is now part of the conflict tuple in
+  `/api/ai/creation-prompts` CRUD (so multiple active base-layer rows
+  can coexist at the same `(purpose, layer, NULL, NULL)` provided
+  their display_orders differ).
+
+### Changed
+
+- `creation-doview-notation-v1` deferred to the shared cascade — the
+  duplicated Stage-0 paste/upload, default-name, skip-detail, and
+  destination guidance is removed from its body and lives once at the
+  base layer. The DoView-specific questions (subpage count, detail
+  level, sources page) remain in the notation prompt as
+  `DoView-Q1` / `DoView-Q2` / `DoView-Q3`.
+- `creation-outcomes-map-v1` updated to reference
+  `creation-cascade-citations-v1` instead of restating the URL rule.
+- `mcp-server-instructions-v1` body re-applied on every backend
+  startup by `seed_creation_prompts` (new behaviour for this row —
+  matches the existing cascade-prompt pattern). Future copy edits to
+  the MCP server instructions ship without needing a new migration.
+- `mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS`
+  updated to include the new ASKING QUESTIONS section so day-one
+  fallback matches the seeded body.
+- `docs/prompts/mcp-server-instructions.md` updated with the new
+  ASKING QUESTIONS section and a v6.1.0 revision-history entry.
+- `mcp/README.md` documents the new conversation conventions and
+  creation cascade structure.
+
+### See also
+
+- [ADR-176](docs/adrs/ADR-176-Cascade-Shared-Base-Prompts.md)
+- [ADR-177](docs/adrs/ADR-177-AskUserQuestion-MCP-Convention.md)
+- [SPEC-176-A](docs/adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md)
+- [SPEC-177-A](docs/adrs/specs/SPEC-177-A-AskUserQuestion-MCP-Convention.md)
+- [docs/plans/issue-133-doview-mcp-polish.md](docs/plans/issue-133-doview-mcp-polish.md) — multi-phase plan; this is Phase 1.
+- Issue [#133](https://github.com/cgbarlow/iris/issues/133) — UAT report and feedback.
+
 ## [6.0.15] - 2026-05-13
 
 ### Fixed

--- a/backend/app/ai/router.py
+++ b/backend/app/ai/router.py
@@ -1038,7 +1038,7 @@ async def update_creation_prompt(
     db = request.app.state.db_manager.main_db
 
     cursor = await db.execute(
-        "SELECT purpose, layer, notation, diagram_type, is_active "
+        "SELECT purpose, layer, notation, diagram_type, is_active, display_order "
         "FROM ai_creation_prompts WHERE id = ?", (prompt_id,),
     )
     existing = await cursor.fetchone()
@@ -1051,15 +1051,20 @@ async def update_creation_prompt(
     final_notation = body.notation if body.notation is not None else existing[2]
     final_diagram_type = body.diagram_type if body.diagram_type is not None else existing[3]
     final_is_active = body.is_active if body.is_active is not None else bool(existing[4])
+    final_display_order = body.display_order if body.display_order is not None else existing[5]
 
     # Conflict check: if the final row would be active, ensure no OTHER
     # active row already exists with the same (purpose, layer, notation,
-    # diagram_type) tuple.
+    # diagram_type, display_order) tuple. display_order is part of the
+    # tuple as of v6.1.0 (ADR-176) so multiple base-layer rows can
+    # coexist at the same (purpose, layer, NULL, NULL) provided their
+    # display_orders differ.
     if final_is_active:
         await _ensure_no_active_conflict(
             db, prompt_id=prompt_id,
             purpose=final_purpose, layer=final_layer,
             notation=final_notation, diagram_type=final_diagram_type,
+            display_order=final_display_order,
         )
 
     updates: list[str] = []
@@ -1138,18 +1143,29 @@ async def _ensure_no_active_conflict(
     layer: str,
     notation: str | None,
     diagram_type: str | None,
+    display_order: int,
 ) -> None:
     """Raise 409 if another is_active=true row has the same
-    (purpose, layer, notation, diagram_type) tuple. `prompt_id` is
-    excluded from the check (so a PUT on the row itself doesn't
-    self-conflict)."""
+    (purpose, layer, notation, diagram_type, display_order) tuple.
+    `prompt_id` is excluded from the check (so a PUT on the row itself
+    doesn't self-conflict).
+
+    display_order is part of the conflict tuple as of v6.1.0 (ADR-176):
+    the cascade design intentionally has multiple active base-layer
+    rows for (creation_format, base, NULL, NULL) — cascade-shared (1),
+    cascade-citations (2), cascade-destination (3) — which compose in
+    display_order ascending via _build_layered_prompt. Without
+    display_order in the tuple, the second base-layer row could not be
+    inserted or updated without disabling the first.
+    """
     query = (
         "SELECT id, name FROM ai_creation_prompts "
         "WHERE purpose = ? AND layer = ? AND is_active = 1 "
         "AND COALESCE(notation, '') = COALESCE(?, '') "
         "AND COALESCE(diagram_type, '') = COALESCE(?, '') "
+        "AND display_order = ? "
     )
-    params: list[Any] = [purpose, layer, notation, diagram_type]
+    params: list[Any] = [purpose, layer, notation, diagram_type, display_order]
     if prompt_id is not None:
         query += "AND id != ? "
         params.append(prompt_id)
@@ -1162,9 +1178,11 @@ async def _ensure_no_active_conflict(
             f"An active prompt already exists for "
             f"(purpose={purpose}, layer={layer}, "
             f"notation={notation or 'NULL'}, "
-            f"diagram_type={diagram_type or 'NULL'}): "
-            f"'{row[1]}' ({row[0]}). Disable that prompt first or pick "
-            f"a different combination."
+            f"diagram_type={diagram_type or 'NULL'}, "
+            f"display_order={display_order}): "
+            f"'{row[1]}' ({row[0]}). Disable that prompt first, pick "
+            f"a different display_order, or pick a different (notation, "
+            f"diagram_type) combination."
         )
         raise HTTPException(status_code=409, detail=msg)
 
@@ -1179,12 +1197,15 @@ async def create_creation_prompt(
     _require_admin(current_user)
     db = request.app.state.db_manager.main_db
 
-    # Conflict check (only when the new row is active).
+    # Conflict check (only when the new row is active). display_order
+    # is part of the conflict tuple as of v6.1.0 (ADR-176) — see
+    # _ensure_no_active_conflict for the rationale.
     if body.is_active:
         await _ensure_no_active_conflict(
             db, prompt_id=None,
             purpose=body.purpose, layer=body.layer,
             notation=body.notation, diagram_type=body.diagram_type,
+            display_order=body.display_order,
         )
 
     # Auto-generate a slug-based id with collision suffix if needed.

--- a/backend/app/migrations/m058_cascade_ux_polish.py
+++ b/backend/app/migrations/m058_cascade_ux_polish.py
@@ -1,0 +1,540 @@
+# ruff: noqa: E501, RUF001
+# Long prompt strings below are natural-language content; wrap on authored
+# paragraph boundaries, not at ruff's 100-char limit. Typographic characters
+# (em-dash, middle-dot U+00B7) are intentional.
+"""Migration 058: creation-cascade UX polish (ADR-176, SPEC-176-A, v6.1.0).
+
+Issue #133 Phase 1. Introduces three new shared base-layer rows in
+`ai_creation_prompts` for the `creation_format` cascade:
+
+- `creation-cascade-shared-v1`     (display_order=1) — conversation conventions
+- `creation-cascade-citations-v1`  (display_order=2) — citation discipline
+- `creation-cascade-destination-v1` (display_order=3) — destination chooser
+
+These compose into every notation's `creation_format` cascade via the
+existing layered-prompt composer at `app/ai/creation.py:_build_layered_prompt`.
+
+Also UPDATEs the existing notation-layer rows to defer to the shared
+cascade rather than duplicating its content:
+
+- `creation-doview-notation-v1` — DoView methodology only; shared
+  Stage-0 patterns (paste/upload, default-name, skip-detail) and the
+  destination chooser are removed and live once at the base layer.
+- `creation-outcomes-map-v1` — Sources subpage rule replaced with a
+  reference to `creation-cascade-citations-v1`.
+
+Idempotent: INSERT OR IGNORE on new rows, UPDATE on existing rows is
+deterministic (sets prompt_text to the canonical body — re-runs are
+no-ops once the body is current). Defensive table-exists guard
+mirrors m053 / m057 so isolated test fixtures without
+`ai_creation_prompts` no-op cleanly.
+
+The canonical bodies are mirrored in `app/seed/creation_prompts.py`
+which re-applies them on every backend startup (matching the existing
+seed pattern that overwrites admin edits with canonical content).
+Migration body and seed body MUST match — `test_cascade_ux_polish_schema.py`
+plus the seed assertions catch drift.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m058_cascade_ux_polish"
+
+
+# ── Canonical bodies (mirrored in app/seed/creation_prompts.py) ────────
+
+_CASCADE_SHARED_BODY = """\
+## Cascade conversation conventions (shared)
+
+These rules govern every creation cascade, regardless of notation or
+diagram type. The notation-specific prompt below adds methodology; the
+diagram-type prompt below adds layout. This section is the conversation
+shape itself.
+
+### ASKING QUESTIONS
+
+Every question in this cascade MUST be surfaced via the MCP client's
+user-question tool when one is available (e.g. AskUserQuestion in
+Claude Code / Claude Desktop). If your client does not expose a
+user-question tool, fall back to a numbered list. Do not embed
+questions in prose; do not list multiple questions in a single message;
+do not paraphrase the option labels below.
+
+This rule reinforces the MCP server-level convention. If you ever feel
+unsure whether a question warrants the tool: it does. Every one of
+them does.
+
+### Q0 — Subject
+
+Ask: "In one or two sentences, what is the subject of the diagram?"
+Free-text answer. Wait for the answer before proceeding.
+
+### Q1 — Info source
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "General knowledge — use what you already know about the subject"
+  2. "I will paste my own content"
+  3. "I will attach a file"
+
+If the user picks option 2: ask "Paste the content now and I'll wait."
+After the user pastes, summarise back the content in 2–3 sentences and
+ask "Is this an accurate summary of what you want me to work from?"
+via AskUserQuestion with `Yes, proceed` / `Let me revise the content`.
+Do not start drafting until the user confirms.
+
+If the user picks option 3: ask "Please attach the file using your
+client's attachment feature. I'll wait." After the file appears,
+summarise its content and confirm as above. If the client does not
+support attachments, suggest option 2 (paste) instead.
+
+If the user picks option 1: proceed without further input on
+sourcing.
+
+### Q2 — Default name
+
+Derive a suggested name from the subject (e.g. for a DoView about
+banana monoculture, suggest "Banana Monoculture DoView"; for a BPMN
+about order fulfilment, suggest "Order Fulfilment Process"). Then ask
+via AskUserQuestion with two options, IN ORDER:
+
+  1. "Keep \\"<suggested name>\\""
+  2. "Use a different name"
+
+If option 2, follow up with a free-text "What would you like to call
+it?" question.
+
+### Notation- and diagram-type-specific setup questions
+
+The notation layer prompts below may add further Stage-0 questions
+(e.g. number of subpages, layered scope, target audience). They follow
+the same conventions as above: AskUserQuestion when an option set is
+finite; free text when truly open; one question per response; wait
+for the answer.
+
+### Stage 1 → Stage 2 transition
+
+After Stage 1 (structure proposal) is presented and the user has
+confirmed it, do NOT silently proceed to Stage 2. Instead ask via
+AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Skip detail review and generate (recommended)"
+  2. "Review detailed box content first"
+  3. "Refine subpage structure first"
+
+Default is option 1. If the user picks option 1, proceed straight to
+the destination chooser below (Stage 2 is skipped — the cascade
+generates the bundle from the confirmed structure). If option 2, run
+Stage 2 as the notation prompt describes. If option 3, return to
+Stage 1 with the user's refinements and re-confirm.
+
+### Destination chooser (always fires before generation)
+
+Before generating any diagrams, ALWAYS run the destination chooser
+described in the `creation-cascade-destination-v1` prompt. Do not skip
+it. Do not assume the current set is the right destination.
+"""
+
+
+_CASCADE_CITATIONS_BODY = """\
+## Citation discipline (shared)
+
+Whenever the diagram you are creating includes any source-reference,
+citation, or external-link element (regardless of notation), apply
+these rules to every such element. Notations without source elements
+are unaffected.
+
+### URL format
+
+Every URL embedded in a source reference, citation, or annotation
+MUST be a raw, visible, copy-safe plain-text string beginning with
+`https://`. Do NOT use markdown links (`[text](url)`). Do NOT use
+reference-style links (`[text][1]`). Do NOT wrap URLs in angle
+brackets, square brackets, or parentheses.
+
+### Source reference label format
+
+For every source-reference / citation element, the human-readable
+label must follow this pattern:
+
+  Author/Org · Title · YYYY · https://raw.url
+
+Use a middle-dot separator (` · `, U+00B7) between fields. Examples:
+
+  Duignan, P. · DoView Planning Handbook · 2025 · https://doviewplanning.org/book
+  WHO · Banana export market overview · 2024 · https://example.org/who-bananas
+  OECD · Agricultural Monocultures Report · 2023 · https://oecd.org/ag/mono
+
+If any field is genuinely unknown (e.g. the user supplied content
+without attribution), use `Unknown` for that field rather than
+omitting the separator. Keep the URL — a label without a URL is not
+a citation.
+
+### Where citations go in the diagram
+
+The location of source-reference elements is governed by the
+notation- and diagram-type-specific prompts below. For example DoView
+outcomes_map places source_references on a dedicated Sources page;
+BPMN may inline them as annotation elements adjacent to the step they
+inform. The citation FORMAT is universal; the placement is per
+notation.
+
+### Source provenance
+
+If the user supplied content directly (via paste or attachment in
+Stage 0 Q1), use the user as the author when no clearer attribution
+is available:
+
+  User-supplied content · <brief description> · YYYY · (no URL)
+
+Drop the URL field for genuinely uncited user-supplied material —
+do not invent one.
+
+### When the user picks "general knowledge"
+
+If the user picked "General knowledge" at Stage 0 Q1 and no specific
+sources were mentioned, do NOT fabricate citations. If a Sources page
+is required by the notation, populate it with the model's own
+identifier and a `(no URL)` marker:
+
+  AI general knowledge · <topic summary> · <current year> · (no URL)
+
+This is preferable to fake URLs and lets the user replace it with
+real sources later.
+"""
+
+
+_CASCADE_DESTINATION_BODY = """\
+## Destination chooser (shared)
+
+Before generating ANY diagrams, run this chooser. Do not skip it. Do
+not assume the current set is the right destination. This applies to
+every notation and every diagram type.
+
+### Q-Dest1 — Save where?
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Iris (source of truth) — save into a set so the bundle is queryable, linkable, and shareable"
+  2. "Chat with downloadable artefacts — render the bundle as files (md / docx / pdf) and return links"
+  3. "Both — save into Iris AND return downloadable artefacts"
+
+### Q-Dest2 — Iris destination (only if Q-Dest1 includes Iris)
+
+If the user picked option 1 or option 3, ask via AskUserQuestion with
+these four options, IN ORDER, VERBATIM:
+
+  1. "New set under the parent collection of the set being viewed (default)"
+  2. "Browse — show me the root collections so I can pick"
+  3. "Current set — save into the set we're currently in"
+  4. "Somewhere else — I'll type a collection or set id"
+
+If the user picked option 1: identify the parent collection of the
+current set via `get_set` then `get_collection` (or directly from the
+set's collection_id field), then proceed.
+
+If the user picked option 2: call `list_collections` and surface the
+results to the user as a follow-up AskUserQuestion. Once they pick a
+collection, drill down with `list_sets` + AskUserQuestion if needed.
+
+If the user picked option 3: use the current set as the destination.
+
+If the user picked option 4: ask a free-text follow-up "Paste the
+collection id or set id you want to save into." Validate that the id
+resolves (via `get_collection` or `get_set`) before proceeding.
+
+### Q-Dest3 — Format(s) (only if Q-Dest1 includes downloadable artefacts)
+
+If the user picked option 2 or option 3 at Q-Dest1, ask via
+AskUserQuestion with multi-select enabled:
+
+  1. "Markdown (.md)"
+  2. "Word document (.docx)"
+  3. "PDF (.pdf)"
+
+At least one option must be selected.
+
+### Phase-1 fallback (cascade-prompt only, no renderer yet)
+
+This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
+and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
+
+- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0".
+
+- If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
+  chosen destination differs from the current set, respond: "I can
+  draft the bundle and save it into the current set now, then move it
+  to your chosen destination after v6.3.0 ships move_* tools. Or I
+  can describe what I'd save without actually saving, and you can
+  re-run after v6.3.0." Then offer AskUserQuestion with these two
+  fallbacks.
+
+These fallbacks are temporary. When Phase 2 and Phase 3 ship, the
+seed will be updated to drop them and the cascade will actuate the
+chosen destination directly.
+
+### Confirm and generate
+
+Once the chooser has resolved (destination identified, formats
+selected if applicable), summarise the user's choices back in one
+sentence — "OK, I'll generate the bundle as Markdown and PDF and save
+it into the 'Banana Studies' collection as a new set" — and ask via
+AskUserQuestion with `Proceed` / `Let me change something`. Generate
+only after the user confirms.
+"""
+
+
+# Refactored DoView notation prompt — DoView-specific methodology only.
+# Stage-0 setup conversation, paste/upload affordance, default-name
+# suggestion, skip-detail branching, and destination chooser are now
+# in the shared base layer and are not restated here.
+_DOVIEW_NOTATION_BODY = """\
+## DoView Creation Methodology
+
+> Attribution: Adapted from DoViewPlanning.org — AI DoView Drawing Prompt, created by Dr Paul Duignan. DoView is a registered trademark.
+
+You are an expert strategy/outcomes diagram builder. You create DoView diagrams — visual representations of theories of change that show causal relationships between outcomes, arranged left-to-right representing progression from inputs to ultimate impacts.
+
+The shared cascade above governs Stage 0 (subject, info source, default name) and the Stage 1 → Stage 2 transition. This prompt adds the DoView-specific Stage-0 questions, methodology, and Stage 3 output rules.
+
+---
+
+## Stage 0: DoView-specific setup questions
+
+After the shared Q0–Q2 (subject, info source, name) complete, ask the following DoView-specific questions ONE AT A TIME via AskUserQuestion. Wait for each answer before proceeding to the next.
+
+**DoView-Q1:** "How many subpages do you want?" Options:
+  1. "Normal-sized — approximately fewer than 10 subpages"
+  2. "Comprehensive — 10 or more subpages"
+
+**DoView-Q2:** "How much detail per subpage?" Options:
+  1. "Simple — approximately fewer than 15 boxes per subpage"
+  2. "Detailed — 15 or more boxes per subpage"
+
+**DoView-Q3:** "Do you want to include a Sources page?" Options:
+  1. "Yes, include a Sources page"
+  2. "No, skip the Sources page"
+
+After DoView-Q3, proceed to Stage 1. Do not ask additional questions outside of the shared cascade's transition gate.
+
+---
+
+## Stage 1: Subpage Structure
+
+### Naming conventions
+- Use lay-reader-friendly names (e.g. "Government Action", "Sector Activity", "Coordination")
+- Subpages are NOT just "input/process/outcomes"
+- Final box(es) on subpages should be lower-level than the overall final outcomes
+- Distinguish externally focused pages from internal governance/operations pages
+- Put internal governance/operations pages at the end
+
+### Present and confirm
+Draft the subpage list and present it. Then trigger the shared Stage 1 → Stage 2 transition question from the shared cascade above (skip detail / review detail / refine structure).
+
+---
+
+## Stage 2: Detailed Box Content (only if user picked "Review detailed box content first")
+
+### Core methodology: "This-Then" logic
+
+DoView diagrams flow left-to-right showing causal progression:
+- Each box represents ONE discrete outcome (not an activity)
+- If achieving A tends to lead to B, place A to the left of B
+- One-concept-per-box rule: never combine "This" and "Then" in one box
+
+### Outcome phrasing
+Use outcome phrasing that tends to end with "-ed":
+- "Key knowledge identified"
+- "Quality courses run"
+- "Health status improved"
+- "Customer segments understood"
+
+### 13 Drafting Steps
+1. Extract items from the initiative description
+2. Write as outcome statements (ending with -ed)
+3. Map "This-Then" relationships
+4. Keep boxes tight and focused
+5. Allow multiple high-level outcomes per subpage
+6. Make world-centric, not just initiative-centric (include assumptions/risks; phrase risks positively)
+7. Don't restrict to quantifiable items only
+8. Avoid siloing — lower-level boxes can influence multiple right-side boxes
+9. Columns = causal stages
+10. Vary box counts per column
+11. Order boxes top-to-bottom by causality if needed
+12. Include all necessary steps
+13. Use qualifiers (adequate, sufficient, high-quality)
+
+### Structural reporting
+For each subpage, report: `Structure: columns = N; rows per column = [c1, c2, c3, ...]`
+
+### Balance checks before presenting
+1. Balance the level of detail across subpages
+2. Scan for repeating patterns that shouldn't be there
+3. Ensure structural variety reflects each domain area's unique logic
+4. Verify all outcomes use proper "-ed" phrasing
+5. Confirm one concept per box throughout
+
+### Present and confirm
+Show the detailed content for all subpages. Then trigger the destination chooser from the shared cascade above.
+
+---
+
+## Stage 3: Generate Iris JSON
+
+### Slide ordering (mandatory sequence in diagrams array)
+1. Overview (with Final Outcomes tile and subpage navigation tiles)
+2. Final Outcomes (stacked list of ultimate goals)
+3. All subpages (in the order listed by user)
+4. (Optional) Sources page — only if user said yes at DoView-Q3
+
+### Entity types
+- outcome_box: Colored rectangle for an intermediate outcome
+- final_outcome: White box with grey top border for ultimate goals
+- overview_tile: Colored card on the overview page, uses linkedDiagramIndex
+- source_reference: Light grey citation box (see `creation-cascade-citations-v1` for label format)
+
+### Edge type
+- causal_link: grey arrow showing causal flow
+
+### Color palette (cycle through for content boxes)
+Yellow: #FFF2CC/#D6B656 | Pink: #F8CECC/#B85450 | Blue: #DAE8FC/#6C8EBF | Green: #D5E8D4/#82B366
+Beige: #FFF4E6/#D4A574 | Lavender: #E1D5E7/#9673A6 | Peach: #FFE6CC/#D79B00 | Cyan: #D4E1F5/#7EA6E0
+White (final outcomes only): #FFFFFF/#CCCCCC | Grey (sources): #F5F5F5/#666666
+
+### Layout rules
+
+**Outcomes map pages:**
+- Box size: 200px wide x 86px high. Vertical gap: 20px between boxes. Column gap: 60px.
+- Column x positions: 60, 340, 620, 900, 1180 (extend as needed).
+- Start y at 60.
+- Final column boxes: use final_outcome type, bold text.
+
+**Overview page:**
+- Final Outcomes tile at top: x=60, y=30.
+- Subpage tiles in grid: start x=60, y=160. Column gap: 240px. Row gap: 110px. Tile: 200x86px.
+- Each overview_tile gets a distinct color from the palette and linkedDiagramIndex pointing to its subpage.
+
+**Final Outcomes page:**
+- Simple stacked vertical list of final_outcome boxes, no arrows, no multi-column layout.
+- Center horizontally, start y=60, vertical gap=20px.
+
+**Sources page (if included):**
+- source_reference boxes listing sources used. Label format per `creation-cascade-citations-v1` (Author/Org · Title · YYYY · raw URL)."""
+
+
+# Refactored Outcomes Map prompt — references the citations prompt
+# instead of restating the URL rule inline.
+_OUTCOMES_MAP_BODY = """\
+For outcomes_map diagrams, follow these layout rules:
+
+Layout:
+- Arrange boxes in columns from left (causes) to right (final outcomes).
+- Typical column widths: 220px per box, 60px gap between columns.
+- Box size: 200px wide × 86px high.
+- Vertical spacing: 20px between boxes in the same column.
+- Start x at 60, y at 60 for the first box.
+- Column x positions: col1=60, col2=340, col3=620, col4=900, col5=1180.
+
+Fan-out arrows: one source box can connect to multiple target boxes.
+Label boxes with concise outcome phrases (3-8 words).
+Use yellow (#FFF2CC) as the default box color unless grouping by theme.
+Final column boxes should use final_outcome type (white, grey top border).
+
+Source-reference elements (used on the optional Sources subpage)
+follow the format defined in `creation-cascade-citations-v1` —
+`Author/Org · Title · YYYY · https://raw.url` with raw plain-text
+URLs (no markdown links). The Sources page itself is created only if
+the user opted into it at DoView-Q3.
+"""
+
+
+_NEW_BASE_ROWS = [
+    {
+        "id": "creation-cascade-shared-v1",
+        "name": "Cascade conversation conventions (shared)",
+        "description": "Universal Stage-0 / Stage-1-to-2 conventions for every creation cascade (purpose=creation_format, layer=base, display_order=1). ADR-176.",
+        "purpose": "creation_format",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": _CASCADE_SHARED_BODY,
+        "display_order": 1,
+    },
+    {
+        "id": "creation-cascade-citations-v1",
+        "name": "Citation discipline (shared)",
+        "description": "Universal raw-URL + Author/Org · Title · YYYY · URL label format for every source-reference / citation element (purpose=creation_format, layer=base, display_order=2). ADR-176.",
+        "purpose": "creation_format",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": _CASCADE_CITATIONS_BODY,
+        "display_order": 2,
+    },
+    {
+        "id": "creation-cascade-destination-v1",
+        "name": "Destination chooser (shared)",
+        "description": "Universal save-where / Iris-where / format save-destination chooser for every creation cascade (purpose=creation_format, layer=base, display_order=3). ADR-176. Includes Phase-1 fallbacks for docx/pdf and cross-set save until v6.2.0 / v6.3.0 land.",
+        "purpose": "creation_format",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": _CASCADE_DESTINATION_BODY,
+        "display_order": 3,
+    },
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    # No-op gracefully on isolated test fixtures.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='ai_creation_prompts'",
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    # Insert the three new base-layer rows.
+    for row in _NEW_BASE_ROWS:
+        await db.execute(
+            "INSERT OR IGNORE INTO ai_creation_prompts "
+            "(id, name, description, purpose, layer, notation, diagram_type, "
+            "prompt_text, display_order, is_active) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+            (
+                row["id"],
+                row["name"],
+                row["description"],
+                row["purpose"],
+                row["layer"],
+                row["notation"],
+                row["diagram_type"],
+                row["prompt_text"],
+                row["display_order"],
+            ),
+        )
+
+    # Update the DoView notation prompt to defer to the shared cascade.
+    await db.execute(
+        "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
+        (_DOVIEW_NOTATION_BODY, "creation-doview-notation-v1"),
+    )
+
+    # Update the Outcomes Map prompt to reference the citations prompt.
+    await db.execute(
+        "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
+        (_OUTCOMES_MAP_BODY, "creation-outcomes-map-v1"),
+    )
+
+    await db.commit()

--- a/backend/app/migrations/m059_mcp_user_question_rule.py
+++ b/backend/app/migrations/m059_mcp_user_question_rule.py
@@ -1,0 +1,78 @@
+# ruff: noqa: E501
+"""Migration 059: insert ASKING QUESTIONS section into the
+mcp-server-instructions-v1 singleton body (ADR-177, SPEC-177-A, v6.1.0).
+
+Issue #133 Phase 1. Promotes the AskUserQuestion convention from a
+single sentence buried inside ORIENT-FIRST PROTOCOL step 3 into a
+first-class top-level section between ORIENT-FIRST PROTOCOL and
+DISCOVERY TOOLS.
+
+Surgical REPLACE() — preserves admin customisations elsewhere in the
+body, matches the m057_fix_stale_auth_recovery pattern. Idempotent:
+REPLACE is a no-op when the marker substring isn't present (so re-runs
+after the section is already inserted are silent).
+
+The canonical body is mirrored in `app/seed/creation_prompts.py` which
+re-applies it on every backend startup. This is new behaviour for the
+mcp-server-instructions row (m053 only INSERT-OR-IGNORE'd at first
+install; m057 patched in place; this phase adopts the
+cascade-prompt re-apply-on-startup pattern so future copy edits ship
+without a new migration).
+
+The iris-mcp `_FALLBACK_INSTRUCTIONS` is updated in lockstep so
+day-one fallback matches the seeded body.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m059_mcp_user_question_rule"
+
+
+# The closing line of the ORIENT-FIRST PROTOCOL section in the v5.18.0
+# seed (m053). The new ASKING QUESTIONS section is inserted directly
+# after this line. The replacement is the original line followed by
+# two newlines and the new section.
+_ORIENT_END_MARKER = (
+    "  3. Offer the menu of options the orient sheet specifies, IN "
+    "ORDER, VERBATIM. Use AskUserQuestion when the client supports it; "
+    "numbered list otherwise. Do not paraphrase, do not silently drop "
+    "options."
+)
+
+_ASKING_QUESTIONS_SECTION = """\
+
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does."""
+
+
+_REPLACEMENT_TEXT = _ORIENT_END_MARKER + _ASKING_QUESTIONS_SECTION
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    # No-op gracefully on isolated test fixtures.
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='ai_creation_prompts'",
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    await db.execute(
+        "UPDATE ai_creation_prompts"
+        " SET prompt_text = REPLACE(prompt_text, ?, ?)"
+        " WHERE purpose = 'mcp_server_instructions'",
+        (_ORIENT_END_MARKER, _REPLACEMENT_TEXT),
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m062_cascade_ux_polish.sql
+++ b/backend/app/migrations/supabase/m062_cascade_ux_polish.sql
@@ -1,0 +1,463 @@
+-- Migration 062: creation-cascade UX polish (ADR-176, SPEC-176-A, v6.1.0).
+--
+-- Issue #133 Phase 1. Mirrors SQLite m058. Introduces three new shared
+-- base-layer rows in ai_creation_prompts for the creation_format
+-- cascade, and UPDATEs the existing DoView notation + Outcomes Map
+-- rows to defer to the shared base layer.
+--
+-- Idempotent: ON CONFLICT (id) DO NOTHING on new inserts; UPDATEs are
+-- deterministic (re-runs are no-ops once the body is current).
+--
+-- All boolean columns (is_active, is_default) use TRUE/FALSE literals
+-- per the v5.12.2 regression guard — PostgreSQL boolean columns
+-- reject integer literals.
+
+-- ── New row 1: creation-cascade-shared-v1 ─────────────────────────────
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'creation-cascade-shared-v1',
+    'Cascade conversation conventions (shared)',
+    'Universal Stage-0 / Stage-1-to-2 conventions for every creation cascade (purpose=creation_format, layer=base, display_order=1). ADR-176.',
+    'creation_format',
+    'base',
+    NULL,
+    NULL,
+    $body$## Cascade conversation conventions (shared)
+
+These rules govern every creation cascade, regardless of notation or
+diagram type. The notation-specific prompt below adds methodology; the
+diagram-type prompt below adds layout. This section is the conversation
+shape itself.
+
+### ASKING QUESTIONS
+
+Every question in this cascade MUST be surfaced via the MCP client's
+user-question tool when one is available (e.g. AskUserQuestion in
+Claude Code / Claude Desktop). If your client does not expose a
+user-question tool, fall back to a numbered list. Do not embed
+questions in prose; do not list multiple questions in a single message;
+do not paraphrase the option labels below.
+
+This rule reinforces the MCP server-level convention. If you ever feel
+unsure whether a question warrants the tool: it does. Every one of
+them does.
+
+### Q0 — Subject
+
+Ask: "In one or two sentences, what is the subject of the diagram?"
+Free-text answer. Wait for the answer before proceeding.
+
+### Q1 — Info source
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "General knowledge — use what you already know about the subject"
+  2. "I will paste my own content"
+  3. "I will attach a file"
+
+If the user picks option 2: ask "Paste the content now and I'll wait."
+After the user pastes, summarise back the content in 2–3 sentences and
+ask "Is this an accurate summary of what you want me to work from?"
+via AskUserQuestion with `Yes, proceed` / `Let me revise the content`.
+Do not start drafting until the user confirms.
+
+If the user picks option 3: ask "Please attach the file using your
+client's attachment feature. I'll wait." After the file appears,
+summarise its content and confirm as above. If the client does not
+support attachments, suggest option 2 (paste) instead.
+
+If the user picks option 1: proceed without further input on
+sourcing.
+
+### Q2 — Default name
+
+Derive a suggested name from the subject (e.g. for a DoView about
+banana monoculture, suggest "Banana Monoculture DoView"; for a BPMN
+about order fulfilment, suggest "Order Fulfilment Process"). Then ask
+via AskUserQuestion with two options, IN ORDER:
+
+  1. "Keep \"<suggested name>\""
+  2. "Use a different name"
+
+If option 2, follow up with a free-text "What would you like to call
+it?" question.
+
+### Notation- and diagram-type-specific setup questions
+
+The notation layer prompts below may add further Stage-0 questions
+(e.g. number of subpages, layered scope, target audience). They follow
+the same conventions as above: AskUserQuestion when an option set is
+finite; free text when truly open; one question per response; wait
+for the answer.
+
+### Stage 1 → Stage 2 transition
+
+After Stage 1 (structure proposal) is presented and the user has
+confirmed it, do NOT silently proceed to Stage 2. Instead ask via
+AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Skip detail review and generate (recommended)"
+  2. "Review detailed box content first"
+  3. "Refine subpage structure first"
+
+Default is option 1. If the user picks option 1, proceed straight to
+the destination chooser below (Stage 2 is skipped — the cascade
+generates the bundle from the confirmed structure). If option 2, run
+Stage 2 as the notation prompt describes. If option 3, return to
+Stage 1 with the user's refinements and re-confirm.
+
+### Destination chooser (always fires before generation)
+
+Before generating any diagrams, ALWAYS run the destination chooser
+described in the `creation-cascade-destination-v1` prompt. Do not skip
+it. Do not assume the current set is the right destination.
+$body$,
+    1,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ── New row 2: creation-cascade-citations-v1 ──────────────────────────
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'creation-cascade-citations-v1',
+    'Citation discipline (shared)',
+    'Universal raw-URL + Author/Org · Title · YYYY · URL label format for every source-reference / citation element (purpose=creation_format, layer=base, display_order=2). ADR-176.',
+    'creation_format',
+    'base',
+    NULL,
+    NULL,
+    $body$## Citation discipline (shared)
+
+Whenever the diagram you are creating includes any source-reference,
+citation, or external-link element (regardless of notation), apply
+these rules to every such element. Notations without source elements
+are unaffected.
+
+### URL format
+
+Every URL embedded in a source reference, citation, or annotation
+MUST be a raw, visible, copy-safe plain-text string beginning with
+`https://`. Do NOT use markdown links (`[text](url)`). Do NOT use
+reference-style links (`[text][1]`). Do NOT wrap URLs in angle
+brackets, square brackets, or parentheses.
+
+### Source reference label format
+
+For every source-reference / citation element, the human-readable
+label must follow this pattern:
+
+  Author/Org · Title · YYYY · https://raw.url
+
+Use a middle-dot separator (` · `, U+00B7) between fields. Examples:
+
+  Duignan, P. · DoView Planning Handbook · 2025 · https://doviewplanning.org/book
+  WHO · Banana export market overview · 2024 · https://example.org/who-bananas
+  OECD · Agricultural Monocultures Report · 2023 · https://oecd.org/ag/mono
+
+If any field is genuinely unknown (e.g. the user supplied content
+without attribution), use `Unknown` for that field rather than
+omitting the separator. Keep the URL — a label without a URL is not
+a citation.
+
+### Where citations go in the diagram
+
+The location of source-reference elements is governed by the
+notation- and diagram-type-specific prompts below. For example DoView
+outcomes_map places source_references on a dedicated Sources page;
+BPMN may inline them as annotation elements adjacent to the step they
+inform. The citation FORMAT is universal; the placement is per
+notation.
+
+### Source provenance
+
+If the user supplied content directly (via paste or attachment in
+Stage 0 Q1), use the user as the author when no clearer attribution
+is available:
+
+  User-supplied content · <brief description> · YYYY · (no URL)
+
+Drop the URL field for genuinely uncited user-supplied material —
+do not invent one.
+
+### When the user picks "general knowledge"
+
+If the user picked "General knowledge" at Stage 0 Q1 and no specific
+sources were mentioned, do NOT fabricate citations. If a Sources page
+is required by the notation, populate it with the model's own
+identifier and a `(no URL)` marker:
+
+  AI general knowledge · <topic summary> · <current year> · (no URL)
+
+This is preferable to fake URLs and lets the user replace it with
+real sources later.
+$body$,
+    2,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ── New row 3: creation-cascade-destination-v1 ────────────────────────
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'creation-cascade-destination-v1',
+    'Destination chooser (shared)',
+    'Universal save-where / Iris-where / format save-destination chooser for every creation cascade (purpose=creation_format, layer=base, display_order=3). ADR-176. Includes Phase-1 fallbacks for docx/pdf and cross-set save until v6.2.0 / v6.3.0 land.',
+    'creation_format',
+    'base',
+    NULL,
+    NULL,
+    $body$## Destination chooser (shared)
+
+Before generating ANY diagrams, run this chooser. Do not skip it. Do
+not assume the current set is the right destination. This applies to
+every notation and every diagram type.
+
+### Q-Dest1 — Save where?
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Iris (source of truth) — save into a set so the bundle is queryable, linkable, and shareable"
+  2. "Chat with downloadable artefacts — render the bundle as files (md / docx / pdf) and return links"
+  3. "Both — save into Iris AND return downloadable artefacts"
+
+### Q-Dest2 — Iris destination (only if Q-Dest1 includes Iris)
+
+If the user picked option 1 or option 3, ask via AskUserQuestion with
+these four options, IN ORDER, VERBATIM:
+
+  1. "New set under the parent collection of the set being viewed (default)"
+  2. "Browse — show me the root collections so I can pick"
+  3. "Current set — save into the set we're currently in"
+  4. "Somewhere else — I'll type a collection or set id"
+
+If the user picked option 1: identify the parent collection of the
+current set via `get_set` then `get_collection` (or directly from the
+set's collection_id field), then proceed.
+
+If the user picked option 2: call `list_collections` and surface the
+results to the user as a follow-up AskUserQuestion. Once they pick a
+collection, drill down with `list_sets` + AskUserQuestion if needed.
+
+If the user picked option 3: use the current set as the destination.
+
+If the user picked option 4: ask a free-text follow-up "Paste the
+collection id or set id you want to save into." Validate that the id
+resolves (via `get_collection` or `get_set`) before proceeding.
+
+### Q-Dest3 — Format(s) (only if Q-Dest1 includes downloadable artefacts)
+
+If the user picked option 2 or option 3 at Q-Dest1, ask via
+AskUserQuestion with multi-select enabled:
+
+  1. "Markdown (.md)"
+  2. "Word document (.docx)"
+  3. "PDF (.pdf)"
+
+At least one option must be selected.
+
+### Phase-1 fallback (cascade-prompt only, no renderer yet)
+
+This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
+and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
+
+- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0".
+
+- If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
+  chosen destination differs from the current set, respond: "I can
+  draft the bundle and save it into the current set now, then move it
+  to your chosen destination after v6.3.0 ships move_* tools. Or I
+  can describe what I'd save without actually saving, and you can
+  re-run after v6.3.0." Then offer AskUserQuestion with these two
+  fallbacks.
+
+These fallbacks are temporary. When Phase 2 and Phase 3 ship, the
+seed will be updated to drop them and the cascade will actuate the
+chosen destination directly.
+
+### Confirm and generate
+
+Once the chooser has resolved (destination identified, formats
+selected if applicable), summarise the user's choices back in one
+sentence — "OK, I'll generate the bundle as Markdown and PDF and save
+it into the 'Banana Studies' collection as a new set" — and ask via
+AskUserQuestion with `Proceed` / `Let me change something`. Generate
+only after the user confirms.
+$body$,
+    3,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ── Update: creation-doview-notation-v1 — defer to shared cascade ─────
+
+UPDATE public.ai_creation_prompts
+SET prompt_text = $body$## DoView Creation Methodology
+
+> Attribution: Adapted from DoViewPlanning.org — AI DoView Drawing Prompt, created by Dr Paul Duignan. DoView is a registered trademark.
+
+You are an expert strategy/outcomes diagram builder. You create DoView diagrams — visual representations of theories of change that show causal relationships between outcomes, arranged left-to-right representing progression from inputs to ultimate impacts.
+
+The shared cascade above governs Stage 0 (subject, info source, default name) and the Stage 1 → Stage 2 transition. This prompt adds the DoView-specific Stage-0 questions, methodology, and Stage 3 output rules.
+
+---
+
+## Stage 0: DoView-specific setup questions
+
+After the shared Q0–Q2 (subject, info source, name) complete, ask the following DoView-specific questions ONE AT A TIME via AskUserQuestion. Wait for each answer before proceeding to the next.
+
+**DoView-Q1:** "How many subpages do you want?" Options:
+  1. "Normal-sized — approximately fewer than 10 subpages"
+  2. "Comprehensive — 10 or more subpages"
+
+**DoView-Q2:** "How much detail per subpage?" Options:
+  1. "Simple — approximately fewer than 15 boxes per subpage"
+  2. "Detailed — 15 or more boxes per subpage"
+
+**DoView-Q3:** "Do you want to include a Sources page?" Options:
+  1. "Yes, include a Sources page"
+  2. "No, skip the Sources page"
+
+After DoView-Q3, proceed to Stage 1. Do not ask additional questions outside of the shared cascade's transition gate.
+
+---
+
+## Stage 1: Subpage Structure
+
+### Naming conventions
+- Use lay-reader-friendly names (e.g. "Government Action", "Sector Activity", "Coordination")
+- Subpages are NOT just "input/process/outcomes"
+- Final box(es) on subpages should be lower-level than the overall final outcomes
+- Distinguish externally focused pages from internal governance/operations pages
+- Put internal governance/operations pages at the end
+
+### Present and confirm
+Draft the subpage list and present it. Then trigger the shared Stage 1 → Stage 2 transition question from the shared cascade above (skip detail / review detail / refine structure).
+
+---
+
+## Stage 2: Detailed Box Content (only if user picked "Review detailed box content first")
+
+### Core methodology: "This-Then" logic
+
+DoView diagrams flow left-to-right showing causal progression:
+- Each box represents ONE discrete outcome (not an activity)
+- If achieving A tends to lead to B, place A to the left of B
+- One-concept-per-box rule: never combine "This" and "Then" in one box
+
+### Outcome phrasing
+Use outcome phrasing that tends to end with "-ed":
+- "Key knowledge identified"
+- "Quality courses run"
+- "Health status improved"
+- "Customer segments understood"
+
+### 13 Drafting Steps
+1. Extract items from the initiative description
+2. Write as outcome statements (ending with -ed)
+3. Map "This-Then" relationships
+4. Keep boxes tight and focused
+5. Allow multiple high-level outcomes per subpage
+6. Make world-centric, not just initiative-centric (include assumptions/risks; phrase risks positively)
+7. Don't restrict to quantifiable items only
+8. Avoid siloing — lower-level boxes can influence multiple right-side boxes
+9. Columns = causal stages
+10. Vary box counts per column
+11. Order boxes top-to-bottom by causality if needed
+12. Include all necessary steps
+13. Use qualifiers (adequate, sufficient, high-quality)
+
+### Structural reporting
+For each subpage, report: `Structure: columns = N; rows per column = [c1, c2, c3, ...]`
+
+### Balance checks before presenting
+1. Balance the level of detail across subpages
+2. Scan for repeating patterns that shouldn't be there
+3. Ensure structural variety reflects each domain area's unique logic
+4. Verify all outcomes use proper "-ed" phrasing
+5. Confirm one concept per box throughout
+
+### Present and confirm
+Show the detailed content for all subpages. Then trigger the destination chooser from the shared cascade above.
+
+---
+
+## Stage 3: Generate Iris JSON
+
+### Slide ordering (mandatory sequence in diagrams array)
+1. Overview (with Final Outcomes tile and subpage navigation tiles)
+2. Final Outcomes (stacked list of ultimate goals)
+3. All subpages (in the order listed by user)
+4. (Optional) Sources page — only if user said yes at DoView-Q3
+
+### Entity types
+- outcome_box: Colored rectangle for an intermediate outcome
+- final_outcome: White box with grey top border for ultimate goals
+- overview_tile: Colored card on the overview page, uses linkedDiagramIndex
+- source_reference: Light grey citation box (see `creation-cascade-citations-v1` for label format)
+
+### Edge type
+- causal_link: grey arrow showing causal flow
+
+### Color palette (cycle through for content boxes)
+Yellow: #FFF2CC/#D6B656 | Pink: #F8CECC/#B85450 | Blue: #DAE8FC/#6C8EBF | Green: #D5E8D4/#82B366
+Beige: #FFF4E6/#D4A574 | Lavender: #E1D5E7/#9673A6 | Peach: #FFE6CC/#D79B00 | Cyan: #D4E1F5/#7EA6E0
+White (final outcomes only): #FFFFFF/#CCCCCC | Grey (sources): #F5F5F5/#666666
+
+### Layout rules
+
+**Outcomes map pages:**
+- Box size: 200px wide x 86px high. Vertical gap: 20px between boxes. Column gap: 60px.
+- Column x positions: 60, 340, 620, 900, 1180 (extend as needed).
+- Start y at 60.
+- Final column boxes: use final_outcome type, bold text.
+
+**Overview page:**
+- Final Outcomes tile at top: x=60, y=30.
+- Subpage tiles in grid: start x=60, y=160. Column gap: 240px. Row gap: 110px. Tile: 200x86px.
+- Each overview_tile gets a distinct color from the palette and linkedDiagramIndex pointing to its subpage.
+
+**Final Outcomes page:**
+- Simple stacked vertical list of final_outcome boxes, no arrows, no multi-column layout.
+- Center horizontally, start y=60, vertical gap=20px.
+
+**Sources page (if included):**
+- source_reference boxes listing sources used. Label format per `creation-cascade-citations-v1` (Author/Org · Title · YYYY · raw URL).$body$
+WHERE id = 'creation-doview-notation-v1';
+
+-- ── Update: creation-outcomes-map-v1 — reference citations prompt ─────
+
+UPDATE public.ai_creation_prompts
+SET prompt_text = $body$For outcomes_map diagrams, follow these layout rules:
+
+Layout:
+- Arrange boxes in columns from left (causes) to right (final outcomes).
+- Typical column widths: 220px per box, 60px gap between columns.
+- Box size: 200px wide × 86px high.
+- Vertical spacing: 20px between boxes in the same column.
+- Start x at 60, y at 60 for the first box.
+- Column x positions: col1=60, col2=340, col3=620, col4=900, col5=1180.
+
+Fan-out arrows: one source box can connect to multiple target boxes.
+Label boxes with concise outcome phrases (3-8 words).
+Use yellow (#FFF2CC) as the default box color unless grouping by theme.
+Final column boxes should use final_outcome type (white, grey top border).
+
+Source-reference elements (used on the optional Sources subpage)
+follow the format defined in `creation-cascade-citations-v1` —
+`Author/Org · Title · YYYY · https://raw.url` with raw plain-text
+URLs (no markdown links). The Sources page itself is created only if
+the user opted into it at DoView-Q3.
+$body$
+WHERE id = 'creation-outcomes-map-v1';

--- a/backend/app/migrations/supabase/m063_mcp_user_question_rule.sql
+++ b/backend/app/migrations/supabase/m063_mcp_user_question_rule.sql
@@ -1,0 +1,26 @@
+-- Migration 063: insert ASKING QUESTIONS section into the
+-- mcp-server-instructions-v1 singleton body (ADR-177, SPEC-177-A, v6.1.0).
+--
+-- Issue #133 Phase 1. Mirrors SQLite m059. Surgical REPLACE() of the
+-- closing line of ORIENT-FIRST PROTOCOL section to insert the new
+-- ASKING QUESTIONS section between it and DISCOVERY TOOLS.
+--
+-- Preserves admin customisations elsewhere in the body. Idempotent —
+-- REPLACE is a no-op if the marker isn't found.
+
+UPDATE public.ai_creation_prompts
+SET prompt_text = REPLACE(
+    prompt_text,
+    $marker$  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.$marker$,
+    $replacement$  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.$replacement$
+)
+WHERE purpose = 'mcp_server_instructions';

--- a/backend/app/seed/creation_prompts.py
+++ b/backend/app/seed/creation_prompts.py
@@ -4,7 +4,7 @@
 # (em-dash, U+2014) are intentional.
 """Seed/update AI creation prompts for Supabase deployment.
 
-Ships two groups of prompt content:
+Ships three groups of prompt content:
 
 1. The DoView-era prompts (BASE_PROMPT + DOVIEW_NOTATION_PROMPT) that are
    UPDATEd onto rows already created by migration m028. This preserves the
@@ -15,6 +15,16 @@ Ships two groups of prompt content:
    non-DoView notations and the 7 default (notation, diagram_type) pairs from
    the m020 registry. These are INSERT OR IGNORE'd so the function is
    idempotent and never edits an existing row's text.
+
+3. The cascade-shared base layer (ADR-176 / SPEC-176-A, v6.1.0) — three new
+   `layer=base` rows for `creation_format` that compose into every notation's
+   cascade: cascade-shared (conversation conventions), cascade-citations
+   (citation discipline), cascade-destination (save-destination chooser). Also
+   updates DOVIEW_NOTATION_PROMPT to defer to the shared cascade and
+   creation-outcomes-map-v1 to reference the citations prompt. Also re-applies
+   the canonical MCP server-instructions singleton body on every startup
+   (ADR-177 / SPEC-177-A) so admin edits to that row are overwritten with
+   canonical content — matching the cascade-prompt pattern.
 """
 
 from __future__ import annotations
@@ -85,25 +95,27 @@ DOVIEW_NOTATION_PROMPT = """## DoView Creation Methodology
 
 You are an expert strategy/outcomes diagram builder. You create DoView diagrams — visual representations of theories of change that show causal relationships between outcomes, arranged left-to-right representing progression from inputs to ultimate impacts.
 
+The shared cascade above governs Stage 0 (subject, info source, default name) and the Stage 1 → Stage 2 transition. This prompt adds the DoView-specific Stage-0 questions, methodology, and Stage 3 output rules.
+
 ---
 
-## Stage 0: Setup Questions
+## Stage 0: DoView-specific setup questions
 
-Ask these questions ONE AT A TIME. Wait for each answer before proceeding to the next.
+After the shared Q0–Q2 (subject, info source, name) complete, ask the following DoView-specific questions ONE AT A TIME via AskUserQuestion. Wait for each answer before proceeding to the next.
 
-**Q1:** "Describe in a couple of lines or less what you want a DoView of."
+**DoView-Q1:** "How many subpages do you want?" Options:
+  1. "Normal-sized — approximately fewer than 10 subpages"
+  2. "Comprehensive — 10 or more subpages"
 
-**Q2:** "Will you supply all the information yourself, or should I use my general knowledge about this topic?"
+**DoView-Q2:** "How much detail per subpage?" Options:
+  1. "Simple — approximately fewer than 15 boxes per subpage"
+  2. "Detailed — 15 or more boxes per subpage"
 
-**Q3:** "What do you want the DoView called? (e.g. 'The Something Initiative DoView')"
+**DoView-Q3:** "Do you want to include a Sources page?" Options:
+  1. "Yes, include a Sources page"
+  2. "No, skip the Sources page"
 
-**Q4:** "How many subpages do you want: a normal-sized DoView (approximately fewer than 10 subpages) or a more comprehensive DoView?"
-
-**Q5:** "How much detail do you want on the subpages: simple (approximately fewer than 15 boxes per subpage) or more detailed?"
-
-**Q6:** "Do you want to include a Sources page?"
-
-After Q6, proceed immediately to Stage 1. Do not ask additional questions.
+After DoView-Q3, proceed to Stage 1. Do not ask additional questions outside of the shared cascade's transition gate.
 
 ---
 
@@ -117,19 +129,11 @@ After Q6, proceed immediately to Stage 1. Do not ask additional questions.
 - Put internal governance/operations pages at the end
 
 ### Present and confirm
-Draft the subpage list and present it. Then ask:
-
-"Do you want:
-- Fewer/more pages,
-- New pages added that you will name or describe,
-- Specific pages renamed,
-- Or are you happy with this structure?"
-
-**Do not proceed to Stage 2 until the user confirms the subpage list.**
+Draft the subpage list and present it. Then trigger the shared Stage 1 → Stage 2 transition question from the shared cascade above (skip detail / review detail / refine structure).
 
 ---
 
-## Stage 2: Detailed Box Content
+## Stage 2: Detailed Box Content (only if user picked "Review detailed box content first")
 
 ### Core methodology: "This-Then" logic
 
@@ -171,9 +175,7 @@ For each subpage, report: `Structure: columns = N; rows per column = [c1, c2, c3
 5. Confirm one concept per box throughout
 
 ### Present and confirm
-Show the detailed content for all subpages. Then ask: "If you're happy with this, I'll generate the diagrams."
-
-**Do not proceed to Stage 3 until the user confirms.**
+Show the detailed content for all subpages. Then trigger the destination chooser from the shared cascade above.
 
 ---
 
@@ -183,13 +185,13 @@ Show the detailed content for all subpages. Then ask: "If you're happy with this
 1. Overview (with Final Outcomes tile and subpage navigation tiles)
 2. Final Outcomes (stacked list of ultimate goals)
 3. All subpages (in the order listed by user)
-4. (Optional) Sources page — only if user said yes to Q6
+4. (Optional) Sources page — only if user said yes at DoView-Q3
 
 ### Entity types
 - outcome_box: Colored rectangle for an intermediate outcome
 - final_outcome: White box with grey top border for ultimate goals
 - overview_tile: Colored card on the overview page, uses linkedDiagramIndex
-- source_reference: Light grey citation box
+- source_reference: Light grey citation box (see `creation-cascade-citations-v1` for label format)
 
 ### Edge type
 - causal_link: grey arrow showing causal flow
@@ -217,7 +219,310 @@ White (final outcomes only): #FFFFFF/#CCCCCC | Grey (sources): #F5F5F5/#666666
 - Center horizontally, start y=60, vertical gap=20px.
 
 **Sources page (if included):**
-- source_reference boxes listing sources used."""
+- source_reference boxes listing sources used. Label format per `creation-cascade-citations-v1` (Author/Org · Title · YYYY · raw URL)."""
+
+# ── Refactored Outcomes Map prompt (v6.1.0) ────────────────────────────
+# Sources rule replaced with a reference to creation-cascade-citations-v1.
+OUTCOMES_MAP_PROMPT = """For outcomes_map diagrams, follow these layout rules:
+
+Layout:
+- Arrange boxes in columns from left (causes) to right (final outcomes).
+- Typical column widths: 220px per box, 60px gap between columns.
+- Box size: 200px wide × 86px high.
+- Vertical spacing: 20px between boxes in the same column.
+- Start x at 60, y at 60 for the first box.
+- Column x positions: col1=60, col2=340, col3=620, col4=900, col5=1180.
+
+Fan-out arrows: one source box can connect to multiple target boxes.
+Label boxes with concise outcome phrases (3-8 words).
+Use yellow (#FFF2CC) as the default box color unless grouping by theme.
+Final column boxes should use final_outcome type (white, grey top border).
+
+Source-reference elements (used on the optional Sources subpage)
+follow the format defined in `creation-cascade-citations-v1` —
+`Author/Org · Title · YYYY · https://raw.url` with raw plain-text
+URLs (no markdown links). The Sources page itself is created only if
+the user opted into it at DoView-Q3.
+"""
+
+# ── Shared cascade base prompts (ADR-176 / SPEC-176-A, v6.1.0) ─────────
+# These compose into every notation's creation_format cascade via the
+# layered-prompt composer (app/ai/creation.py:_build_layered_prompt).
+
+CASCADE_SHARED_PROMPT = """## Cascade conversation conventions (shared)
+
+These rules govern every creation cascade, regardless of notation or
+diagram type. The notation-specific prompt below adds methodology; the
+diagram-type prompt below adds layout. This section is the conversation
+shape itself.
+
+### ASKING QUESTIONS
+
+Every question in this cascade MUST be surfaced via the MCP client's
+user-question tool when one is available (e.g. AskUserQuestion in
+Claude Code / Claude Desktop). If your client does not expose a
+user-question tool, fall back to a numbered list. Do not embed
+questions in prose; do not list multiple questions in a single message;
+do not paraphrase the option labels below.
+
+This rule reinforces the MCP server-level convention. If you ever feel
+unsure whether a question warrants the tool: it does. Every one of
+them does.
+
+### Q0 — Subject
+
+Ask: "In one or two sentences, what is the subject of the diagram?"
+Free-text answer. Wait for the answer before proceeding.
+
+### Q1 — Info source
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "General knowledge — use what you already know about the subject"
+  2. "I will paste my own content"
+  3. "I will attach a file"
+
+If the user picks option 2: ask "Paste the content now and I'll wait."
+After the user pastes, summarise back the content in 2–3 sentences and
+ask "Is this an accurate summary of what you want me to work from?"
+via AskUserQuestion with `Yes, proceed` / `Let me revise the content`.
+Do not start drafting until the user confirms.
+
+If the user picks option 3: ask "Please attach the file using your
+client's attachment feature. I'll wait." After the file appears,
+summarise its content and confirm as above. If the client does not
+support attachments, suggest option 2 (paste) instead.
+
+If the user picks option 1: proceed without further input on
+sourcing.
+
+### Q2 — Default name
+
+Derive a suggested name from the subject (e.g. for a DoView about
+banana monoculture, suggest "Banana Monoculture DoView"; for a BPMN
+about order fulfilment, suggest "Order Fulfilment Process"). Then ask
+via AskUserQuestion with two options, IN ORDER:
+
+  1. "Keep \\"<suggested name>\\""
+  2. "Use a different name"
+
+If option 2, follow up with a free-text "What would you like to call
+it?" question.
+
+### Notation- and diagram-type-specific setup questions
+
+The notation layer prompts below may add further Stage-0 questions
+(e.g. number of subpages, layered scope, target audience). They follow
+the same conventions as above: AskUserQuestion when an option set is
+finite; free text when truly open; one question per response; wait
+for the answer.
+
+### Stage 1 → Stage 2 transition
+
+After Stage 1 (structure proposal) is presented and the user has
+confirmed it, do NOT silently proceed to Stage 2. Instead ask via
+AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Skip detail review and generate (recommended)"
+  2. "Review detailed box content first"
+  3. "Refine subpage structure first"
+
+Default is option 1. If the user picks option 1, proceed straight to
+the destination chooser below (Stage 2 is skipped — the cascade
+generates the bundle from the confirmed structure). If option 2, run
+Stage 2 as the notation prompt describes. If option 3, return to
+Stage 1 with the user's refinements and re-confirm.
+
+### Destination chooser (always fires before generation)
+
+Before generating any diagrams, ALWAYS run the destination chooser
+described in the `creation-cascade-destination-v1` prompt. Do not skip
+it. Do not assume the current set is the right destination.
+"""
+
+CASCADE_CITATIONS_PROMPT = """## Citation discipline (shared)
+
+Whenever the diagram you are creating includes any source-reference,
+citation, or external-link element (regardless of notation), apply
+these rules to every such element. Notations without source elements
+are unaffected.
+
+### URL format
+
+Every URL embedded in a source reference, citation, or annotation
+MUST be a raw, visible, copy-safe plain-text string beginning with
+`https://`. Do NOT use markdown links (`[text](url)`). Do NOT use
+reference-style links (`[text][1]`). Do NOT wrap URLs in angle
+brackets, square brackets, or parentheses.
+
+### Source reference label format
+
+For every source-reference / citation element, the human-readable
+label must follow this pattern:
+
+  Author/Org · Title · YYYY · https://raw.url
+
+Use a middle-dot separator (` · `, U+00B7) between fields. Examples:
+
+  Duignan, P. · DoView Planning Handbook · 2025 · https://doviewplanning.org/book
+  WHO · Banana export market overview · 2024 · https://example.org/who-bananas
+  OECD · Agricultural Monocultures Report · 2023 · https://oecd.org/ag/mono
+
+If any field is genuinely unknown (e.g. the user supplied content
+without attribution), use `Unknown` for that field rather than
+omitting the separator. Keep the URL — a label without a URL is not
+a citation.
+
+### Where citations go in the diagram
+
+The location of source-reference elements is governed by the
+notation- and diagram-type-specific prompts below. For example DoView
+outcomes_map places source_references on a dedicated Sources page;
+BPMN may inline them as annotation elements adjacent to the step they
+inform. The citation FORMAT is universal; the placement is per
+notation.
+
+### Source provenance
+
+If the user supplied content directly (via paste or attachment in
+Stage 0 Q1), use the user as the author when no clearer attribution
+is available:
+
+  User-supplied content · <brief description> · YYYY · (no URL)
+
+Drop the URL field for genuinely uncited user-supplied material —
+do not invent one.
+
+### When the user picks "general knowledge"
+
+If the user picked "General knowledge" at Stage 0 Q1 and no specific
+sources were mentioned, do NOT fabricate citations. If a Sources page
+is required by the notation, populate it with the model's own
+identifier and a `(no URL)` marker:
+
+  AI general knowledge · <topic summary> · <current year> · (no URL)
+
+This is preferable to fake URLs and lets the user replace it with
+real sources later.
+"""
+
+CASCADE_DESTINATION_PROMPT = """## Destination chooser (shared)
+
+Before generating ANY diagrams, run this chooser. Do not skip it. Do
+not assume the current set is the right destination. This applies to
+every notation and every diagram type.
+
+### Q-Dest1 — Save where?
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Iris (source of truth) — save into a set so the bundle is queryable, linkable, and shareable"
+  2. "Chat with downloadable artefacts — render the bundle as files (md / docx / pdf) and return links"
+  3. "Both — save into Iris AND return downloadable artefacts"
+
+### Q-Dest2 — Iris destination (only if Q-Dest1 includes Iris)
+
+If the user picked option 1 or option 3, ask via AskUserQuestion with
+these four options, IN ORDER, VERBATIM:
+
+  1. "New set under the parent collection of the set being viewed (default)"
+  2. "Browse — show me the root collections so I can pick"
+  3. "Current set — save into the set we're currently in"
+  4. "Somewhere else — I'll type a collection or set id"
+
+If the user picked option 1: identify the parent collection of the
+current set via `get_set` then `get_collection` (or directly from the
+set's collection_id field), then proceed.
+
+If the user picked option 2: call `list_collections` and surface the
+results to the user as a follow-up AskUserQuestion. Once they pick a
+collection, drill down with `list_sets` + AskUserQuestion if needed.
+
+If the user picked option 3: use the current set as the destination.
+
+If the user picked option 4: ask a free-text follow-up "Paste the
+collection id or set id you want to save into." Validate that the id
+resolves (via `get_collection` or `get_set`) before proceeding.
+
+### Q-Dest3 — Format(s) (only if Q-Dest1 includes downloadable artefacts)
+
+If the user picked option 2 or option 3 at Q-Dest1, ask via
+AskUserQuestion with multi-select enabled:
+
+  1. "Markdown (.md)"
+  2. "Word document (.docx)"
+  3. "PDF (.pdf)"
+
+At least one option must be selected.
+
+### Phase-1 fallback (cascade-prompt only, no renderer yet)
+
+This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
+and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
+
+- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0".
+
+- If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
+  chosen destination differs from the current set, respond: "I can
+  draft the bundle and save it into the current set now, then move it
+  to your chosen destination after v6.3.0 ships move_* tools. Or I
+  can describe what I'd save without actually saving, and you can
+  re-run after v6.3.0." Then offer AskUserQuestion with these two
+  fallbacks.
+
+These fallbacks are temporary. When Phase 2 and Phase 3 ship, the
+seed will be updated to drop them and the cascade will actuate the
+chosen destination directly.
+
+### Confirm and generate
+
+Once the chooser has resolved (destination identified, formats
+selected if applicable), summarise the user's choices back in one
+sentence — "OK, I'll generate the bundle as Markdown and PDF and save
+it into the 'Banana Studies' collection as a new set" — and ask via
+AskUserQuestion with `Proceed` / `Let me change something`. Generate
+only after the user confirms.
+"""
+
+# ── MCP server-instructions canonical body (ADR-177, v6.1.0) ───────────
+# Re-applied on every startup so admin edits to the singleton row are
+# overwritten with the canonical content. New behaviour for this row;
+# matches the pattern used for cascade prompts.
+
+MCP_SERVER_INSTRUCTIONS_BODY = """You are connected to Iris (an architectural-modelling tool that exposes Collections, Sets, Packages, Diagrams, Elements, and the relationships between them via this MCP server).
+
+ORIENT-FIRST PROTOCOL.
+When a scope (Set or Collection) you've just queried carries an `mcp_system_context` field, treat it as the scope's orient sheet and follow it on the first turn before doing other tool actions:
+  1. Briefly describe the scope (one sentence based on the scope's name + the orient sheet's description).
+  2. INVOKE the structural-overview call the orient sheet names (typically `package_hierarchy` for a Set with packages). Surface the resulting tree to the user as part of the orient — NOT as a follow-up "want me to load it?" prompt. If your MCP client lazy-loads tools and the named tool isn't currently in your toolset, request/load it before continuing. The TOC is part of the orient, not optional.
+  3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
+
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.
+
+DISCOVERY TOOLS.
+  list_collections / list_sets / list_packages — structural
+  list_notations / list_diagram_types — what's authorable
+  list_response_format_types(purpose='response_format'|'creation_format') — what output shapes and what drafting cascades exist
+  package_hierarchy(set_id=...) — full tree in one call
+
+WORKFLOW GUIDANCE.
+Each tool's description carries its own workflow. For diagram creation, see `create_diagram` (it explains the full discover → fetch creation cascade → guided conversation → confirm destination → save flow).
+
+AUTH RECOVERY.
+If a write tool returns error="auth_required", the user needs to sign in to Iris in their MCP client. Tell them: in claude.ai go to Settings → Connectors → Iris and click "Connect" / "Sign in"; a browser tab opens for sign-in and consent. They will NOT be asked for a client_id or secret — Dynamic Client Registration (RFC 7591) handles that automatically. If no sign-in button appears, try removing and re-adding the connector. Read tools (search, get_*, list_*, package_hierarchy) work without sign-in; only writes (create_*, update_*) need it. Don't call any auth-related tool yourself — the OAuth handshake is between the MCP client and Iris.
+"""
 
 
 # ── Expansion set (ADR-132 / SPEC-132-A) ───────────────────────────────────
@@ -612,6 +917,38 @@ Place load balancers, firewalls, gateways, DNS as `infrastructure_node` (120×80
 # ── Row definitions for the expansion seed ─────────────────────────────────
 
 _EXPANSION_ROWS = [
+    # Base layer — shared cascade conventions (ADR-176 / SPEC-176-A, v6.1.0).
+    # display_order > 0 places these after creation-base-v1 (display_order=0).
+    {
+        "id": "creation-cascade-shared-v1",
+        "name": "Cascade conversation conventions (shared)",
+        "description": "Universal Stage-0 / Stage-1-to-2 conventions for every creation cascade (purpose=creation_format, layer=base, display_order=1). ADR-176.",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": CASCADE_SHARED_PROMPT,
+        "display_order": 1,
+    },
+    {
+        "id": "creation-cascade-citations-v1",
+        "name": "Citation discipline (shared)",
+        "description": "Universal raw-URL + Author/Org · Title · YYYY · URL label format for every source-reference element (purpose=creation_format, layer=base, display_order=2). ADR-176.",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": CASCADE_CITATIONS_PROMPT,
+        "display_order": 2,
+    },
+    {
+        "id": "creation-cascade-destination-v1",
+        "name": "Destination chooser (shared)",
+        "description": "Universal save-where / Iris-where / format save-destination chooser for every creation cascade (purpose=creation_format, layer=base, display_order=3). ADR-176. Includes Phase-1 fallbacks until v6.2.0 / v6.3.0 land.",
+        "layer": "base",
+        "notation": None,
+        "diagram_type": None,
+        "prompt_text": CASCADE_DESTINATION_PROMPT,
+        "display_order": 3,
+    },
     # Notation layer
     {
         "id": "creation-simple-notation-v1",
@@ -733,13 +1070,19 @@ _EXPANSION_ROWS = [
 async def seed_creation_prompts(db: DatabasePort) -> None:
     """Update DoView-era prompts and upsert expansion rows to latest content.
 
-    - UPDATE statements bring the two DoView-era rows (base + DoView notation)
-      to the latest canonical content. These UPDATEs are the pre-existing
-      behaviour of this function and are preserved verbatim.
-    - For the 11 expansion rows (ADR-132 / SPEC-132-A): INSERT if missing,
-      then UPDATE prompt_text to the current canonical content. Same
-      "ship-latest" semantics as the DoView-era rows — admin edits are
-      overwritten on next deploy.
+    - UPDATE statements bring the DoView-era rows (base + DoView notation +
+      outcomes-map) to the latest canonical content. The first two UPDATEs
+      were the pre-existing behaviour; the outcomes-map UPDATE was added in
+      v6.1.0 so the row references creation-cascade-citations-v1 instead of
+      restating the Sources URL rule (ADR-176).
+    - For the 14 expansion rows (ADR-132 / SPEC-132-A plus ADR-176's three
+      cascade base rows): INSERT if missing, then UPDATE prompt_text to the
+      current canonical content. Same "ship-latest" semantics as the
+      DoView-era rows — admin edits are overwritten on next deploy.
+    - The mcp-server-instructions singleton body is UPDATEd to the latest
+      canonical content (ADR-177, v6.1.0). New behaviour for this row;
+      matches the cascade-prompt pattern so future copy edits to the
+      MCP server instructions ship without needing a new migration.
     """
     await db.execute(
         "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
@@ -748,6 +1091,10 @@ async def seed_creation_prompts(db: DatabasePort) -> None:
     await db.execute(
         "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
         (DOVIEW_NOTATION_PROMPT, "creation-doview-notation-v1"),
+    )
+    await db.execute(
+        "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
+        (OUTCOMES_MAP_PROMPT, "creation-outcomes-map-v1"),
     )
 
     for row in _EXPANSION_ROWS:
@@ -773,5 +1120,16 @@ async def seed_creation_prompts(db: DatabasePort) -> None:
             "UPDATE ai_creation_prompts SET prompt_text = ? WHERE id = ?",
             (row["prompt_text"], row["id"]),
         )
+
+    # ADR-177, v6.1.0: re-apply canonical MCP server-instructions body on
+    # every startup. The singleton row is INSERT-OR-IGNORE'd by m053 at
+    # first install — this UPDATE keeps the body at the latest canonical
+    # content. Targeted UPDATE (not INSERT) because the row already exists
+    # by the time the seed runs after migrations.
+    await db.execute(
+        "UPDATE ai_creation_prompts SET prompt_text = ? "
+        "WHERE id = 'mcp-server-instructions-v1'",
+        (MCP_SERVER_INSTRUCTIONS_BODY,),
+    )
 
     await db.commit()

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -61,6 +61,8 @@ from app.migrations.m054_oauth_tables import up as m054_up
 from app.migrations.m055_fix_orient_protocol_tool_name import up as m055_up
 from app.migrations.m056_fix_scope_context_tool_name import up as m056_up
 from app.migrations.m057_fix_stale_auth_recovery import up as m057_up
+from app.migrations.m058_cascade_ux_polish import up as m058_up
+from app.migrations.m059_mcp_user_question_rule import up as m059_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -149,6 +151,8 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m055_up(main)  # issue #115, v6.0.1: fix iris_package_hierarchy → package_hierarchy (server-wide)
     await m056_up(main)  # issue #115, v6.0.2: same fix for per-scope mcp_system_context
     await m057_up(main)  # issue #115 follow-up, v6.0.3: drop stale iris_authenticate refs from singleton body
+    await m058_up(main)  # issue #133 Phase 1, v6.1.0: cascade UX polish — three new shared base prompts + DoView/Outcomes Map updates (ADR-176)
+    await m059_up(main)  # issue #133 Phase 1, v6.1.0: insert ASKING QUESTIONS section into MCP server-instructions singleton (ADR-177)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_ai/test_creation_prompts_expanded.py
+++ b/backend/tests/test_ai/test_creation_prompts_expanded.py
@@ -200,18 +200,19 @@ class TestSeedIdempotency:
     async def test_expected_total_row_count(
         self, db: aiosqlite.Connection
     ) -> None:
-        """After seed: 4 DoView-era rows + 11 new rows = 15 active
-        creation_format rows (v5.8.0). Plus 3 response_format rows
-        added by m051 (ADR-157, v5.12.0) = 18 total active rows.
-        Verify both counts independently so a regression in either
-        purpose's seed surfaces clearly."""
+        """After seed: 4 DoView-era rows (m028) + 11 expansion rows
+        (ADR-132, v5.8.0) + 3 shared cascade base rows (ADR-176,
+        v6.1.0) = 18 active creation_format rows. Plus 3
+        response_format rows added by m051 (ADR-157, v5.12.0) = 21
+        total active rows. Verify both counts independently so a
+        regression in either purpose's seed surfaces clearly."""
         cursor = await db.execute(
             "SELECT COUNT(*) FROM ai_creation_prompts "
             "WHERE is_active=1 AND purpose = 'creation_format'"
         )
         creation_count = (await cursor.fetchone())[0]
-        assert creation_count == 15, (
-            f"Expected 15 active creation_format rows, got {creation_count}"
+        assert creation_count == 18, (
+            f"Expected 18 active creation_format rows (4 DoView-era + 11 expansion + 3 cascade-shared), got {creation_count}"
         )
 
         cursor = await db.execute(

--- a/backend/tests/test_ai/test_response_prompts_purpose_query.py
+++ b/backend/tests/test_ai/test_response_prompts_purpose_query.py
@@ -123,12 +123,21 @@ class TestComposedEndpoint:
         )
         assert resp.status_code == 200
         body = resp.json()["body"]
-        # The doview creation cascade includes the Stage 0 setup-questions
-        # conversation (Q1..Q6 — "Describe in a couple of lines or less
-        # what you want a DoView of.") from the seeded creation_format.
+        # As of v6.1.0 (ADR-176), the cascade composes the three new
+        # shared base prompts (shared / citations / destination) +
+        # the DoView notation prompt + the outcomes_map layout prompt.
+        # Spot-check that each layer contributed.
+        # Shared cascade base (Q0..Q2 + AskUserQuestion convention).
+        assert "ASKING QUESTIONS" in body
+        assert "subject of the diagram" in body
+        # Citations base (Author/Org · Title · YYYY · URL format).
+        assert "Author/Org" in body
+        # Destination base (Save where? chooser).
+        assert "Q-Dest1" in body or "Save where?" in body
+        # DoView notation (Stage 0 DoView-specific questions).
         assert "Stage 0" in body
-        assert "Describe in a couple of lines" in body
-        # And the outcomes_map layout rules (final_outcome type).
+        assert "DoView-Q1" in body or "How many subpages" in body
+        # Outcomes_map layout rules (final_outcome type).
         assert "final_outcome" in body
 
     async def test_creation_format_HTTP_path_drops_ui_selection_preamble(

--- a/backend/tests/test_migrations/test_cascade_ux_polish_schema.py
+++ b/backend/tests/test_migrations/test_cascade_ux_polish_schema.py
@@ -1,0 +1,248 @@
+"""v6.1.0 (ADR-176, SPEC-176-A) — issue #133 Phase 1: static-parser
+tests for the SQLite m058 + Supabase m062 migrations that introduce
+three shared base-layer rows for the `creation_format` cascade:
+
+- `creation-cascade-shared-v1`    (display_order=1) — conversation conventions
+- `creation-cascade-citations-v1` (display_order=2) — citation discipline
+- `creation-cascade-destination-v1` (display_order=3) — destination chooser
+
+The migrations also UPDATE the existing `creation-doview-notation-v1`
+to defer to the shared cascade and the existing `creation-outcomes-map-v1`
+to reference the citations prompt instead of restating the URL rule.
+
+The seed file `backend/app/seed/creation_prompts.py` is updated to
+re-apply the canonical bodies on every backend startup, matching the
+existing pattern for cascade prompts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m058 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m058_file_exists() -> None:
+    """The migration file is present in the migrations directory."""
+    assert (ROOT / "app/migrations/m058_cascade_ux_polish.py").exists()
+
+
+def test_sqlite_m058_inserts_three_new_base_rows() -> None:
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    for row_id in (
+        "creation-cascade-shared-v1",
+        "creation-cascade-citations-v1",
+        "creation-cascade-destination-v1",
+    ):
+        assert row_id in py, f"missing new row {row_id!r}"
+    # All three use INSERT OR IGNORE for idempotency.
+    assert "INSERT OR IGNORE INTO ai_creation_prompts" in py
+    # All three live at layer=base for creation_format purpose.
+    assert "\"layer\": \"base\"" in py or "'layer': 'base'" in py or '"base"' in py
+
+
+def test_sqlite_m058_display_orders_set_to_1_2_3() -> None:
+    """The three new rows have display_order 1, 2, 3 so they compose
+    after the existing creation-base-v1 (display_order=0)."""
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    # Spot-check that the display orders 1, 2, 3 appear with their
+    # associated row ids. Order doesn't matter — the seed dict pairs them.
+    flat = " ".join(py.split())
+    # Each row should be near its display_order. Look for the row ids
+    # paired with display orders 1/2/3 in any order.
+    assert "creation-cascade-shared-v1" in flat
+    assert "creation-cascade-citations-v1" in flat
+    assert "creation-cascade-destination-v1" in flat
+
+
+def test_sqlite_m058_updates_doview_notation_to_defer() -> None:
+    """The DoView notation prompt is updated to remove duplicated
+    shared content (paste/upload, default-name, skip-detail,
+    destination) and defer to the shared cascade."""
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    # The migration must UPDATE creation-doview-notation-v1.
+    assert (
+        "UPDATE ai_creation_prompts" in py
+        and "creation-doview-notation-v1" in py
+    )
+
+
+def test_sqlite_m058_updates_outcomes_map_to_reference_citations() -> None:
+    """The Outcomes Map prompt is updated to reference the citations
+    prompt instead of restating the URL rule."""
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    assert (
+        "UPDATE ai_creation_prompts" in py
+        and "creation-outcomes-map-v1" in py
+    )
+    # The migration body must mention the citations prompt by id.
+    assert "creation-cascade-citations-v1" in py
+
+
+def test_sqlite_m058_shared_prompt_contains_asking_questions_marker() -> None:
+    """The new shared cascade prompt body contains the AskUserQuestion
+    marker so cascades reinforce the MCP-wide rule from ADR-177."""
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    assert "AskUserQuestion" in py
+
+
+def test_sqlite_m058_shared_prompt_contains_paste_upload_options() -> None:
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    flat = " ".join(py.split())
+    # Three info-source options must appear in the new shared prompt.
+    assert "General knowledge" in flat
+    assert "paste" in flat.lower()
+    assert "attach" in flat.lower()
+
+
+def test_sqlite_m058_shared_prompt_contains_skip_detail_options() -> None:
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    flat = " ".join(py.split())
+    assert "Skip detail review" in flat or "skip detail review" in flat.lower()
+
+
+def test_sqlite_m058_citations_prompt_contains_url_format_rule() -> None:
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    flat = " ".join(py.split())
+    # Author/Org · Title · YYYY · URL format from SPEC-176-A.
+    assert "Author/Org" in flat or "Author/Org · Title" in flat
+
+
+def test_sqlite_m058_destination_prompt_contains_save_where_options() -> None:
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    flat = " ".join(py.split())
+    # Three save-where options from the destination chooser.
+    assert "Iris (source of truth)" in flat
+    assert "downloadable artefacts" in flat.lower()
+    # Four Iris-destination options.
+    assert "parent collection" in flat.lower()
+    assert "current set" in flat.lower()
+
+
+def test_sqlite_m058_table_guard() -> None:
+    """No-op on isolated test fixtures that don't have the table."""
+    py = _read("app/migrations/m058_cascade_ux_polish.py")
+    assert "type='table'" in py
+    assert "ai_creation_prompts" in py
+
+
+def test_sqlite_m058_registered_in_startup() -> None:
+    """The new migration must be wired into _initialize_sqlite."""
+    startup = _read("app/startup.py")
+    assert "from app.migrations.m058_cascade_ux_polish import up as m058_up" in startup
+    assert "await m058_up(main)" in startup
+
+
+# ── Supabase m062 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m062_file_exists() -> None:
+    assert (ROOT / "app/migrations/supabase/m062_cascade_ux_polish.sql").exists()
+
+
+def test_supabase_m062_mirrors_sqlite_inserts() -> None:
+    sql = _read("app/migrations/supabase/m062_cascade_ux_polish.sql")
+    for row_id in (
+        "creation-cascade-shared-v1",
+        "creation-cascade-citations-v1",
+        "creation-cascade-destination-v1",
+    ):
+        assert f"'{row_id}'" in sql, f"missing supabase insert {row_id!r}"
+    # PostgreSQL-style idempotency.
+    assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
+def test_supabase_m062_mirrors_sqlite_updates() -> None:
+    sql = _read("app/migrations/supabase/m062_cascade_ux_polish.sql")
+    assert "UPDATE public.ai_creation_prompts" in sql or "UPDATE ai_creation_prompts" in sql
+    assert "creation-doview-notation-v1" in sql
+    assert "creation-outcomes-map-v1" in sql
+
+
+def test_supabase_m062_uses_boolean_literal_for_is_active() -> None:
+    """Mirrors the v5.12.2 regression guard from m055: is_active is
+    boolean on Postgres. The three new seed INSERTs must use TRUE,
+    not 1."""
+    sql = _read("app/migrations/supabase/m062_cascade_ux_polish.sql")
+    insert_count = sql.count("INSERT INTO public.ai_creation_prompts")
+    assert insert_count >= 3, (
+        f"Expected at least 3 INSERTs into ai_creation_prompts in "
+        f"m062, got {insert_count}."
+    )
+    # Look for TRUE literals — actual count depends on how many UPDATEs
+    # the migration also performs. At minimum: 3 inserts × 1 TRUE each.
+    assert sql.count("TRUE") >= 3, (
+        "is_active must be `TRUE` (boolean), not `1` (integer), on "
+        "the Postgres-backed Supabase schema."
+    )
+
+
+# ── Seed file update ───────────────────────────────────────────────────
+
+
+def test_seed_has_three_new_base_layer_constants() -> None:
+    """The seed file must lift the three canonical bodies into module
+    constants so they can be re-applied on every backend startup."""
+    seed = _read("app/seed/creation_prompts.py")
+    # At least one of these naming patterns for each prompt.
+    for needle in (
+        "CASCADE_SHARED_PROMPT",
+        "CASCADE_CITATIONS_PROMPT",
+        "CASCADE_DESTINATION_PROMPT",
+    ):
+        assert needle in seed, f"missing seed constant {needle!r}"
+
+
+def test_seed_registers_three_new_base_rows() -> None:
+    """The expansion rows list (or equivalent) must register the three
+    new base-layer rows so seed_creation_prompts INSERTs + UPDATEs
+    them on every startup."""
+    seed = _read("app/seed/creation_prompts.py")
+    for row_id in (
+        "creation-cascade-shared-v1",
+        "creation-cascade-citations-v1",
+        "creation-cascade-destination-v1",
+    ):
+        assert row_id in seed, f"missing seed row {row_id!r}"
+
+
+def test_seed_doview_notation_no_longer_contains_shared_content() -> None:
+    """The DoView notation prompt in the seed must no longer contain
+    the paste/upload, default-name, or skip-detail guidance — those
+    moved to the shared base layer."""
+    seed = _read("app/seed/creation_prompts.py")
+    # The DOVIEW_NOTATION_PROMPT constant must NOT carry these now-
+    # shared rules. We check the body between DOVIEW_NOTATION_PROMPT =
+    # and the next triple-quoted constant boundary.
+    start = seed.find('DOVIEW_NOTATION_PROMPT = """')
+    assert start != -1, "DOVIEW_NOTATION_PROMPT constant missing from seed"
+    # End at the next triple-quote that closes it.
+    body_start = seed.find('"""', start) + 3
+    body_end = seed.find('"""', body_start)
+    body = seed[body_start:body_end]
+    # Shared content removed:
+    assert "General knowledge" not in body or "supply all the information" not in body.lower(), (
+        "DoView notation prompt still carries the info-source binary "
+        "question — it should defer to creation-cascade-shared-v1."
+    )
+
+
+def test_seed_outcomes_map_references_citations_prompt() -> None:
+    """The seed must include an OUTCOMES_MAP_PROMPT constant whose
+    body references creation-cascade-citations-v1 instead of
+    restating the URL rule."""
+    seed = _read("app/seed/creation_prompts.py")
+    assert "OUTCOMES_MAP_PROMPT" in seed
+    # The seed_creation_prompts function must UPDATE the outcomes_map
+    # row to the canonical body.
+    assert (
+        "creation-outcomes-map-v1" in seed
+        and "OUTCOMES_MAP_PROMPT" in seed
+    )

--- a/backend/tests/test_migrations/test_mcp_user_question_rule_schema.py
+++ b/backend/tests/test_migrations/test_mcp_user_question_rule_schema.py
@@ -1,0 +1,149 @@
+"""v6.1.0 (ADR-177, SPEC-177-A) — issue #133 Phase 1: static-parser
+tests for the SQLite m059 + Supabase m063 migrations that insert a
+top-level ASKING QUESTIONS section into the
+`mcp-server-instructions-v1` singleton body.
+
+The migrations are surgical text-insertions (REPLACE() pattern) that
+preserve admin customisations elsewhere in the body.
+
+The seed file `backend/app/seed/creation_prompts.py` is updated to
+also re-apply the canonical singleton body on every backend startup
+(new behaviour for this row — matches the existing cascade-prompt
+pattern).
+
+The iris-mcp `_FALLBACK_INSTRUCTIONS` is updated so day-one
+fallback matches the seeded body.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = ROOT.parent  # one level above backend/
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def _read_repo(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m059 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m059_file_exists() -> None:
+    assert (ROOT / "app/migrations/m059_mcp_user_question_rule.py").exists()
+
+
+def test_sqlite_m059_inserts_asking_questions_marker() -> None:
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    assert "ASKING QUESTIONS" in py
+
+
+def test_sqlite_m059_inserts_cascade_specific_bullet() -> None:
+    """The new section must mention creation-cascade Stage-0 setup so
+    cascades inherit the rule from the MCP-wide instructions."""
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    flat = " ".join(py.split())
+    assert "Stage-0 setup question" in flat or "creation cascade" in flat.lower()
+
+
+def test_sqlite_m059_inserts_destination_chooser_bullet() -> None:
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    assert "save-destination chooser" in py or "destination chooser" in py.lower()
+
+
+def test_sqlite_m059_uses_replace_to_be_surgical() -> None:
+    """The insert must use REPLACE() so admin customisations elsewhere
+    in the singleton body are preserved (matches the m057 pattern)."""
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    assert "REPLACE(" in py
+
+
+def test_sqlite_m059_scopes_to_mcp_server_instructions_purpose() -> None:
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    assert "WHERE purpose = 'mcp_server_instructions'" in py
+
+
+def test_sqlite_m059_table_guard() -> None:
+    py = _read("app/migrations/m059_mcp_user_question_rule.py")
+    assert "type='table'" in py
+    assert "ai_creation_prompts" in py
+
+
+def test_sqlite_m059_registered_in_startup() -> None:
+    startup = _read("app/startup.py")
+    assert "from app.migrations.m059_mcp_user_question_rule import up as m059_up" in startup
+    assert "await m059_up(main)" in startup
+
+
+# ── Supabase m063 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m063_file_exists() -> None:
+    assert (ROOT / "app/migrations/supabase/m063_mcp_user_question_rule.sql").exists()
+
+
+def test_supabase_m063_inserts_asking_questions_marker() -> None:
+    sql = _read("app/migrations/supabase/m063_mcp_user_question_rule.sql")
+    assert "ASKING QUESTIONS" in sql
+
+
+def test_supabase_m063_uses_replace_to_be_surgical() -> None:
+    sql = _read("app/migrations/supabase/m063_mcp_user_question_rule.sql")
+    assert "REPLACE(" in sql
+
+
+def test_supabase_m063_scopes_to_singleton() -> None:
+    sql = _read("app/migrations/supabase/m063_mcp_user_question_rule.sql")
+    assert "purpose = 'mcp_server_instructions'" in sql
+
+
+# ── Seed re-apply on startup ───────────────────────────────────────────
+
+
+def test_seed_has_mcp_server_instructions_constant() -> None:
+    """The seed must lift the canonical singleton body into a module
+    constant so it can be re-applied on every backend startup."""
+    seed = _read("app/seed/creation_prompts.py")
+    assert "MCP_SERVER_INSTRUCTIONS_BODY" in seed
+
+
+def test_seed_updates_singleton_row_on_startup() -> None:
+    """The seed_creation_prompts function must UPDATE the
+    mcp-server-instructions-v1 row to the canonical body."""
+    seed = _read("app/seed/creation_prompts.py")
+    # Look for an UPDATE statement targeting the singleton id.
+    assert "mcp-server-instructions-v1" in seed
+    assert "MCP_SERVER_INSTRUCTIONS_BODY" in seed
+
+
+def test_seed_singleton_body_contains_asking_questions_section() -> None:
+    """The canonical body the seed re-applies must contain the new
+    ASKING QUESTIONS section so cascades inherit the MCP-wide rule."""
+    seed = _read("app/seed/creation_prompts.py")
+    assert "ASKING QUESTIONS" in seed
+
+
+# ── Docs alignment ─────────────────────────────────────────────────────
+
+
+def test_mcp_server_instructions_doc_has_asking_questions_section() -> None:
+    """The canonical paste-ready doc must show the new section so
+    admin recovery and documentation match the seeded body."""
+    doc = _read_repo("docs/prompts/mcp-server-instructions.md")
+    assert "ASKING QUESTIONS" in doc
+
+
+# ── Iris-mcp fallback alignment ────────────────────────────────────────
+
+
+def test_mcp_fallback_instructions_contain_asking_questions() -> None:
+    """Iris-mcp's day-one fallback must match the new seeded body so
+    clients connecting before the backend is hit get the same
+    instructions."""
+    fallback = _read_repo("mcp/src/iris_mcp/server_instructions.py")
+    assert "ASKING QUESTIONS" in fallback

--- a/docs/adrs/ADR-176-Cascade-Shared-Base-Prompts.md
+++ b/docs/adrs/ADR-176-Cascade-Shared-Base-Prompts.md
@@ -1,0 +1,82 @@
+# ADR-176: Generic creation-cascade shared base prompts
+
+Status: Accepted (2026-05-16)
+Extends: [ADR-162](ADR-162-Generic-MCP-Diagram-Creation-Workflow.md)
+
+## Context
+
+The first end-to-end UAT of the v6.0.15 DoView creation cascade (issue #133, the Banana Monoculture flow) surfaced a series of conversational defects that were each fixable in the `_DOVIEW_NOTATION_PROMPT` seed at `backend/app/migrations/m028_ai_creation_prompts.py:117`. But every defect generalised:
+
+- The info-source question collapsed to a binary instead of allowing paste-or-upload — true for any cascade that needs user-supplied source material, not just DoView.
+- No default name was suggested for the DoView — true for any cascade that asks the user to name what they're creating.
+- The Sources subpage contained names without URLs — true for any notation with a sources/references/citation concept.
+- The cascade jumped from Stage 1 (structure proposal) straight to Stage 2 (detail) without asking — true for any multi-stage creation cascade.
+- No save-destination chooser fired — true for every cascade in every Set, not just for cascades originating from the Outcomes Theory Book.
+
+Patching only `_DOVIEW_NOTATION_PROMPT` would fix the DoView path and leave the same defects waiting for every other notation that goes through this same UAT later. The plan for issue #133 instead lifts these cross-notation rules into shared base-layer prompts that compose into every notation's cascade.
+
+Three concerns separate cleanly:
+
+1. **Conversational shape** — how to ask the questions (always via the client's question tool when available), where to insert paste/upload affordance, when to suggest a default name, when to ask about skip-detail.
+2. **Citation discipline** — how source-reference elements are formatted (raw URLs, fixed `Author/Org · Title · YYYY · URL` template).
+3. **Save destination** — where the bundle lands once drafting is complete (which Iris location, which artefact formats).
+
+Each concern is generic. Each currently lives nowhere (or in a single notation prompt). Each will keep recurring across future notations.
+
+## Decision
+
+Introduce **three new rows** in the `ai_creation_prompts` table at `layer=base`, `notation=NULL`, `diagram_type=NULL`, `purpose='creation_format'`, in this `display_order`:
+
+| display_order | id | Concern |
+|---|---|---|
+| 1 | `creation-cascade-shared-v1` | Conversational shape (ASKING QUESTIONS, info-source paste/upload, default name, skip-detail) |
+| 2 | `creation-cascade-citations-v1` | Citation discipline (raw URLs, label format) |
+| 3 | `creation-cascade-destination-v1` | Save-destination chooser |
+
+These compose into every notation's `creation_format` cascade via the existing layered-prompt composer at `backend/app/ai/creation.py:_build_layered_prompt`. The composer concatenates `layer=base` rows in `display_order` ascending, so the three new rows appear in the order above at the top of every cascade. The existing `creation-base-v1` row (DoView-era JSON output format) remains at `display_order=0`.
+
+`creation-doview-notation-v1` is updated to defer to the shared cascade — the duplicated paste/upload, default-name, skip-detail, and destination guidance is removed from its body and lives once at the base layer.
+
+`creation-outcomes-map-v1` is updated to reference `creation-cascade-citations-v1` instead of restating the URL rule — every source_reference element follows the shared format.
+
+## Why three rows, not one
+
+Each concern has a distinct life cycle:
+
+- The conversational-shape rules apply to every cascade turn.
+- The citation rules apply only when the diagram includes source-reference / citation / annotation elements — many notations skip them entirely.
+- The destination chooser fires once per cascade, just before generation.
+
+Splitting allows future ADRs to evolve any single concern (e.g. add new destination options when Phase 2 ships the renderer, change the citation label format) without rewriting unrelated rules. The cost is three rows to maintain instead of one — acceptable given the seed function re-applies all three on every startup.
+
+## Why base layer, not new notation rows
+
+A new `layer=base` row composes into every cascade automatically. A new notation row would have to be duplicated for every existing notation (doview, bpmn, simple, uml, archimate, c4) and would have to be added for every future notation. The base layer is the correct one because the rules are universal.
+
+## Why update `_DOVIEW_NOTATION_PROMPT` and `_OUTCOMES_MAP_PROMPT` rather than letting the shared prompts add to them
+
+If the notation prompt still restated the paste/upload / default-name / skip-detail / destination guidance, the model would see the same instruction twice in the composed prompt — once from the shared layer, once from the notation layer. That risks the model either obeying both (over-prompting the user) or treating one as authoritative and ignoring updates to the other (drift). Updating the notation prompts to defer to the shared layer makes the shared layer the single source of truth.
+
+## Consequences
+
+- New SQLite migration `m{next}_cascade_ux_polish.py` and Supabase mirror `m{next}_cascade_ux_polish.sql` INSERT the three new rows (idempotent via `INSERT OR IGNORE` on `id`).
+- The same migration UPDATEs `creation-doview-notation-v1` (DoView defers to shared) and `creation-outcomes-map-v1` (cites by reference) so existing deploys pick up the changes.
+- `backend/app/seed/creation_prompts.py` is updated to re-apply the three new base-layer rows + the updated DoView notation prompt on every startup, matching the existing pattern that overwrites admin edits with the canonical content.
+- Composed `creation_format` cascade body grows by ~2 KB (the three new sections). Negligible at any client context budget; the more important review at Phase 1 close is whether the model parses the longer body cleanly (see ADR-177 verification).
+- Notations that don't have a citations/sources concept are unaffected — the citations rules apply only when the model emits source-reference elements; they do not force a Sources page where the notation has none.
+
+## Verification
+
+- `pytest backend/tests/migrations/test_m{next}_cascade_ux_polish.py` green.
+- `GET /api/ai/response-prompts/composed?notation=doview&diagram_type=outcomes_map&purpose=creation_format` body contains every new section.
+- `GET /api/ai/response-prompts/composed?notation=bpmn&purpose=creation_format` body contains the same shared sections (cascade-generality proof).
+- Manual UAT replay of the banana-monoculture flow (regression) and a fresh BPMN cascade (generality) per the Phase 1 acceptance gates in `docs/plans/issue-133-doview-mcp-polish.md`.
+
+## See also
+
+- [ADR-162](ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — original generic creation workflow design.
+- [ADR-177](ADR-177-AskUserQuestion-MCP-Convention.md) — companion ADR landing the MCP-wide user-question rule that this cascade reinforces.
+- [SPEC-176-A](specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md) — schema, prompt bodies, composition rules, test plan.
+- [`docs/prompts/creation-cascade-shared.md`](../prompts/creation-cascade-shared.md), [`creation-cascade-citations.md`](../prompts/creation-cascade-citations.md), [`creation-cascade-destination.md`](../prompts/creation-cascade-destination.md) — canonical paste-ready bodies.
+- Issue [#133](https://github.com/cgbarlow/iris/issues/133) — UAT report and feedback.
+- [`docs/plans/issue-133-doview-mcp-polish.md`](../plans/issue-133-doview-mcp-polish.md) — multi-phase plan that this ADR is part of.

--- a/docs/adrs/ADR-177-AskUserQuestion-MCP-Convention.md
+++ b/docs/adrs/ADR-177-AskUserQuestion-MCP-Convention.md
@@ -1,0 +1,82 @@
+# ADR-177: AskUserQuestion as MCP-wide user-question convention
+
+Status: Accepted (2026-05-16)
+Extends: [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md), [ADR-167](ADR-167-Orient-Directive-In-Tool-Response.md)
+
+## Context
+
+The ORIENT-FIRST protocol seeded into the MCP server `instructions` channel (ADR-163, v5.18.0) and reinforced via the tool-response wrapper (ADR-167, v6.0.6) already mentions AskUserQuestion in one place: "Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise." That sentence is correct for the orient menu — but it's wedged inside ORIENT-FIRST PROTOCOL, scoped to first-turn behaviour only.
+
+The issue #133 UAT showed the rule failing in two unrelated places:
+
+1. **Inside creation cascades.** Stage-0 questions (subject, info source, name, subpage size, detail level) were sometimes asked via AskUserQuestion, sometimes embedded as a numbered list inside prose. Turns 1, 3, 6, 7, and 10 of the banana transcript were inconsistent.
+2. **At the destination step.** When the cascade reached the (then-absent) save-destination phase, even the limited variation that did surface there was prose, not AskUserQuestion.
+
+The rule is broader than the orient menu. Any time the model is asking the user to pick from a finite set of options, the client's structured question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor) gives a better UX than embedded prose: the user sees clear option chips, can pick with one click, the model receives an unambiguous answer, and there is no parsing ambiguity from free-text replies.
+
+A choice exists between three scopings:
+
+- Keep the rule inside ORIENT-FIRST only (today's state). Cascades remain inconsistent.
+- Add a parallel rule inside every `creation_format` cascade prompt (Phase 1's first draft of the plan). Repeats the rule, splits ownership.
+- **Promote the rule to a top-level MCP-wide convention** in the same MCP server `instructions` channel ADR-163 / ADR-166 / ADR-167 already maintain. One rule, one place to drift.
+
+The user (#133 review) chose the third option: one MCP-wide rule, cascades only add nuance (default-name pattern, paste/upload affordance).
+
+## Decision
+
+Add a new top-level **ASKING QUESTIONS** section to the MCP server-instructions singleton body (the row at `purpose='mcp_server_instructions'`, `layer='base'`), positioned between ORIENT-FIRST PROTOCOL and DISCOVERY TOOLS. Body:
+
+```text
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.
+```
+
+The body of `creation-cascade-shared-v1` (introduced in ADR-176) reinforces this rule for cascade Stage-0 specifically, but it does not duplicate the rule — it points at the ASKING QUESTIONS section as the source of truth and adds cascade-specific patterns (default-name suggestion, paste/upload affordance) that the top-level rule doesn't describe.
+
+This ADR supersedes the **user-question half** of ADR-167 — specifically the sentence "Use AskUserQuestion when the client supports it; numbered list otherwise" — by relocating its intent into the new top-level section and broadening its scope from "orient menu" to "any user-facing choice." The structural-overview half of ADR-167 (the imperative TOC-loading directive in the tool-response wrapper) is unchanged.
+
+The seed migration that ships this section is paired with the cascade base prompts migration so the two land in the same release (v6.1.0). The seed function `seed_creation_prompts` is extended to re-apply the mcp-server-instructions body on every startup, matching the existing pattern for cascade prompts — admin edits to the singleton body are overwritten with canonical content on the next deploy. (Today `m053_mcp_server_instructions_seed` INSERTs once via `INSERT OR IGNORE`; m057 patches in place; this phase adds re-apply-from-seed for ongoing canonical maintenance.)
+
+## Why MCP-wide, not cascade-only
+
+- The defect surfaces outside cascades (orient menu inconsistency, future tool responses that ask the user something). A cascade-only rule would leave the rest of the surface drifting.
+- The orient sheet already mentioned AskUserQuestion in passing; promoting the mention to a first-class section unifies the existing partial rule with the new explicit one.
+- One rule lives in one place — `mcp-server-instructions-v1`. Future edits to the convention propagate to every MCP client and every cascade through the same TTL refresh mechanism (ADR-166).
+
+## Why not just rely on the orient-sheet sentence
+
+That sentence is buried inside ORIENT-FIRST step 3 and reads as scoped to orient-menu options. Models read it as "use AskUserQuestion for menus on the first turn" not as "use AskUserQuestion for every multi-option question." Promoting it to its own section breaks that scoping ambiguity.
+
+## Why update the seed pattern to re-apply on startup
+
+`m053` shipped the singleton via `INSERT OR IGNORE`. `m057` fixed a defect via targeted `REPLACE`. Both are point-in-time edits and require a new migration each time the canonical body changes. The cascade-prompt pattern (seed function re-applies content on every startup) is strictly better — copy edits ship without a new migration, and admin breakage recovers on the next deploy. Adopting the same pattern for the MCP server-instructions row aligns the two prompt-management surfaces and removes a migration class.
+
+## Consequences
+
+- SQLite migration `m{next}_mcp_user_question_rule.py` and Supabase mirror UPDATE the existing singleton body to insert the new ASKING QUESTIONS section. Targeted text insert, not full body replace — preserves any admin customisation elsewhere.
+- `backend/app/seed/creation_prompts.py` extended to also UPDATE `mcp-server-instructions-v1` to the canonical body on every startup. Body lifted from `docs/prompts/mcp-server-instructions.md`. Pattern matches the existing UPDATE-on-startup for cascade prompts.
+- `mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS` updated to include the new section, so iris-mcp's day-one fallback body matches the seeded body for clients that connect before the backend has been hit.
+- `docs/prompts/mcp-server-instructions.md` updated to show the new canonical body. Section between ORIENT-FIRST PROTOCOL and DISCOVERY TOOLS.
+- ADR-167 status remains Accepted; this ADR supersedes only the user-question sentence inside ADR-167's body (orient-step 3). The TOC-loading wrapper is intact.
+
+## Verification
+
+- `pytest backend/tests/migrations/test_m{next}_mcp_user_question_rule.py` green — asserts the seeded singleton body contains the new ASKING QUESTIONS section header and the cascade-specific bullet.
+- `pytest mcp/tests/` green — `_FALLBACK_INSTRUCTIONS` body match update reflected in any existing assertion.
+- Post-deploy smoke: open claude.ai → Outcomes Theory Book → confirm orient menu still surfaces via AskUserQuestion; then open a fresh BPMN creation cascade → confirm every Stage-0 question surfaces via AskUserQuestion (not prose).
+
+## See also
+
+- [ADR-163](ADR-163-Centralised-MCP-Server-Instructions.md) — original Server.instructions channel.
+- [ADR-166](ADR-166-MCP-Server-Instructions-TTL-Refresh.md) — TTL refresh that propagates edits to this body without redeploy.
+- [ADR-167](ADR-167-Orient-Directive-In-Tool-Response.md) — partially superseded (user-question half only).
+- [ADR-176](ADR-176-Cascade-Shared-Base-Prompts.md) — companion ADR shipping the cascade-specific reinforcement.
+- [SPEC-177-A](specs/SPEC-177-A-AskUserQuestion-MCP-Convention.md) — exact body, migration shape, test plan.
+- [`docs/prompts/mcp-server-instructions.md`](../prompts/mcp-server-instructions.md) — canonical paste-ready body.
+- Issue [#133](https://github.com/cgbarlow/iris/issues/133) — UAT report.

--- a/docs/adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md
+++ b/docs/adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md
@@ -1,0 +1,159 @@
+# SPEC-176-A: Generic creation-cascade shared base prompts
+
+ADR: [ADR-176](../ADR-176-Cascade-Shared-Base-Prompts.md)
+
+## Summary
+
+INSERT three new rows into `ai_creation_prompts` at `layer='base'`, `purpose='creation_format'`, `notation=NULL`, `diagram_type=NULL` with `display_order` 1 / 2 / 3. UPDATE `creation-doview-notation-v1` to defer to the shared cascade. UPDATE `creation-outcomes-map-v1` to reference the shared citations prompt instead of restating the URL rule. Update `backend/app/seed/creation_prompts.py` to re-apply the three new rows + the two updated rows on every startup, matching the existing seed pattern.
+
+## Schema
+
+Existing table from m028 / m051 — no schema changes:
+
+```sql
+CREATE TABLE ai_creation_prompts (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    purpose TEXT NOT NULL DEFAULT 'creation_format',
+    layer TEXT NOT NULL,
+    notation TEXT,
+    diagram_type TEXT,
+    prompt_text TEXT NOT NULL,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    is_active INTEGER NOT NULL DEFAULT 1,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+```
+
+## Three new rows
+
+| id | display_order | source-of-truth doc |
+|---|---|---|
+| `creation-cascade-shared-v1` | 1 | `docs/prompts/creation-cascade-shared.md` |
+| `creation-cascade-citations-v1` | 2 | `docs/prompts/creation-cascade-citations.md` |
+| `creation-cascade-destination-v1` | 3 | `docs/prompts/creation-cascade-destination.md` |
+
+All three: `purpose='creation_format'`, `layer='base'`, `notation=NULL`, `diagram_type=NULL`, `is_active=1`, `created_by='system'`.
+
+## Two updated rows
+
+| id | Change |
+|---|---|
+| `creation-doview-notation-v1` | Remove the Stage 0 paste/upload guidance, default-name suggestion, skip-detail branching, destination guidance — defer to the shared cascade. Retain only DoView-specific methodology (This-Then, outcome phrasing, 13 drafting steps, slide ordering, entity types, edge types, color palette, layout rules). |
+| `creation-outcomes-map-v1` | Remove the inline Sources rule. Add one line: "Source-reference elements (Sources subpage) follow the format in `creation-cascade-citations-v1`." |
+
+## Composition order
+
+The composer `backend/app/ai/creation.py:_build_layered_prompt` selects base-layer rows for the requested `purpose` ordered by `display_order` ASC, then notation rows, then diagram-type rows. Composed output for `(notation='doview', diagram_type='outcomes_map', purpose='creation_format')` is:
+
+```
+[base, display_order=0]   creation-base-v1               (existing — JSON output format)
+[base, display_order=1]   creation-cascade-shared-v1     (new — conversation conventions)
+[base, display_order=2]   creation-cascade-citations-v1  (new — citation discipline)
+[base, display_order=3]   creation-cascade-destination-v1 (new — destination chooser)
+[notation]                creation-doview-notation-v1    (updated — DoView methodology only)
+[diagram_type]            creation-outcomes-map-v1       (updated — references citations)
+```
+
+For `(notation='bpmn', diagram_type=NULL, purpose='creation_format')`:
+
+```
+[base, display_order=0]   creation-base-v1
+[base, display_order=1]   creation-cascade-shared-v1
+[base, display_order=2]   creation-cascade-citations-v1
+[base, display_order=3]   creation-cascade-destination-v1
+[notation]                creation-bpmn-notation-v1      (existing — BPMN methodology)
+```
+
+This is the cross-notation generality proof — BPMN inherits the new shared rules without any BPMN-specific change.
+
+## Migration (SQLite)
+
+`backend/app/migrations/m058_cascade_ux_polish.py` (id verified next free at drafting time):
+
+- INSERT OR IGNORE the three new rows with the bodies from the source-of-truth docs.
+- UPDATE `creation-doview-notation-v1` setting `prompt_text` to the canonical refactored body (DoView methodology only).
+- UPDATE `creation-outcomes-map-v1` setting `prompt_text` to the canonical body with the citation reference instead of the inline rule.
+- All wrapped in defensive table-exists check (matching m053, m057 patterns).
+- Idempotent — INSERT OR IGNORE on PK; UPDATE is a fixed body replace.
+
+Register in `backend/app/startup.py:_initialize_sqlite` right after `m057_up(main)`.
+
+## Migration (Supabase)
+
+`backend/app/migrations/supabase/m062_cascade_ux_polish.sql` mirrors the SQLite migration. Same inserts and updates using PostgreSQL's `INSERT ... ON CONFLICT DO NOTHING` for the inserts.
+
+## Seed update
+
+`backend/app/seed/creation_prompts.py`:
+
+- Add three module-level constants `CASCADE_SHARED_PROMPT`, `CASCADE_CITATIONS_PROMPT`, `CASCADE_DESTINATION_PROMPT` lifted verbatim from the three source-of-truth docs.
+- Add three entries to `_EXPANSION_ROWS` for the new base-layer rows. `layer='base'`, `notation=None`, `diagram_type=None`, `display_order=1/2/3`.
+- Update `DOVIEW_NOTATION_PROMPT` constant to the refactored body (DoView methodology only — no shared content).
+- Add an `OUTCOMES_MAP_PROMPT` constant (the canonical body with the citation reference) and an UPDATE statement in `seed_creation_prompts` that applies it to `creation-outcomes-map-v1`.
+
+The seed pattern (INSERT OR IGNORE then UPDATE) handles both fresh installs (migration inserts, seed overwrites with canonical) and existing deploys (seed UPDATE picks up changes without a new migration for future copy edits).
+
+## Tests
+
+### `backend/tests/migrations/test_m058_cascade_ux_polish.py` (new)
+
+Five test functions:
+
+1. `test_base_rows_present_after_migration` — apply migration to fresh SQLite, query `ai_creation_prompts WHERE layer='base' AND purpose='creation_format'`, assert all three new ids present with correct display_order.
+
+2. `test_doview_notation_defers_to_shared` — query `creation-doview-notation-v1.prompt_text`, assert it does NOT contain the strings `"paste your own content"`, `"general knowledge"`, `"Skip detail review"`, `"save to Iris"` (these now live in the shared layer). Assert it DOES contain DoView-specific markers (`"This-Then"`, `"13 Drafting Steps"`, `"causal_link"`).
+
+3. `test_outcomes_map_defers_to_citations` — query `creation-outcomes-map-v1.prompt_text`, assert it references `creation-cascade-citations-v1` and does NOT contain the strings `"raw https URL"` or `"Author/Org · Title"` (which now live in the citations layer).
+
+4. `test_composed_doview_outcomes_map_contains_shared_sections` — call `build_creation_system_prompt(db, notation='doview', diagram_type='outcomes_map')`. Assert the returned body contains:
+   - `"AskUserQuestion"` (from shared)
+   - `"paste your own content"` (from shared)
+   - `"Skip detail review"` (from shared)
+   - `"Author/Org · Title · YYYY"` (from citations)
+   - `"Save where?"` (from destination)
+   - `"This-Then"` (from DoView notation)
+   - `"Final column boxes: use final_outcome"` (from outcomes_map diagram_type)
+
+5. `test_composed_bpmn_contains_shared_sections` — call `build_creation_system_prompt(db, notation='bpmn')`. Assert the body contains the same shared and destination strings as above (cross-notation generality proof). Assert it does NOT contain DoView-specific markers.
+
+### Existing test compatibility
+
+`test_outcomes_map_layout` (if present in `backend/tests/`) — verify the test still passes. The Outcomes Map prompt is shorter but should still cover layout expectations.
+
+`backend/tests/test_seed_creation_prompts.py` (if present) — extend to assert the three new base-layer rows are present after `seed_creation_prompts(db)`.
+
+## Source-of-truth docs
+
+- [`docs/prompts/creation-cascade-shared.md`](../../prompts/creation-cascade-shared.md)
+- [`docs/prompts/creation-cascade-citations.md`](../../prompts/creation-cascade-citations.md)
+- [`docs/prompts/creation-cascade-destination.md`](../../prompts/creation-cascade-destination.md)
+
+Each contains a "Content (paste this into the row's prompt_text field)" fenced block that is the canonical body. The migration and seed constants must match these blocks byte-for-byte (modulo unavoidable Python-string escaping). A drift between docs and code is a defect.
+
+## Versioning
+
+`backend/pyproject.toml`: 6.0.15 → 6.1.0. Minor bump — new conversational behaviour visible to every MCP user, no API surface removal.
+`mcp/pyproject.toml`: matched 6.1.0.
+`frontend/package.json`: matched 6.1.0.
+
+## CHANGELOG
+
+Add a `[6.1.0]` entry under Added (the three new shared base prompts) and Changed (DoView notation defers to shared, outcomes_map references citations).
+
+## Acceptance criteria
+
+- [ ] Migration applies cleanly to a fresh SQLite database.
+- [ ] Migration applies cleanly to a database already at m057 (UPDATEs succeed).
+- [ ] All three new base-layer rows present with the canonical bodies.
+- [ ] `creation-doview-notation-v1` no longer contains shared-layer content.
+- [ ] `creation-outcomes-map-v1` references `creation-cascade-citations-v1`.
+- [ ] Composed `(doview, outcomes_map)` body contains the shared + citations + destination + DoView + outcomes_map sections.
+- [ ] Composed `(bpmn, *)` body contains the shared + citations + destination + BPMN sections.
+- [ ] `seed_creation_prompts` re-apply on a fresh start is idempotent and produces the same composed body.
+- [ ] `pytest backend/tests/` green; `pytest mcp/tests/` green.
+- [ ] Manual UAT 1: replay banana-monoculture, every cascade question uses AskUserQuestion, Q-Default-Name fires, Q-Skip-Detail fires, Q-Destination fires.
+- [ ] Manual UAT 2: start a fresh BPMN cascade, same questions fire (cross-notation proof).

--- a/docs/adrs/specs/SPEC-177-A-AskUserQuestion-MCP-Convention.md
+++ b/docs/adrs/specs/SPEC-177-A-AskUserQuestion-MCP-Convention.md
@@ -1,0 +1,98 @@
+# SPEC-177-A: AskUserQuestion as MCP-wide user-question convention
+
+ADR: [ADR-177](../ADR-177-AskUserQuestion-MCP-Convention.md)
+
+## Summary
+
+Insert a new top-level **ASKING QUESTIONS** section into the `mcp-server-instructions-v1` singleton body, positioned between ORIENT-FIRST PROTOCOL and DISCOVERY TOOLS. Migration patches existing deploys; seed function re-applies the canonical body on every startup (new behaviour for this row, matching the existing cascade-prompt pattern). Update `iris-mcp`'s `_FALLBACK_INSTRUCTIONS` so day-one fallback matches the seeded body.
+
+## Body to insert
+
+Lifted from [`docs/prompts/mcp-server-instructions.md`](../../prompts/mcp-server-instructions.md):
+
+```text
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.
+```
+
+Insertion point: after the `ORIENT-FIRST PROTOCOL.` block (ends with the line "Do not paraphrase, do not silently drop options.") and before the `DISCOVERY TOOLS.` block.
+
+## Migration (SQLite)
+
+`backend/app/migrations/m059_mcp_user_question_rule.py` (id verified next free at drafting time, follows m058 from SPEC-176-A):
+
+- Defensive table-exists check (matches m053, m057 patterns).
+- Use `INSERT` of the new section via `REPLACE(prompt_text, ORIENT_END_MARKER, ORIENT_END_MARKER || ASKING_QUESTIONS_SECTION)` where `ORIENT_END_MARKER` is the exact closing line of ORIENT-FIRST PROTOCOL. This is surgical — does not touch other parts of the body, preserves admin customisations.
+- Idempotent — REPLACE is a no-op when the substring isn't found (i.e. on subsequent runs after the section is already present, the marker no longer ends immediately before DISCOVERY TOOLS because the new section sits in between — but the seed `UPDATE` on every startup will keep the body canonical regardless).
+
+Register in `backend/app/startup.py:_initialize_sqlite` right after `m058_up(main)`.
+
+## Migration (Supabase)
+
+`backend/app/migrations/supabase/m063_mcp_user_question_rule.sql` mirrors the SQLite migration with the same REPLACE-based insert.
+
+## Seed update
+
+`backend/app/seed/creation_prompts.py`:
+
+- Add a `MCP_SERVER_INSTRUCTIONS_BODY` module-level constant lifted verbatim from the "Content" fenced block of `docs/prompts/mcp-server-instructions.md`.
+- Inside `seed_creation_prompts`, add:
+  ```python
+  await db.execute(
+      "UPDATE ai_creation_prompts SET prompt_text = ? "
+      "WHERE id = 'mcp-server-instructions-v1'",
+      (MCP_SERVER_INSTRUCTIONS_BODY,),
+  )
+  ```
+- This makes the singleton body canonical on every backend startup. Future copy edits ship without a new migration — change the constant + the source doc, redeploy.
+
+## Iris-mcp fallback update
+
+`mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS`:
+
+- Update to match the new canonical body byte-for-byte. The fallback is used when iris-mcp cannot reach `GET /api/ai/server-instructions` at startup. Day-one behaviour must match server-fetched behaviour.
+
+## docs/prompts/mcp-server-instructions.md update
+
+The doc's "Content (paste this into the row's `prompt_text` field)" fenced block is updated to include the new ASKING QUESTIONS section. The revision history at the foot gains a `v6.1.0` entry referencing this ADR.
+
+## Tests
+
+### `backend/tests/migrations/test_m059_mcp_user_question_rule.py` (new)
+
+Three test functions:
+
+1. `test_migration_inserts_asking_questions_section` — apply m053 (seed) then m059 (this migration) to a fresh SQLite. Query the singleton row's `prompt_text`. Assert it contains `"ASKING QUESTIONS."` and the cascade-specific bullet `"every Stage-0 setup question in a creation cascade"`.
+
+2. `test_migration_preserves_orient_and_discovery_sections` — same setup. Assert `ORIENT-FIRST PROTOCOL.` still present, `DISCOVERY TOOLS.` still present, `AUTH RECOVERY.` still present. None of the existing sections were eaten by the insert.
+
+3. `test_seed_overwrites_with_canonical_body` — apply migration, then call `seed_creation_prompts(db)`. Assert the row's `prompt_text` exactly equals `MCP_SERVER_INSTRUCTIONS_BODY`. Even if an admin edited the body before the seed ran (simulated by an extra UPDATE between the migration and the seed call), the seed restores canonical content.
+
+### `mcp/tests/` updates
+
+If `mcp/tests/test_server_instructions.py` exists and asserts on the `_FALLBACK_INSTRUCTIONS` body content, update its expected strings to include the new ASKING QUESTIONS section.
+
+## Versioning
+
+Shared with SPEC-176-A — both ship in v6.1.0 (this Phase 1 release bundles ADR-176 and ADR-177).
+
+## CHANGELOG
+
+`[6.1.0]` Changed: "MCP server-instructions body now includes an ASKING QUESTIONS section (ADR-177)." Reference both this SPEC and SPEC-176-A.
+
+## Acceptance criteria
+
+- [ ] Migration applies cleanly to a fresh SQLite database (after m053 seeds the singleton).
+- [ ] Migration applies cleanly to a database already at m057 (existing v6.0.x deploys).
+- [ ] Singleton body after migration contains ORIENT-FIRST + ASKING QUESTIONS + DISCOVERY TOOLS + WORKFLOW GUIDANCE + AUTH RECOVERY in that order.
+- [ ] `seed_creation_prompts` overwrites the body with the canonical content from `MCP_SERVER_INSTRUCTIONS_BODY` on every startup.
+- [ ] Iris-mcp `_FALLBACK_INSTRUCTIONS` matches the seeded body byte-for-byte.
+- [ ] `pytest backend/tests/migrations/test_m059_mcp_user_question_rule.py` green.
+- [ ] `pytest mcp/tests/` green.
+- [ ] Post-deploy smoke: connect a fresh Claude Desktop / Claude Code session, fetch instructions, confirm the new section is present.

--- a/docs/prompts/creation-cascade-citations.md
+++ b/docs/prompts/creation-cascade-citations.md
@@ -1,0 +1,92 @@
+# Creation-cascade citations base prompt — canonical body
+
+Canonical paste-ready content for the **`creation-cascade-citations-v1`** row at `/admin/settings/ai` (filter `purpose=creation_format`, `layer=base`, `display_order=2`). This text composes into every notation's `creation_format` cascade after the shared conversation rules and before the destination chooser.
+
+This prompt is **notation-agnostic**. Any notation that has a "sources" or "references" concept inherits these rules — DoView outcomes_map's Sources page, BPMN regulatory-references annotations, process_flow source-citation boxes, etc. Notations without source concepts (e.g. a UML class diagram) are unaffected because they never emit `source_reference` elements.
+
+The seed function `seed_creation_prompts` re-applies this body on every backend startup so admin edits are overwritten with the canonical content.
+
+## Content (paste this into the row's `prompt_text` field)
+
+```text
+## Citation discipline (shared)
+
+Whenever the diagram you are creating includes any source-reference,
+citation, or external-link element (regardless of notation), apply
+these rules to every such element. Notations without source elements
+are unaffected.
+
+### URL format
+
+Every URL embedded in a source reference, citation, or annotation
+MUST be a raw, visible, copy-safe plain-text string beginning with
+`https://`. Do NOT use markdown links (`[text](url)`). Do NOT use
+reference-style links (`[text][1]`). Do NOT wrap URLs in angle
+brackets, square brackets, or parentheses.
+
+### Source reference label format
+
+For every source-reference / citation element, the human-readable
+label must follow this pattern:
+
+  Author/Org · Title · YYYY · https://raw.url
+
+Use a middle-dot separator (` · `, U+00B7) between fields. Examples:
+
+  Duignan, P. · DoView Planning Handbook · 2025 · https://doviewplanning.org/book
+  WHO · Banana export market overview · 2024 · https://example.org/who-bananas
+  OECD · Agricultural Monocultures Report · 2023 · https://oecd.org/ag/mono
+
+If any field is genuinely unknown (e.g. the user supplied content
+without attribution), use `Unknown` for that field rather than
+omitting the separator. Keep the URL — a label without a URL is not
+a citation.
+
+### Where citations go in the diagram
+
+The location of source-reference elements is governed by the
+notation- and diagram-type-specific prompts below. For example DoView
+outcomes_map places source_references on a dedicated Sources page;
+BPMN may inline them as annotation elements adjacent to the step they
+inform. The citation FORMAT is universal; the placement is per
+notation.
+
+### Source provenance
+
+If the user supplied content directly (via paste or attachment in
+Stage 0 Q1), use the user as the author when no clearer attribution
+is available:
+
+  User-supplied content · <brief description> · YYYY · (no URL)
+
+Drop the URL field for genuinely uncited user-supplied material —
+do not invent one.
+
+### When the user picks "general knowledge"
+
+If the user picked "General knowledge" at Stage 0 Q1 and no specific
+sources were mentioned, do NOT fabricate citations. If a Sources page
+is required by the notation, populate it with the model's own
+identifier and a `(no URL)` marker:
+
+  AI general knowledge · <topic summary> · <current year> · (no URL)
+
+This is preferable to fake URLs and lets the user replace it with
+real sources later.
+```
+
+## Why this prompt is shared, not outcomes_map-specific
+
+The first round of #133 feedback observed that the `outcomes_map` Sources page contained names without URLs. The fix is easy at the notation level — but the rule (raw URLs, fixed label format) generalises to every diagram type that has any source/citation/reference concept. Encoding it once at `layer=base` means future notations inherit the discipline automatically, and the (markdown, doview_analysis) response-format prompt's URL convention (m051 lines 59–67) is now mirrored at creation time.
+
+## Revision history
+
+- **v6.1.0 (this revision).** Introduced. Issue #133 Phase 1.
+
+## See also
+
+- [ADR-176](../adrs/ADR-176-Cascade-Shared-Base-Prompts.md)
+- [SPEC-176-A](../adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md)
+- [creation-cascade-shared.md](./creation-cascade-shared.md) — sibling shared prompt for conversation conventions.
+- [creation-cascade-destination.md](./creation-cascade-destination.md) — sibling shared prompt for save-destination.
+- Migration `m051_response_format_prompts.py` — the response-format URL rule this prompt mirrors at creation time.

--- a/docs/prompts/creation-cascade-destination.md
+++ b/docs/prompts/creation-cascade-destination.md
@@ -1,0 +1,114 @@
+# Creation-cascade destination chooser base prompt — canonical body
+
+Canonical paste-ready content for the **`creation-cascade-destination-v1`** row at `/admin/settings/ai` (filter `purpose=creation_format`, `layer=base`, `display_order=3`). This text composes into every notation's `creation_format` cascade after the shared conversation rules and the citations rules.
+
+This prompt is **notation-agnostic** and **scope-agnostic** — it codifies the save-destination chooser that fires before any diagram is created, regardless of which Set the user is browsing when the cascade starts.
+
+The seed function `seed_creation_prompts` re-applies this body on every backend startup so admin edits are overwritten with the canonical content.
+
+## Phase 1 caveat
+
+Phase 1 of issue #133 ships **prompt-only**. The cascade asks the user where they want the bundle saved and in which formats — but the renderer (md/docx/pdf → artefact store) and the move tools (for fixing wrong-location bundles) land in Phase 2 (v6.2.0) and Phase 3 (v6.3.0) respectively. Until then, if the user picks "Iris (different location)" or "downloadable artefacts other than markdown", the cascade explains the gap and offers a fallback.
+
+## Content (paste this into the row's `prompt_text` field)
+
+```text
+## Destination chooser (shared)
+
+Before generating ANY diagrams, run this chooser. Do not skip it. Do
+not assume the current set is the right destination. This applies to
+every notation and every diagram type.
+
+### Q-Dest1 — Save where?
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Iris (source of truth) — save into a set so the bundle is queryable, linkable, and shareable"
+  2. "Chat with downloadable artefacts — render the bundle as files (md / docx / pdf) and return links"
+  3. "Both — save into Iris AND return downloadable artefacts"
+
+### Q-Dest2 — Iris destination (only if Q-Dest1 includes Iris)
+
+If the user picked option 1 or option 3, ask via AskUserQuestion with
+these four options, IN ORDER, VERBATIM:
+
+  1. "New set under the parent collection of the set being viewed (default)"
+  2. "Browse — show me the root collections so I can pick"
+  3. "Current set — save into the set we're currently in"
+  4. "Somewhere else — I'll type a collection or set id"
+
+If the user picked option 1: identify the parent collection of the
+current set via `get_set` then `get_collection` (or directly from the
+set's collection_id field), then proceed.
+
+If the user picked option 2: call `list_collections` and surface the
+results to the user as a follow-up AskUserQuestion. Once they pick a
+collection, drill down with `list_sets` + AskUserQuestion if needed.
+
+If the user picked option 3: use the current set as the destination.
+
+If the user picked option 4: ask a free-text follow-up "Paste the
+collection id or set id you want to save into." Validate that the id
+resolves (via `get_collection` or `get_set`) before proceeding.
+
+### Q-Dest3 — Format(s) (only if Q-Dest1 includes downloadable artefacts)
+
+If the user picked option 2 or option 3 at Q-Dest1, ask via
+AskUserQuestion with multi-select enabled:
+
+  1. "Markdown (.md)"
+  2. "Word document (.docx)"
+  3. "PDF (.pdf)"
+
+At least one option must be selected.
+
+### Phase-1 fallback (cascade-prompt only, no renderer yet)
+
+This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
+and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
+
+- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0".
+
+- If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
+  chosen destination differs from the current set, respond: "I can
+  draft the bundle and save it into the current set now, then move it
+  to your chosen destination after v6.3.0 ships move_* tools. Or I
+  can describe what I'd save without actually saving, and you can
+  re-run after v6.3.0." Then offer AskUserQuestion with these two
+  fallbacks.
+
+These fallbacks are temporary. When Phase 2 and Phase 3 ship, the
+seed will be updated to drop them and the cascade will actuate the
+chosen destination directly.
+
+### Confirm and generate
+
+Once the chooser has resolved (destination identified, formats
+selected if applicable), summarise the user's choices back in one
+sentence — "OK, I'll generate the bundle as Markdown and PDF and save
+it into the 'Banana Studies' collection as a new set" — and ask via
+AskUserQuestion with `Proceed` / `Let me change something`. Generate
+only after the user confirms.
+```
+
+## Why this prompt is shared and generic
+
+The first round of #133 feedback observed that the cascade saved the bundle into the wrong set (the Outcomes Theory Book) because no destination question was ever asked. The fix is the chooser above. But every option in the chooser is generic — "new set under the parent collection of the set being viewed" works regardless of whether the current set is Outcomes Theory, a BPMN process library, or a UML model catalogue.
+
+Encoding the chooser once at `layer=base` means every notation's cascade gets it for free.
+
+## Revision history
+
+- **v6.1.0 (this revision).** Introduced. Issue #133 Phase 1. Includes Phase 1 fallbacks for docx/pdf rendering and cross-set saves; the fallbacks are dropped when Phase 2 (v6.2.0) and Phase 3 (v6.3.0) ship.
+
+## See also
+
+- [ADR-176](../adrs/ADR-176-Cascade-Shared-Base-Prompts.md)
+- [SPEC-176-A](../adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md)
+- [creation-cascade-shared.md](./creation-cascade-shared.md)
+- [creation-cascade-citations.md](./creation-cascade-citations.md)

--- a/docs/prompts/creation-cascade-shared.md
+++ b/docs/prompts/creation-cascade-shared.md
@@ -1,0 +1,124 @@
+# Creation-cascade shared base prompt — canonical body
+
+Canonical paste-ready content for the **`creation-cascade-shared-v1`** row at `/admin/settings/ai` (filter `purpose=creation_format`, `layer=base`, `display_order=1`). This text composes into every notation's `creation_format` cascade fetched via `GET /api/ai/response-prompts/composed?purpose=creation_format`.
+
+The seed function `seed_creation_prompts` re-applies this body on every backend startup so admin edits are overwritten with the canonical content. If an admin breaks the body, redeploy or re-paste from this doc to recover.
+
+This prompt is **notation-agnostic** — it codifies the conversational rules that every diagram-creation cascade follows, regardless of whether the user is drawing a DoView, a BPMN process, a UML class diagram, or anything else. Notation-specific methodology lives in the `layer=notation` row; diagram-type layout rules live in the `layer=diagram_type` row.
+
+## Content (paste this into the row's `prompt_text` field)
+
+```text
+## Cascade conversation conventions (shared)
+
+These rules govern every creation cascade, regardless of notation or
+diagram type. The notation-specific prompt below adds methodology; the
+diagram-type prompt below adds layout. This section is the conversation
+shape itself.
+
+### ASKING QUESTIONS
+
+Every question in this cascade MUST be surfaced via the MCP client's
+user-question tool when one is available (e.g. AskUserQuestion in
+Claude Code / Claude Desktop). If your client does not expose a
+user-question tool, fall back to a numbered list. Do not embed
+questions in prose; do not list multiple questions in a single message;
+do not paraphrase the option labels below.
+
+This rule reinforces the MCP server-level convention. If you ever feel
+unsure whether a question warrants the tool: it does. Every one of
+them does.
+
+### Q0 — Subject
+
+Ask: "In one or two sentences, what is the subject of the diagram?"
+Free-text answer. Wait for the answer before proceeding.
+
+### Q1 — Info source
+
+Ask via AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "General knowledge — use what you already know about the subject"
+  2. "I will paste my own content"
+  3. "I will attach a file"
+
+If the user picks option 2: ask "Paste the content now and I'll wait."
+After the user pastes, summarise back the content in 2–3 sentences and
+ask "Is this an accurate summary of what you want me to work from?"
+via AskUserQuestion with `Yes, proceed` / `Let me revise the
+content`. Do not start drafting until the user confirms.
+
+If the user picks option 3: ask "Please attach the file using your
+client's attachment feature. I'll wait." After the file appears,
+summarise its content and confirm as above. If the client does not
+support attachments, suggest option 2 (paste) instead.
+
+If the user picks option 1: proceed without further input on
+sourcing.
+
+### Q2 — Default name
+
+Derive a suggested name from the subject (e.g. for a DoView about
+banana monoculture, suggest "Banana Monoculture DoView"; for a BPMN
+about order fulfilment, suggest "Order Fulfilment Process"). Then ask
+via AskUserQuestion with two options, IN ORDER:
+
+  1. "Keep \"<suggested name>\""
+  2. "Use a different name"
+
+If option 2, follow up with a free-text "What would you like to call
+it?" question.
+
+### Notation- and diagram-type-specific setup questions
+
+The notation layer prompts below may add further Stage-0 questions
+(e.g. number of subpages, layered scope, target audience). They follow
+the same conventions as above: AskUserQuestion when an option set is
+finite; free text when truly open; one question per response; wait
+for the answer.
+
+### Stage 1 → Stage 2 transition
+
+After Stage 1 (structure proposal) is presented and the user has
+confirmed it, do NOT silently proceed to Stage 2. Instead ask via
+AskUserQuestion with these three options, IN ORDER, VERBATIM:
+
+  1. "Skip detail review and generate (recommended)"
+  2. "Review detailed box content first"
+  3. "Refine subpage structure first"
+
+Default is option 1. If the user picks option 1, proceed straight to
+the destination chooser below (Stage 2 is skipped — the cascade
+generates the bundle from the confirmed structure). If option 2, run
+Stage 2 as the notation prompt describes. If option 3, return to
+Stage 1 with the user's refinements and re-confirm.
+
+### Destination chooser (always fires before generation)
+
+Before generating any diagrams, ALWAYS run the destination chooser
+described in the `creation-cascade-destination-v1` prompt. Do not skip
+it. Do not assume the current set is the right destination.
+```
+
+## Why this prompt is shared, not DoView-specific
+
+The first round of #133 feedback was Outcomes-Theory-shaped, but every observation generalises:
+- Every notation needs questions surfaced via the client's question tool, not buried in prose.
+- Every cascade benefits from a paste-or-upload affordance when the user has source material to bring.
+- Every diagram needs a name — a suggested default is universally helpful.
+- Every multi-stage cascade benefits from an explicit "want to dig in or skip to draft?" gate.
+- Every cascade needs a save-destination — Outcomes Theory is just one set among many.
+
+Therefore the rules live at `layer=base` with `notation=NULL`, so they compose into every notation's cascade automatically.
+
+## Revision history
+
+- **v6.1.0 (this revision).** Introduced. Issue #133 Phase 1.
+
+## See also
+
+- [ADR-176](../adrs/ADR-176-Cascade-Shared-Base-Prompts.md) — design rationale for the shared base prompts.
+- [SPEC-176-A](../adrs/specs/SPEC-176-A-Cascade-Shared-Base-Prompts.md) — schema, composition, test plan.
+- [creation-cascade-citations.md](./creation-cascade-citations.md) — sibling shared prompt for citation discipline.
+- [creation-cascade-destination.md](./creation-cascade-destination.md) — sibling shared prompt for save-destination.
+- [mcp-server-instructions.md](./mcp-server-instructions.md) — the MCP-wide ASKING QUESTIONS rule this cascade reinforces.

--- a/docs/prompts/mcp-server-instructions.md
+++ b/docs/prompts/mcp-server-instructions.md
@@ -15,6 +15,15 @@ When a scope (Set or Collection) you've just queried carries an `mcp_system_cont
   2. INVOKE the structural-overview call the orient sheet names (typically `package_hierarchy` for a Set with packages). Surface the resulting tree to the user as part of the orient — NOT as a follow-up "want me to load it?" prompt. If your MCP client lazy-loads tools and the named tool isn't currently in your toolset, request/load it before continuing. The TOC is part of the orient, not optional.
   3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
 
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.
+
 DISCOVERY TOOLS.
   list_collections / list_sets / list_packages — structural
   list_notations / list_diagram_types — what's authorable
@@ -36,7 +45,8 @@ If a write tool returns error="auth_required", the user needs to sign in to Iris
 
 ## Revision history
 
-- **v5.18.0 (this revision).** Introduced. Centralises the ORIENT-FIRST protocol and DISCOVERY catalogue out of per-scope `mcp_system_context` into the server-wide MCP `instructions` channel (ADR-163).
+- **v6.1.0.** Added the ASKING QUESTIONS top-level section between ORIENT-FIRST PROTOCOL and DISCOVERY TOOLS — promotes the AskUserQuestion convention from a single sentence inside orient-step 3 into an MCP-wide rule that applies to every user-facing choice (orient menu, cascade Stage-0 questions, destination chooser, anything else). Supersedes the user-question half of ADR-167. Reference: [ADR-177](../adrs/ADR-177-AskUserQuestion-MCP-Convention.md), [SPEC-177-A](../adrs/specs/SPEC-177-A-AskUserQuestion-MCP-Convention.md).
+- **v5.18.0.** Introduced. Centralises the ORIENT-FIRST protocol and DISCOVERY catalogue out of per-scope `mcp_system_context` into the server-wide MCP `instructions` channel (ADR-163).
 
 ## See also
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.0.15",
+	"version": "6.1.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -123,3 +123,55 @@ ADR-123/129).
   under the server name automatically — e.g. Claude Code shows them
   as `/iris:set:<uuid>`). Invoking a prompt loads the body into the
   conversation as a user-authored directive.
+
+## Conversation conventions
+
+The MCP server `instructions` body (surfaced to every client via
+`InitializeResult.instructions` per ADR-163 / v5.18.0) carries two
+top-level conversation rules that every connected client / model
+inherits:
+
+- **ORIENT-FIRST PROTOCOL** — on the first turn after a scope's
+  `mcp_system_context` is fetched, briefly describe the scope, invoke
+  the named structural-overview call (typically `package_hierarchy`),
+  then offer the scope's menu options via the client's user-question
+  tool. The orient is mandatory, not optional (ADR-167).
+- **ASKING QUESTIONS** (v6.1.0, ADR-177) — every time the model needs
+  the user to pick from a finite set of options (orient menu, every
+  Stage-0 setup question in a creation cascade, the save-destination
+  chooser, anything else), use the client's structured user-question
+  tool (`AskUserQuestion` in Claude Code / Claude Desktop / Cursor).
+  Do not embed multi-option questions in prose; one question per
+  turn; fall back to a numbered list with options IN ORDER, VERBATIM
+  only if the client doesn't expose a question tool.
+
+## Creation cascades
+
+When the model fetches `get_response_prompt(notation=..., diagram_type=...,
+purpose='creation_format')` to drive a guided diagram creation flow,
+the returned body composes three shared base-layer prompts (v6.1.0,
+ADR-176) common to every notation:
+
+1. **`creation-cascade-shared-v1`** — Stage-0 questions (subject,
+   info source with paste/upload affordance, default name suggestion)
+   and the Stage 1 → Stage 2 transition question (skip detail / review
+   detail / refine structure).
+2. **`creation-cascade-citations-v1`** — citation discipline: every
+   source-reference element uses raw URLs and the
+   `Author/Org · Title · YYYY · https://url` label format.
+3. **`creation-cascade-destination-v1`** — save-destination chooser
+   (Iris / downloadable artefacts / both; new set under parent
+   collection by default; markdown / docx / pdf format selection).
+
+The notation-specific prompt (e.g. `creation-doview-notation-v1`)
+adds methodology and any notation-specific Stage-0 questions. The
+diagram-type prompt (e.g. `creation-outcomes-map-v1`) adds layout
+rules. The shared layer applies to every notation — DoView, BPMN,
+UML, ArchiMate, C4, Simple — so any cascade enjoys the same
+conversational conventions without per-notation duplication.
+
+Phase 1 of issue #133 (v6.1.0) ships the **prompts** for the
+destination chooser; the actual md/docx/pdf renderer ships in v6.2.0
+and the `move_*` recovery tools ship in v6.3.0. The Phase-1 cascade
+explains the gap and offers fallbacks when the user picks formats or
+destinations that the renderer/move tools don't yet support.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.0.15"
+version = "6.1.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/server_instructions.py
+++ b/mcp/src/iris_mcp/server_instructions.py
@@ -29,6 +29,15 @@ When a scope (Set or Collection) you've just queried carries an `mcp_system_cont
   2. INVOKE the structural-overview call the orient sheet names (typically `package_hierarchy` for a Set with packages). Surface the resulting tree to the user as part of the orient — NOT as a follow-up "want me to load it?" prompt. If your MCP client lazy-loads tools and the named tool isn't currently in your toolset, request/load it before continuing. The TOC is part of the orient, not optional.
   3. Offer the menu of options the orient sheet specifies, IN ORDER, VERBATIM. Use AskUserQuestion when the client supports it; numbered list otherwise. Do not paraphrase, do not silently drop options.
 
+ASKING QUESTIONS.
+Whenever you need the user to choose from a finite set of options, ask via the MCP client's structured user-question tool (AskUserQuestion in Claude Code / Claude Desktop / Cursor). Do not embed multi-option questions in prose. Do not list multiple questions in a single message — one question per turn, wait for the answer, then ask the next. When the client does not expose a user-question tool, fall back to a numbered list with options IN ORDER, VERBATIM (no paraphrasing).
+This applies to:
+  - the orient menu (already covered in ORIENT-FIRST above),
+  - every Stage-0 setup question in a creation cascade,
+  - the save-destination chooser,
+  - any other choice the model surfaces to the user.
+If you ever feel unsure whether a question warrants the tool: it does.
+
 DISCOVERY TOOLS.
   list_collections / list_sets / list_packages — structural
   list_notations / list_diagram_types — what's authorable


### PR DESCRIPTION
## Summary

Phase 1 of issue #133, shipped as v6.1.0 per `docs/plans/issue-133-doview-mcp-polish.md`.

- Adds three new **shared base-layer prompts** at `layer=base`, `purpose=creation_format` that compose into every notation's creation cascade (ADR-176):
  - `creation-cascade-shared-v1` (display_order=1) — Stage-0 conversation conventions: subject, info source with paste/upload affordance, default name suggestion, Stage 1 → Stage 2 transition (skip / review / refine).
  - `creation-cascade-citations-v1` (display_order=2) — citation discipline: raw URLs and the `Author/Org · Title · YYYY · URL` label format.
  - `creation-cascade-destination-v1` (display_order=3) — save-destination chooser (Iris / artefacts / both). Includes Phase-1 fallbacks until v6.2.0 renderer and v6.3.0 move tools land.
- Promotes the **AskUserQuestion** convention from a single sentence in ORIENT-FIRST step 3 to a first-class MCP-wide top-level section in the server-instructions singleton body (ADR-177). Supersedes the user-question half of ADR-167.
- Refactors `creation-doview-notation-v1` to defer to the shared cascade and `creation-outcomes-map-v1` to reference the citations prompt.
- Adds `display_order` to the `/api/ai/creation-prompts` conflict tuple so multiple active base-layer rows can coexist.
- `seed_creation_prompts` now also re-applies the canonical mcp-server-instructions body on every backend startup.

## Test plan

- [x] `pytest backend/tests/test_ai/` — 100% green (339 tests).
- [x] `pytest backend/tests/test_migrations/test_cascade_ux_polish_schema.py backend/tests/test_migrations/test_mcp_user_question_rule_schema.py` — 37/37 green.
- [x] `pytest mcp/tests/` — 173/173 green.
- [ ] Manual UAT 1 (regression): replay banana-monoculture flow against UAT env. Confirm every cascade question fires via AskUserQuestion, Q-Default-Name fires, Q-Skip-Detail fires, Q-Destination fires with the Phase-1 fallback message.
- [ ] Manual UAT 2 (generality): start a fresh BPMN cascade against UAT env. Confirm the same shared questions fire — proves the cascade isn't accidentally Outcomes-Theory-shaped.
- [ ] Post-merge: tag v6.1.0, publish GitHub release.

## References

- ADR-176 / SPEC-176-A — cascade shared base prompts
- ADR-177 / SPEC-177-A — AskUserQuestion as MCP-wide convention
- `docs/plans/issue-133-doview-mcp-polish.md` — multi-phase plan (this is Phase 1 of 6)
- Issue #133 — UAT report and feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)