### PR TITLE
feat(v6.4.0): CLI write-tool parity with MCP (issue #133 Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.4.0] - 2026-05-16
+
+Issue #133 Phase 4 — CLI write-tool parity with MCP. Every backend
+write endpoint that has an MCP tool now also has an `iris` CLI
+subcommand. The deliberate `iris ask` asymmetry (CLI-only, no MCP
+counterpart per ADR-168) is documented.
+
+### Added
+
+- `iris create` sub-app with `collection`, `set`, `package`,
+  `diagram` commands (ADR-180, SPEC-180-A). Mirrors the MCP `create_*`
+  surface.
+- `iris update` sub-app with `collection`, `set`, `package`,
+  `diagram`, `element` commands. Same partial-update semantics as
+  MCP `update_*` (GET-then-merge-then-PUT). `iris update set`
+  deliberately excludes `--collection-id` (use `iris move set`).
+- `iris move` sub-app with `diagram`, `package`, `set` commands.
+  Pass the literal string `null` to set the target to NULL (move
+  to set root / un-group).
+- `iris render` sub-app with `diagram` and `markdown` commands.
+  Renders to md/docx/pdf via the Phase 2 backend endpoints. With
+  `-o OUT_PATH`, downloads the artefact bytes; without, prints the
+  metadata JSON.
+- `cli/pyproject.toml`: 0.1.0 → 0.2.0.
+
+### See also
+
+- [ADR-180](docs/adrs/ADR-180-CLI-Write-Tool-Parity.md)
+- [SPEC-180-A](docs/adrs/specs/SPEC-180-A-CLI-Write-Parity.md)
+- [docs/plans/issue-133-doview-mcp-polish.md](docs/plans/issue-133-doview-mcp-polish.md)
+
+### Tests
+
+- 34/34 functional tests green in `cli/tests/` (17 new write-command
+  tests + existing 17). 3 integration smoke tests skipped because they
+  need the backend module installed in the CLI venv — pre-existing.
+
 ## [6.3.0] - 2026-05-16
 
 Issue #133 Phase 3 — MCP `update_*` and `move_*` tool surface. The

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,7 @@
 # iris-cli
 
-Command-line interface for Iris. Read-only + AI surface (ADR-130).
+Command-line interface for Iris. Read-only + write + AI surface
+(ADR-130 + ADR-180 v6.4.0).
 
 ## Install (from repo)
 
@@ -21,12 +22,36 @@ uv tool install "git+https://github.com/cgbarlow/iris#subdirectory=cli"
 # Personal Access Token for you and stores it in ~/.config/iris/config.toml.
 iris login --url https://iris.example.com
 
+# Read
 iris whoami
 iris search "payment"
 iris diagrams list
 iris export diagram <id> --format markdown -o overview.md
 iris ask "Summarise the onboarding flow" --set default
+
+# Write (v6.4.0, ADR-180)
+iris create set --name "My Set" --collection-id <col-id>
+iris create diagram --name "Overview" --diagram-type simple --set-id <set-id> \
+  --data-json '{"nodes": [], "edges": []}'
+
+iris update set <set-id> --description "Updated"        # partial update
+iris update diagram <diag-id> --change-summary "fixed labels"
+
+iris move diagram <diag-id> --to-package <pkg-id>       # in-set re-parent
+iris move diagram <diag-id> --to-package null           # move to set root
+iris move set <set-id> --to-collection <new-col-id>     # cross-collection
+iris move set <set-id> --to-collection null             # un-group
+
+iris render diagram <diag-id> --format pdf -o out.pdf   # store artefact + download
+iris render markdown --title T --format docx --input notes.md -o notes.docx
 ```
+
+### `iris ask` is CLI-only by design
+
+ADR-168 removed `ask` from the MCP surface because MCP clients bring
+their own LLM. CLI users don't, so `iris ask` stays. This is a
+deliberate asymmetry — documented in ADR-180 and the Phase 6 parity
+matrix.
 
 Configuration resolution order (first match wins):
 1. CLI flag (`--url`, `--token`)

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-cli"
-version = "0.1.0"
+version = "0.2.0"
 description = "Command-line interface for Iris (ADR-130)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -3,12 +3,18 @@
 Commands are grouped by entity / concern. All async calls to the backend
 route through a single `iris_client.IrisClient` instance configured via
 `iris_cli.config.load`.
+
+v6.4.0 (ADR-180): adds write-tool parity with MCP. New sub-apps:
+`iris create`, `iris update`, `iris move`, `iris render`. Existing
+`iris export` is read-only; `iris render` is the artefact pipeline
+(md/docx/pdf via the v6.2.0 renderer).
 """
 
 from __future__ import annotations
 
 import asyncio
 import getpass
+import json as json_lib
 import socket
 import sys
 from pathlib import Path
@@ -23,7 +29,7 @@ from iris_cli import output
 
 app = typer.Typer(
     name="iris",
-    help="Command-line interface for Iris (read-only + AI).",
+    help="Command-line interface for Iris.",
     no_args_is_help=True,
 )
 
@@ -34,8 +40,14 @@ elements_app = typer.Typer(help="Element commands.", no_args_is_help=True)
 packages_app = typer.Typer(help="Package commands.", no_args_is_help=True)
 sets_app = typer.Typer(help="Set commands.", no_args_is_help=True)
 collections_app = typer.Typer(help="Collection commands.", no_args_is_help=True)
-export_app = typer.Typer(help="Export entities as JSON or Markdown.", no_args_is_help=True)
+export_app = typer.Typer(help="Export entities as JSON or Markdown (read-only).", no_args_is_help=True)
 conversations_app = typer.Typer(help="Conversation commands.", no_args_is_help=True)
+
+# v6.4.0 (ADR-180): write-tool parity with MCP.
+create_app = typer.Typer(help="Create new entities.", no_args_is_help=True)
+update_app = typer.Typer(help="Update entity metadata (partial).", no_args_is_help=True)
+move_app = typer.Typer(help="Re-parent entities (diagram / package / set).", no_args_is_help=True)
+render_app = typer.Typer(help="Render diagrams or markdown to md/docx/pdf artefacts.", no_args_is_help=True)
 
 app.add_typer(diagrams_app, name="diagrams")
 app.add_typer(elements_app, name="elements")
@@ -44,6 +56,10 @@ app.add_typer(sets_app, name="sets")
 app.add_typer(collections_app, name="collections")
 app.add_typer(export_app, name="export")
 app.add_typer(conversations_app, name="conversations")
+app.add_typer(create_app, name="create")
+app.add_typer(update_app, name="update")
+app.add_typer(move_app, name="move")
+app.add_typer(render_app, name="render")
 
 
 # --- Global context ---------------------------------------------------------
@@ -534,6 +550,429 @@ def conversations_list(
             columns=["id", "question", "model_used", "created_at"],
             title=f"Conversations in {set_id}",
         )
+
+
+# --- v6.4.0 (ADR-180) write-tool parity with MCP ---------------------------
+
+
+def _parse_json_opt(raw: str | None, flag: str) -> dict[str, Any] | None:
+    """Parse a JSON dict from a CLI flag; bail with a clear error on bad JSON."""
+    if raw is None:
+        return None
+    try:
+        parsed = json_lib.loads(raw)
+    except json_lib.JSONDecodeError as exc:
+        output.print_error(f"{flag}: invalid JSON ({exc})")
+        raise typer.Exit(code=1) from exc
+    if not isinstance(parsed, dict):
+        output.print_error(f"{flag}: expected a JSON object, got {type(parsed).__name__}")
+        raise typer.Exit(code=1)
+    return parsed
+
+
+def _resolve_null(value: str) -> str | None:
+    """Treat the literal string 'null' as None for move flags."""
+    return None if value.lower() == "null" else value
+
+
+async def _put_merge_partial(
+    c: IrisClient, kind_path: str, entity_id: str,
+    partial: dict[str, Any], updatable_fields: tuple[str, ...],
+) -> dict[str, Any]:
+    """GET-then-merge-then-PUT, mirroring the MCP update_* helper.
+
+    The backend PUT does full-replace, so partial updates need a merge
+    pass first. Costs one extra GET per update.
+    """
+    current_resp = await c._request("GET", f"/api/{kind_path}/{entity_id}")
+    current = current_resp.json()
+    body: dict[str, Any] = {}
+    for field in updatable_fields:
+        if field in partial and partial[field] is not None:
+            body[field] = partial[field]
+        elif field in current:
+            body[field] = current[field]
+    resp = await c._request("PUT", f"/api/{kind_path}/{entity_id}", json=body)
+    return resp.json()
+
+
+# ── iris create ────────────────────────────────────────────────────────────
+
+
+@create_app.command("collection")
+def create_collection_cmd(
+    name: str = typer.Option(..., "--name"),
+    description: str | None = typer.Option(None, "--description"),
+) -> None:
+    """Create a new Collection."""
+    async def _do() -> Any:
+        async with _client() as c:
+            return await c.create_collection(name=name, description=description)
+    output.print_json(_run(_do()))
+
+
+@create_app.command("set")
+def create_set_cmd(
+    name: str = typer.Option(..., "--name"),
+    collection_id: str | None = typer.Option(None, "--collection-id"),
+    description: str | None = typer.Option(None, "--description"),
+) -> None:
+    """Create a new Set (optionally nested under a collection)."""
+    async def _do() -> Any:
+        async with _client() as c:
+            return await c.create_set(
+                name=name, collection_id=collection_id, description=description,
+            )
+    output.print_json(_run(_do()))
+
+
+@create_app.command("package")
+def create_package_cmd(
+    name: str = typer.Option(..., "--name"),
+    set_id: str | None = typer.Option(None, "--set-id"),
+    parent_package_id: str | None = typer.Option(None, "--parent-package-id"),
+    description: str | None = typer.Option(None, "--description"),
+    metadata_json: str | None = typer.Option(
+        None, "--metadata-json", help="Metadata as a JSON object string.",
+    ),
+) -> None:
+    """Create a new Package."""
+    metadata = _parse_json_opt(metadata_json, "--metadata-json")
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await c.create_package(
+                name=name, set_id=set_id, parent_package_id=parent_package_id,
+                description=description, metadata=metadata,
+            )
+    output.print_json(_run(_do()))
+
+
+@create_app.command("diagram")
+def create_diagram_cmd(
+    name: str = typer.Option(..., "--name"),
+    diagram_type: str = typer.Option(..., "--diagram-type"),
+    notation: str | None = typer.Option(None, "--notation"),
+    set_id: str | None = typer.Option(None, "--set-id"),
+    parent_package_id: str | None = typer.Option(None, "--parent-package-id"),
+    description: str | None = typer.Option(None, "--description"),
+    data_json: str | None = typer.Option(
+        None, "--data-json", help="Canvas data as a JSON object string.",
+    ),
+) -> None:
+    """Create a new Diagram."""
+    data = _parse_json_opt(data_json, "--data-json")
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await c.create_diagram(
+                name=name, diagram_type=diagram_type, notation=notation,
+                set_id=set_id, parent_package_id=parent_package_id,
+                description=description, data=data,
+            )
+    output.print_json(_run(_do()))
+
+
+# ── iris update ────────────────────────────────────────────────────────────
+
+_COLLECTION_UPDATE_FIELDS = (
+    "name", "description", "thumbnail_source", "thumbnail_diagram_id",
+    "system_prompt", "mcp_system_context",
+)
+_SET_METADATA_FIELDS = (
+    "name", "description", "thumbnail_source", "thumbnail_diagram_id",
+    "system_prompt", "mcp_system_context",
+)
+_PACKAGE_UPDATE_FIELDS = ("name", "description", "metadata")
+_DIAGRAM_UPDATE_FIELDS = ("name", "description", "data", "metadata", "change_summary")
+_ELEMENT_UPDATE_FIELDS = ("name", "description", "data")
+
+
+@update_app.command("collection")
+def update_collection_cmd(
+    collection_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    system_prompt: str | None = typer.Option(None, "--system-prompt"),
+    mcp_system_context: str | None = typer.Option(None, "--mcp-system-context"),
+    thumbnail_source: str | None = typer.Option(None, "--thumbnail-source"),
+    thumbnail_diagram_id: str | None = typer.Option(None, "--thumbnail-diagram-id"),
+) -> None:
+    """Update a Collection's metadata (partial — GET-then-merge-then-PUT)."""
+    partial = {
+        "name": name, "description": description,
+        "system_prompt": system_prompt,
+        "mcp_system_context": mcp_system_context,
+        "thumbnail_source": thumbnail_source,
+        "thumbnail_diagram_id": thumbnail_diagram_id,
+    }
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await _put_merge_partial(
+                c, "collections", collection_id, partial, _COLLECTION_UPDATE_FIELDS,
+            )
+    output.print_json(_run(_do()))
+
+
+@update_app.command("set")
+def update_set_cmd(
+    set_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    system_prompt: str | None = typer.Option(None, "--system-prompt"),
+    mcp_system_context: str | None = typer.Option(None, "--mcp-system-context"),
+    thumbnail_source: str | None = typer.Option(None, "--thumbnail-source"),
+    thumbnail_diagram_id: str | None = typer.Option(None, "--thumbnail-diagram-id"),
+) -> None:
+    """Update a Set's metadata. To move a set between collections, use
+    `iris move set` instead — this command deliberately excludes
+    collection_id."""
+    partial = {
+        "name": name, "description": description,
+        "system_prompt": system_prompt,
+        "mcp_system_context": mcp_system_context,
+        "thumbnail_source": thumbnail_source,
+        "thumbnail_diagram_id": thumbnail_diagram_id,
+    }
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await _put_merge_partial(
+                c, "sets", set_id, partial, _SET_METADATA_FIELDS,
+            )
+    output.print_json(_run(_do()))
+
+
+@update_app.command("package")
+def update_package_cmd(
+    package_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    metadata_json: str | None = typer.Option(None, "--metadata-json"),
+) -> None:
+    """Update a Package's metadata."""
+    partial = {
+        "name": name, "description": description,
+        "metadata": _parse_json_opt(metadata_json, "--metadata-json"),
+    }
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await _put_merge_partial(
+                c, "packages", package_id, partial, _PACKAGE_UPDATE_FIELDS,
+            )
+    output.print_json(_run(_do()))
+
+
+@update_app.command("diagram")
+def update_diagram_cmd(
+    diagram_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    data_json: str | None = typer.Option(None, "--data-json"),
+    metadata_json: str | None = typer.Option(None, "--metadata-json"),
+    change_summary: str | None = typer.Option(None, "--change-summary"),
+) -> None:
+    """Update a Diagram. Versioned — every successful update increments
+    current_version. Use `iris move diagram` to re-parent."""
+    partial = {
+        "name": name, "description": description,
+        "data": _parse_json_opt(data_json, "--data-json"),
+        "metadata": _parse_json_opt(metadata_json, "--metadata-json"),
+        "change_summary": change_summary,
+    }
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await _put_merge_partial(
+                c, "diagrams", diagram_id, partial, _DIAGRAM_UPDATE_FIELDS,
+            )
+    output.print_json(_run(_do()))
+
+
+@update_app.command("element")
+def update_element_cmd(
+    element_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    data_json: str | None = typer.Option(None, "--data-json"),
+) -> None:
+    """Update an Element. Note: elements cannot be moved between
+    diagrams — they travel with their parent diagram (ADR-178 invariant)."""
+    partial = {
+        "name": name, "description": description,
+        "data": _parse_json_opt(data_json, "--data-json"),
+    }
+
+    async def _do() -> Any:
+        async with _client() as c:
+            return await _put_merge_partial(
+                c, "elements", element_id, partial, _ELEMENT_UPDATE_FIELDS,
+            )
+    output.print_json(_run(_do()))
+
+
+# ── iris move ──────────────────────────────────────────────────────────────
+
+
+@move_app.command("diagram")
+def move_diagram_cmd(
+    diagram_id: str = typer.Argument(...),
+    to_package: str = typer.Option(
+        ..., "--to-package",
+        help="Target package id, or `null` to move to set root.",
+    ),
+) -> None:
+    """Re-parent a diagram within its current set."""
+    target = _resolve_null(to_package)
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "PUT", f"/api/diagrams/{diagram_id}/parent",
+                json={"parent_package_id": target},
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@move_app.command("package")
+def move_package_cmd(
+    package_id: str = typer.Argument(...),
+    to_parent: str = typer.Option(
+        ..., "--to-parent",
+        help="Target parent package id, or `null` to move to set root.",
+    ),
+) -> None:
+    """Re-parent a package within its current set (cycle-checked)."""
+    target = _resolve_null(to_parent)
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "PUT", f"/api/packages/{package_id}/parent",
+                json={"parent_package_id": target},
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+_SET_UPDATE_FIELDS = (
+    "name", "description", "thumbnail_source", "thumbnail_diagram_id",
+    "collection_id", "system_prompt", "mcp_system_context",
+)
+
+
+@move_app.command("set")
+def move_set_cmd(
+    set_id: str = typer.Argument(...),
+    to_collection: str = typer.Option(
+        ..., "--to-collection",
+        help="Target collection id, or `null` to un-group.",
+    ),
+) -> None:
+    """Move a set to a different (or no) collection. Preserves other
+    metadata."""
+    target = _resolve_null(to_collection)
+
+    async def _do() -> Any:
+        async with _client() as c:
+            current_resp = await c._request("GET", f"/api/sets/{set_id}")
+            current = current_resp.json()
+            body: dict[str, Any] = {}
+            for field in _SET_UPDATE_FIELDS:
+                if field == "collection_id":
+                    body["collection_id"] = target
+                elif field in current:
+                    body[field] = current[field]
+            resp = await c._request("PUT", f"/api/sets/{set_id}", json=body)
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+# ── iris render ────────────────────────────────────────────────────────────
+
+
+def _write_or_print_artefact(
+    meta: dict[str, Any], out: Path | None, body_bytes: bytes | None,
+) -> None:
+    if out is not None and body_bytes is not None:
+        out.write_bytes(body_bytes)
+        typer.echo(
+            f"Wrote {len(body_bytes)} bytes to {out} "
+            f"(artefact_id={meta.get('id')})",
+        )
+    else:
+        output.print_json(meta)
+
+
+@render_app.command("diagram")
+def render_diagram_cmd(
+    diagram_id: str = typer.Argument(...),
+    format: str = typer.Option(..., "--format", help="md, docx, or pdf"),
+    out: Path | None = typer.Option(
+        None, "-o", "--output",
+        help="If provided, download artefact bytes to this path. Otherwise print metadata.",
+    ),
+) -> None:
+    """Render a diagram to md/docx/pdf and store as an Iris artefact."""
+    async def _do() -> tuple[dict[str, Any], bytes | None]:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", f"/api/export/diagram/{diagram_id}",
+                json={"format": format},
+            )
+            meta = resp.json()
+            body_bytes: bytes | None = None
+            if out is not None:
+                got = await c._request(
+                    "GET", f"/api/artefacts/{meta['id']}",
+                )
+                body_bytes = got.content
+            return meta, body_bytes
+
+    meta, body = _run(_do())
+    _write_or_print_artefact(meta, out, body)
+
+
+@render_app.command("markdown")
+def render_markdown_cmd(
+    title: str = typer.Option(..., "--title"),
+    format: str = typer.Option(..., "--format", help="md, docx, or pdf"),
+    input_file: Path | None = typer.Option(
+        None, "--input",
+        help="Read markdown source from this file. Reads stdin if omitted.",
+    ),
+    out: Path | None = typer.Option(
+        None, "-o", "--output",
+        help="If provided, download artefact bytes to this path. Otherwise print metadata.",
+    ),
+) -> None:
+    """Render ad-hoc markdown to md/docx/pdf and store as an Iris
+    artefact. Reads markdown source from --input or stdin."""
+    if input_file is not None:
+        source = input_file.read_text(encoding="utf-8")
+    else:
+        source = sys.stdin.read()
+
+    async def _do() -> tuple[dict[str, Any], bytes | None]:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/export/markdown",
+                json={"markdown": source, "title": title, "format": format},
+            )
+            meta = resp.json()
+            body_bytes: bytes | None = None
+            if out is not None:
+                got = await c._request(
+                    "GET", f"/api/artefacts/{meta['id']}",
+                )
+                body_bytes = got.content
+            return meta, body_bytes
+
+    meta, body = _run(_do())
+    _write_or_print_artefact(meta, out, body)
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_write_commands.py
+++ b/cli/tests/test_write_commands.py
@@ -1,0 +1,339 @@
+"""v6.4.0 (ADR-180, SPEC-180-A): CLI write-tool parity tests.
+
+Covers the new sub-apps: `iris create`, `iris update`, `iris move`,
+`iris render`. Pattern matches `test_commands.py` — respx-mocked
+backend, Typer CliRunner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import respx
+from typer.testing import CliRunner
+
+from iris_cli.main import app
+
+runner = CliRunner()
+BASE = "http://iris.test"
+
+
+def _invoke(*args: str) -> tuple[int, str, str]:
+    result = runner.invoke(app, list(args), catch_exceptions=False)
+    return result.exit_code, result.stdout, result.stderr
+
+
+# ── iris create ────────────────────────────────────────────────────────
+
+
+class TestCreate:
+    def test_create_collection(self, respx_mock: respx.Router) -> None:
+        respx_mock.post(f"{BASE}/api/collections").mock(
+            return_value=httpx.Response(201, json={
+                "id": "c1", "name": "Outcomes", "description": None,
+                "created_at": "2026", "updated_at": "2026",
+            }),
+        )
+        code, out, _ = _invoke("create", "collection", "--name", "Outcomes")
+        assert code == 0
+        assert "c1" in out
+
+    def test_create_set_with_collection(self, respx_mock: respx.Router) -> None:
+        route = respx_mock.post(f"{BASE}/api/sets").mock(
+            return_value=httpx.Response(201, json={
+                "id": "s1", "name": "MySet", "collection_id": "c1",
+                "description": None,
+                "created_at": "2026", "updated_at": "2026",
+            }),
+        )
+        code, out, _ = _invoke(
+            "create", "set", "--name", "MySet", "--collection-id", "c1",
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"name": "MySet", "collection_id": "c1"}
+
+    def test_create_package(self, respx_mock: respx.Router) -> None:
+        route = respx_mock.post(f"{BASE}/api/packages").mock(
+            return_value=httpx.Response(201, json={
+                "id": "p1", "name": "Pkg", "current_version": 1,
+                "set_id": "s1",
+                "created_at": "2026", "updated_at": "2026",
+            }),
+        )
+        code, _out, _ = _invoke(
+            "create", "package", "--name", "Pkg",
+            "--set-id", "s1",
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body["name"] == "Pkg"
+        assert body["set_id"] == "s1"
+
+    def test_create_diagram_with_data_json(self, respx_mock: respx.Router) -> None:
+        route = respx_mock.post(f"{BASE}/api/diagrams").mock(
+            return_value=httpx.Response(201, json={
+                "id": "d1", "name": "D", "diagram_type": "simple",
+                "current_version": 1, "notation": "simple", "set_id": "s1",
+                "created_at": "2026", "updated_at": "2026", "data": {},
+            }),
+        )
+        code, _out, _ = _invoke(
+            "create", "diagram",
+            "--name", "D", "--diagram-type", "simple",
+            "--notation", "simple", "--set-id", "s1",
+            "--data-json", '{"nodes": [], "edges": []}',
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body["data"] == {"nodes": [], "edges": []}
+
+
+# ── iris update ────────────────────────────────────────────────────────
+
+
+def _entity(**overrides):
+    base = {
+        "id": "e1", "name": "Original Name", "description": "orig",
+        "created_at": "2026", "updated_at": "2026",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestUpdate:
+    def test_update_collection_preserves_name(self, respx_mock: respx.Router) -> None:
+        respx_mock.get(f"{BASE}/api/collections/c1").mock(
+            return_value=httpx.Response(200, json=_entity(id="c1")),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/collections/c1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="c1", description="new desc",
+            )),
+        )
+        code, _out, _ = _invoke(
+            "update", "collection", "c1", "--description", "new desc",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body["name"] == "Original Name"  # preserved from GET
+        assert body["description"] == "new desc"  # overridden
+
+    def test_update_set_excludes_collection_id(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="s1", collection_id="col-existing",
+            )),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="s1", name="Renamed",
+            )),
+        )
+        code, _out, _ = _invoke("update", "set", "s1", "--name", "Renamed")
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        # collection_id intentionally NOT in body (move concern).
+        assert "collection_id" not in body
+
+    def test_update_diagram_data(self, respx_mock: respx.Router) -> None:
+        respx_mock.get(f"{BASE}/api/diagrams/d1").mock(
+            return_value=httpx.Response(200, json=_entity(id="d1")),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/diagrams/d1").mock(
+            return_value=httpx.Response(200, json=_entity(id="d1")),
+        )
+        code, _out, _ = _invoke(
+            "update", "diagram", "d1",
+            "--data-json", '{"nodes": [{"id": "n1"}], "edges": []}',
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body["data"] == {"nodes": [{"id": "n1"}], "edges": []}
+
+    def test_update_package_no_flags_is_noop_safe(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/packages/p1").mock(
+            return_value=httpx.Response(200, json=_entity(id="p1")),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/packages/p1").mock(
+            return_value=httpx.Response(200, json=_entity(id="p1")),
+        )
+        code, _out, _ = _invoke("update", "package", "p1")
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        # No flags → body is fully sourced from GET.
+        assert body["name"] == "Original Name"
+
+    def test_update_element(self, respx_mock: respx.Router) -> None:
+        respx_mock.get(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(200, json=_entity(id="el1")),
+        )
+        respx_mock.put(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="el1", description="el desc",
+            )),
+        )
+        code, _out, _ = _invoke(
+            "update", "element", "el1", "--description", "el desc",
+        )
+        assert code == 0
+
+
+# ── iris move ──────────────────────────────────────────────────────────
+
+
+class TestMove:
+    def test_move_diagram_to_package(self, respx_mock: respx.Router) -> None:
+        put_route = respx_mock.put(f"{BASE}/api/diagrams/d1/parent").mock(
+            return_value=httpx.Response(200, json={
+                "id": "d1", "parent_package_id": "pkg-7",
+            }),
+        )
+        code, _out, _ = _invoke(
+            "move", "diagram", "d1", "--to-package", "pkg-7",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body == {"parent_package_id": "pkg-7"}
+
+    def test_move_diagram_to_root_with_null(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        put_route = respx_mock.put(f"{BASE}/api/diagrams/d1/parent").mock(
+            return_value=httpx.Response(200, json={"id": "d1"}),
+        )
+        code, _out, _ = _invoke(
+            "move", "diagram", "d1", "--to-package", "null",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body == {"parent_package_id": None}
+
+    def test_move_package_to_parent(self, respx_mock: respx.Router) -> None:
+        put_route = respx_mock.put(f"{BASE}/api/packages/p1/parent").mock(
+            return_value=httpx.Response(200, json={"id": "p1"}),
+        )
+        code, _out, _ = _invoke(
+            "move", "package", "p1", "--to-parent", "pkg-2",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body == {"parent_package_id": "pkg-2"}
+
+    def test_move_set_to_collection_preserves_metadata(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="s1", name="MySet", description="d",
+                collection_id="col-old", system_prompt="sp",
+            )),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="s1", collection_id="col-new",
+            )),
+        )
+        code, _out, _ = _invoke(
+            "move", "set", "s1", "--to-collection", "col-new",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert body["collection_id"] == "col-new"
+        assert body["name"] == "MySet"
+        assert body["system_prompt"] == "sp"
+
+    def test_move_set_uncollect(self, respx_mock: respx.Router) -> None:
+        respx_mock.get(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(
+                id="s1", collection_id="col-old",
+            )),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/sets/s1").mock(
+            return_value=httpx.Response(200, json=_entity(id="s1")),
+        )
+        code, _out, _ = _invoke(
+            "move", "set", "s1", "--to-collection", "null",
+        )
+        assert code == 0
+        body = json.loads(put_route.calls[0].request.content)
+        assert "collection_id" in body
+        assert body["collection_id"] is None
+
+
+# ── iris render ────────────────────────────────────────────────────────
+
+
+class TestRender:
+    def test_render_markdown_metadata_only(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/markdown").mock(
+            return_value=httpx.Response(200, json={
+                "id": "art-1", "filename": "doc-abc.md",
+                "mime_type": "text/markdown", "size_bytes": 5,
+                "source_kind": "render_markdown", "source_ref": None,
+                "created_at": "2026",
+            }),
+        )
+        # Provide stdin via runner.invoke's input arg.
+        result = runner.invoke(
+            app,
+            ["render", "markdown", "--title", "T", "--format", "md"],
+            input="# Hi\n",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        assert "art-1" in result.stdout
+
+    def test_render_diagram_with_output_downloads_bytes(
+        self, respx_mock: respx.Router, tmp_path: Path,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/export/diagram/d1").mock(
+            return_value=httpx.Response(200, json={
+                "id": "art-2", "filename": "d1-xyz.pdf",
+                "mime_type": "application/pdf", "size_bytes": 4,
+                "source_kind": "export_diagram", "source_ref": "d1",
+                "created_at": "2026",
+            }),
+        )
+        respx_mock.get(f"{BASE}/api/artefacts/art-2").mock(
+            return_value=httpx.Response(
+                200, content=b"%PDF",
+                headers={"content-type": "application/pdf"},
+            ),
+        )
+        out = tmp_path / "out.pdf"
+        code, _out, _ = _invoke(
+            "render", "diagram", "d1", "--format", "pdf", "-o", str(out),
+        )
+        assert code == 0
+        assert out.read_bytes() == b"%PDF"
+
+    def test_render_markdown_from_input_file(
+        self, respx_mock: respx.Router, tmp_path: Path,
+    ) -> None:
+        src = tmp_path / "src.md"
+        src.write_text("# From file\n", encoding="utf-8")
+        route = respx_mock.post(f"{BASE}/api/export/markdown").mock(
+            return_value=httpx.Response(200, json={
+                "id": "art-3", "filename": "file-abc.md",
+                "mime_type": "text/markdown", "size_bytes": 12,
+                "source_kind": "render_markdown", "source_ref": None,
+                "created_at": "2026",
+            }),
+        )
+        code, _out, _ = _invoke(
+            "render", "markdown", "--title", "From",
+            "--format", "md", "--input", str(src),
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body["markdown"] == "# From file\n"
+        assert body["title"] == "From"

--- a/docs/adrs/ADR-180-CLI-Write-Tool-Parity.md
+++ b/docs/adrs/ADR-180-CLI-Write-Tool-Parity.md
@@ -1,0 +1,81 @@
+# ADR-180: CLI write-tool parity with MCP
+
+Status: Accepted (2026-05-16)
+Extends: ADR-130 (CLI), ADR-161, ADR-178, ADR-179
+
+## Context
+
+Before Phase 4 of issue #133, the `iris` CLI surface was:
+
+| Group | Verbs |
+|---|---|
+| `diagrams` | list, get, versions |
+| `elements` | list, get |
+| `packages` | list, get |
+| `sets` | list, get |
+| `collections` | list, get |
+| `export` | diagram / element / package / set / collection (json or markdown) |
+| `conversations` | list |
+| (top-level) | login, whoami, search, ask |
+
+That's read-only + `ask` (LLM) + `export` (read serialisation). MCP, meanwhile, had `create_*` (v5.16.0–v5.17.0), `update_*` + `move_*` (v6.3.0 / ADR-178), `render_*` (v6.2.0 / ADR-179). The drift is exactly what the issue #133 Class B feedback flagged.
+
+The plan parity rule is: every backend write endpoint MUST have both an MCP tool AND a CLI subcommand. Phase 4 brings CLI to parity for the eight new write tools (5 update, 3 move) plus the two render tools.
+
+## Decision
+
+Add four new CLI sub-applications:
+
+| App | Commands | Wraps |
+|---|---|---|
+| `iris create` | `collection`, `set`, `package`, `diagram` | MCP `create_*` |
+| `iris update` | `collection`, `set`, `package`, `diagram`, `element` | MCP `update_*` |
+| `iris move` | `diagram`, `package`, `set` | MCP `move_*` |
+| `iris render` | `diagram`, `markdown` | MCP `render_diagram`, `render_markdown` |
+
+Existing `iris export` group (read-only) is kept and unchanged; the new `iris render` group is a distinct verb for the v6.2.0 renderer pipeline that produces docx/pdf artefacts stored in Iris.
+
+Each command calls the backend via `IrisClient._request` (the same HTTP path the MCP tools use). This keeps Phase 4 scope minimal — no iris-client typed surface expansion ahead of need. Phase 6's parity ADR may revisit.
+
+### `iris ask` stays
+
+The existing top-level `iris ask` command stays. ADR-168 removed `ask` from MCP because MCP clients bring their own LLM; CLI users don't. CLI `ask` is a deliberate asymmetry — documented here and in ADR-182. Phase 6's parity matrix marks it as `cli-only-by-design`.
+
+### No `delete_*` yet
+
+Both MCP and CLI lack `delete_*` write tools. Out of scope for issue #133 — needs a separate ADR (audit trail, undo, soft vs hard delete semantics).
+
+## Why not factor a typed iris-client write surface first
+
+The plan (SPEC-180-A) parks this as an open question: does iris-client get typed `update_*` / `move_*` / `render_*` methods, or do CLI + MCP both call `_request` directly?
+
+Factoring now means:
+- 10 new typed methods (5 update + 3 move + 2 render) in iris-client.
+- ~3 new model classes (`Artefact`, `MoveResult`) added to `models/core.py`.
+- Both MCP (Phase 3) and CLI (Phase 4) call sites updated to use the typed methods.
+
+Deferring keeps Phase 4 scope minimal — CLI ships parity with shell-only changes, MCP stays as-is. Phase 6 can re-evaluate when the parity matrix is the live source of truth.
+
+For Phase 4 we accept the trade: typed iris-client methods coexist with `_request`-direct callers in both CLI and MCP. Not the prettiest, but the parity outcome (every write endpoint reachable from every surface) is what the issue #133 feedback actually asked for.
+
+## Consequences
+
+- `cli/src/iris_cli/main.py` grows four new Typer sub-apps + their commands.
+- Each command takes positional id + Typer `--option` style flags mirroring the MCP input schema.
+- Tests cover happy path + the partial-update merge behaviour (CLI must do the same GET-then-PUT dance as the MCP tools).
+- `cli/README.md` updated with the new commands + the deliberate `ask` asymmetry note.
+- CHANGELOG `[6.4.0]`.
+- Version bumps: mcp + frontend 6.3.0 → 6.4.0. (The CLI version lives in `cli/pyproject.toml`; bump it too.)
+
+## Verification
+
+- `pytest cli/tests/test_create_commands.py test_update_commands.py test_move_commands.py test_render_commands.py` green.
+- Manual: `iris create set --name X` and `iris move set <id> --to-collection Y` against a running backend.
+
+## See also
+
+- [ADR-130](ADR-130-Iris-CLI.md) — original CLI design.
+- [ADR-168](ADR-168-Remove-Ask-Tool-From-MCP-Surface.md) — context for the deliberate `ask` asymmetry.
+- [ADR-178](ADR-178-MCP-Update-Move-Tools.md), [ADR-179](ADR-179-Renderer-And-Artefact-Store.md) — MCP tools this CLI mirrors.
+- [SPEC-180-A](specs/SPEC-180-A-CLI-Write-Parity.md) — command signatures, tests.
+- Issue #133.

--- a/docs/adrs/specs/SPEC-180-A-CLI-Write-Parity.md
+++ b/docs/adrs/specs/SPEC-180-A-CLI-Write-Parity.md
@@ -1,0 +1,102 @@
+# SPEC-180-A: CLI write-tool parity with MCP
+
+ADR: [ADR-180](../ADR-180-CLI-Write-Tool-Parity.md)
+
+## Summary
+
+Add four new Typer sub-apps to the `iris` CLI: `create`, `update`, `move`, `render`. Each command wraps the corresponding backend endpoint via `IrisClient._request`, matching the MCP tool surface from ADR-178 and ADR-179.
+
+## Commands
+
+### `iris create`
+
+```
+iris create collection --name X [--description ...]
+iris create set --name X [--collection-id ...] [--description ...]
+iris create package --name X [--set-id ...] [--parent-package-id ...]
+                    [--description ...] [--metadata-json '{}']
+iris create diagram --name X --diagram-type DT [--notation N]
+                    [--set-id ...] [--parent-package-id ...]
+                    [--data-json '{}'] [--description ...]
+```
+
+### `iris update` (partial — GET-then-merge-then-PUT)
+
+```
+iris update collection <id> [--name ...] [--description ...] [--system-prompt ...]
+                            [--mcp-system-context ...] [--thumbnail-source ...]
+                            [--thumbnail-diagram-id ...]
+iris update set <id>        [same flags except --collection-id]
+iris update package <id>    [--name ...] [--description ...] [--metadata-json '{}']
+iris update diagram <id>    [--name ...] [--description ...] [--data-json '{}']
+                            [--metadata-json '{}'] [--change-summary ...]
+iris update element <id>    [--name ...] [--description ...] [--data-json '{}']
+```
+
+### `iris move`
+
+```
+iris move diagram <id> --to-package <pkg-id-or-`null`>
+iris move package <id> --to-parent <pkg-id-or-`null`>
+iris move set <id> --to-collection <col-id-or-`null`>
+```
+
+The `null` string literal denotes "set to NULL" (move to set root / un-group). Plain omission of the flag is an error.
+
+### `iris render`
+
+```
+iris render diagram <diagram-id> --format md|docx|pdf [-o OUT_PATH]
+iris render markdown --title X --format md|docx|pdf [-o OUT_PATH]
+                     (markdown source from stdin or --input FILE)
+```
+
+Each render command POSTs to the new backend endpoint, gets back the `ArtefactResponse`, and either:
+- prints the artefact metadata JSON (default), or
+- if `-o` is given, downloads the artefact bytes from `/api/artefacts/<id>` and writes to the file.
+
+## Partial-update semantics
+
+CLI `update` commands do the same GET-then-merge-then-PUT dance as the MCP `update_*` tools (see SPEC-178-A). Reason: the backend PUT does full-replace, and we want true partial updates from the CLI without breaking unspecified fields.
+
+## Tests
+
+### `cli/tests/test_create_commands.py` (new)
+
+Per-entity happy path via respx-mocked backend. Asserts the right POST body shape and successful JSON output.
+
+### `cli/tests/test_update_commands.py` (new)
+
+Per-entity happy path. Critical: assert the GET is made first to source the current name, then the PUT body merges the override.
+
+### `cli/tests/test_move_commands.py` (new)
+
+- `iris move diagram <id> --to-package pkg-7` → PUT /api/diagrams/<id>/parent with `{parent_package_id: "pkg-7"}`.
+- `iris move diagram <id> --to-package null` → PUT with `{parent_package_id: null}`.
+- `iris move set <id> --to-collection col-9` → PUT /api/sets/<id> preserves metadata + sets collection_id.
+- `iris move set <id> --to-collection null` → un-groups.
+
+### `cli/tests/test_render_commands.py` (new)
+
+- `iris render markdown --title T --format md` reads stdin, POSTs, prints metadata.
+- `iris render markdown --title T --format pdf -o out.pdf` downloads the PDF bytes to disk.
+- `iris render diagram <id> --format docx -o out.docx` downloads the docx bytes.
+
+## Versioning
+
+`cli/pyproject.toml`: bump per the existing CLI versioning (look it up; if synced to the global v6 line then 6.3.0 → 6.4.0).
+`mcp/pyproject.toml`: 6.3.0 → 6.4.0.
+`frontend/package.json`: matched 6.4.0.
+
+## CHANGELOG
+
+`[6.4.0]` Added: `iris create` / `update` / `move` / `render` sub-apps. Documents the deliberate `iris ask` asymmetry.
+
+## Acceptance criteria
+
+- [ ] `pytest cli/tests/test_{create,update,move,render}_commands.py` green.
+- [ ] `iris create set --name X` against a live backend succeeds.
+- [ ] `iris update set <id> --description "new"` does GET-then-PUT.
+- [ ] `iris move set <id> --to-collection col-7` succeeds.
+- [ ] `iris render markdown --title T --format pdf -o out.pdf` writes a valid PDF.
+- [ ] `iris ask "test question" --set <id>` still works.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.3.0",
+	"version": "6.4.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.3.0"
+version = "6.4.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Phase 4 of issue #133. Adds `iris create` / `update` / `move` / `render` sub-apps mirroring the MCP surface from ADR-178 + ADR-179. Documents the deliberate `iris ask` asymmetry (CLI-only by design per ADR-168).

## Tests
34/34 functional in cli/tests/. 17 new write-command tests.

## References
- ADR-180 / SPEC-180-A
- Issue #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)