### PR TITLE
fix(v6.7.1): m069 boolean literal + Protocol §15 SQLite↔Supabase parity (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.1] - 2026-05-16
+
+### Fixed
+
+- Supabase migration m069 used `0` for `diagram_type_notations.is_default`,
+  which PostgreSQL rejects with `column "is_default" is of type boolean
+  but expression is of type integer`. Now uses `FALSE`, matching the
+  v5.12.x boolean-literal convention. Re-running m069 against an
+  affected Supabase database is now a clean no-op (the prior failure
+  rolled back, so no partial state to repair).
+
+### Added
+
+- Protocol §15 — SQLite ↔ Supabase Migration Parity
+  ([issue #152](https://github.com/cgbarlow/iris/issues/152)).
+  Codifies the rules that prevent SQLite-passing changes from
+  500-ing on Supabase: paired SQLite/Supabase migrations in the
+  same PR, `TRUE`/`FALSE` boolean literals on Postgres,
+  positional row access in service code, no dollar-quoted SQL in
+  the startup path, migrate-before-roll-forward release ordering,
+  and a per-migration schema test in `backend/tests/test_migrations/`.
+  Motivated by the v6.7.0 m069 incident (`0` vs `FALSE` for
+  `diagram_type_notations.is_default`) and the v6.6.5 export-service
+  row-key incident.
+
 ## [6.7.0] - 2026-05-16
 
 Issues [#147](https://github.com/cgbarlow/iris/issues/147) and

--- a/backend/app/migrations/supabase/m069_dynamic_list_diagram_type.sql
+++ b/backend/app/migrations/supabase/m069_dynamic_list_diagram_type.sql
@@ -8,6 +8,7 @@ VALUES ('dynamic_list', 'Dynamic List',
         'Auto-generated markdown bullet list', 16)
 ON CONFLICT (id) DO NOTHING;
 
+-- Postgres `is_default` is boolean (Supabase schema); SQLite uses 0.
 INSERT INTO public.diagram_type_notations (diagram_type_id, notation_id, is_default)
-VALUES ('dynamic_list', 'markdown', 0)
+VALUES ('dynamic_list', 'markdown', FALSE)
 ON CONFLICT (diagram_type_id, notation_id) DO NOTHING;

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -144,3 +144,15 @@ These protocols must be followed when using plan mode. They are non-negotiable.
 - Documented asymmetries (CLI `ask`, no `delete_*`, no `move_element`, no cross-set moves) are codified in the script's exception list. New asymmetries need a corresponding ADR and the script update.
 - DRY corollary (§13): the md → docx and md → pdf renderers exist only in `backend/app/export/renderers/`. The script also checks this — no other module may import `weasyprint` or `markdown_it` for rendering.
 - See [ADR-182](./adrs/ADR-182-Surface-Parity-Discipline.md) for the full rationale and the exception catalogue.
+
+## 15. SQLite ↔ Supabase Migration Parity
+
+**Every database change must work on both SQLite and Supabase (PostgreSQL) deployments. Passing tests on SQLite is not sufficient.**
+
+- Every SQLite migration in `backend/app/migrations/m{NNN}_*.py` must ship in the same PR as its Supabase mirror in `backend/app/migrations/supabase/m{NNN}_*.sql`. Numbering is independent per family — link the pair in the SQL header (`-- Mirrors SQLite m{NNN}.`) so reviewers can pair them at a glance.
+- Both halves must be idempotent: SQLite via `IF NOT EXISTS` / `INSERT OR IGNORE`; Supabase via `IF NOT EXISTS` and `ON CONFLICT ... DO NOTHING`. Migrations may be re-run.
+- Boolean columns: PostgreSQL rejects integer literals where a `BOOLEAN` is expected. Supabase migrations MUST use `TRUE`/`FALSE`, even when the SQLite mirror uses `0`/`1`. This is the most common slip — see the v5.12.x regression guards in `backend/tests/test_migrations/test_response_format_prompts_schema.py` and the m069 / issue #152 incident.
+- Row access in service code: asyncpg returns native `datetime` / `UUID` objects (normalised to strings by `_normalize_row` in `backend/app/db/adapter.py`) wrapped in plain tuples; aiosqlite returns `Row` objects that support string-key access. Service-layer code MUST read rows positionally (`r[0]`, `r[1]`, …) — `row["col"]` works on SQLite and 500s on Supabase. The export-service incident (v6.6.5) is the cautionary tale.
+- Dollar-quoted SQL (`$$ … $$`), trigger and function definitions cannot be executed by asyncpg at startup. They live only in the Supabase `.sql` files and are applied via `scripts/supabase-migrate.sh`; the Supabase startup path in `backend/app/startup.py:_initialize_supabase` deliberately does NOT run the migration runner.
+- **Release ordering for Supabase deployments**: schema-dependent code MUST NOT go live before its column exists. The release checklist for any version that adds a Supabase migration must include applying the migration BEFORE rolling the app forward. Render auto-deploys on push, so the safe sequence is: (a) merge migration-only PR, (b) run `scripts/supabase-migrate.sh` against the target DB, (c) merge the code change that depends on the new schema.
+- Every new migration ships with a per-migration schema test in `backend/tests/test_migrations/` that asserts the boolean-literal convention, idempotency markers, and any cross-mode constraints. Copy the pattern from `test_response_format_prompts_schema.py` / `test_cascade_ux_polish_schema.py`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.7.0",
+	"version": "6.7.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.7.0"
+version = "6.7.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- **m069 fix**: Supabase migration m069 used `0` for `diagram_type_notations.is_default`; PostgreSQL rejects it with `column "is_default" is of type boolean but expression is of type integer`. Now uses `FALSE`, matching the v5.12.x convention. The failed run rolled back, so re-running m069 is a clean no-op.
- **Protocol §15 — SQLite ↔ Supabase Migration Parity** ([#152](https://github.com/cgbarlow/iris/issues/152)): codifies the rules that prevent SQLite-passing changes from 500-ing on Supabase. Covers paired migrations, boolean-literal convention, positional row access, dollar-quoted SQL restrictions, migrate-before-roll-forward release ordering, and per-migration schema tests.
- Version bumps: `frontend/package.json` and `mcp/pyproject.toml` → `6.7.1`. CHANGELOG entry under `[6.7.1]`.

## Test plan

- [x] m069 re-applied successfully against UAT Supabase (manual)
- [ ] `/api/elements?page_size=1` returns 200 on UAT
- [ ] Confirm no `dynamic_list` row collisions on the second run (idempotent via `ON CONFLICT DO NOTHING`)
- [ ] Surface parity CI gate passes (no router/MCP/CLI changes — should be a no-op)
- [ ] Existing `backend/tests/test_migrations/` schema tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)