### PR TITLE
feat(v6.4.0): add create_element MCP tool + iris create element CLI (Phase 4 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ counterpart per ADR-168) is documented.
   Renders to md/docx/pdf via the Phase 2 backend endpoints. With
   `-o OUT_PATH`, downloads the artefact bytes; without, prints the
   metadata JSON.
+- **`create_element`** MCP tool + **`iris create element`** CLI
+  command (Phase 4 follow-up). Backfills a parity gap that predates
+  Phase 4: every other entity type had a `create_*` tool, but
+  standalone elements could only be created via
+  `apply_diagram_creation` (atomic with a diagram canvas). The new
+  surface targets the element-pool use case where an element exists
+  independently and is referenced by diagrams later.
 - `cli/pyproject.toml`: 0.1.0 → 0.2.0.
 
 ### See also

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -648,6 +648,46 @@ def create_package_cmd(
     output.print_json(_run(_do()))
 
 
+@create_app.command("element")
+def create_element_cmd(
+    name: str = typer.Option(..., "--name"),
+    element_type: str = typer.Option(..., "--element-type"),
+    set_id: str | None = typer.Option(None, "--set-id"),
+    notation: str | None = typer.Option(None, "--notation"),
+    description: str | None = typer.Option(None, "--description"),
+    data_json: str | None = typer.Option(None, "--data-json"),
+    metadata_json: str | None = typer.Option(None, "--metadata-json"),
+) -> None:
+    """Create a standalone Element in a set's element pool.
+
+    For drawing elements onto a diagram in one step, use
+    `iris diagrams ...` flows or the API/MCP `apply_diagram_creation`
+    tool instead.
+    """
+    body: dict[str, Any] = {
+        "element_type": element_type,
+        "name": name,
+    }
+    if set_id is not None:
+        body["set_id"] = set_id
+    if notation is not None:
+        body["notation"] = notation
+    if description is not None:
+        body["description"] = description
+    data = _parse_json_opt(data_json, "--data-json")
+    if data is not None:
+        body["data"] = data
+    metadata = _parse_json_opt(metadata_json, "--metadata-json")
+    if metadata is not None:
+        body["metadata"] = metadata
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request("POST", "/api/elements", json=body)
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
 @create_app.command("diagram")
 def create_diagram_cmd(
     name: str = typer.Option(..., "--name"),

--- a/cli/tests/test_write_commands.py
+++ b/cli/tests/test_write_commands.py
@@ -72,6 +72,28 @@ class TestCreate:
         assert body["name"] == "Pkg"
         assert body["set_id"] == "s1"
 
+    def test_create_element(self, respx_mock: respx.Router) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(201, json={
+                "id": "el1", "name": "Widget",
+                "element_type": "component",
+                "current_version": 1, "notation": "simple", "set_id": "s1",
+                "created_at": "2026", "updated_at": "2026", "data": {},
+            }),
+        )
+        code, out, _ = _invoke(
+            "create", "element",
+            "--name", "Widget", "--element-type", "component",
+            "--set-id", "s1", "--notation", "simple",
+        )
+        assert code == 0
+        assert "el1" in out
+        body = json.loads(route.calls[0].request.content)
+        assert body["element_type"] == "component"
+        assert body["name"] == "Widget"
+        assert body["set_id"] == "s1"
+        assert body["notation"] == "simple"
+
     def test_create_diagram_with_data_json(self, respx_mock: respx.Router) -> None:
         route = respx_mock.post(f"{BASE}/api/diagrams").mock(
             return_value=httpx.Response(201, json={

--- a/docs/adrs/ADR-180-CLI-Write-Tool-Parity.md
+++ b/docs/adrs/ADR-180-CLI-Write-Tool-Parity.md
@@ -28,10 +28,16 @@ Add four new CLI sub-applications:
 
 | App | Commands | Wraps |
 |---|---|---|
-| `iris create` | `collection`, `set`, `package`, `diagram` | MCP `create_*` |
+| `iris create` | `collection`, `set`, `package`, `diagram`, `element` | MCP `create_*` |
 | `iris update` | `collection`, `set`, `package`, `diagram`, `element` | MCP `update_*` |
 | `iris move` | `diagram`, `package`, `set` | MCP `move_*` |
 | `iris render` | `diagram`, `markdown` | MCP `render_diagram`, `render_markdown` |
+
+**v6.4.0 follow-up:** `create_element` was missing from MCP
+(pre-existed Phase 4 — only `apply_diagram_creation` existed for
+element materialisation). The follow-up commit adds both
+`create_element` MCP tool and `iris create element` CLI command so
+the parity matrix is complete.
 
 Existing `iris export` group (read-only) is kept and unchanged; the new `iris render` group is a distinct verb for the v6.2.0 renderer pipeline that produces docx/pdf artefacts stored in Iris.
 

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -340,6 +340,29 @@ async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
     return with_web_url(result.model_dump_json(), "package")
 
 
+async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
+    """ADR-178 (v6.4.0): create a standalone Element.
+
+    Elements created this way are not bound to a diagram — they exist
+    in the set's element pool. To draw an element onto a diagram, use
+    `apply_diagram_creation` (which materialises elements + their
+    diagram representation atomically) or create the diagram with an
+    inline element via `create_diagram` data payload.
+    """
+    body: dict[str, Any] = {
+        "element_type": args["element_type"],
+        "name": args["name"],
+    }
+    for key in ("description", "data", "set_id", "metadata", "notation"):
+        if args.get(key) is not None:
+            body[key] = args[key]
+    try:
+        resp = await c._request("POST", "/api/elements", json=body)
+    except IrisAuthError:
+        return _auth_required_payload("Create element")
+    return with_web_url(json.dumps(resp.json()), "element")
+
+
 async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
     """ADR-162 (v5.17.0): generic save for a new diagram of any
     (notation, diagram_type) pair. The caller is expected to have
@@ -1124,6 +1147,58 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_create_diagram,
+    ),
+    Tool(
+        name="create_element",
+        description=(
+            "Create a standalone Element in a set's element pool "
+            "(v6.4.0, ADR-180 follow-up). Elements created here are "
+            "NOT bound to a diagram — they exist in the set's element "
+            "pool and can be referenced by diagrams later. For drawing "
+            "elements onto a diagram in one step, prefer "
+            "`apply_diagram_creation` (atomic element + canvas "
+            "materialisation) or `create_diagram` with an inline data "
+            "payload."
+        ),
+        input_schema=_schema({
+            "element_type": _str_arg(
+                "element_type",
+                "Element type (e.g. 'component', 'class', "
+                "'outcome_box') — must be a registered type for the "
+                "chosen notation",
+            ),
+            "name": _str_arg(
+                "name", "Display name for the element",
+            ),
+            "set_id": _str_arg(
+                "set_id",
+                "Set to anchor the element under (optional — omitted "
+                "elements live in no set)",
+                required=False,
+            ),
+            "notation": _str_arg(
+                "notation",
+                "Notation id (default 'simple'). Should match the "
+                "element_type's notation.",
+                required=False,
+            ),
+            "description": _str_arg(
+                "description", "Optional description", required=False,
+            ),
+            "data": (
+                {
+                    "type": "object",
+                    "description": "Optional data payload (notation-specific)",
+                    "additionalProperties": True,
+                },
+                False,
+            ),
+            "metadata": (
+                {"type": "object", "additionalProperties": True},
+                False,
+            ),
+        }),
+        handler=_create_element,
     ),
     # ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────
     Tool(

--- a/mcp/tests/test_create_element_tool.py
+++ b/mcp/tests/test_create_element_tool.py
@@ -1,0 +1,76 @@
+"""v6.4.0: MCP create_element tool test (ADR-180 follow-up).
+
+Backfills MCP element creation parity — previously elements could
+only be created via apply_diagram_creation (atomic with a diagram
+canvas). v6.4.0 adds a standalone create_element for the
+element-pool use case.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+class TestInventory:
+    def test_create_element_registered(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        assert "create_element" in names
+
+    def test_create_element_schema_requires_type_and_name(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        schema = defs["create_element"].inputSchema
+        assert set(schema["required"]) == {"element_type", "name"}
+
+
+class TestCreateElement:
+    @pytest.mark.asyncio
+    async def test_happy(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(201, json={
+                "id": "el-1", "element_type": "component",
+                "name": "Widget", "current_version": 1,
+                "notation": "simple", "set_id": "s-1",
+                "created_at": "2026", "updated_at": "2026", "data": {},
+            }),
+        )
+        result = await tools.dispatch(
+            "create_element", client,
+            {
+                "element_type": "component",
+                "name": "Widget",
+                "set_id": "s-1",
+                "notation": "simple",
+            },
+        )
+        body = json.loads(result[0].text)
+        assert body["id"] == "el-1"
+        post_body = json.loads(route.calls[0].request.content)
+        assert post_body["element_type"] == "component"
+        assert post_body["name"] == "Widget"
+        assert post_body["set_id"] == "s-1"
+
+    @pytest.mark.asyncio
+    async def test_401_returns_auth_required(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(401, json={"detail": "no auth"}),
+        )
+        result = await tools.dispatch(
+            "create_element", client,
+            {"element_type": "component", "name": "X"},
+        )
+        body = json.loads(result[0].text)
+        assert body["success"] is False
+        assert body["error"] == "auth_required"


### PR DESCRIPTION
Backfills the only create_* gap — standalone element creation. Lands before v6.4.0 tag so the release captures complete parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)