### PR TITLE
fix(v6.7.2): DynamicListCanvas imports apiFetch from $lib/utils/api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.2] - 2026-05-16
+
+### Fixed
+
+- `DynamicListCanvas.svelte` imported `apiFetch` from `$lib/api` —
+  a directory containing only `named-prompts.ts` (no `index.ts`), so
+  Vite errored with `EISDIR: illegal operation on a directory, read`
+  and every frontend deploy on Render aborted at 1041 modules
+  transformed. Now imports from `$lib/utils/api`, matching the
+  convention used everywhere else in the canvas tree.
+
 ## [6.7.1] - 2026-05-16
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.7.1",
+	"version": "6.7.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
+++ b/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
@@ -11,7 +11,7 @@
 	 */
 	import MarkdownView from '$lib/components/MarkdownView.svelte';
 	import type { TocHeading } from '$lib/components/markdownHelpers';
-	import { apiFetch } from '$lib/api';
+	import { apiFetch } from '$lib/utils/api';
 	import { onMount } from 'svelte';
 
 	interface PackageOption {

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.7.1"
+version = "6.7.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `DynamicListCanvas.svelte:14` imported `apiFetch` from `$lib/api`, which resolves to the **directory** `frontend/src/lib/api/` (only contains `named-prompts.ts`, no `index.ts`). Vite errors with `EISDIR: illegal operation on a directory, read` and the Render frontend build aborts at 1041 modules transformed.
- Every other file in the canvas tree imports `apiFetch` from `$lib/utils/api`. This change aligns DynamicListCanvas with that convention.
- Version bumps: `frontend/package.json` and `mcp/pyproject.toml` → `6.7.2`. CHANGELOG entry under `[6.7.2]`.

## Test plan

- [x] Local `vite build` passes
- [ ] Render frontend deploy succeeds
- [ ] `/views/[id]` page renders Dynamic List diagrams without runtime errors
- [ ] No other `$lib/api` import references exist (grep clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)