### PR TITLE
fix(v6.6.5): render_diagram on Supabase — export service positional row indexing (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.6.5] - 2026-05-16
+
+Issue [#145](https://github.com/cgbarlow/iris/issues/145) — Phase 1
+UAT of the deployed v6.6.4 stack reported that the primary MCP path
+for `render_diagram` failed with `HTTP 500 Internal Server Error`.
+The documented `render_markdown` fallback worked, so the user still
+got their three artefacts, but the headline path was broken on every
+render call from a live MCP session.
+
+### Root cause
+
+`backend/app/export/service.py` read every database row by string
+column key (`row["id"]`, `row["data"]`, …). The SQLite adapter sets
+`db.row_factory = aiosqlite.Row`, so string keys work in the test
+suite. The Supabase adapter normalises every asyncpg `Record` to a
+plain `tuple[Any, ...]` (so it can convert PG `datetime` / `UUID`
+to SQLite-compatible strings — see
+`backend/app/db/adapter.py::_normalize_row`). Tuples only support
+integer indexing. Every export call on Supabase raised
+`TypeError: tuple indices must be integers or slices, not str`,
+which FastAPI surfaced as a 500.
+
+Every other backend service module (`app/diagrams/service.py`,
+`app/sets/`, `app/elements/`, `app/packages/`, …) already uses
+positional indexing for exactly this reason. The export service
+was the only outlier — which is why the bug only showed up against
+production, not the SQLite test suite. The same defect was also
+silently breaking every other `GET /api/export/*` bundle endpoint
+on Supabase deployments.
+
+### Fix
+
+- All `row["col"]` reads in `app/export/service.py` converted to
+  positional indexing matching `_ELEMENT_SELECT` / `_DIAGRAM_SELECT`
+  / `_PACKAGE_SELECT` column order. Touches `_row_to_element`,
+  `_row_to_diagram`, `_row_to_package`, `_fetch_set`,
+  `_fetch_collection`, `build_collection_export`,
+  `_fetch_elements_for_diagram`, `_descendant_package_ids`.
+- Helper type annotations widened from `aiosqlite.Row` to `object`
+  with a comment noting both adapters are now supported.
+
+### Tests
+
+- New `backend/tests/test_export/test_service_tuple_rows.py` —
+  three unit tests against `_row_to_diagram` / `_row_to_element` /
+  `_row_to_package` with plain-tuple inputs (the Supabase row
+  shape). Pre-fix these raise `TypeError`; post-fix they pass.
+  A future maintainer that reintroduces `row["col"]` reads in the
+  export service trips the test without needing a live Supabase
+  connection.
+- All 44 existing export-suite tests still pass against SQLite.
+
+### Files
+
+- `backend/app/export/service.py` — positional indexing throughout.
+- `backend/tests/test_export/test_service_tuple_rows.py` (new).
+- `docs/adrs/ADR-183-Export-Service-Adapter-Parity.md` (new).
+- `docs/adrs/specs/SPEC-183-A-Export-Service-Adapter-Parity.md` (new).
+- `mcp/pyproject.toml` 6.6.4 → 6.6.5.
+- `frontend/package.json` 6.6.4 → 6.6.5.
+
+### Deploy
+
+Backend-only fix. After the Render rebuild lands, re-run the
+`render_diagram` smoke from `docs/issue-133-deploy-verification.md`
+step 6 / Phase 2 — both the curl and the cascade-driven MCP path
+should return 200 + artefact URLs.
+
 ## [6.6.4] - 2026-05-16
 
 Issue #133 Phase 1 deploy-verification UAT — two unrelated defects

--- a/backend/app/export/service.py
+++ b/backend/app/export/service.py
@@ -147,10 +147,11 @@ async def build_element_export(
         "   ON d.id = dv.diagram_id AND d.current_version = dv.version"
         " WHERE (d.is_deleted = 0 OR d.is_deleted IS NULL)",
     )
+    # SELECT d.id, dv.data — positional indexing for Supabase parity.
     linked: list[str] = [
-        row["id"]
+        row[0]
         for row in await cursor.fetchall()
-        if element_id in _element_ids_from_diagram_data(_json_load(row["data"]))
+        if element_id in _element_ids_from_diagram_data(_json_load(row[1]))
     ]
 
     return ElementExport(
@@ -186,7 +187,7 @@ async def _descendant_package_ids(
             " AND (is_deleted = 0 OR is_deleted IS NULL)",
             frontier,
         )
-        children = [r["id"] for r in await cursor.fetchall()]
+        children = [r[0] for r in await cursor.fetchall()]
         children = [c for c in children if c not in seen]
         descendants.extend(children)
         seen.update(children)
@@ -262,13 +263,13 @@ async def _fetch_set(db: aiosqlite.Connection, set_id: str) -> SetResponse:
     if row is None:
         raise ExportNotFoundError(f"Set {set_id} not found")
     return SetResponse(
-        id=row["id"],
-        name=row["name"],
-        description=row["description"],
-        created_at=row["created_at"],
-        created_by=row["created_by"] or "",
-        updated_at=row["updated_at"],
-        collection_id=row["collection_id"],
+        id=row[0],
+        name=row[1],
+        description=row[2],
+        created_at=row[3],
+        created_by=row[4] or "",
+        updated_at=row[5],
+        collection_id=row[6],
     )
 
 
@@ -322,12 +323,12 @@ async def _fetch_collection(
     if row is None:
         raise ExportNotFoundError(f"Collection {collection_id} not found")
     return CollectionResponse(
-        id=row["id"],
-        name=row["name"],
-        description=row["description"],
-        created_at=row["created_at"],
-        created_by=row["created_by"] or "",
-        updated_at=row["updated_at"],
+        id=row[0],
+        name=row[1],
+        description=row[2],
+        created_at=row[3],
+        created_by=row[4] or "",
+        updated_at=row[5],
     )
 
 
@@ -340,7 +341,7 @@ async def build_collection_export(
         " AND (is_deleted = 0 OR is_deleted IS NULL)",
         (collection_id,),
     )
-    set_ids = [r["id"] for r in await cursor.fetchall()]
+    set_ids = [r[0] for r in await cursor.fetchall()]
 
     set_exports: list[SetExport] = []
     running_total = 0
@@ -396,50 +397,53 @@ def _element_ids_from_diagram_data(data: dict[str, object]) -> list[str]:
     return out
 
 
-def _row_to_element(row: aiosqlite.Row) -> ElementResponse:
+# Positional indexing matches _ELEMENT_SELECT / _DIAGRAM_SELECT / _PACKAGE_SELECT.
+# Both adapters return tuple-compatible rows; only aiosqlite.Row also supports
+# str keys, so we stay positional for Supabase parity (issue #145).
+def _row_to_element(row: object) -> ElementResponse:
     return ElementResponse(
-        id=row["id"],
-        element_type=row["element_type"],
-        current_version=row["current_version"],
-        name=row["name"],
-        description=row["description"],
-        data=_json_load(row["data"]),
-        created_at=row["created_at"],
-        created_by=row["created_by"] or "",
-        updated_at=row["updated_at"],
-        set_id=row["set_id"],
-        notation=row["notation"] or "simple",
+        id=row[0],
+        element_type=row[1],
+        current_version=row[2],
+        name=row[3],
+        description=row[4],
+        data=_json_load(row[5]),
+        created_at=row[6],
+        created_by=row[7] or "",
+        updated_at=row[8],
+        set_id=row[9],
+        notation=row[10] or "simple",
     )
 
 
-def _row_to_diagram(row: aiosqlite.Row) -> DiagramResponse:
+def _row_to_diagram(row: object) -> DiagramResponse:
     return DiagramResponse(
-        id=row["id"],
-        diagram_type=row["diagram_type"],
-        current_version=row["current_version"],
-        name=row["name"],
-        description=row["description"],
-        data=_json_load(row["data"]),
-        created_at=row["created_at"],
-        created_by=row["created_by"] or "",
-        updated_at=row["updated_at"],
-        parent_package_id=row["parent_package_id"],
-        set_id=row["set_id"],
-        notation=row["notation"] or "simple",
+        id=row[0],
+        diagram_type=row[1],
+        current_version=row[2],
+        name=row[3],
+        description=row[4],
+        data=_json_load(row[5]),
+        created_at=row[6],
+        created_by=row[7] or "",
+        updated_at=row[8],
+        parent_package_id=row[9],
+        set_id=row[10],
+        notation=row[11] or "simple",
     )
 
 
-def _row_to_package(row: aiosqlite.Row) -> PackageResponse:
+def _row_to_package(row: object) -> PackageResponse:
     return PackageResponse(
-        id=row["id"],
-        current_version=row["current_version"],
-        name=row["name"],
-        description=row["description"],
-        created_at=row["created_at"],
-        created_by=row["created_by"] or "",
-        updated_at=row["updated_at"],
-        parent_package_id=row["parent_package_id"],
-        set_id=row["set_id"],
+        id=row[0],
+        current_version=row[1],
+        name=row[2],
+        description=row[3],
+        created_at=row[4],
+        created_by=row[5] or "",
+        updated_at=row[6],
+        parent_package_id=row[7],
+        set_id=row[8],
     )
 
 

--- a/backend/tests/test_export/test_service_tuple_rows.py
+++ b/backend/tests/test_export/test_service_tuple_rows.py
@@ -1,0 +1,86 @@
+"""Issue #145: export service must work with positional (tuple) rows.
+
+The SQLite adapter returns rows that support both ``row["col"]`` and
+``row[0]`` thanks to ``aiosqlite.Row`` factory. The Supabase adapter
+normalizes asyncpg records into plain tuples (see
+``app/db/adapter.py::_normalize_row``) — tuples only support integer
+indexing. ``app/export/service.py`` was reading every column via the
+string form, so the production (Supabase) deployment hit a
+``TypeError`` and surfaced an HTTP 500 from
+``POST /api/export/diagram/{diagram_id}``.
+
+These tests pin the row-conversion helpers to positional indexing so
+both adapters work uniformly.
+"""
+
+from __future__ import annotations
+
+from app.export.service import _row_to_diagram, _row_to_element, _row_to_package
+
+
+def test_row_to_diagram_accepts_tuple_row() -> None:
+    row = (
+        "diag-id",          # id
+        "doview_analysis",  # diagram_type
+        1,                  # current_version
+        "Diagram name",     # name
+        "desc",             # description
+        '{"content": "hi"}',# data
+        "2026-05-16T00:00:00+00:00",
+        "user-id",
+        "2026-05-16T00:00:00+00:00",
+        "pkg-id",
+        "set-id",
+        "markdown",         # notation
+    )
+
+    diagram = _row_to_diagram(row)
+
+    assert diagram.id == "diag-id"
+    assert diagram.notation == "markdown"
+    assert diagram.data == {"content": "hi"}
+    assert diagram.parent_package_id == "pkg-id"
+    assert diagram.set_id == "set-id"
+
+
+def test_row_to_element_accepts_tuple_row() -> None:
+    row = (
+        "elem-id",
+        "Component",
+        1,
+        "Widget",
+        "desc",
+        "{}",
+        "2026-05-16T00:00:00+00:00",
+        "user-id",
+        "2026-05-16T00:00:00+00:00",
+        "set-id",
+        "simple",
+    )
+
+    element = _row_to_element(row)
+
+    assert element.id == "elem-id"
+    assert element.element_type == "Component"
+    assert element.set_id == "set-id"
+
+
+def test_row_to_package_accepts_tuple_row() -> None:
+    row = (
+        "pkg-id",
+        1,
+        "Root",
+        "desc",
+        "2026-05-16T00:00:00+00:00",
+        "user-id",
+        "2026-05-16T00:00:00+00:00",
+        None,
+        "set-id",
+    )
+
+    package = _row_to_package(row)
+
+    assert package.id == "pkg-id"
+    assert package.name == "Root"
+    assert package.parent_package_id is None
+    assert package.set_id == "set-id"

--- a/docs/adrs/ADR-183-Export-Service-Adapter-Parity.md
+++ b/docs/adrs/ADR-183-Export-Service-Adapter-Parity.md
@@ -1,0 +1,104 @@
+# ADR-183: Export service uses positional row indexing for adapter parity
+
+Status: Accepted (2026-05-16)
+
+## Context
+
+Issue [#145](https://github.com/cgbarlow/iris/issues/145) — Phase 1 UAT
+of the deployed v6.6.4 stack reported that the primary MCP path for
+`render_diagram` failed with `HTTP 500 Internal Server Error`. The
+documented Phase-1 fallback (`render_markdown` with a re-pasted body)
+worked, so users still got their artefacts, but the headline path was
+broken on every render call from a live MCP session.
+
+`POST /api/export/diagram/{diagram_id}` and the other
+`GET /api/export/*` bundle endpoints all flow through
+`backend/app/export/service.py`, which fetches diagram / element /
+package / set / collection rows and converts them to Pydantic
+responses via helpers like `_row_to_diagram(row)`.
+
+Every helper read columns by string key (`row["id"]`, `row["data"]`,
+`row["notation"]`, …). That works on the SQLite adapter — the
+`get_connection` helper sets `db.row_factory = aiosqlite.Row`, and
+`aiosqlite.Row` supports both `row["col"]` and `row[0]`. It does **not**
+work on the Supabase / asyncpg adapter: `SupabaseAdapter._execute_on`
+returns an `_AsyncpgCursor` whose `_normalize_row(record)` packs each
+asyncpg `Record` into a plain `tuple[Any, ...]` (so it can normalise
+`datetime`, `date`, and `UUID` to SQLite-compatible strings). Tuples
+only support integer indexing. Every `row["id"]` on Supabase raised
+`TypeError: tuple indices must be integers or slices, not str`, which
+FastAPI surfaced as a 500.
+
+Every other service module (`app/diagrams/`, `app/sets/`,
+`app/elements/`, `app/packages/`, …) already uses positional indexing
+for exactly this reason — see `app/diagrams/service.py` lines 176–193.
+The export service was the only outlier, which is why the bug only
+showed up against Supabase production, not the SQLite test suite.
+
+## Decision
+
+**`app/export/service.py` must read every database row by positional
+index, never by string key.** This matches the convention already in
+use across the rest of the backend service layer.
+
+In practice that means:
+
+- `_row_to_element`, `_row_to_diagram`, `_row_to_package` use `row[0]`,
+  `row[1]`, … to match the literal column order of `_ELEMENT_SELECT`,
+  `_DIAGRAM_SELECT`, `_PACKAGE_SELECT`.
+- Inline reads in `_fetch_set`, `_fetch_collection`,
+  `build_collection_export`, `_fetch_elements_for_diagram`, and
+  `_descendant_package_ids` also use positional indexing.
+- The helper type annotations widen from `aiosqlite.Row` to `object`
+  so the cross-adapter intent is visible at the signature.
+
+## Why not give the Supabase adapter a Row-like wrapper
+
+- Touching `_AsyncpgCursor` would change the shape of every existing
+  call site in the codebase that already relies on tuple semantics.
+  The whole codebase has already converged on positional indexing —
+  the export service is the divergent caller, so fix the caller.
+- A Row-like wrapper means carrying column-name metadata through the
+  adapter for every query. asyncpg already gives us `Record.keys()`
+  but threading that through the normalised-tuple path adds overhead
+  to the hot read path for one outlier module's benefit.
+- Positional indexing is the convention; codify it instead of
+  introducing a second convention.
+
+## Why not catch the `TypeError` in the renderer route
+
+- Hiding the symptom doesn't fix the source. Every `GET /api/export/*`
+  read endpoint would still throw on Supabase; we'd just relabel the
+  500 as a 502 or similar.
+- The structural fix is small (~10 lines of edits) and removes a
+  whole class of bug.
+
+## Consequences
+
+- `backend/app/export/service.py` row reads converted to positional
+  indexing.
+- New regression test `backend/tests/test_export/test_service_tuple_rows.py`
+  exercises `_row_to_diagram`, `_row_to_element`, `_row_to_package`
+  with plain tuples (the Supabase row shape) so a future
+  string-keyed regression fails locally without needing a Supabase
+  connection.
+- CHANGELOG `[6.6.5]`.
+- Version bumps: mcp + frontend 6.6.4 → 6.6.5.
+
+## Verification
+
+- Failing test (`test_row_to_diagram_accepts_tuple_row`) reproduces
+  the `TypeError` against pre-fix code.
+- Post-fix: `uv run pytest tests/test_export/` — all 44 export tests
+  pass (3 new tuple-row tests + 41 existing SQLite-backed tests).
+- Manual smoke against deployed iris-api after rebuild: call
+  `POST /api/export/diagram/{any-markdown-diagram-id}` with
+  `{"format":"md"}` and confirm 200 + `web_url` artefact.
+
+## See also
+
+- [SPEC-183-A](specs/SPEC-183-A-Export-Service-Adapter-Parity.md)
+- ADR-094 (database adapter)
+- ADR-179 (renderer + artefact store) — the consumer surface affected
+- Issue [#145](https://github.com/cgbarlow/iris/issues/145)
+- Issue [#133](https://github.com/cgbarlow/iris/issues/133) Phase 1 UAT

--- a/docs/adrs/specs/SPEC-183-A-Export-Service-Adapter-Parity.md
+++ b/docs/adrs/specs/SPEC-183-A-Export-Service-Adapter-Parity.md
@@ -1,0 +1,62 @@
+# SPEC-183-A: Export service uses positional row indexing
+
+ADR: [ADR-183](../ADR-183-Export-Service-Adapter-Parity.md)
+
+## Summary
+
+Convert every row-column read in `backend/app/export/service.py` from
+string-key (`row["col"]`) to positional (`row[N]`) indexing, matching
+the convention already in use across the rest of the backend service
+layer. Add a regression test that exercises the row helpers with
+plain-tuple inputs so the SQLite-only test suite would catch the
+defect a future maintainer would otherwise reintroduce.
+
+## Touched files
+
+### `backend/app/export/service.py`
+
+- `_row_to_element(row)` → all 11 columns indexed by position
+  (matches `_ELEMENT_SELECT` column order).
+- `_row_to_diagram(row)` → all 12 columns indexed by position
+  (matches `_DIAGRAM_SELECT` column order).
+- `_row_to_package(row)` → all 9 columns indexed by position
+  (matches `_PACKAGE_SELECT` column order).
+- `_fetch_elements_for_diagram` inline `linked` comprehension —
+  positional `(row[0], row[1])` for the `(id, data)` tuple.
+- `_fetch_set` inline `SetResponse(...)` build — positional.
+- `_fetch_collection` inline `CollectionResponse(...)` build — positional.
+- `build_collection_export` `set_ids` comprehension — positional.
+- `_descendant_package_ids` `children` comprehension — positional.
+
+Type annotations on the three `_row_to_*` helpers widen from
+`aiosqlite.Row` to `object` so the cross-adapter intent is visible at
+the signature. A short comment notes that positional indexing works
+on both `aiosqlite.Row` (SQLite) and plain `tuple` (Supabase via
+`_AsyncpgCursor._normalize_row`).
+
+### `backend/tests/test_export/test_service_tuple_rows.py` (new)
+
+Three unit tests exercise `_row_to_diagram`, `_row_to_element`, and
+`_row_to_package` with a plain tuple matching each SELECT's column
+order. Pre-fix these tests raise `TypeError`; post-fix they pass.
+The tests do not require a database connection — they are pure
+function tests against the row-conversion helpers.
+
+## Out of scope
+
+- The Supabase adapter's row-normalisation strategy
+  (`_normalize_row → tuple`) is not changed. ADR-183 documents why
+  fixing the caller is preferred to changing the adapter.
+- Other services already use positional indexing; no audit pass is
+  required.
+
+## Verification
+
+- `uv run pytest tests/test_export/test_service_tuple_rows.py` — new
+  tests pass.
+- `uv run pytest tests/test_export/` — all 44 tests pass (no
+  regression in the SQLite-backed integration tests).
+- Manual smoke against the deployed iris-api once v6.6.5 ships:
+  step 6 / Phase 1 of `docs/issue-133-deploy-verification.md` —
+  `POST /api/export/diagram/{any-markdown-diagram-id}` with
+  `{"format":"md"}` must return 200 + an artefact `web_url`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.6.4",
+	"version": "6.6.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.6.4"
+version = "6.6.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- **Closes #145.** `POST /api/export/diagram/{id}` returned HTTP 500 against the deployed Supabase backend; only the `render_markdown` fallback worked.
- Root cause: `app/export/service.py` read every row by string column key (`row["id"]`). aiosqlite.Row supports str-keyed access (so the SQLite-backed test suite passed), but the Supabase adapter normalises asyncpg Records to plain tuples for type conversion — tuples only support integer indexing, so every export call raised `TypeError`. Every other backend service module already uses positional indexing.
- Fix: convert all row reads in `app/export/service.py` to positional indexing matching `_ELEMENT_SELECT` / `_DIAGRAM_SELECT` / `_PACKAGE_SELECT` column order. ADR-183 + SPEC-183-A document the convention.
- New regression test `tests/test_export/test_service_tuple_rows.py` exercises the row helpers with plain tuples (Supabase row shape) — pre-fix raises `TypeError`, post-fix passes. Doesn't need a live Supabase connection.

## Test plan

- [x] `uv run pytest tests/test_export/` — 44 / 44 pass (3 new tuple-row + 41 existing SQLite integration tests).
- [x] `python3 scripts/check_surface_parity.py` — clean.
- [ ] Post-deploy: re-run `docs/issue-133-deploy-verification.md` step 6 / Phase 2 `render_diagram` smoke against the rebuilt iris-api — must return 200 with an artefact `web_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)