### PR TITLE
fix(v6.6.2): doview_analysis cascade fetches response_format rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.2] - 2026-05-16
+
+Issue #133 Phase 1 UAT defect fix — doview_analysis content
+structure regression that crept in at v6.0.0 (ADR-164).
+
+### Background
+
+A doview_analysis created via the cascade
+(`https://iris-uat.chrisbarlow.nz/views/3e196c18-b061-4656-b841-395509a9c611`,
+2026-05-16) didn't follow the response_format output structure —
+no opening sentence, no Summary/Full/Diagrams sections, no
+outcomes-theory framing, no tool URLs, no handbook reference. Zero
+compliance.
+
+### Root cause
+
+v5.12.0 (ADR-157) introduced the response_format prompts for
+`(markdown, doview_analysis)` and a dedicated `save_doview_analysis`
+MCP tool whose description hinted at the expected structure
+("Markdown body of the analysis (Summary + Full + Diagrams
+sections)"). The model would fetch `purpose='response_format'`,
+draft compliant markdown, then save.
+
+v5.17.0 (ADR-162) added generic `create_diagram` with a
+`_CREATION_FLOW_PREAMBLE` that directs the model to fetch
+`purpose='creation_format'`. At v5.17.0 both tools coexisted —
+doview_analysis still went through `save_doview_analysis`.
+
+v6.0.0 (ADR-164) removed `save_doview_analysis`, leaving
+doview_analysis creation to go through generic `create_diagram`.
+But `_CREATION_FLOW_PREAMBLE` was not updated to tell the model
+"for markdown-content diagrams like doview_analysis, ALSO fetch
+`purpose='response_format'` to get the output-structure rules."
+The structure-rules dependency was lost.
+
+v6.1.0's Phase 1 work made cascade-driven creation more attractive
+(AskUserQuestion, destination chooser), so the latent defect from
+v6.0.0 became much more visible.
+
+### Fixed
+
+- **`mcp/src/iris_mcp/tools.py:_CREATION_FLOW_PREAMBLE`** gains a
+  step 2a: explicit instruction for the model to fetch
+  `get_response_prompt(notation='markdown', diagram_type=...,
+  purpose='response_format')` when creating any content-bearing
+  markdown diagram, and to apply those rules to the markdown body.
+- **New backstop prompt** `creation-format-doview-analysis-pointer-v1`
+  at `(purpose='creation_format', layer='diagram_type',
+  diagram_type='doview_analysis')` instructs the model to fetch the
+  response_format cascade and apply its rules. Composes into every
+  creation_format cascade for doview_analysis. Single source of
+  truth for the actual rules stays on the response_format side per
+  protocols §13 DRY — this row is a pointer, not duplicated content.
+- SQLite migration `m063_doview_analysis_creation_format_pointer.py`
+  + Supabase mirror `m067_…sql`.
+- Seed file `backend/app/seed/creation_prompts.py` extended with
+  `DOVIEW_ANALYSIS_CREATION_FORMAT_POINTER` constant; re-applied
+  on every backend startup so admin edits get overwritten with
+  canonical content.
+
+### Verification
+
+- `pytest backend/tests/test_migrations/test_doview_analysis_creation_pointer_schema.py`
+  — 12 new green.
+- `pytest backend/tests/test_ai/test_creation_prompts_expanded.py`
+  — row-count assertion updated 18 → 19 active creation_format rows.
+- 376/376 + 201/201 (backend + MCP) green.
+- Manual UAT after redeploy: re-create a doview_analysis via the
+  cascade; expect compliant Summary/Full/Diagrams structure.
+
+### Deploy
+
+Run new Supabase migration (`m067_doview_analysis_creation_format_pointer.sql`)
+via the Supabase SQL Editor or `./scripts/supabase-migrate.sh`,
+then redeploy backend + iris-mcp on Render. No frontend changes.
+
 ## [6.6.1] - 2026-05-16
 
 Issue #133 deploy fix — Render base image was missing WeasyPrint

--- a/backend/app/migrations/m063_doview_analysis_creation_format_pointer.py
+++ b/backend/app/migrations/m063_doview_analysis_creation_format_pointer.py
@@ -1,0 +1,111 @@
+# ruff: noqa: E501
+"""Migration 063: backstop creation_format pointer to response_format
+for (markdown, doview_analysis) — v6.6.2 regression fix.
+
+Issue #133 Phase 1 UAT (banana monoculture macroeconomics doview
+analysis) surfaced a regression that crept in at v6.0.0 (ADR-164):
+removing `save_doview_analysis` left the doview_analysis flow
+relying on `create_diagram`, but the `_CREATION_FLOW_PREAMBLE` in
+mcp/src/iris_mcp/tools.py only directs the model to fetch
+`purpose='creation_format'`. The response_format rules (3-section
+structure, opening sentence, outcomes-theory framing, tool URLs,
+handbook reference) for (markdown, doview_analysis) live only on the
+response_format side — the model never fetches them when creating
+via the cascade.
+
+This migration adds a small creation_format pointer row at
+(layer='diagram_type', diagram_type='doview_analysis') so that any
+model fetching the creation_format cascade for doview_analysis sees
+an explicit instruction to also fetch and apply the response_format
+rules. Single source of truth for the actual rules stays on the
+response_format side (m051) per protocols §13 DRY.
+
+Companion change: mcp/src/iris_mcp/tools.py
+`_CREATION_FLOW_PREAMBLE` step 2a explicitly tells the model the same.
+
+Idempotent (INSERT OR IGNORE on id).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m063_doview_analysis_creation_format_pointer"
+
+
+_BODY = """\
+## CRITICAL: doview_analysis output structure rules
+
+This diagram's markdown content (`data.content`) MUST follow the
+output-structure rules defined in the corresponding response_format
+cascade. Those rules are the single source of truth for the
+doview_analysis output shape (required opening sentence, three
+standalone sections — Summary / Full / Diagrams — outcomes-theory
+framing, outcomes-system definition, tool URLs, full handbook
+reference at the end).
+
+Before composing the markdown body, fetch and apply:
+
+  get_response_prompt(
+    notation='markdown',
+    diagram_type='doview_analysis',
+    purpose='response_format'
+  )
+
+The body returned by that call contains the full set of rules. The
+markdown you generate for `data.content` must comply with every one.
+Without this fetch, the doview_analysis you produce will not match
+the expected output structure and will fail content review.
+
+This pointer exists because the creation_format cascade and
+response_format cascade are separate code paths (purpose-discriminated
+since ADR-157 / v5.12.0). Cascade-driven creation needs to know that
+for (markdown, doview_analysis) the content rules live on the OTHER
+purpose. Single source of truth (response_format) preserved; this row
+is a pointer, not duplicated content.
+"""
+
+
+_NEW_ROW = {
+    "id": "creation-format-doview-analysis-pointer-v1",
+    "name": "DoView Analysis — response_format pointer (creation cascade)",
+    "description": "Backstop instruction telling the model to fetch and apply the response_format rules when creating a (markdown, doview_analysis) via the creation cascade. Single source of truth for the actual rules stays on the response_format side per DRY. ADR-157 + ADR-180 follow-up, v6.6.2.",
+    "purpose": "creation_format",
+    "layer": "diagram_type",
+    "notation": None,
+    "diagram_type": "doview_analysis",
+    "prompt_text": _BODY,
+    "display_order": 0,
+}
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up."""
+    cursor = await db.execute(
+        "SELECT name FROM sqlite_master"
+        " WHERE type='table' AND name='ai_creation_prompts'",
+    )
+    if await cursor.fetchone() is None:
+        return
+
+    await db.execute(
+        "INSERT OR IGNORE INTO ai_creation_prompts "
+        "(id, name, description, purpose, layer, notation, diagram_type, "
+        "prompt_text, display_order, is_active) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)",
+        (
+            _NEW_ROW["id"],
+            _NEW_ROW["name"],
+            _NEW_ROW["description"],
+            _NEW_ROW["purpose"],
+            _NEW_ROW["layer"],
+            _NEW_ROW["notation"],
+            _NEW_ROW["diagram_type"],
+            _NEW_ROW["prompt_text"],
+            _NEW_ROW["display_order"],
+        ),
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m067_doview_analysis_creation_format_pointer.sql
+++ b/backend/app/migrations/supabase/m067_doview_analysis_creation_format_pointer.sql
@@ -1,0 +1,54 @@
+-- Migration 067: backstop creation_format pointer to response_format
+-- for (markdown, doview_analysis) — v6.6.2 regression fix.
+--
+-- Mirrors SQLite m063. Adds a creation_format row at
+-- (layer='diagram_type', diagram_type='doview_analysis') that tells
+-- the model to also fetch the response_format cascade when creating a
+-- doview_analysis via create_diagram.
+--
+-- Idempotent (ON CONFLICT DO NOTHING).
+
+INSERT INTO public.ai_creation_prompts
+    (id, name, description, purpose, layer, notation, diagram_type, prompt_text, display_order, is_active)
+VALUES (
+    'creation-format-doview-analysis-pointer-v1',
+    'DoView Analysis — response_format pointer (creation cascade)',
+    'Backstop instruction telling the model to fetch and apply the response_format rules when creating a (markdown, doview_analysis) via the creation cascade. Single source of truth for the actual rules stays on the response_format side per DRY. ADR-157 + ADR-180 follow-up, v6.6.2.',
+    'creation_format',
+    'diagram_type',
+    NULL,
+    'doview_analysis',
+    $body$## CRITICAL: doview_analysis output structure rules
+
+This diagram's markdown content (`data.content`) MUST follow the
+output-structure rules defined in the corresponding response_format
+cascade. Those rules are the single source of truth for the
+doview_analysis output shape (required opening sentence, three
+standalone sections — Summary / Full / Diagrams — outcomes-theory
+framing, outcomes-system definition, tool URLs, full handbook
+reference at the end).
+
+Before composing the markdown body, fetch and apply:
+
+  get_response_prompt(
+    notation='markdown',
+    diagram_type='doview_analysis',
+    purpose='response_format'
+  )
+
+The body returned by that call contains the full set of rules. The
+markdown you generate for `data.content` must comply with every one.
+Without this fetch, the doview_analysis you produce will not match
+the expected output structure and will fail content review.
+
+This pointer exists because the creation_format cascade and
+response_format cascade are separate code paths (purpose-discriminated
+since ADR-157 / v5.12.0). Cascade-driven creation needs to know that
+for (markdown, doview_analysis) the content rules live on the OTHER
+purpose. Single source of truth (response_format) preserved; this row
+is a pointer, not duplicated content.
+$body$,
+    0,
+    TRUE
+)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/app/seed/creation_prompts.py
+++ b/backend/app/seed/creation_prompts.py
@@ -406,6 +406,38 @@ This is preferable to fake URLs and lets the user replace it with
 real sources later.
 """
 
+DOVIEW_ANALYSIS_CREATION_FORMAT_POINTER = """## CRITICAL: doview_analysis output structure rules
+
+This diagram's markdown content (`data.content`) MUST follow the
+output-structure rules defined in the corresponding response_format
+cascade. Those rules are the single source of truth for the
+doview_analysis output shape (required opening sentence, three
+standalone sections — Summary / Full / Diagrams — outcomes-theory
+framing, outcomes-system definition, tool URLs, full handbook
+reference at the end).
+
+Before composing the markdown body, fetch and apply:
+
+  get_response_prompt(
+    notation='markdown',
+    diagram_type='doview_analysis',
+    purpose='response_format'
+  )
+
+The body returned by that call contains the full set of rules. The
+markdown you generate for `data.content` must comply with every one.
+Without this fetch, the doview_analysis you produce will not match
+the expected output structure and will fail content review.
+
+This pointer exists because the creation_format cascade and
+response_format cascade are separate code paths (purpose-discriminated
+since ADR-157 / v5.12.0). Cascade-driven creation needs to know that
+for (markdown, doview_analysis) the content rules live on the OTHER
+purpose. Single source of truth (response_format) preserved; this row
+is a pointer, not duplicated content.
+"""
+
+
 CASCADE_DESTINATION_PROMPT = """## Destination chooser (shared)
 
 Before generating ANY diagrams, run this chooser. Do not skip it. Do
@@ -941,6 +973,16 @@ _EXPANSION_ROWS = [
         "diagram_type": None,
         "prompt_text": CASCADE_CITATIONS_PROMPT,
         "display_order": 2,
+    },
+    {
+        "id": "creation-format-doview-analysis-pointer-v1",
+        "name": "DoView Analysis — response_format pointer (creation cascade)",
+        "description": "Backstop instruction telling the model to fetch and apply the response_format rules when creating a (markdown, doview_analysis) via the creation cascade. Single source of truth for the actual rules stays on the response_format side per DRY. ADR-157 + ADR-180 follow-up, v6.6.2.",
+        "layer": "diagram_type",
+        "notation": None,
+        "diagram_type": "doview_analysis",
+        "prompt_text": DOVIEW_ANALYSIS_CREATION_FORMAT_POINTER,
+        "display_order": 0,
     },
     {
         "id": "creation-cascade-destination-v1",

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -66,6 +66,7 @@ from app.migrations.m059_mcp_user_question_rule import up as m059_up
 from app.migrations.m060_artefacts_table import up as m060_up
 from app.migrations.m061_drop_phase1_docx_fallback import up as m061_up
 from app.migrations.m062_drop_phase1_move_fallback import up as m062_up
+from app.migrations.m063_doview_analysis_creation_format_pointer import up as m063_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -159,6 +160,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m060_up(main)  # issue #133 Phase 2, v6.2.0: artefacts table for rendered md/docx/pdf (ADR-179)
     await m061_up(main)  # issue #133 Phase 2, v6.2.0: drop Phase-1 docx/pdf fallback from cascade destination prompt (ADR-179)
     await m062_up(main)  # issue #133 Phase 3, v6.3.0: drop Phase-1 cross-set move fallback (ADR-178)
+    await m063_up(main)  # issue #133 Phase 1 UAT defect, v6.6.2: backstop creation_format pointer to response_format for (markdown, doview_analysis)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_ai/test_creation_prompts_expanded.py
+++ b/backend/tests/test_ai/test_creation_prompts_expanded.py
@@ -202,17 +202,18 @@ class TestSeedIdempotency:
     ) -> None:
         """After seed: 4 DoView-era rows (m028) + 11 expansion rows
         (ADR-132, v5.8.0) + 3 shared cascade base rows (ADR-176,
-        v6.1.0) = 18 active creation_format rows. Plus 3
-        response_format rows added by m051 (ADR-157, v5.12.0) = 21
-        total active rows. Verify both counts independently so a
-        regression in either purpose's seed surfaces clearly."""
+        v6.1.0) + 1 doview_analysis pointer (v6.6.2) = 19 active
+        creation_format rows. Plus 3 response_format rows added by
+        m051 (ADR-157, v5.12.0) = 22 total active rows. Verify both
+        counts independently so a regression in either purpose's
+        seed surfaces clearly."""
         cursor = await db.execute(
             "SELECT COUNT(*) FROM ai_creation_prompts "
             "WHERE is_active=1 AND purpose = 'creation_format'"
         )
         creation_count = (await cursor.fetchone())[0]
-        assert creation_count == 18, (
-            f"Expected 18 active creation_format rows (4 DoView-era + 11 expansion + 3 cascade-shared), got {creation_count}"
+        assert creation_count == 19, (
+            f"Expected 19 active creation_format rows (4 DoView-era + 11 expansion + 3 cascade-shared + 1 doview_analysis pointer), got {creation_count}"
         )
 
         cursor = await db.execute(

--- a/backend/tests/test_migrations/test_doview_analysis_creation_pointer_schema.py
+++ b/backend/tests/test_migrations/test_doview_analysis_creation_pointer_schema.py
@@ -1,0 +1,122 @@
+"""v6.6.2: static-parser tests for SQLite m063 + Supabase m067 — the
+backstop creation_format pointer for (markdown, doview_analysis)
+that fixes the Phase 1 UAT regression where cascade-created
+doview_analyses didn't follow the response_format output structure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m063 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m063_file_exists() -> None:
+    assert (ROOT / "app/migrations/m063_doview_analysis_creation_format_pointer.py").exists()
+
+
+def test_sqlite_m063_inserts_pointer_row() -> None:
+    py = _read("app/migrations/m063_doview_analysis_creation_format_pointer.py")
+    assert "creation-format-doview-analysis-pointer-v1" in py
+    assert "INSERT OR IGNORE INTO ai_creation_prompts" in py
+
+
+def test_sqlite_m063_pointer_is_diagram_type_layer() -> None:
+    py = _read("app/migrations/m063_doview_analysis_creation_format_pointer.py")
+    # Must be scoped to (creation_format, diagram_type, doview_analysis)
+    # so it only composes when creating a doview_analysis.
+    assert '"purpose": "creation_format"' in py
+    assert '"layer": "diagram_type"' in py
+    assert '"diagram_type": "doview_analysis"' in py
+
+
+def test_sqlite_m063_pointer_references_response_format() -> None:
+    py = _read("app/migrations/m063_doview_analysis_creation_format_pointer.py")
+    # The body must instruct the model to fetch the response_format
+    # cascade — otherwise the pointer is useless.
+    flat = " ".join(py.split())
+    assert "response_format" in flat
+    assert "get_response_prompt" in flat
+    assert "purpose='response_format'" in flat or "purpose=\"response_format\"" in flat
+
+
+def test_sqlite_m063_table_guard() -> None:
+    py = _read("app/migrations/m063_doview_analysis_creation_format_pointer.py")
+    assert "type='table'" in py
+
+
+def test_sqlite_m063_registered_in_startup() -> None:
+    startup = _read("app/startup.py")
+    assert (
+        "from app.migrations.m063_doview_analysis_creation_format_pointer "
+        "import up as m063_up"
+    ) in startup
+    assert "await m063_up(main)" in startup
+
+
+# ── Supabase m067 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m067_file_exists() -> None:
+    assert (ROOT / "app/migrations/supabase/m067_doview_analysis_creation_format_pointer.sql").exists()
+
+
+def test_supabase_m067_mirrors_sqlite() -> None:
+    sql = _read("app/migrations/supabase/m067_doview_analysis_creation_format_pointer.sql")
+    assert "creation-format-doview-analysis-pointer-v1" in sql
+    assert "'creation_format'" in sql
+    assert "'diagram_type'" in sql
+    assert "'doview_analysis'" in sql
+    assert "get_response_prompt" in sql
+    assert "purpose='response_format'" in sql
+    assert "ON CONFLICT (id) DO NOTHING" in sql
+
+
+def test_supabase_m067_is_active_uses_true_literal() -> None:
+    """Boolean column on PostgreSQL — must use TRUE, not 1
+    (v5.12.2 regression guard pattern)."""
+    sql = _read("app/migrations/supabase/m067_doview_analysis_creation_format_pointer.sql")
+    assert "TRUE" in sql
+
+
+# ── Seed canonical body ────────────────────────────────────────────────
+
+
+def test_seed_has_doview_analysis_pointer_constant() -> None:
+    seed = _read("app/seed/creation_prompts.py")
+    assert "DOVIEW_ANALYSIS_CREATION_FORMAT_POINTER" in seed
+
+
+def test_seed_registers_pointer_row_in_expansion() -> None:
+    seed = _read("app/seed/creation_prompts.py")
+    # The expansion-rows list must include the pointer so it's
+    # re-applied on every backend startup (matches the existing
+    # ship-latest pattern for cascade prompts).
+    assert "creation-format-doview-analysis-pointer-v1" in seed
+
+
+# ── tools.py preamble update ───────────────────────────────────────────
+
+
+REPO_ROOT = ROOT.parent
+
+
+def test_creation_flow_preamble_mentions_response_format_for_markdown() -> None:
+    """The companion fix in mcp/src/iris_mcp/tools.py adds explicit
+    instructions in _CREATION_FLOW_PREAMBLE step 2a for the model to
+    fetch and apply response_format rules when creating markdown
+    content-bearing diagrams. Without this, the cascade-create path
+    silently produces unstructured markdown for doview_analysis (the
+    bug this fix closes)."""
+    tools_py = (REPO_ROOT / "mcp/src/iris_mcp/tools.py").read_text(encoding="utf-8")
+    flat = " ".join(tools_py.split())
+    assert "CRITICAL for content-bearing markdown diagrams" in flat
+    assert "purpose='response_format'" in flat
+    assert "doview_analysis" in flat

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.6.1",
+	"version": "6.6.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.6.1"
+version = "6.6.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -115,12 +115,24 @@ CREATION FLOW (recommended):
      used by Iris AI when generating diagrams. For DoView it includes
      the Stage 0 setup questions (Q1..Q6), the entity types, the
      colour palette, and the outcomes_map layout rules.
+  2a. CRITICAL for content-bearing markdown diagrams
+      (notation='markdown', e.g. diagram_type='doview_analysis'):
+      ALSO fetch get_response_prompt(notation='markdown',
+      diagram_type=..., purpose='response_format'). The response_format
+      rules govern the OUTPUT STRUCTURE of the markdown body
+      (required opening sentence, section headings, citation format,
+      framing language). Apply BOTH cascades to the content you
+      generate. Without this fetch, the markdown body will not
+      follow the structure rules and the diagram will fail
+      content-compliance review.
   3. Run the guided conversation IN CHAT with the user. Use
      AskUserQuestion when supported; numbered list otherwise.
   4. Compose the `data` JSON locally per the creation prompt's rules.
      For visual diagrams (notation in doview / archimate / c4 / uml /
      simple / bpmn), data is a Svelte-Flow-shaped {nodes, edges}
-     payload. For markdown diagrams, data is {"content": "<markdown>"}.
+     payload. For markdown diagrams, data is {"content": "<markdown>"}
+     and the <markdown> must follow the response_format rules from
+     step 2a.
   5. Confirm destination with the user (see destination preamble
      below).
   6. Call create_diagram with the composed data.


### PR DESCRIPTION
Phase 1 UAT defect fix. doview_analyses created via the cascade were freelancing the markdown content rather than following the response_format structure rules (opening sentence, Summary/Full/Diagrams sections, outcomes-theory framing, etc.).

## Root cause
Regression introduced at v6.0.0 (ADR-164) — removing `save_doview_analysis` didn't preserve the response_format dependency in the new generic `create_diagram` flow. The `_CREATION_FLOW_PREAMBLE` only directs the model to fetch `purpose='creation_format'`, which doesn't carry doview_analysis output-structure rules (those live on the response_format side per ADR-157).

## Fix
- Update `_CREATION_FLOW_PREAMBLE` step 2a — explicit instruction to also fetch response_format for content-bearing markdown diagrams.
- Backstop creation_format pointer row at `(layer=diagram_type, diagram_type=doview_analysis)` — composes into the cascade and tells the model to fetch response_format. Pointer not duplicate — response_format rows stay the single source of truth.
- SQLite m063 + Supabase m067 + seed file + tests.

## Tests
- 376/376 backend + 201/201 mcp green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)