### PR TITLE
fix(v6.6.3): Phase 5 UAT — export JSON error, visibility, button wrapping, delete nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.3] - 2026-05-16
+
+UI/UX patch — four minor issues caught during Phase 5 manual UAT.
+
+### Fixed
+
+- **GUI Export menu: "Unexpected end of JSON input"** for every
+  format (markdown / docx / pdf). Root cause: `DiagramExportMenu.svelte`
+  used bare `fetch('/api/export/diagram/...')`, which resolves
+  against the FRONTEND host in production (chrisbarlow.nz), not the
+  backend (iris-api-gtb3.onrender.com). The SPA fallback returned an
+  HTML document that `JSON.parse` rejected. Switched to `apiFetch`
+  which prefixes `API_BASE_URL` and carries the JWT bearer. The
+  artefact download `<a href>` now also uses `${API_BASE_URL}/api/artefacts/<id>`
+  so the browser hits the backend directly.
+- **SVG/PNG export options visible on markdown diagrams** (and then
+  failed with "no canvas element to capture"). Root cause: the
+  parent `+page.svelte` computed `isMarkdownContent={(notation as string) === 'markdown'}`,
+  but the page's `notation` $derived value resolves to `'text'` (the
+  canvas-type token) for markdown-notation diagrams, not
+  `'markdown'`. Now uses `diagram?.notation === 'markdown' || (canvasType as string) === 'text'`
+  which matches the actual diagram metadata.
+- **Hierarchy panel "+ New" and "Show" buttons wrap to two lines** in
+  narrow side-panel widths. Added `whitespace-nowrap` to both
+  buttons in `HierarchyControls.svelte`.
+- **View toolbar "Add to context" wraps to two lines**, doubling the
+  height of the whole button row. Added `whitespace-nowrap` to
+  Add to context, Bookmark, Clone, Delete buttons.
+- **Delete diagram navigates to `/views` (loses set context)**. Now
+  pre-computes a sensible "up" destination before the DELETE: prefer
+  the previous sibling diagram in the same set, then the next
+  sibling, then any other diagram in the set, then the parent
+  package, then the set page, then `/views` as last resort.
+
+### Frontend type checks
+
+`npm run check`: 165 → 165 errors (zero new from this patch — all
+pre-existing in unrelated files).
+
+### Deploy
+
+Frontend redeploy only. No backend / Supabase / MCP changes.
+
 ## [6.6.2] - 2026-05-16
 
 Issue #133 Phase 1 UAT defect fix — doview_analysis content

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.6.2",
+	"version": "6.6.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/DiagramExportMenu.svelte
+++ b/frontend/src/lib/components/DiagramExportMenu.svelte
@@ -10,6 +10,8 @@
   2781-2789 pre-v6.5.0).
 -->
 <script lang="ts">
+	import { API_BASE_URL } from '$lib/config';
+	import { apiFetch } from '$lib/utils/api';
 	import { exportToPng, exportToSvg } from '$lib/utils/export';
 
 	interface Props {
@@ -31,28 +33,41 @@
 	let busy = $state<string | null>(null);
 	let errorMsg = $state<string | null>(null);
 
+	// v6.6.3: markdown-content diagrams have no canvas, so SVG/PNG would
+	// always fail with "no canvas element to capture". Hide those menu
+	// items in that case. For visual diagrams, only show them if a flow
+	// element accessor was actually provided by the parent.
 	const showVisualOptions = $derived(!isMarkdownContent && flowElement !== undefined);
+
+	type ArtefactMeta = {
+		id: string;
+		filename: string;
+		mime_type: string;
+		size_bytes: number;
+	};
 
 	async function renderServerSide(format: 'md' | 'docx' | 'pdf') {
 		busy = format;
 		errorMsg = null;
 		try {
-			const resp = await fetch(`/api/export/diagram/${diagramId}`, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ format }),
-				credentials: 'include',
-			});
-			if (!resp.ok) {
-				const detail = await resp.text();
-				throw new Error(
-					`Render failed (${resp.status}): ${detail.slice(0, 200)}`,
-				);
-			}
-			const meta = (await resp.json()) as { id: string; filename: string };
-			// Browser-native download via Content-Disposition: attachment.
+			// v6.6.3: route through apiFetch so the request hits
+			// `${API_BASE_URL}/api/export/...` (the backend host, not the
+			// frontend host) AND carries the JWT bearer. Pre-v6.6.3 the
+			// component used bare `fetch('/api/export/...')` which 404'd on
+			// the frontend host in production — surfaced as "Unexpected end
+			// of JSON input" because the SPA fallback returned an HTML
+			// document that JSON.parse rejected.
+			const meta = await apiFetch<ArtefactMeta>(
+				`/api/export/diagram/${diagramId}`,
+				{
+					method: 'POST',
+					body: JSON.stringify({ format }),
+				},
+			);
+			// Artefact download URL is the BACKEND host
+			// (Content-Disposition: attachment serves the bytes directly).
 			const a = document.createElement('a');
-			a.href = `/api/artefacts/${meta.id}`;
+			a.href = `${API_BASE_URL}/api/artefacts/${meta.id}`;
 			a.download = meta.filename;
 			document.body.appendChild(a);
 			a.click();

--- a/frontend/src/lib/components/HierarchyControls.svelte
+++ b/frontend/src/lib/components/HierarchyControls.svelte
@@ -44,7 +44,7 @@
 		<button
 			type="button"
 			onclick={() => { newOpen = !newOpen; showOpen = false; }}
-			class="rounded px-3 py-1.5 text-sm text-white"
+			class="whitespace-nowrap rounded px-3 py-1.5 text-sm text-white"
 			style="background-color: var(--color-primary)"
 			aria-haspopup="menu"
 			aria-expanded={newOpen}
@@ -83,7 +83,7 @@
 		<button
 			type="button"
 			onclick={() => { showOpen = !showOpen; newOpen = false; }}
-			class="rounded border px-3 py-1.5 text-sm"
+			class="whitespace-nowrap rounded border px-3 py-1.5 text-sm"
 			style="border-color: var(--color-border); color: var(--color-fg)"
 			aria-haspopup="menu"
 			aria-expanded={showOpen}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -941,13 +941,47 @@
 
 	async function handleDelete() {
 		if (!diagram) return;
+		// v6.6.3: pre-compute a sensible "up" destination BEFORE deleting,
+		// so the user lands on something familiar instead of /views (which
+		// loses set context). Order of preference:
+		//   1. Previous diagram in the same set (alphabetical by name,
+		//      then created_at — matches the list_diagrams default order)
+		//   2. Parent package page if the diagram has one
+		//   3. Set page if not (or if listing fails)
+		//   4. /views as last resort
+		const setId = diagram.set_id;
+		const parentPackageId = diagram.parent_package_id;
+		const currentId = diagram.id;
+		let upHref = '/views';
+		try {
+			if (setId) {
+				const siblings = await apiFetch<Array<{ id: string }>>(
+					`/api/diagrams?set_id=${setId}`,
+				);
+				const idx = siblings.findIndex((d) => d.id === currentId);
+				const fallback = (
+					(idx > 0 && siblings[idx - 1]?.id) ||
+					(idx >= 0 && idx + 1 < siblings.length && siblings[idx + 1]?.id) ||
+					siblings.find((d) => d.id !== currentId)?.id
+				);
+				if (fallback) {
+					upHref = `/views/${fallback}`;
+				} else if (parentPackageId) {
+					upHref = `/packages/${parentPackageId}`;
+				} else {
+					upHref = `/sets/${setId}`;
+				}
+			}
+		} catch {
+			// Network / listing error — fall through to /views.
+		}
 		try {
 			await apiFetch(`/api/diagrams/${diagram.id}`, {
 				method: 'DELETE',
 				headers: { 'If-Match': String(diagram.current_version) },
 			});
 			showDeleteDialog = false;
-			await goto('/views');
+			await goto(upHref);
 		} catch (e) {
 			error = e instanceof ApiError ? e.message : 'Failed to delete diagram';
 		}
@@ -1963,7 +1997,7 @@
 			{:else}
 				<button
 					onclick={() => addAiContextItem({ id: diagram.id, result_type: 'diagram', name: diagram.name, set_id: diagram.set_id ?? null, set_name: diagram.set_name ?? null })}
-					class="flex items-center gap-2 rounded px-4 py-2 text-sm"
+					class="flex items-center gap-2 whitespace-nowrap rounded px-4 py-2 text-sm"
 					style="border: 1px solid var(--color-border); color: var(--color-fg); background: transparent"
 				>
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="14" height="14" aria-hidden="true" style="color: var(--color-primary)"><path d="M248,124a56.11,56.11,0,0,0-32-50.61V72a48,48,0,0,0-88-26.49A48,48,0,0,0,40,72v1.39a56,56,0,0,0,0,101.2V176a48,48,0,0,0,88,26.49A48,48,0,0,0,216,176v-1.41A56.09,56.09,0,0,0,248,124ZM88,208a32,32,0,0,1-31.81-28.56A55.87,55.87,0,0,0,64,180h8a8,8,0,0,0,0-16H64A40,40,0,0,1,50.67,86.27,8,8,0,0,0,56,78.73V72a32,32,0,0,1,64,0v68.26A47.8,47.8,0,0,0,88,128a8,8,0,0,0,0,16,32,32,0,0,1,0,64Zm104-44h-8a8,8,0,0,0,0,16h8a55.87,55.87,0,0,0,7.81-.56A32,32,0,1,1,168,144a8,8,0,0,0,0-16,47.8,47.8,0,0,0-32,12.26V72a32,32,0,0,1,64,0v6.73a8,8,0,0,0,5.33,7.54A40,40,0,0,1,192,164Zm16-52a8,8,0,0,1-8,8h-4a36,36,0,0,1-36-36V80a8,8,0,0,1,16,0v4a20,20,0,0,0,20,20h4A8,8,0,0,1,208,112ZM60,120H56a8,8,0,0,1,0-16h4A20,20,0,0,0,80,84V80a8,8,0,0,1,16,0v4A36,36,0,0,1,60,120Z"/></svg>
@@ -1973,21 +2007,21 @@
 			<button
 				onclick={toggleBookmark}
 				disabled={bookmarkLoading}
-				class="rounded px-4 py-2 text-sm"
+				class="whitespace-nowrap rounded px-4 py-2 text-sm"
 				style="border: 1px solid {isBookmarked ? 'var(--color-primary)' : 'var(--color-border)'}; color: {isBookmarked ? 'var(--color-primary)' : 'var(--color-fg)'}; background: {isBookmarked ? 'var(--color-surface, transparent)' : 'transparent'}"
 			>
 				{isBookmarked ? 'Bookmarked' : 'Bookmark'}
 			</button>
 			<button
 				onclick={() => (showCloneDialog = true)}
-				class="rounded px-4 py-2 text-sm"
+				class="whitespace-nowrap rounded px-4 py-2 text-sm"
 				style="border: 1px solid var(--color-border); color: var(--color-fg)"
 			>
 				Clone
 			</button>
 			<button
 				onclick={() => (showDeleteDialog = true)}
-				class="rounded px-4 py-2 text-sm text-white"
+				class="whitespace-nowrap rounded px-4 py-2 text-sm text-white"
 				style="background-color: var(--color-danger)"
 			>
 				Delete
@@ -2442,7 +2476,7 @@
 							<DiagramExportMenu
 								diagramId={diagram.id}
 								diagramName={diagram.name}
-								isMarkdownContent={(notation as string) === 'markdown'}
+								isMarkdownContent={diagram?.notation === 'markdown' || (canvasType as string) === 'text'}
 								flowElement={() => getFlowElement()}
 							/>
 						{/if}
@@ -2746,7 +2780,7 @@
 							<DiagramExportMenu
 								diagramId={diagram.id}
 								diagramName={diagram.name}
-								isMarkdownContent={(notation as string) === 'markdown'}
+								isMarkdownContent={diagram?.notation === 'markdown' || (canvasType as string) === 'text'}
 								flowElement={() => getFlowElement()}
 							/>
 						{/if}

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.6.2"
+version = "6.6.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Four small UI/UX defects caught during manual UAT of v6.5.0:

1. **GUI Export menu** returned 'Unexpected end of JSON input' — bare `fetch` resolved to frontend host, SPA fallback returned HTML. Switched to `apiFetch` with `API_BASE_URL`.
2. **SVG/PNG on markdown diagrams** — wrong derived value for isMarkdownContent. Fixed.
3. **'+New' / 'Show' buttons** wrapped to two lines — added `whitespace-nowrap`.
4. **Toolbar 'Add to context'** wrapped to two lines — added `whitespace-nowrap` to all four.
5. **Delete navigates to /views** — now goes to a sensible 'up' destination (sibling diagram → parent package → set page → /views).

Frontend-only patch. Type checks clean (165 → 165 errors, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)