### PR TITLE
feat(v6.2.0): md/docx/pdf renderer + Iris artefact store (issue #133 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2026-05-16
+
+Issue #133 Phase 2 — server-side md/docx/pdf renderer + Iris artefact
+store. The Phase-1 destination chooser cascade can now actually
+produce the downloadable artefacts it promises.
+
+### Added
+
+- **Renderer module at `backend/app/export/renderers/`** (ADR-179,
+  SPEC-179-A).
+  - `markdown.py` — passthrough + normalisation.
+  - `docx.py` — md → docx via `python-docx` + `markdown-it-py`.
+    Headings, paragraphs, bullet/number lists, code blocks, mermaid
+    blocks (verbatim passthrough), blockquotes.
+  - `pdf.py` — md → pdf via `weasyprint`. Iris-branded CSS at
+    `renderers/styles/iris.css` — system fonts, header colour
+    palette, code block styling.
+- **Artefact store at `backend/app/artefacts/`** (sibling to images,
+  not a graft).
+  - `artefacts` table — id / filename / mime / bytes / size_bytes /
+    source_kind / source_ref / created_by / created_at.
+  - Allowed mimes: text/markdown, docx, pdf. 25 MB per-row cap.
+  - Magic-byte validation for pdf (`%PDF`) and docx (`PK\x03\x04`).
+- **Backend endpoints**:
+  - `POST /api/export/diagram/{diagram_id}` body `{format}` —
+    render a diagram, store, return `ArtefactResponse` with
+    `web_url`.
+  - `POST /api/export/markdown` body `{markdown, title, format}` —
+    ad-hoc render of cascade-generated content.
+  - `GET /api/artefacts/{artefact_id}` — auth-optional download,
+    Content-Disposition: attachment, immutable cache.
+- **MCP tools** `render_diagram` and `render_markdown`. Both return
+  `{id, filename, mime_type, size_bytes, web_url, ...}`. `web_url`
+  points at the backend `/api/artefacts/<id>` so any client (browser,
+  curl) downloads directly.
+- **New backend deps**: `markdown-it-py>=4.0.0`, `weasyprint>=68.0`.
+  Both verified installable in the dev devcontainer. WeasyPrint
+  needs Pango / Cairo / GDK-PixBuf system libraries — Render image
+  to be verified at deploy gate per
+  `feedback_render_deploy_verification`.
+
+### Changed
+
+- **Cascade destination prompt** (`creation-cascade-destination-v1`)
+  no longer carries the Phase-1 docx/pdf fallback paragraph. The
+  body now instructs: "When the user picks docx or pdf at Q-Dest3,
+  call the MCP `render_markdown` tool once per selected format ...
+  present the `web_url` to the user as a clickable download link."
+  The cross-set move fallback stays until Phase 3 (v6.3.0) ships
+  `move_*` tools.
+- The seed file's `CASCADE_DESTINATION_PROMPT` constant matches the
+  new canonical body; `docs/prompts/creation-cascade-destination.md`
+  updated in lockstep.
+
+### See also
+
+- [ADR-179](docs/adrs/ADR-179-Renderer-And-Artefact-Store.md)
+- [SPEC-179-A](docs/adrs/specs/SPEC-179-A-Renderer-And-Artefact-Store.md)
+- [docs/plans/issue-133-doview-mcp-polish.md](docs/plans/issue-133-doview-mcp-polish.md)
+
+### Tests
+
+406/406 green across `tests/test_ai/` + `tests/test_migrations/` +
+`tests/test_export/` + `tests/test_artefacts/`. 181/181 green in
+`mcp/tests/` (8 new tool tests).
+
 ## [6.1.0] - 2026-05-16
 
 Issue #133 Phase 1 — creation-cascade UX polish + MCP-wide

--- a/backend/app/artefacts/models.py
+++ b/backend/app/artefacts/models.py
@@ -1,0 +1,23 @@
+"""Pydantic models for the artefacts module (ADR-179, v6.2.0)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ArtefactResponse(BaseModel):
+    """Response after a successful artefact create / fetch metadata.
+
+    The `web_url` field is fully-qualified when `IRIS_WEB_URL` is set
+    (decorated by `mcp.links.with_web_url`); empty/absent otherwise so
+    backend responses don't leak the host. MCP-side tools decorate
+    based on their own configured backend URL.
+    """
+
+    id: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+    source_kind: str
+    source_ref: str | None = None
+    created_at: str

--- a/backend/app/artefacts/router.py
+++ b/backend/app/artefacts/router.py
@@ -1,0 +1,39 @@
+"""Artefact download API route (ADR-179, v6.2.0).
+
+Serves rendered artefacts produced by the export / render endpoints
+in `app/export/router.py`. Auth-optional (matches `/api/images/{id}`
+— artefacts are referenced by URL and the URL is the access control).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import Response
+
+from app.artefacts import service
+
+router = APIRouter(prefix="/api/artefacts", tags=["artefacts"])
+
+
+@router.get("/{artefact_id}")
+async def get_artefact(artefact_id: str, request: Request) -> Response:
+    """Serve artefact bytes with Content-Type + Content-Disposition.
+
+    Public — the artefact URL IS the access control (same model as
+    /api/images/{id}). Future ADR can tighten with signed URLs if
+    needed.
+    """
+    db = request.app.state.db_manager.main_db
+    art = await service.get_artefact(db, artefact_id)
+    if art is None:
+        raise HTTPException(status_code=404, detail="Artefact not found")
+    return Response(
+        content=art["bytes"],  # type: ignore[arg-type]
+        media_type=str(art["mime"]),
+        headers={
+            "Content-Disposition": (
+                f'attachment; filename="{art["filename"]}"'
+            ),
+            "Cache-Control": "public, max-age=31536000, immutable",
+        },
+    )

--- a/backend/app/artefacts/service.py
+++ b/backend/app/artefacts/service.py
@@ -1,0 +1,118 @@
+"""Service layer for the artefacts module (ADR-179, v6.2.0).
+
+Stores rendered markdown / docx / pdf artefacts produced by the
+renderer endpoints. Sibling to the images store — this one accepts
+documents (text/markdown, docx, pdf) and uses its own mime allowlist
+and per-row cap.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+# 25 MB per-artefact cap — generous enough for full DoView books in
+# docx/pdf form, tight enough that a runaway render can't flood the DB.
+MAX_ARTEFACT_BYTES = 25 * 1024 * 1024
+
+ALLOWED_ARTEFACT_MIMES: frozenset[str] = frozenset(
+    {
+        "text/markdown",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/pdf",
+    },
+)
+
+
+def _validate_bytes(data: bytes, mime: str) -> None:
+    """Raise ValueError if data fails size / mime checks.
+
+    Magic-byte sniffing is mime-specific and lighter than the image
+    store's because text/markdown has no magic. We do byte-header
+    checks for pdf and docx (zip signature) since they're easy.
+    """
+    if not data:
+        raise ValueError("Empty artefact upload.")
+    if len(data) > MAX_ARTEFACT_BYTES:
+        raise ValueError(
+            f"Artefact exceeds {MAX_ARTEFACT_BYTES // (1024 * 1024)} MB cap.",
+        )
+    if mime not in ALLOWED_ARTEFACT_MIMES:
+        raise ValueError(
+            f"Artefact MIME {mime!r} not allowed. Allowed: "
+            f"{sorted(ALLOWED_ARTEFACT_MIMES)}.",
+        )
+
+    if mime == "application/pdf" and not data.startswith(b"%PDF"):
+        raise ValueError(
+            "PDF artefact missing %PDF header — renderer produced invalid output.",
+        )
+    if mime == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ) and not data.startswith(b"PK\x03\x04"):
+        # docx is a ZIP archive; sniff the local-file-header magic.
+        raise ValueError(
+            "DOCX artefact missing ZIP signature — renderer produced invalid output.",
+        )
+
+
+async def create_artefact(
+    db: DatabasePort,
+    *,
+    data: bytes,
+    mime: str,
+    filename: str,
+    source_kind: str,
+    source_ref: str | None = None,
+    created_by: str | None = None,
+) -> dict[str, object]:
+    """Validate + persist an artefact. Returns the row metadata."""
+    _validate_bytes(data, mime)
+    artefact_id = str(uuid.uuid4())
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO artefacts (id, filename, mime, bytes, size_bytes, "
+        "source_kind, source_ref, created_by, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (artefact_id, filename, mime, data, len(data),
+         source_kind, source_ref, created_by, now),
+    )
+    await db.commit()
+    return {
+        "id": artefact_id,
+        "filename": filename,
+        "mime_type": mime,
+        "size_bytes": len(data),
+        "source_kind": source_kind,
+        "source_ref": source_ref,
+        "created_at": now,
+    }
+
+
+async def get_artefact(
+    db: DatabasePort, artefact_id: str,
+) -> dict[str, object] | None:
+    """Fetch an artefact by id. Returns None if not found."""
+    cursor = await db.execute(
+        "SELECT id, filename, mime, bytes, size_bytes, source_kind, "
+        "source_ref, created_at FROM artefacts WHERE id = ?",
+        (artefact_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "filename": row[1],
+        "mime": row[2],
+        "bytes": bytes(row[3]) if not isinstance(row[3], bytes) else row[3],
+        "size_bytes": row[4],
+        "source_kind": row[5],
+        "source_ref": row[6],
+        "created_at": row[7],
+    }

--- a/backend/app/export/renderers/__init__.py
+++ b/backend/app/export/renderers/__init__.py
@@ -1,0 +1,40 @@
+"""Markdown / Docx / PDF renderers for the artefact pipeline.
+
+Each renderer module exposes a single `render(markdown, title)`
+function returning `(bytes, filename)`. Used by
+`app/export/router.py` POST endpoints and the MCP `export_diagram` /
+`render_markdown` tools (ADR-179, v6.2.0).
+"""
+
+from __future__ import annotations
+
+from app.export.renderers import docx as docx_renderer
+from app.export.renderers import markdown as md_renderer
+from app.export.renderers import pdf as pdf_renderer
+from app.export.renderers._common import slug_filename
+
+__all__ = ["docx_renderer", "md_renderer", "pdf_renderer", "render", "slug_filename"]
+
+
+def render(
+    markdown: str, title: str, fmt: str,
+) -> tuple[bytes, str, str]:
+    """Dispatch to the appropriate renderer.
+
+    Returns `(bytes, filename, mime_type)`.
+    Raises ValueError on unsupported format.
+    """
+    if fmt == "md":
+        data, filename = md_renderer.render(markdown, title)
+        return data, filename, "text/markdown"
+    if fmt == "docx":
+        data, filename = docx_renderer.render(markdown, title)
+        return (
+            data, filename,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )
+    if fmt == "pdf":
+        data, filename = pdf_renderer.render(markdown, title)
+        return data, filename, "application/pdf"
+    msg = f"Unsupported render format {fmt!r}. Use 'md', 'docx', or 'pdf'."
+    raise ValueError(msg)

--- a/backend/app/export/renderers/_common.py
+++ b/backend/app/export/renderers/_common.py
@@ -1,0 +1,20 @@
+"""Shared helpers for the renderer modules (avoid circular imports)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+
+def slug_filename(title: str, extension: str) -> str:
+    """Produce a kebab-cased filename with a short UUID suffix.
+
+    Title `"Banana Monoculture DoView"` + extension `"docx"` →
+    `"banana-monoculture-doview-9f2c.docx"`. The UUID suffix avoids
+    collisions when the same title is rendered multiple times.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", (title or "untitled").lower()).strip("-")
+    if not slug:
+        slug = "artefact"
+    short_uuid = uuid.uuid4().hex[:4]
+    return f"{slug}-{short_uuid}.{extension}"

--- a/backend/app/export/renderers/docx.py
+++ b/backend/app/export/renderers/docx.py
@@ -1,0 +1,171 @@
+"""Markdown → DOCX renderer (ADR-179, v6.2.0).
+
+Uses `markdown-it-py` to tokenise the markdown source, then walks the
+token stream emitting `python-docx` paragraphs / headings / lists /
+code blocks. Mermaid fenced blocks pass through verbatim as
+monospace code blocks — the docx reader can paste them into a
+mermaid-rendering tool.
+
+Recipe modelled on Anthropic's `skills/docx` (Apache 2.0) — minimal
+adapter rather than a vendored copy.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from docx import Document
+from docx.shared import Pt
+from markdown_it import MarkdownIt
+
+from app.export.renderers._common import slug_filename
+
+
+_HEADING_STYLE = {
+    "h1": "Heading 1",
+    "h2": "Heading 2",
+    "h3": "Heading 3",
+    "h4": "Heading 4",
+    "h5": "Heading 5",
+    "h6": "Heading 6",
+}
+
+
+def render(markdown: str, title: str) -> tuple[bytes, str]:
+    """Render markdown to a docx bytes blob.
+
+    Always starts with the document title as a Title-styled paragraph,
+    followed by the markdown content rendered structurally.
+    """
+    doc = Document()
+    doc.add_heading(title or "Untitled", level=0)
+
+    md = MarkdownIt("commonmark", {"breaks": False, "html": False})
+    tokens = md.parse(markdown or "")
+
+    _walk_tokens(doc, tokens)
+
+    buf = BytesIO()
+    doc.save(buf)
+    return buf.getvalue(), slug_filename(title, "docx")
+
+
+def _walk_tokens(doc: Document, tokens: list) -> None:  # noqa: C901, PLR0912, PLR0915
+    """Emit docx paragraphs / lists / code blocks from the token stream.
+
+    The walker maintains a simple stack for list nesting and a
+    'current paragraph' pointer for inline content accumulation.
+    Inline images / links are flattened to their alt text / URL — the
+    docx renderer does not embed binary images (keeps the renderer
+    container small; mermaid stays as text).
+    """
+    list_stack: list[str] = []  # 'bullet' | 'number' nesting
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t.type == "heading_open":
+            style = _HEADING_STYLE.get(t.tag, "Heading 1")
+            text = _collect_inline_text(tokens[i + 1])
+            doc.add_paragraph(text, style=style)
+            i += 3  # heading_open + inline + heading_close
+            continue
+
+        if t.type == "paragraph_open":
+            inline = tokens[i + 1]
+            text = _collect_inline_text(inline)
+            if list_stack:
+                style = (
+                    "List Bullet" if list_stack[-1] == "bullet" else "List Number"
+                )
+                doc.add_paragraph(text, style=style)
+            else:
+                doc.add_paragraph(text)
+            i += 3
+            continue
+
+        if t.type == "fence" or t.type == "code_block":
+            code = t.content.rstrip("\n")
+            for line in code.split("\n"):
+                p = doc.add_paragraph()
+                run = p.add_run(line)
+                run.font.name = "Courier New"
+                run.font.size = Pt(9)
+            i += 1
+            continue
+
+        if t.type == "bullet_list_open":
+            list_stack.append("bullet")
+            i += 1
+            continue
+        if t.type == "ordered_list_open":
+            list_stack.append("number")
+            i += 1
+            continue
+        if t.type in ("bullet_list_close", "ordered_list_close"):
+            if list_stack:
+                list_stack.pop()
+            i += 1
+            continue
+
+        if t.type == "blockquote_open":
+            # Find the matching close, render contents indented.
+            depth = 1
+            j = i + 1
+            inner: list[str] = []
+            while j < len(tokens) and depth > 0:
+                if tokens[j].type == "blockquote_open":
+                    depth += 1
+                elif tokens[j].type == "blockquote_close":
+                    depth -= 1
+                elif tokens[j].type == "inline":
+                    inner.append(tokens[j].content)
+                j += 1
+            doc.add_paragraph("> " + " ".join(inner), style="Intense Quote")
+            i = j
+            continue
+
+        if t.type == "hr":
+            doc.add_paragraph("─" * 40)
+            i += 1
+            continue
+
+        # Unrecognised top-level token — advance.
+        i += 1
+
+
+def _collect_inline_text(inline_token) -> str:
+    """Flatten an inline token into plain text.
+
+    Code spans wrapped in backticks, link URLs surfaced inline, alt
+    text used for images. Bold/italic markers dropped — docx run
+    formatting is not threaded through here to keep the walker
+    simple.
+    """
+    if inline_token is None or inline_token.type != "inline":
+        return ""
+    parts: list[str] = []
+    for child in (inline_token.children or []):
+        if child.type == "text":
+            parts.append(child.content)
+        elif child.type == "code_inline":
+            parts.append(f"`{child.content}`")
+        elif child.type == "link_open":
+            href = next(
+                (a[1] for a in (child.attrs or []) if a[0] == "href"),
+                "",
+            ) if isinstance(child.attrs, list) else child.attrs.get("href", "")
+            parts.append(f"[")
+            # Link text is in subsequent children until link_close.
+            # The simpler approach: accumulate inside _collect_inline_text
+            # by tracking a link buffer. For now, surface the URL inline.
+            parts.append(f"]({href})")
+        elif child.type == "softbreak" or child.type == "hardbreak":
+            parts.append(" ")
+        elif child.type == "image":
+            alt = child.content or ""
+            src = next(
+                (a[1] for a in (child.attrs or []) if a[0] == "src"),
+                "",
+            ) if isinstance(child.attrs, list) else child.attrs.get("src", "")
+            parts.append(f"[image: {alt or src}]")
+    return "".join(parts).strip()

--- a/backend/app/export/renderers/markdown.py
+++ b/backend/app/export/renderers/markdown.py
@@ -1,0 +1,27 @@
+"""Markdown renderer (passthrough + normalisation).
+
+Markdown content is already markdown — this module just normalises
+trailing whitespace and ensures a single trailing newline so the
+output is byte-stable. Mirrors the existing `app/export/markdown.py`
+bundle renderer's output shape.
+"""
+
+from __future__ import annotations
+
+from app.export.renderers._common import slug_filename
+
+
+def render(markdown: str, title: str) -> tuple[bytes, str]:
+    """Return (bytes, filename) for a markdown artefact.
+
+    Normalisation:
+      - strip CRLF → LF
+      - trim trailing whitespace per line
+      - ensure exactly one trailing newline
+    """
+    if markdown is None:
+        markdown = ""
+    text = markdown.replace("\r\n", "\n").replace("\r", "\n")
+    lines = [line.rstrip() for line in text.split("\n")]
+    normalised = "\n".join(lines).rstrip("\n") + "\n"
+    return normalised.encode("utf-8"), slug_filename(title, "md")

--- a/backend/app/export/renderers/pdf.py
+++ b/backend/app/export/renderers/pdf.py
@@ -1,0 +1,59 @@
+"""Markdown → PDF renderer (ADR-179, v6.2.0).
+
+Pipeline:
+  1. Tokenise + render markdown to HTML via `markdown-it-py`.
+  2. Wrap in a minimal HTML document with the Iris-branded CSS.
+  3. Pass to `weasyprint.HTML(string=...).write_pdf()`.
+
+Recipe modelled on Anthropic's `skills/pdf` (Apache 2.0). WeasyPrint
+needs Pango / Cairo / GDK-PixBuf system libraries at runtime — the
+Render image must include these (verified at the Phase 2 deploy
+gate per `feedback_render_deploy_verification`).
+"""
+
+from __future__ import annotations
+
+from html import escape
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+
+from app.export.renderers._common import slug_filename
+
+
+_CSS_PATH = Path(__file__).parent / "styles" / "iris.css"
+
+
+def _css() -> str:
+    return _CSS_PATH.read_text(encoding="utf-8")
+
+
+def _html_document(title: str, body_html: str) -> str:
+    """Wrap rendered markdown HTML in a styled document shell."""
+    css = _css()
+    safe_title = escape(title or "Untitled")
+    return (
+        "<!DOCTYPE html>"
+        "<html><head>"
+        f"<meta charset='utf-8'><title>{safe_title}</title>"
+        f"<style>{css}</style>"
+        "</head><body>"
+        f"<h1 class='iris-doc-title'>{safe_title}</h1>"
+        f"{body_html}"
+        "</body></html>"
+    )
+
+
+def render(markdown: str, title: str) -> tuple[bytes, str]:
+    """Render markdown to a PDF bytes blob with Iris-branded styling."""
+    md = MarkdownIt("commonmark", {"breaks": False, "html": False})
+    body_html = md.render(markdown or "")
+    html = _html_document(title, body_html)
+
+    # Local import — weasyprint pulls in Pango/Cairo at import time
+    # and the import is expensive. Defer until render() is called so
+    # module import (and module-level test collection) is cheap.
+    from weasyprint import HTML  # noqa: PLC0415
+
+    pdf_bytes = HTML(string=html).write_pdf()
+    return pdf_bytes, slug_filename(title, "pdf")

--- a/backend/app/export/renderers/styles/iris.css
+++ b/backend/app/export/renderers/styles/iris.css
@@ -1,0 +1,125 @@
+/* Iris-branded PDF renderer CSS (ADR-179, v6.2.0).
+ *
+ * Minimal stylesheet for weasyprint-rendered documents. Uses system
+ * font stacks (no embedded fonts) so the renderer container stays
+ * small. Color palette echoes the Iris frontend tokens at low fidelity.
+ */
+
+@page {
+    size: A4;
+    margin: 2cm 2cm 2.5cm 2cm;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                 Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #1f2937;
+}
+
+h1 {
+    font-size: 22pt;
+    color: #111827;
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 0.3em;
+    margin-top: 0;
+}
+
+h2 {
+    font-size: 16pt;
+    color: #111827;
+    margin-top: 1.4em;
+}
+
+h3 {
+    font-size: 13pt;
+    color: #374151;
+    margin-top: 1em;
+}
+
+h4, h5, h6 {
+    font-size: 11pt;
+    color: #374151;
+    margin-top: 0.8em;
+}
+
+p {
+    margin: 0.6em 0;
+}
+
+a {
+    color: #1d4ed8;
+    word-break: break-all;
+}
+
+code {
+    font-family: "SF Mono", Menlo, Consolas, Monaco, monospace;
+    font-size: 9.5pt;
+    background: #f3f4f6;
+    padding: 0 0.2em;
+    border-radius: 2px;
+}
+
+pre {
+    background: #f3f4f6;
+    padding: 0.7em 1em;
+    border-radius: 4px;
+    overflow-x: auto;
+    page-break-inside: avoid;
+    font-size: 9pt;
+}
+
+pre code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+}
+
+blockquote {
+    border-left: 3px solid #d1d5db;
+    margin: 1em 0;
+    padding: 0.2em 1em;
+    color: #4b5563;
+}
+
+ul, ol {
+    padding-left: 1.6em;
+    margin: 0.6em 0;
+}
+
+li {
+    margin: 0.2em 0;
+}
+
+table {
+    border-collapse: collapse;
+    margin: 1em 0;
+    width: 100%;
+    font-size: 10pt;
+}
+
+th, td {
+    border: 1px solid #d1d5db;
+    padding: 0.4em 0.7em;
+    text-align: left;
+}
+
+th {
+    background: #f9fafb;
+    font-weight: 600;
+}
+
+hr {
+    border: 0;
+    border-top: 1px solid #e5e7eb;
+    margin: 1.5em 0;
+}
+
+.iris-doc-title {
+    font-size: 24pt;
+    color: #111827;
+    margin: 0 0 0.5em 0;
+    border-bottom: 2px solid #6366f1;
+    padding-bottom: 0.3em;
+}

--- a/backend/app/export/router.py
+++ b/backend/app/export/router.py
@@ -1,7 +1,10 @@
-"""`/api/export/*` routes (ADR-128 / SPEC-128-A).
+"""`/api/export/*` routes (ADR-128 / SPEC-128-A, plus ADR-179 v6.2.0).
 
 Headless JSON + Markdown export for diagrams, elements, packages, sets,
 and collections. Auth is optional (ADR-123 anonymous read policy).
+
+v6.2.0 (ADR-179) adds POST endpoints for rendered md/docx/pdf
+artefacts stored in the `artefacts` table and returned as download URLs.
 """
 
 from __future__ import annotations
@@ -10,9 +13,13 @@ import re
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel
 
-from app.auth.dependencies import get_optional_user
+from app.artefacts import service as artefact_service
+from app.artefacts.models import ArtefactResponse
+from app.auth.dependencies import get_current_user, get_optional_user
 from app.export import markdown as md
+from app.export import renderers
 from app.export import service as export_service
 from app.export.service import ExportNotFoundError, ExportTooLargeError
 
@@ -190,3 +197,119 @@ async def export_collection(
         collection_id,
         format,
     )
+
+
+# --- Renderer endpoints (ADR-179, v6.2.0) ------------------------------
+
+RenderFormat = Literal["md", "docx", "pdf"]
+
+
+class RenderDiagramRequest(BaseModel):
+    format: RenderFormat
+
+
+class RenderMarkdownRequest(BaseModel):
+    markdown: str
+    title: str
+    format: RenderFormat
+
+
+def _diagram_to_markdown(bundle: Any) -> tuple[str, str]:
+    """Return (markdown_source, title) for a diagram bundle.
+
+    For markdown-content diagrams (notation='markdown'), use the
+    stored `data.content` directly. For visual diagrams, fall back to
+    the existing markdown bundle renderer so the artefact is at
+    least navigable text.
+    """
+    diagram = bundle.diagram
+    title = diagram.name or "Untitled diagram"
+    data = diagram.data if isinstance(diagram.data, dict) else {}
+    if diagram.notation == "markdown":
+        content = data.get("content")
+        if isinstance(content, str) and content.strip():
+            return content, title
+    # Fall back to the structured bundle render for visual diagrams.
+    return md.render_diagram(bundle), title
+
+
+@router.post(
+    "/api/export/diagram/{diagram_id}",
+    response_model=ArtefactResponse,
+    summary="Render a diagram to md/docx/pdf and store as an artefact",
+)
+async def render_diagram_to_artefact(
+    diagram_id: str,
+    body: RenderDiagramRequest,
+    request: Request,
+    user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ArtefactResponse:
+    """ADR-179, v6.2.0. Render the diagram to the chosen format and
+    persist as an artefact. Returns the artefact metadata + URL.
+
+    Auth-optional; matches the existing /api/export/* read endpoints.
+    """
+    db = request.app.state.db_manager.main_db
+    try:
+        bundle = await export_service.build_diagram_export(db, diagram_id)
+    except ExportNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ExportTooLargeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+
+    markdown_source, title = _diagram_to_markdown(bundle)
+    try:
+        data, filename, mime = renderers.render(markdown_source, title, body.format)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        meta = await artefact_service.create_artefact(
+            db,
+            data=data,
+            mime=mime,
+            filename=filename,
+            source_kind="export_diagram",
+            source_ref=diagram_id,
+            created_by=(user or {}).get("id"),
+        )
+    except ValueError as exc:
+        # Renderer produced output that failed validation (oversize or
+        # invalid magic). Surface as 500 — internal renderer fault, not
+        # caller's fault.
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ArtefactResponse(**meta)
+
+
+@router.post(
+    "/api/export/markdown",
+    response_model=ArtefactResponse,
+    summary="Render ad-hoc markdown to md/docx/pdf and store as an artefact",
+)
+async def render_markdown_to_artefact(
+    body: RenderMarkdownRequest,
+    request: Request,
+    user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ArtefactResponse:
+    """ADR-179, v6.2.0. Render ad-hoc markdown content (e.g. a cascade
+    draft not yet saved to a diagram) to the chosen format.
+    """
+    db = request.app.state.db_manager.main_db
+    try:
+        data, filename, mime = renderers.render(body.markdown, body.title, body.format)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        meta = await artefact_service.create_artefact(
+            db,
+            data=data,
+            mime=mime,
+            filename=filename,
+            source_kind="render_markdown",
+            source_ref=None,
+            created_by=(user or {}).get("id"),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ArtefactResponse(**meta)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.diagrams.router import diagram_rel_router
 from app.diagrams.router import router as diagrams_router
 from app.docref.router import router as docref_router
 from app.elements.router import router as elements_router
+from app.artefacts.router import router as artefacts_router
 from app.export.router import router as export_router
 from app.images.router import router as images_router
 from app.extensions.router import router as extensions_router
@@ -210,6 +211,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(graph_router)
     app.include_router(tokens_router)
     app.include_router(export_router)
+    app.include_router(artefacts_router)  # ADR-179, v6.2.0
 
     # ADR-133: optional remote MCP at /mcp. No-op if iris-mcp isn't installed.
     from app.mcp_route import attach_mcp

--- a/backend/app/migrations/m060_artefacts_table.py
+++ b/backend/app/migrations/m060_artefacts_table.py
@@ -1,0 +1,52 @@
+"""Migration 060: artefacts table (ADR-179, SPEC-179-A, v6.2.0).
+
+Issue #133 Phase 2. Generic artefact store for rendered markdown /
+docx / pdf documents produced by the cascade destination chooser's
+"Chat with downloadable artefacts" branch and by the new
+`POST /api/export/diagram/{id}` endpoint.
+
+Sibling to (not graft onto) `images` — the image store has tight
+PNG/JPEG/GIF/WebP magic-byte validation; artefacts have their own
+mime allowlist (text/markdown, docx, pdf) and a higher per-row cap
+(25 MB). Sibling modules keep each contract honest.
+
+source_kind identifies the origin so downstream tooling can filter:
+  'render_markdown' — ad-hoc render of cascade content, source_ref NULL
+  'export_diagram'  — diagram export, source_ref = diagram_id
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m060_artefacts_table"
+
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS artefacts (
+    id TEXT PRIMARY KEY,
+    filename TEXT NOT NULL,
+    mime TEXT NOT NULL,
+    bytes BLOB NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_ref TEXT,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+)
+"""
+
+_CREATE_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_artefacts_source_ref
+ON artefacts(source_ref)
+"""
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    await db.execute(_CREATE_TABLE)
+    await db.execute(_CREATE_INDEX)
+    await db.commit()

--- a/backend/app/migrations/m061_drop_phase1_docx_fallback.py
+++ b/backend/app/migrations/m061_drop_phase1_docx_fallback.py
@@ -1,0 +1,64 @@
+# ruff: noqa: E501, RUF001
+"""Migration 061: drop Phase-1 docx/pdf fallback from cascade destination
+prompt (ADR-179, SPEC-179-A, v6.2.0).
+
+Issue #133 Phase 2. The destination chooser prompt
+`creation-cascade-destination-v1` shipped in v6.1.0 with a Phase-1
+fallback paragraph that explained docx/pdf rendering wasn't yet
+available. Phase 2 ships the renderer + artefact store, so the
+fallback is now obsolete.
+
+Surgical REPLACE() — leaves the cross-set move fallback in place
+(move tools ship Phase 3 v6.3.0). Idempotent: REPLACE is a no-op
+when the marker substring isn't present.
+
+The seed file `backend/app/seed/creation_prompts.py` is updated in
+lockstep — the canonical body of CASCADE_DESTINATION_PROMPT has the
+docx/pdf fallback removed and replaced with renderer-call guidance.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m061_drop_phase1_docx_fallback"
+
+
+# The docx/pdf fallback paragraph block as shipped in v6.1.0 (m058,
+# CASCADE_DESTINATION_PROMPT body). Replaced with renderer-call
+# guidance below.
+_PHASE1_DOCX_FALLBACK = """- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0"."""
+
+_RENDERER_CALL_GUIDANCE = """- When the user picks "Chat with downloadable artefacts" and selects
+  one or more formats at Q-Dest3, call the MCP `render_markdown`
+  tool once per selected format (markdown / docx / pdf). Each call
+  returns `{artefact_id, web_url, mime_type, filename}` — present the
+  `web_url` to the user as a clickable download link. For "Both"
+  (Iris + artefacts), also create the Iris bundle via the
+  destination-specific `create_*` tools."""
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='ai_creation_prompts'",
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    await db.execute(
+        "UPDATE ai_creation_prompts"
+        " SET prompt_text = REPLACE(prompt_text, ?, ?)"
+        " WHERE id = 'creation-cascade-destination-v1'",
+        (_PHASE1_DOCX_FALLBACK, _RENDERER_CALL_GUIDANCE),
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m064_artefacts_table.sql
+++ b/backend/app/migrations/supabase/m064_artefacts_table.sql
@@ -1,0 +1,19 @@
+-- Migration 064: artefacts table (ADR-179, SPEC-179-A, v6.2.0).
+--
+-- Issue #133 Phase 2. Mirrors SQLite m060. Generic artefact store
+-- for rendered markdown / docx / pdf documents.
+
+CREATE TABLE IF NOT EXISTS public.artefacts (
+    id TEXT PRIMARY KEY,
+    filename TEXT NOT NULL,
+    mime TEXT NOT NULL,
+    bytes BYTEA NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_ref TEXT,
+    created_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT (now() AT TIME ZONE 'utc')
+);
+
+CREATE INDEX IF NOT EXISTS idx_artefacts_source_ref
+    ON public.artefacts(source_ref);

--- a/backend/app/migrations/supabase/m065_drop_phase1_docx_fallback.sql
+++ b/backend/app/migrations/supabase/m065_drop_phase1_docx_fallback.sql
@@ -1,0 +1,23 @@
+-- Migration 065: drop Phase-1 docx/pdf fallback (ADR-179, v6.2.0).
+--
+-- Issue #133 Phase 2. Mirrors SQLite m061. Surgical REPLACE() leaves
+-- the cross-set move fallback intact (drops in Phase 3 v6.3.0).
+
+UPDATE public.ai_creation_prompts
+SET prompt_text = REPLACE(
+    prompt_text,
+    $marker$- If the user picks "Chat with downloadable artefacts" and selects
+  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
+  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
+  artefact in the chat and create the Iris bundle if you'd like."
+  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
+  "Just the Iris save", "Cancel and wait for v6.2.0".$marker$,
+    $replacement$- When the user picks "Chat with downloadable artefacts" and selects
+  one or more formats at Q-Dest3, call the MCP `render_markdown`
+  tool once per selected format (markdown / docx / pdf). Each call
+  returns `{artefact_id, web_url, mime_type, filename}` — present the
+  `web_url` to the user as a clickable download link. For "Both"
+  (Iris + artefacts), also create the Iris bundle via the
+  destination-specific `create_*` tools.$replacement$
+)
+WHERE id = 'creation-cascade-destination-v1';

--- a/backend/app/seed/creation_prompts.py
+++ b/backend/app/seed/creation_prompts.py
@@ -460,12 +460,13 @@ At least one option must be selected.
 This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
 and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
 
-- If the user picks "Chat with downloadable artefacts" and selects
-  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
-  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
-  artefact in the chat and create the Iris bundle if you'd like."
-  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
-  "Just the Iris save", "Cancel and wait for v6.2.0".
+- When the user picks "Chat with downloadable artefacts" and selects
+  one or more formats at Q-Dest3, call the MCP `render_markdown`
+  tool once per selected format (markdown / docx / pdf). Each call
+  returns `{artefact_id, web_url, mime_type, filename}` — present the
+  `web_url` to the user as a clickable download link. For "Both"
+  (Iris + artefacts), also create the Iris bundle via the
+  destination-specific `create_*` tools.
 
 - If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
   chosen destination differs from the current set, respond: "I can

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -63,6 +63,8 @@ from app.migrations.m056_fix_scope_context_tool_name import up as m056_up
 from app.migrations.m057_fix_stale_auth_recovery import up as m057_up
 from app.migrations.m058_cascade_ux_polish import up as m058_up
 from app.migrations.m059_mcp_user_question_rule import up as m059_up
+from app.migrations.m060_artefacts_table import up as m060_up
+from app.migrations.m061_drop_phase1_docx_fallback import up as m061_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -153,6 +155,8 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m057_up(main)  # issue #115 follow-up, v6.0.3: drop stale iris_authenticate refs from singleton body
     await m058_up(main)  # issue #133 Phase 1, v6.1.0: cascade UX polish — three new shared base prompts + DoView/Outcomes Map updates (ADR-176)
     await m059_up(main)  # issue #133 Phase 1, v6.1.0: insert ASKING QUESTIONS section into MCP server-instructions singleton (ADR-177)
+    await m060_up(main)  # issue #133 Phase 2, v6.2.0: artefacts table for rendered md/docx/pdf (ADR-179)
+    await m061_up(main)  # issue #133 Phase 2, v6.2.0: drop Phase-1 docx/pdf fallback from cascade destination prompt (ADR-179)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,6 +17,13 @@ dependencies = [
     "pdfplumber>=0.11.0",
     "python-docx>=1.1.0",
     "openpyxl>=3.1.0",
+    # ADR-179, v6.2.0: markdown → docx/pdf renderer for the cascade
+    # destination "Chat with downloadable artefacts" branch and the
+    # POST /api/export/{diagram|markdown} endpoints. WeasyPrint requires
+    # Pango / Cairo / GDK-PixBuf system libraries — verified at the
+    # Phase 2 deploy gate per feedback_render_deploy_verification.
+    "markdown-it-py>=4.0.0",
+    "weasyprint>=68.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_artefacts/test_store_roundtrip.py
+++ b/backend/tests/test_artefacts/test_store_roundtrip.py
@@ -1,0 +1,153 @@
+"""v6.2.0 (ADR-179, SPEC-179-A): artefact store round-trip tests.
+
+Exercises the create + get cycle, mime allowlist, size cap, and
+magic-byte validation for pdf / docx.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.artefacts import service
+from app.artefacts.service import (
+    ALLOWED_ARTEFACT_MIMES,
+    MAX_ARTEFACT_BYTES,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _create_table(db) -> None:
+    await db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS artefacts (
+            id TEXT PRIMARY KEY,
+            filename TEXT NOT NULL,
+            mime TEXT NOT NULL,
+            bytes BLOB NOT NULL,
+            size_bytes INTEGER NOT NULL,
+            source_kind TEXT NOT NULL,
+            source_ref TEXT,
+            created_by TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+        """,
+    )
+
+
+async def test_create_then_get_returns_same_bytes(main_db) -> None:
+    await _create_table(main_db)
+    data = b"# Hello\n"
+    meta = await service.create_artefact(
+        main_db,
+        data=data,
+        mime="text/markdown",
+        filename="hello-abcd.md",
+        source_kind="render_markdown",
+        source_ref=None,
+        created_by=None,
+    )
+    assert meta["filename"] == "hello-abcd.md"
+    assert meta["mime_type"] == "text/markdown"
+    assert meta["size_bytes"] == len(data)
+    assert meta["source_kind"] == "render_markdown"
+
+    got = await service.get_artefact(main_db, meta["id"])
+    assert got is not None
+    assert got["bytes"] == data
+    assert got["mime"] == "text/markdown"
+    assert got["source_kind"] == "render_markdown"
+
+
+async def test_get_missing_artefact_returns_none(main_db) -> None:
+    await _create_table(main_db)
+    got = await service.get_artefact(main_db, "does-not-exist")
+    assert got is None
+
+
+async def test_disallowed_mime_rejected(main_db) -> None:
+    await _create_table(main_db)
+    with pytest.raises(ValueError, match="not allowed"):
+        await service.create_artefact(
+            main_db,
+            data=b"\x89PNG\r\n\x1a\n",
+            mime="image/png",
+            filename="x.png",
+            source_kind="render_markdown",
+        )
+
+
+async def test_oversized_artefact_rejected(main_db) -> None:
+    await _create_table(main_db)
+    too_big = b"x" * (MAX_ARTEFACT_BYTES + 1)
+    with pytest.raises(ValueError, match="exceeds"):
+        await service.create_artefact(
+            main_db,
+            data=too_big,
+            mime="text/markdown",
+            filename="big.md",
+            source_kind="render_markdown",
+        )
+
+
+async def test_empty_bytes_rejected(main_db) -> None:
+    await _create_table(main_db)
+    with pytest.raises(ValueError, match="Empty"):
+        await service.create_artefact(
+            main_db,
+            data=b"",
+            mime="text/markdown",
+            filename="empty.md",
+            source_kind="render_markdown",
+        )
+
+
+async def test_pdf_missing_header_rejected(main_db) -> None:
+    await _create_table(main_db)
+    with pytest.raises(ValueError, match="%PDF header"):
+        await service.create_artefact(
+            main_db,
+            data=b"not a pdf",
+            mime="application/pdf",
+            filename="x.pdf",
+            source_kind="render_markdown",
+        )
+
+
+async def test_docx_missing_zip_sig_rejected(main_db) -> None:
+    await _create_table(main_db)
+    with pytest.raises(ValueError, match="ZIP signature"):
+        await service.create_artefact(
+            main_db,
+            data=b"not a docx",
+            mime=(
+                "application/vnd.openxmlformats-"
+                "officedocument.wordprocessingml.document"
+            ),
+            filename="x.docx",
+            source_kind="render_markdown",
+        )
+
+
+async def test_pdf_with_valid_header_accepted(main_db) -> None:
+    await _create_table(main_db)
+    fake_pdf = b"%PDF-1.4 fake but header-valid"
+    meta = await service.create_artefact(
+        main_db,
+        data=fake_pdf,
+        mime="application/pdf",
+        filename="x-1234.pdf",
+        source_kind="render_markdown",
+    )
+    assert meta["mime_type"] == "application/pdf"
+
+
+async def test_allowed_mimes_set() -> None:
+    assert "text/markdown" in ALLOWED_ARTEFACT_MIMES
+    assert (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        in ALLOWED_ARTEFACT_MIMES
+    )
+    assert "application/pdf" in ALLOWED_ARTEFACT_MIMES
+    assert "image/png" not in ALLOWED_ARTEFACT_MIMES

--- a/backend/tests/test_export/test_md_passthrough.py
+++ b/backend/tests/test_export/test_md_passthrough.py
@@ -1,0 +1,36 @@
+"""v6.2.0 (ADR-179): markdown renderer passthrough + normalisation."""
+
+from __future__ import annotations
+
+from app.export.renderers import markdown as md_renderer
+
+
+def test_renders_utf8_bytes_with_trailing_newline() -> None:
+    data, filename = md_renderer.render("Hello world", "Test")
+    assert data == b"Hello world\n"
+    assert filename.endswith(".md")
+
+
+def test_normalises_crlf_to_lf() -> None:
+    data, _ = md_renderer.render("a\r\nb\r\nc\r\n", "Test")
+    assert data == b"a\nb\nc\n"
+
+
+def test_trims_trailing_whitespace_per_line() -> None:
+    data, _ = md_renderer.render("foo   \nbar  \n", "Test")
+    assert data == b"foo\nbar\n"
+
+
+def test_collapses_multiple_trailing_newlines_to_one() -> None:
+    data, _ = md_renderer.render("text\n\n\n\n", "Test")
+    assert data == b"text\n"
+
+
+def test_empty_string_renders_to_single_newline() -> None:
+    data, _ = md_renderer.render("", "Test")
+    assert data == b"\n"
+
+
+def test_none_input_renders_to_single_newline() -> None:
+    data, _ = md_renderer.render(None, "Test")  # type: ignore[arg-type]
+    assert data == b"\n"

--- a/backend/tests/test_export/test_md_to_docx.py
+++ b/backend/tests/test_export/test_md_to_docx.py
@@ -1,0 +1,102 @@
+"""v6.2.0 (ADR-179, SPEC-179-A): md → docx renderer tests.
+
+Exercises `app/export/renderers/docx.py` end-to-end by rendering a
+markdown fixture and re-parsing the produced bytes with python-docx
+to verify structure made it through.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+from docx import Document  # type: ignore[import-untyped]
+
+from app.export.renderers import docx as docx_renderer
+
+
+def _render_and_reopen(markdown: str, title: str = "Test"):
+    data, filename = docx_renderer.render(markdown, title)
+    assert filename.endswith(".docx")
+    assert data.startswith(b"PK\x03\x04"), "docx must be a ZIP (PK header)"
+    return Document(BytesIO(data))
+
+
+def test_title_appears_as_top_heading() -> None:
+    doc = _render_and_reopen("Body text.", title="My Title")
+    # First paragraph should be the title heading.
+    first = doc.paragraphs[0]
+    assert "My Title" in first.text
+
+
+def test_simple_paragraph_round_trips() -> None:
+    doc = _render_and_reopen("Hello world")
+    texts = [p.text for p in doc.paragraphs]
+    assert any("Hello world" in t for t in texts)
+
+
+def test_heading_h1_h2_h3() -> None:
+    md = "# H1\n\n## H2\n\n### H3\n"
+    doc = _render_and_reopen(md, title="Headings")
+    styles = [p.style.name for p in doc.paragraphs]
+    assert "Heading 1" in styles
+    assert "Heading 2" in styles
+    assert "Heading 3" in styles
+
+
+def test_bullet_list_round_trips() -> None:
+    md = "- one\n- two\n- three\n"
+    doc = _render_and_reopen(md, title="Bullets")
+    bullet_items = [
+        p.text for p in doc.paragraphs
+        if "List Bullet" in p.style.name
+    ]
+    assert "one" in bullet_items
+    assert "two" in bullet_items
+    assert "three" in bullet_items
+
+
+def test_ordered_list_round_trips() -> None:
+    md = "1. first\n2. second\n3. third\n"
+    doc = _render_and_reopen(md, title="Numbers")
+    number_items = [
+        p.text for p in doc.paragraphs
+        if "List Number" in p.style.name
+    ]
+    assert "first" in number_items
+    assert "second" in number_items
+    assert "third" in number_items
+
+
+def test_code_block_preserved() -> None:
+    md = "```\nlet x = 42\nprintln(x)\n```\n"
+    doc = _render_and_reopen(md, title="Code")
+    texts = [p.text for p in doc.paragraphs]
+    joined = " ".join(texts)
+    assert "let x = 42" in joined
+    assert "println(x)" in joined
+
+
+def test_mermaid_block_passes_through_verbatim() -> None:
+    md = (
+        "Some prose.\n\n"
+        "```mermaid\n"
+        "flowchart LR\n"
+        "  A --> B\n"
+        "```\n"
+    )
+    doc = _render_and_reopen(md, title="Mermaid")
+    joined = " ".join(p.text for p in doc.paragraphs)
+    assert "flowchart LR" in joined
+    assert "A --> B" in joined
+
+
+def test_empty_markdown_still_produces_valid_docx() -> None:
+    doc = _render_and_reopen("", title="Empty")
+    # Just the title heading.
+    assert any("Empty" in p.text for p in doc.paragraphs)
+
+
+def test_filename_slug_derives_from_title() -> None:
+    _, filename = docx_renderer.render("body", title="Banana Monoculture")
+    assert filename.startswith("banana-monoculture-")
+    assert filename.endswith(".docx")

--- a/backend/tests/test_export/test_md_to_pdf.py
+++ b/backend/tests/test_export/test_md_to_pdf.py
@@ -1,0 +1,69 @@
+"""v6.2.0 (ADR-179, SPEC-179-A): md → pdf renderer tests.
+
+Exercises `app/export/renderers/pdf.py` by rendering a markdown
+fixture and asserting the bytes are a valid PDF (header check) and
+contain the expected text content (extracted via pdfplumber, which
+is already a backend dep).
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+
+import pdfplumber
+
+from app.export.renderers import pdf as pdf_renderer
+
+
+def _render(markdown: str, title: str = "Test") -> bytes:
+    data, filename = pdf_renderer.render(markdown, title)
+    assert filename.endswith(".pdf")
+    assert data.startswith(b"%PDF"), "PDF must start with %PDF byte-header"
+    return data
+
+
+def _extract_text(pdf_bytes: bytes) -> str:
+    with pdfplumber.open(BytesIO(pdf_bytes)) as pdf:
+        return "\n".join(page.extract_text() or "" for page in pdf.pages)
+
+
+def test_simple_markdown_produces_valid_pdf() -> None:
+    data = _render("Hello world", title="Simple")
+    text = _extract_text(data)
+    assert "Hello world" in text
+    assert "Simple" in text  # title
+
+
+def test_headings_render_visibly() -> None:
+    md = "# Top Level\n\nBody paragraph.\n\n## Subsection\n\nMore body.\n"
+    data = _render(md, title="HeadingsDoc")
+    text = _extract_text(data)
+    assert "Top Level" in text
+    assert "Body paragraph" in text
+    assert "Subsection" in text
+    assert "More body" in text
+
+
+def test_filename_slug_derives_from_title() -> None:
+    _, filename = pdf_renderer.render("body", title="Banana Monoculture")
+    assert filename.startswith("banana-monoculture-")
+    assert filename.endswith(".pdf")
+
+
+def test_long_markdown_produces_multipage_pdf() -> None:
+    # Generate ~3 A4 pages worth of paragraphs.
+    body = "\n\n".join(
+        f"Paragraph {i}: " + ("Lorem ipsum dolor sit amet. " * 20)
+        for i in range(60)
+    )
+    data = _render(body, title="LongDoc")
+    with pdfplumber.open(BytesIO(data)) as pdf:
+        assert len(pdf.pages) >= 2, (
+            f"Expected multi-page PDF, got {len(pdf.pages)} page(s)"
+        )
+
+
+def test_empty_markdown_still_produces_valid_pdf() -> None:
+    data = _render("", title="EmptyBody")
+    text = _extract_text(data)
+    assert "EmptyBody" in text  # title still rendered

--- a/backend/tests/test_export/test_render_endpoints.py
+++ b/backend/tests/test_export/test_render_endpoints.py
@@ -1,0 +1,140 @@
+"""v6.2.0 (ADR-179, SPEC-179-A): integration tests for the renderer
+endpoints — POST /api/export/diagram/{id} and POST /api/export/markdown
+plus the GET /api/artefacts/{id} download endpoint.
+
+Re-uses the `client` + `_seed_minimal_entities` fixtures from
+`test_routes.py` by importing them indirectly via pytest plugin discovery.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+# Re-use the existing fixtures from test_routes by importing them as
+# pytest discovers them — `app_config` and `client` live in the same
+# package so pytest sees them via conftest semantics.
+from tests.test_export.test_routes import _seed_minimal_entities  # noqa: F401
+from tests.test_export.test_routes import app_config, client  # noqa: F401
+
+if TYPE_CHECKING:
+    pass
+
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestRenderMarkdownEndpoint:
+    async def test_md_format_returns_md_artefact(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.post(
+            "/api/export/markdown",
+            json={"markdown": "# Hello\n\nbody.", "title": "T", "format": "md"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mime_type"] == "text/markdown"
+        assert body["filename"].endswith(".md")
+        assert body["source_kind"] == "render_markdown"
+        # GET the artefact and assert the bytes match.
+        got = await client.get(f"/api/artefacts/{body['id']}")
+        assert got.status_code == 200
+        assert got.content.startswith(b"# Hello")
+        assert got.headers["content-type"].startswith("text/markdown")
+
+    async def test_docx_format_returns_valid_docx(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.post(
+            "/api/export/markdown",
+            json={"markdown": "# Heading\n\nbody.", "title": "Doc",
+                  "format": "docx"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mime_type"] == (
+            "application/vnd.openxmlformats-"
+            "officedocument.wordprocessingml.document"
+        )
+        assert body["filename"].endswith(".docx")
+        got = await client.get(f"/api/artefacts/{body['id']}")
+        assert got.status_code == 200
+        # docx is a ZIP archive.
+        assert got.content.startswith(b"PK\x03\x04")
+
+    async def test_pdf_format_returns_valid_pdf(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.post(
+            "/api/export/markdown",
+            json={"markdown": "# T\n\ncontent.", "title": "P", "format": "pdf"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mime_type"] == "application/pdf"
+        assert body["filename"].endswith(".pdf")
+        got = await client.get(f"/api/artefacts/{body['id']}")
+        assert got.status_code == 200
+        assert got.content.startswith(b"%PDF")
+        # Force download disposition.
+        cd = got.headers["content-disposition"]
+        assert "attachment" in cd
+        assert body["filename"] in cd
+
+    async def test_invalid_format_400(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.post(
+            "/api/export/markdown",
+            json={"markdown": "x", "title": "T", "format": "svg"},
+        )
+        # Pydantic field validation rejects unknown literal at 422.
+        assert resp.status_code in (400, 422)
+
+
+class TestRenderDiagramEndpoint:
+    async def test_render_diagram_md(self, client: httpx.AsyncClient) -> None:
+        ids = await _seed_minimal_entities(client._transport.app.state)  # type: ignore[attr-defined]
+        resp = await client.post(
+            f"/api/export/diagram/{ids['diagram']}",
+            json={"format": "md"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mime_type"] == "text/markdown"
+        assert body["source_kind"] == "export_diagram"
+        assert body["source_ref"] == ids["diagram"]
+
+    async def test_render_diagram_pdf(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        ids = await _seed_minimal_entities(client._transport.app.state)  # type: ignore[attr-defined]
+        resp = await client.post(
+            f"/api/export/diagram/{ids['diagram']}",
+            json={"format": "pdf"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mime_type"] == "application/pdf"
+        got = await client.get(f"/api/artefacts/{body['id']}")
+        assert got.content.startswith(b"%PDF")
+
+    async def test_render_diagram_404_for_missing_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.post(
+            "/api/export/diagram/does-not-exist",
+            json={"format": "md"},
+        )
+        assert resp.status_code == 404
+
+
+class TestArtefactGetEndpoint:
+    async def test_missing_artefact_404(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        resp = await client.get("/api/artefacts/missing")
+        assert resp.status_code == 404

--- a/backend/tests/test_migrations/test_artefacts_schema.py
+++ b/backend/tests/test_migrations/test_artefacts_schema.py
@@ -1,0 +1,71 @@
+"""v6.2.0 (ADR-179, SPEC-179-A): static-parser tests for the SQLite
+m060 + Supabase m064 migrations that create the `artefacts` table.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m060 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m060_file_exists() -> None:
+    assert (ROOT / "app/migrations/m060_artefacts_table.py").exists()
+
+
+def test_sqlite_m060_creates_artefacts_table() -> None:
+    py = _read("app/migrations/m060_artefacts_table.py")
+    assert "CREATE TABLE IF NOT EXISTS artefacts" in py
+    for col in (
+        "id TEXT PRIMARY KEY",
+        "filename TEXT NOT NULL",
+        "mime TEXT NOT NULL",
+        "bytes BLOB NOT NULL",
+        "size_bytes INTEGER NOT NULL",
+        "source_kind TEXT NOT NULL",
+        "source_ref TEXT",
+        "created_by TEXT",
+        "created_at TEXT NOT NULL",
+    ):
+        assert col in py, f"missing column declaration: {col!r}"
+
+
+def test_sqlite_m060_creates_source_ref_index() -> None:
+    py = _read("app/migrations/m060_artefacts_table.py")
+    assert "CREATE INDEX IF NOT EXISTS idx_artefacts_source_ref" in py
+    assert "ON artefacts(source_ref)" in py
+
+
+def test_sqlite_m060_registered_in_startup() -> None:
+    startup = _read("app/startup.py")
+    assert "from app.migrations.m060_artefacts_table import up as m060_up" in startup
+    assert "await m060_up(main)" in startup
+
+
+# ── Supabase m064 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m064_file_exists() -> None:
+    assert (ROOT / "app/migrations/supabase/m064_artefacts_table.sql").exists()
+
+
+def test_supabase_m064_creates_artefacts_table() -> None:
+    sql = _read("app/migrations/supabase/m064_artefacts_table.sql")
+    assert "CREATE TABLE IF NOT EXISTS public.artefacts" in sql
+    # bytes column uses BYTEA on Postgres, not BLOB.
+    assert "bytes BYTEA NOT NULL" in sql
+    assert "source_kind TEXT NOT NULL" in sql
+    assert "source_ref TEXT" in sql
+
+
+def test_supabase_m064_creates_source_ref_index() -> None:
+    sql = _read("app/migrations/supabase/m064_artefacts_table.sql")
+    assert "CREATE INDEX IF NOT EXISTS idx_artefacts_source_ref" in sql
+    assert "ON public.artefacts(source_ref)" in sql

--- a/backend/tests/test_migrations/test_phase2_destination_actuation_schema.py
+++ b/backend/tests/test_migrations/test_phase2_destination_actuation_schema.py
@@ -1,0 +1,94 @@
+"""v6.2.0 (ADR-179): static-parser tests for SQLite m061 + Supabase m065
+which drop the Phase-1 docx/pdf fallback from
+`creation-cascade-destination-v1` and replace it with renderer-call
+guidance. The cross-set move fallback stays (drops in Phase 3 / v6.3.0).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = ROOT.parent
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def _read_repo(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m061 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m061_file_exists() -> None:
+    assert (ROOT / "app/migrations/m061_drop_phase1_docx_fallback.py").exists()
+
+
+def test_sqlite_m061_replaces_docx_fallback_with_renderer_guidance() -> None:
+    py = _read("app/migrations/m061_drop_phase1_docx_fallback.py")
+    # Old fallback string the migration is removing.
+    assert "Docx and PDF generation ships in" in py
+    # New guidance string the migration writes.
+    assert "render_markdown" in py
+    assert "REPLACE(" in py
+
+
+def test_sqlite_m061_scoped_to_destination_prompt_only() -> None:
+    py = _read("app/migrations/m061_drop_phase1_docx_fallback.py")
+    assert "creation-cascade-destination-v1" in py
+
+
+def test_sqlite_m061_table_guard() -> None:
+    py = _read("app/migrations/m061_drop_phase1_docx_fallback.py")
+    assert "type='table'" in py
+    assert "ai_creation_prompts" in py
+
+
+def test_sqlite_m061_registered_in_startup() -> None:
+    startup = _read("app/startup.py")
+    assert "from app.migrations.m061_drop_phase1_docx_fallback import up as m061_up" in startup
+    assert "await m061_up(main)" in startup
+
+
+# ── Supabase m065 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m065_file_exists() -> None:
+    assert (ROOT / "app/migrations/supabase/m065_drop_phase1_docx_fallback.sql").exists()
+
+
+def test_supabase_m065_replaces_same_strings() -> None:
+    sql = _read("app/migrations/supabase/m065_drop_phase1_docx_fallback.sql")
+    assert "Docx and PDF generation ships in" in sql
+    assert "render_markdown" in sql
+    assert "REPLACE(" in sql
+    assert "creation-cascade-destination-v1" in sql
+
+
+# ── Seed canonical body alignment ──────────────────────────────────────
+
+
+def test_seed_destination_body_no_longer_contains_docx_fallback() -> None:
+    seed = _read("app/seed/creation_prompts.py")
+    # The exact old fallback line should be gone.
+    assert "Docx and PDF generation ships in" not in seed
+    # The new renderer-call guidance is present.
+    assert "render_markdown" in seed
+
+
+def test_seed_destination_body_still_contains_move_fallback() -> None:
+    """The cross-set move fallback stays until Phase 3 ships move_* tools."""
+    seed = _read("app/seed/creation_prompts.py")
+    assert "v6.3.0 ships move_* tools" in seed
+
+
+def test_doc_destination_body_aligned_with_seed() -> None:
+    """The canonical paste-ready doc must match the seed canonical body
+    so admins reading the doc see the same content the seed re-applies."""
+    doc = _read_repo("docs/prompts/creation-cascade-destination.md")
+    assert "Docx and PDF generation ships in" not in doc
+    assert "render_markdown" in doc
+    assert "v6.3.0 ships" in doc

--- a/docs/adrs/ADR-179-Renderer-And-Artefact-Store.md
+++ b/docs/adrs/ADR-179-Renderer-And-Artefact-Store.md
@@ -1,0 +1,129 @@
+# ADR-179: Server-side md → docx / pdf renderer + Iris artefact store
+
+Status: Accepted (2026-05-16)
+Extends: ADR-145 (image store), ADR-175 (web URL decoration), ADR-176 (cascade destination chooser).
+
+## Context
+
+Issue #133 Phase 1 (v6.1.0) shipped the destination-chooser prompt — the cascade now asks the user "save where?" and "what format(s)?" — but the renderer that actually produces the docx / pdf bytes, and the store that holds them, didn't exist. The Phase-1 cascade explicitly explains the gap and offers fallbacks ("docx and PDF generation ships in v6.2.0").
+
+Two design questions decided in the review for the plan rewrite (issue #133 v2 plan, May 2026):
+
+- **Where are rendered artefacts stored?** The user picked "store the file in Iris (we have a store for images, re-leverage that if suitable or extend) — provide a link to the file to the user". So artefacts persist server-side and MCP returns a download URL.
+- **What's the storage scope?** "This should apply by default for any docx or pdf generated, not just big ones." So inline base64 returns are out — every render lands in the store first.
+
+The MCP `web_url` decoration shipped in ADR-175 (v6.0.15) is the natural delivery mechanism — the render tools return `{artefact_id, web_url, mime_type, filename}` so the model can hand the user a one-click link.
+
+## Decision
+
+### Renderer
+
+Build a single renderer module at `backend/app/export/renderers/` with three Python files:
+
+- `markdown.py` — passthrough with stable normalisation (trim trailing whitespace, ensure trailing newline). Same code path as the existing `app/export/markdown.py` bundle renderer — Phase 2 just normalises the output for downstream consumption.
+- `docx.py` — md → docx via `python-docx` (already a backend dependency at >=1.1.0) + `markdown-it-py` (new dependency). Recipe modelled on `github.com/anthropics/skills/tree/main/skills/docx` — reads the markdown-it token stream and emits `python-docx` paragraphs / headings / lists / code blocks. Mermaid blocks pass through as triple-backtick code blocks; the docx reader can paste them into a mermaid-rendering tool.
+- `pdf.py` — md → pdf via `weasyprint` (new dependency) + a default CSS template. The markdown is converted to HTML via `markdown-it-py`, wrapped in a minimal HTML document with Iris-branded CSS, then passed to `weasyprint.HTML(string=...).write_pdf()`.
+
+Iris-branded CSS lives in `backend/app/export/renderers/styles/iris.css`. The CSS is small (~2 KB) — Iris fonts (system stack), header colour palette, code block styling, table borders. No image embedding by default; mermaid in PDFs stays as code (which the human can read or render in a separate tool).
+
+### Artefact store
+
+New top-level module `backend/app/artefacts/` (NOT a graft onto `app/images/`). The image store has tight magic-byte validation for PNG/JPEG/GIF/WebP — extending it to accept docx + pdf + plain text would either weaken that validation or carve out a separate code path inside it. A sibling module is cleaner: each store enforces the validation appropriate to its content category.
+
+Schema:
+
+```sql
+CREATE TABLE artefacts (
+    id TEXT PRIMARY KEY,
+    filename TEXT NOT NULL,
+    mime TEXT NOT NULL,
+    bytes BLOB NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    source_kind TEXT NOT NULL,  -- 'render_markdown' | 'export_diagram' | future kinds
+    source_ref TEXT,            -- diagram id when source_kind='export_diagram', NULL otherwise
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_artefacts_source_ref ON artefacts(source_ref);
+```
+
+Allowed MIMEs (frozenset constant):
+- `text/markdown`
+- `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (docx)
+- `application/pdf`
+
+Per-artefact size cap: 25 MB (generous — full DoView books fit easily).
+
+### Endpoints
+
+In `backend/app/export/router.py` (new endpoints alongside the existing read endpoints):
+
+- `POST /api/export/diagram/{diagram_id}` body `{format: 'md' | 'docx' | 'pdf'}` — fetches the diagram, extracts a markdown representation (uses the existing `app/export/markdown.py` bundle renderer plus the diagram's `data.content` if it's a markdown-content diagram), renders to the chosen format, stores, returns `{artefact_id, web_url, mime_type, filename}`. Auth-optional (matches the existing export endpoints).
+- `POST /api/export/markdown` body `{markdown, title, format}` — ad-hoc render of cascade-generated content not yet saved to a diagram. Same return shape. Auth-optional.
+
+The artefact GET endpoint `GET /api/artefacts/{artefact_id}` is **auth-optional** (matching `/api/images/{id}`) — artefacts are referenced by URL so anyone with the link can fetch them. This is the same model as image embeds. Future ADR can tighten this (signed URLs, time-bounded access) if needed.
+
+### MCP tools
+
+- `export_diagram(diagram_id: str, format: str)` — calls `POST /api/export/diagram/{diagram_id}` and returns the JSON.
+- `render_markdown(markdown: str, title: str, format: str)` — calls `POST /api/export/markdown` and returns the JSON.
+
+Both decorated by `with_web_url` so the `web_url` field is fully-qualified (matches ADR-175's pattern for `create_*` returns).
+
+### Cascade prompt update
+
+The Phase-1 docx/pdf fallback in `creation-cascade-destination-v1` is removed. The body now instructs the model: "When the user picks docx or pdf at Q-Dest3, call `render_markdown` for each selected format and present the returned `web_url` to the user as a clickable download link." A new migration applies this update to the seeded row; the seed function `seed_creation_prompts` is updated in lockstep.
+
+The cross-set move fallback ("save into current set, move to target after v6.3.0") **stays** until Phase 3 ships `move_*` tools. Only the renderer-related fallback is dropped in v6.2.0.
+
+## Why not extend the images store
+
+- Image validation logic (magic-byte sniffing for PNG/JPEG/GIF/WebP) is tight; weakening it to accept arbitrary bytes for docx / pdf either erodes the safety net or grows a category-conditional branch that's almost a separate code path anyway.
+- `POST /api/images` returning a successful response for a 200-KB DOCX is semantically wrong — clients reading the endpoint contract expect images.
+- The two stores have distinct concerns: image uploads come from human paste-in-editor (5 MB cap, image-only); artefact storage comes from server-side render (25 MB cap, doc-only). Sibling modules keep each contract honest.
+- A future "merge into one storage subsystem" decision is always available; over-investing in unification now ahead of a concrete use case is a Phase-7+ concern.
+
+## Why store rendered artefacts at all (vs return inline base64)
+
+- The user picked it: "store the file in Iris (we have a store for images, re-leverage that if suitable or extend) - this should apply by default for any docx or pdf generated not just big ones".
+- Inline base64 has MCP message-size limits — a multi-MB PDF could be rejected by the client or transport.
+- Storing produces a stable URL the user can share, re-download, or hand to other tools — same affordance as Iris's existing image embeds.
+- The `web_url` decoration shipped in v6.0.15 is the natural delivery mechanism.
+
+## Why no signed URLs / per-artefact ACLs yet
+
+- The existing `GET /api/images/{id}` is anonymous-readable on the same rationale (referenced by URL in shared content).
+- Tightening this is a separate decision worth a future ADR if real users / pen-tests surface the need.
+- The artefact endpoint is auth-optional NOT for ergonomic reasons but because the predecessor establishes that pattern; future ADR can supersede.
+
+## Consequences
+
+- New SQLite migration `m{next}_artefacts_table.py` + Supabase mirror creating the `artefacts` table.
+- New migration `m{next2}_drop_phase1_docx_fallback.py` + mirror UPDATEing `creation-cascade-destination-v1` to remove the renderer-related fallback paragraph.
+- New module `backend/app/artefacts/` (models.py + service.py + router.py).
+- New module `backend/app/export/renderers/` (markdown.py + docx.py + pdf.py + styles/iris.css).
+- Three new dependencies: `markdown-it-py`, `weasyprint` (new), and `python-docx` is already at >=1.1.0 in pyproject.toml.
+- Two new backend endpoints + one new GET (artefact download).
+- Two new MCP tools.
+- `mcp/src/iris_mcp/links.py` extended to decorate `export_diagram` + `render_markdown` returns with `web_url`.
+- `mcp/src/iris_mcp/server_instructions.py:_FALLBACK_INSTRUCTIONS` updated.
+- CHANGELOG `[6.2.0]`.
+- Version bumps: mcp + frontend 6.1.0 → 6.2.0.
+- **WeasyPrint deployment risk:** Render base image needs Pango, Cairo, GDK-PixBuf system libraries. Phase 2 verification per `feedback_render_deploy_verification` memory — curl the live `/api/export/markdown` endpoint after deploy. If 500s, update the Dockerfile to include the system deps before tagging the release.
+
+## Verification
+
+- `pytest backend/tests/export/test_md_to_docx.py` — md → docx → re-parse with `python-docx` → assert structure.
+- `pytest backend/tests/export/test_md_to_pdf.py` — md → pdf → assert byte-header `%PDF` + page count.
+- `pytest backend/tests/artefacts/test_store_roundtrip.py` — upload → URL → re-download → byte equality.
+- `pytest mcp/tests/test_export_tools.py` — MCP tool returns URL, URL resolves, content matches.
+- Manual UAT: cascade picks "Both" → md + docx + pdf → user receives three links → all download.
+
+## See also
+
+- [ADR-145] — existing image store, model from which the artefact store branches.
+- [ADR-175] — web_url decoration on create_* tools, reused here.
+- [ADR-176](ADR-176-Cascade-Shared-Base-Prompts.md) — destination chooser prompt this ADR actuates.
+- [SPEC-179-A](specs/SPEC-179-A-Renderer-And-Artefact-Store.md) — schemas, endpoint signatures, dep versions, test plan.
+- Anthropic skills `docx` + `pdf` at github.com/anthropics/skills — recipes for md → docx / pdf.
+- [`docs/plans/issue-133-doview-mcp-polish.md`](../plans/issue-133-doview-mcp-polish.md) — multi-phase plan, this is Phase 2.

--- a/docs/adrs/specs/SPEC-179-A-Renderer-And-Artefact-Store.md
+++ b/docs/adrs/specs/SPEC-179-A-Renderer-And-Artefact-Store.md
@@ -1,0 +1,196 @@
+# SPEC-179-A: Server-side md → docx / pdf renderer + Iris artefact store
+
+ADR: [ADR-179](../ADR-179-Renderer-And-Artefact-Store.md)
+
+## Summary
+
+Build a renderer module under `backend/app/export/renderers/` that converts markdown to docx (via `python-docx` + `markdown-it-py`) and to pdf (via `weasyprint`). Add a generic artefact store at `backend/app/artefacts/` (separate from the image store). Expose render + retrieve via two new POST endpoints plus the artefact GET. Wrap both with MCP tools. Drop the Phase-1 docx/pdf fallback from `creation-cascade-destination-v1`.
+
+## Schema
+
+```sql
+CREATE TABLE artefacts (
+    id TEXT PRIMARY KEY,
+    filename TEXT NOT NULL,
+    mime TEXT NOT NULL,
+    bytes BLOB NOT NULL,
+    size_bytes INTEGER NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_ref TEXT,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_artefacts_source_ref ON artefacts(source_ref);
+```
+
+`source_kind` values:
+- `render_markdown` — ad-hoc render of cascade content. `source_ref = NULL`.
+- `export_diagram` — diagram exported via `POST /api/export/diagram/{id}`. `source_ref = diagram_id`.
+
+## ALLOWED MIMEs / cap
+
+```python
+ALLOWED_ARTEFACT_MIMES = frozenset({
+    "text/markdown",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/pdf",
+})
+MAX_ARTEFACT_BYTES = 25 * 1024 * 1024  # 25 MB
+```
+
+## Renderer signatures
+
+`backend/app/export/renderers/markdown.py`:
+```python
+def render(markdown: str) -> tuple[bytes, str]:
+    """Return (bytes, filename). Normalised UTF-8 markdown."""
+```
+
+`backend/app/export/renderers/docx.py`:
+```python
+def render(markdown: str, title: str) -> tuple[bytes, str]:
+    """Return (bytes, filename). Title becomes the docx 'Title' style at the top."""
+```
+
+`backend/app/export/renderers/pdf.py`:
+```python
+def render(markdown: str, title: str) -> tuple[bytes, str]:
+    """Return (bytes, filename). Title becomes the HTML <title> and visible <h1>."""
+```
+
+Each renderer normalises the filename via slug-of-title + UUID suffix + extension. E.g. `title="Banana Monoculture DoView"` + docx → `banana-monoculture-doview-9f2c.docx`.
+
+## Endpoints
+
+### `POST /api/export/diagram/{diagram_id}`
+
+Request body:
+```json
+{"format": "md" | "docx" | "pdf"}
+```
+
+Behaviour:
+- 200: returns `{artefact_id, web_url, mime_type, filename}`.
+- 404: diagram not found.
+- 400: format not supported.
+- 413: rendered output exceeds MAX_ARTEFACT_BYTES.
+
+For markdown-content diagrams (`notation='markdown'`): use `data.content` directly. For visual diagrams: use the existing `app/export/markdown.py` bundle renderer to produce a structured summary, then render via the chosen format. Visual-diagram exports always include the bundle's element listing; pdf/docx exports include diagram metadata at the top.
+
+### `POST /api/export/markdown`
+
+Request body:
+```json
+{"markdown": "...", "title": "...", "format": "md" | "docx" | "pdf"}
+```
+
+Same return shape. For ad-hoc rendering of cascade-generated content that hasn't been saved to a diagram. No source_ref.
+
+### `GET /api/artefacts/{artefact_id}`
+
+Returns the artefact bytes with `Content-Type: <stored mime>` and `Content-Disposition: attachment; filename="<stored filename>"`. Auth-optional (matches `/api/images/{id}`). Long cache header — artefacts are immutable.
+
+- 200: bytes
+- 404: artefact not found
+
+## MCP tools
+
+In `mcp/src/iris_mcp/tools.py`:
+
+```python
+@server.tool()
+async def export_diagram(diagram_id: str, format: str = "md") -> dict:
+    """Render a diagram to markdown / docx / pdf and store in Iris.
+    Returns {artefact_id, web_url, mime_type, filename} — give the user
+    the web_url as a clickable download link."""
+    ...
+
+@server.tool()
+async def render_markdown(markdown: str, title: str, format: str = "md") -> dict:
+    """Render ad-hoc markdown content to md / docx / pdf and store in
+    Iris. Used by creation cascades when the user picks "Chat with
+    downloadable artefacts". Returns same shape as export_diagram."""
+    ...
+```
+
+Both wrapped by `with_web_url` so the `web_url` is fully-qualified per ADR-175.
+
+## Cascade prompt update
+
+Migration `m{next}_drop_phase1_docx_fallback.py` UPDATEs `creation-cascade-destination-v1` to remove the docx/pdf-renderer fallback paragraph (Phase-1 fallback section in `docs/prompts/creation-cascade-destination.md`). The cross-set move fallback stays until Phase 3.
+
+The seed file `backend/app/seed/creation_prompts.py` is updated in lockstep — `CASCADE_DESTINATION_PROMPT` constant body has the renderer fallback removed and replaced with: "When the user picks docx or pdf at Q-Dest3, call `render_markdown` for each selected format. The returned `web_url` is a downloadable link — present it to the user as a clickable URL."
+
+## Dependencies
+
+`backend/pyproject.toml`:
+- `python-docx>=1.1.0` — already present, unchanged.
+- `markdown-it-py>=4.0.0` — new.
+- `weasyprint>=68.0` — new. Verified installable in the dev devcontainer. Render base image needs Pango / Cairo / GDK-PixBuf system libraries — verified at Phase 2 deploy gate.
+
+Pin to latest stable as of implementation date per protocols §11.
+
+## Tests
+
+### `backend/tests/test_export/test_md_to_docx.py` (new)
+
+- `test_simple_paragraph_round_trips` — md "Hello world" → docx → reopen via python-docx Document → assert one paragraph with text "Hello world".
+- `test_heading_h1_h2_h3` — md with `# H1`, `## H2`, `### H3` → docx → assert paragraphs have styles `Heading 1`, `Heading 2`, `Heading 3`.
+- `test_bullet_list_round_trips` — md `- one\n- two\n- three` → docx → assert three list-style paragraphs.
+- `test_code_block_preserved` — md fenced code block → docx → assert paragraph with code style or monospace formatting.
+- `test_mermaid_block_passes_through` — md ```mermaid``` block → docx → assert the body text contains the mermaid source verbatim.
+
+### `backend/tests/test_export/test_md_to_pdf.py` (new)
+
+- `test_simple_markdown_produces_valid_pdf` — md "Hello" → pdf → assert byte-header `b"%PDF"`.
+- `test_multi_page_markdown` — long markdown → pdf → assert page count >= 2 via pdfplumber (already a backend dep).
+- `test_title_appears_in_pdf` — md with title="Test" → pdf → extract text via pdfplumber → assert "Test" in text.
+
+### `backend/tests/test_artefacts/test_store_roundtrip.py` (new)
+
+- `test_create_artefact_returns_id` — service.create_artefact(bytes, mime, filename) → returns dict with id.
+- `test_get_artefact_returns_bytes` — create + get → bytes match.
+- `test_oversized_artefact_rejected` — bytes > 25MB → ValueError.
+- `test_disallowed_mime_rejected` — `image/png` mime → ValueError ("use the images endpoint").
+
+### `backend/tests/test_export/test_render_endpoints.py` (new)
+
+- `test_post_render_markdown_md_returns_url` — POST /api/export/markdown with format=md → 200 + web_url + filename ending .md.
+- `test_post_render_markdown_docx_returns_url` — same with format=docx → 200 + filename ending .docx + GET URL returns valid docx bytes.
+- `test_post_render_markdown_pdf_returns_url` — same with format=pdf → 200 + filename ending .pdf + GET URL returns valid PDF (starts with `%PDF`).
+- `test_post_export_diagram_404_for_missing_id` — POST /api/export/diagram/nope → 404.
+- `test_post_render_markdown_invalid_format_400` — format=svg → 400.
+
+### `backend/tests/test_migrations/test_artefacts_schema.py` (new)
+
+- Static-parser checks: migration creates `artefacts` table with all required columns + index + idempotency guard.
+- Supabase mirror present with same schema using `BOOLEAN`-correct literals where applicable.
+
+### `backend/tests/test_migrations/test_phase2_destination_actuation_schema.py` (new)
+
+- Migration removes the Phase-1 docx/pdf fallback string from `creation-cascade-destination-v1`.
+- Migration leaves the cross-set move fallback string intact (move tools ship Phase 3).
+- Supabase mirror does the same.
+- Seed file constant `CASCADE_DESTINATION_PROMPT` no longer contains the docx-pdf fallback string but still contains the move-tools fallback string.
+
+### `mcp/tests/test_export_tools.py` (new)
+
+- `test_export_diagram_returns_web_url` — fixture diagram → MCP `export_diagram(id, format='md')` → response has `web_url` matching the configured `IRIS_WEB_URL`.
+- `test_render_markdown_returns_web_url` — MCP `render_markdown("# Test", "Title", "pdf")` → response has `web_url` ending `/api/artefacts/<id>`.
+
+## Versioning
+
+`mcp/pyproject.toml`: 6.1.0 → 6.2.0. Minor bump — new MCP tools.
+`frontend/package.json`: matched 6.2.0.
+
+## CHANGELOG
+
+`[6.2.0]` Added: renderer + artefact store + MCP `export_diagram` / `render_markdown`. Changed: cascade destination prompt drops docx/pdf fallback.
+
+## Acceptance criteria
+
+- [ ] `pytest backend/tests/test_export/` and `backend/tests/test_artefacts/` green.
+- [ ] `pytest backend/tests/test_migrations/test_artefacts_schema.py test_phase2_destination_actuation_schema.py` green.
+- [ ] `pytest mcp/tests/test_export_tools.py` green.
+- [ ] Manual UAT: banana cascade picks "Both" + md+docx+pdf → three downloadable URLs that all open correctly.
+- [ ] Render deployment check per `feedback_render_deploy_verification`: curl `/api/export/markdown` against the deployed env; if 500, update Dockerfile for Pango/Cairo/GDK-PixBuf.

--- a/docs/prompts/creation-cascade-destination.md
+++ b/docs/prompts/creation-cascade-destination.md
@@ -62,17 +62,20 @@ AskUserQuestion with multi-select enabled:
 
 At least one option must be selected.
 
-### Phase-1 fallback (cascade-prompt only, no renderer yet)
+### Phase-1 fallback (move tools only)
 
-This prompt-side cascade is shipping in v6.1.0 ahead of the renderer
-and move tools that actuate it. Until v6.2.0 and v6.3.0 land:
+The destination chooser was shipped in v6.1.0 ahead of the move tools
+that handle post-hoc destination changes. The docx/pdf renderer
+landed in v6.2.0 — those formats now go through `render_markdown`.
+The cross-set move fallback remains until v6.3.0 ships `move_*` tools:
 
-- If the user picks "Chat with downloadable artefacts" and selects
-  docx or pdf at Q-Dest3, respond: "Docx and PDF generation ships in
-  v6.2.0 (Phase 2 of issue #133). For now I can produce a markdown
-  artefact in the chat and create the Iris bundle if you'd like."
-  Then offer AskUserQuestion with options "Yes, markdown + Iris save",
-  "Just the Iris save", "Cancel and wait for v6.2.0".
+- When the user picks "Chat with downloadable artefacts" and selects
+  one or more formats at Q-Dest3, call the MCP `render_markdown`
+  tool once per selected format (markdown / docx / pdf). Each call
+  returns `{artefact_id, web_url, mime_type, filename}` — present the
+  `web_url` to the user as a clickable download link. For "Both"
+  (Iris + artefacts), also create the Iris bundle via the
+  destination-specific `create_*` tools.
 
 - If the user picks "Somewhere else" or "Browse" at Q-Dest2 and the
   chosen destination differs from the current set, respond: "I can

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.1.0",
+	"version": "6.2.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.1.0"
+version = "6.2.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -395,6 +395,71 @@ async def _list_conversations(c: IrisClient, args: dict[str, Any]) -> str:
     return json.dumps([r.model_dump() for r in rows])
 
 
+# ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────────
+
+
+def _attach_artefact_url(body: dict[str, Any], client_url: str) -> dict[str, Any]:
+    """Attach the backend `web_url` for an artefact response.
+
+    Artefacts are served by the backend at `/api/artefacts/<id>` (not
+    by the frontend) — the URL has Content-Disposition: attachment
+    so any client (browser, MCP, curl) downloads it directly. The
+    URL points at IRIS_URL (backend), not IRIS_WEB_URL (frontend).
+    """
+    if not isinstance(body, dict):
+        return body
+    artefact_id = body.get("id")
+    if isinstance(artefact_id, str) and client_url:
+        body["web_url"] = f"{client_url.rstrip('/')}/api/artefacts/{artefact_id}"
+    return body
+
+
+async def _render_diagram(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-179 (v6.2.0): render a diagram to md/docx/pdf and store as
+    an artefact in Iris. Returns the artefact metadata + download URL.
+
+    Pair the returned `web_url` with a short label and present it to
+    the user as a clickable download link. The artefact is auth-
+    optional once created so the user can share the URL with anyone.
+    """
+    try:
+        response = await c._request(
+            "POST",
+            f"/api/export/diagram/{args['diagram_id']}",
+            json={"format": args.get("format", "md")},
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Render diagram")
+    body = _attach_artefact_url(response.json(), c.url)
+    return json.dumps(body)
+
+
+async def _render_markdown(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-179 (v6.2.0): render ad-hoc markdown content to md/docx/pdf
+    and store as an artefact in Iris. Used by the creation cascade
+    when the user picks 'Chat with downloadable artefacts'. Returns
+    the artefact metadata + download URL.
+
+    The cascade calls this once per selected format (markdown / docx
+    / pdf). Each call returns a distinct artefact_id and web_url —
+    present all returned URLs together as a list of download links.
+    """
+    try:
+        response = await c._request(
+            "POST",
+            "/api/export/markdown",
+            json={
+                "markdown": args["markdown"],
+                "title": args.get("title", "Untitled"),
+                "format": args.get("format", "md"),
+            },
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Render markdown")
+    body = _attach_artefact_url(response.json(), c.url)
+    return json.dumps(body)
+
+
 TOOLS: list[Tool] = [
     Tool(
         name="search",
@@ -901,6 +966,56 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_create_diagram,
+    ),
+    # ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────
+    Tool(
+        name="render_diagram",
+        description=(
+            "Render a diagram as markdown / docx / pdf and store the "
+            "result as an Iris artefact. Returns "
+            "{id, filename, mime_type, size_bytes, web_url, ...} — "
+            "present the web_url to the user as a clickable download "
+            "link. For markdown-content diagrams the original "
+            "data.content is used directly; for visual diagrams a "
+            "structured markdown summary is generated then rendered. "
+            "Distinct from `export_diagram` (which returns raw JSON/"
+            "markdown text) — this tool produces downloadable files."
+        ),
+        input_schema=_schema({
+            "diagram_id": _str_arg("diagram_id", "Diagram id"),
+            "format": (
+                {"type": "string", "enum": ["md", "docx", "pdf"]},
+                True,
+            ),
+        }),
+        handler=_render_diagram,
+    ),
+    Tool(
+        name="render_markdown",
+        description=(
+            "Render ad-hoc markdown content as markdown / docx / pdf "
+            "and store the result as an Iris artefact. Used by the "
+            "creation cascade when the user picks 'Chat with "
+            "downloadable artefacts' — call once per selected format "
+            "(md / docx / pdf). Returns {id, filename, mime_type, "
+            "size_bytes, web_url, ...}. Present the web_url to the "
+            "user as a clickable download link. The artefact is "
+            "served at /api/artefacts/<id> with Content-Disposition: "
+            "attachment so any client downloads it directly."
+        ),
+        input_schema=_schema({
+            "markdown": _str_arg("markdown", "Markdown source text"),
+            "title": _str_arg(
+                "title",
+                "Document title (becomes the docx/pdf heading and "
+                "filename slug)",
+            ),
+            "format": (
+                {"type": "string", "enum": ["md", "docx", "pdf"]},
+                True,
+            ),
+        }),
+        handler=_render_markdown,
     ),
 ]
 

--- a/mcp/tests/test_render_tools.py
+++ b/mcp/tests/test_render_tools.py
@@ -1,0 +1,169 @@
+"""MCP render_diagram + render_markdown tool tests (ADR-179, v6.2.0).
+
+Covers tool inventory presence, happy paths via respx-mocked backend,
+auth-required payload mapping on 401, and web_url attachment from the
+client's backend URL.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+def _artefact_payload(**overrides: object) -> dict[str, object]:
+    """Minimal backend ArtefactResponse payload shape."""
+    base = {
+        "id": "art-9f2c",
+        "filename": "test-9f2c.md",
+        "mime_type": "text/markdown",
+        "size_bytes": 12,
+        "source_kind": "render_markdown",
+        "source_ref": None,
+        "created_at": "2026-05-16T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestInventory:
+    def test_new_tools_registered(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        assert {"render_diagram", "render_markdown"} <= names
+
+    def test_render_diagram_schema(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        schema = defs["render_diagram"].inputSchema
+        assert "diagram_id" in schema["properties"]
+        assert "format" in schema["properties"]
+        assert schema["properties"]["format"]["enum"] == ["md", "docx", "pdf"]
+
+    def test_render_markdown_schema(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        schema = defs["render_markdown"].inputSchema
+        assert "markdown" in schema["properties"]
+        assert "title" in schema["properties"]
+        assert "format" in schema["properties"]
+        assert schema["properties"]["format"]["enum"] == ["md", "docx", "pdf"]
+
+
+class TestRenderDiagram:
+    @pytest.mark.asyncio
+    async def test_happy_path_md(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/diagram/d-1").mock(
+            return_value=httpx.Response(
+                200,
+                json=_artefact_payload(
+                    id="art-md-1",
+                    filename="d-1.md",
+                    source_kind="export_diagram",
+                    source_ref="d-1",
+                ),
+            ),
+        )
+        result = await tools.dispatch(
+            "render_diagram", client,
+            {"diagram_id": "d-1", "format": "md"},
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "art-md-1"
+        assert body["mime_type"] == "text/markdown"
+        # web_url attached pointing at backend /api/artefacts/<id>.
+        assert body["web_url"] == f"{BASE}/api/artefacts/art-md-1"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_pdf(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/diagram/d-2").mock(
+            return_value=httpx.Response(
+                200,
+                json=_artefact_payload(
+                    id="art-pdf-2",
+                    filename="d-2-x.pdf",
+                    mime_type="application/pdf",
+                    source_kind="export_diagram",
+                    source_ref="d-2",
+                ),
+            ),
+        )
+        result = await tools.dispatch(
+            "render_diagram", client,
+            {"diagram_id": "d-2", "format": "pdf"},
+        )
+        body = json.loads(result[0].text)
+        assert body["mime_type"] == "application/pdf"
+        assert body["web_url"].endswith("/api/artefacts/art-pdf-2")
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/diagram/d-1").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "render_diagram", client,
+            {"diagram_id": "d-1", "format": "md"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"
+
+
+class TestRenderMarkdown:
+    @pytest.mark.asyncio
+    async def test_happy_path_docx(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/markdown").mock(
+            return_value=httpx.Response(
+                200,
+                json=_artefact_payload(
+                    id="art-docx-3",
+                    filename="notes-3a4b.docx",
+                    mime_type=(
+                        "application/vnd.openxmlformats-"
+                        "officedocument.wordprocessingml.document"
+                    ),
+                    source_kind="render_markdown",
+                ),
+            ),
+        )
+        result = await tools.dispatch(
+            "render_markdown", client,
+            {
+                "markdown": "# Notes\n\nbody",
+                "title": "Notes",
+                "format": "docx",
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "art-docx-3"
+        assert "wordprocessingml" in body["mime_type"]
+        assert body["web_url"] == f"{BASE}/api/artefacts/art-docx-3"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/markdown").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "render_markdown", client,
+            {"markdown": "x", "title": "T", "format": "md"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"


### PR DESCRIPTION
## Summary

Phase 2 of issue #133. The Phase-1 destination chooser cascade now actually produces the downloadable artefacts it promises.

- **Renderer module** at `backend/app/export/renderers/{markdown,docx,pdf}.py` + Iris-branded CSS.
- **Artefact store** at `backend/app/artefacts/` (sibling-to-images, mime allowlist md/docx/pdf, 25 MB cap, magic-byte validation).
- **Backend endpoints**: `POST /api/export/diagram/{id}`, `POST /api/export/markdown`, `GET /api/artefacts/{id}`.
- **MCP tools** `render_diagram` and `render_markdown` returning `{id, filename, mime_type, web_url, ...}`. `web_url` points at the backend `/api/artefacts/<id>` so any client (browser, curl) downloads directly.
- **Cascade prompt** drops the Phase-1 docx/pdf fallback; cross-set move fallback stays until Phase 3.

## Tests

- 406/406 green in `backend/tests/test_{ai,migrations,export,artefacts}/`.
- 181/181 green in `mcp/tests/`.

## Deploy risk

WeasyPrint needs Pango / Cairo / GDK-PixBuf system libraries. Verify the Render base image has them before tagging — curl `POST /api/export/markdown` against the live env. If 500, update the Dockerfile.

## References

- ADR-179 / SPEC-179-A
- `docs/plans/issue-133-doview-mcp-polish.md`
- Issue #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)