### PR TITLE
fix(v6.7.3): MCP/CLI update_* tools send If-Match header (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.7.3] - 2026-05-16
+
+### Fixed
+
+- MCP `update_element` / `update_diagram` / `update_package` and the
+  CLI's shared `_put_merge_partial` helper never sent the `If-Match`
+  header. Backend update routes require it (HTTP 428 without) for
+  optimistic concurrency on versioned entities, so every call from
+  these surfaces failed in production. Both helpers now extract
+  `current_version` from the GET response and inject `If-Match` on
+  the PUT; unversioned endpoints (collections, sets) continue without
+  it since their GET responses don't include the field. Regression
+  guard added in `mcp/tests/test_update_tools.py::TestIfMatchHeader`
+  and `cli/tests/test_write_commands.py::TestUpdateIfMatch`.
+  ([issue #158](https://github.com/cgbarlow/iris/issues/157))
+
 ## [6.7.2] - 2026-05-16
 
 ### Fixed

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -622,6 +622,12 @@ async def _put_merge_partial(
 
     The backend PUT does full-replace, so partial updates need a merge
     pass first. Costs one extra GET per update.
+
+    Versioned entities (elements / diagrams / packages) require an
+    ``If-Match`` header carrying the current version — backend rejects
+    without it (HTTP 428). We inject it from the GET response when
+    ``current_version`` is present; unversioned endpoints (collections,
+    sets) omit the field and don't require the header.
     """
     current_resp = await c._request("GET", f"/api/{kind_path}/{entity_id}")
     current = current_resp.json()
@@ -631,7 +637,12 @@ async def _put_merge_partial(
             body[field] = partial[field]
         elif field in current:
             body[field] = current[field]
-    resp = await c._request("PUT", f"/api/{kind_path}/{entity_id}", json=body)
+    headers: dict[str, str] | None = None
+    if "current_version" in current:
+        headers = {"If-Match": str(current["current_version"])}
+    resp = await c._request(
+        "PUT", f"/api/{kind_path}/{entity_id}", json=body, headers=headers,
+    )
     return resp.json()
 
 

--- a/cli/tests/test_write_commands.py
+++ b/cli/tests/test_write_commands.py
@@ -207,6 +207,63 @@ class TestUpdate:
         assert code == 0
 
 
+class TestUpdateIfMatch:
+    """Versioned update endpoints require an ``If-Match`` header —
+    backend returns HTTP 428 without it. Regression guard for v6.7.3 /
+    issue #158."""
+
+    def test_update_diagram_sends_if_match(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/diagrams/d1").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="d1", current_version=7),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/diagrams/d1").mock(
+            return_value=httpx.Response(200, json=_entity(id="d1")),
+        )
+        code, _out, _ = _invoke(
+            "update", "diagram", "d1", "--description", "x",
+        )
+        assert code == 0
+        assert put_route.calls[0].request.headers.get("If-Match") == "7"
+
+    def test_update_package_sends_if_match(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/packages/p1").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="p1", current_version=2),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/packages/p1").mock(
+            return_value=httpx.Response(200, json=_entity(id="p1")),
+        )
+        code, _out, _ = _invoke(
+            "update", "package", "p1", "--description", "x",
+        )
+        assert code == 0
+        assert put_route.calls[0].request.headers.get("If-Match") == "2"
+
+    def test_update_collection_omits_if_match(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        """Unversioned endpoints don't include current_version → no
+        If-Match header sent."""
+        respx_mock.get(f"{BASE}/api/collections/c1").mock(
+            return_value=httpx.Response(200, json=_entity(id="c1")),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/collections/c1").mock(
+            return_value=httpx.Response(200, json=_entity(id="c1")),
+        )
+        code, _out, _ = _invoke(
+            "update", "collection", "c1", "--description", "x",
+        )
+        assert code == 0
+        assert "If-Match" not in put_route.calls[0].request.headers
+
+
 # ── iris move ──────────────────────────────────────────────────────────
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.7.2",
+	"version": "6.7.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.7.2"
+version = "6.7.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -508,6 +508,13 @@ async def _put_merge_partial(
 
     Costs one extra GET per update. Trade-off for partial-update UX
     without a backend PATCH refactor.
+
+    Versioned entities (elements / diagrams / packages) require an
+    ``If-Match`` header carrying the current version — backend rejects
+    without it (HTTP 428). The GET we already do supplies the value;
+    we add the header when ``current_version`` is present in the
+    response. Unversioned endpoints (collections, sets) don't include
+    the field and don't require the header.
     """
     current_resp = await c._request("GET", f"/api/{kind_path}/{entity_id}")
     current = current_resp.json()
@@ -517,7 +524,12 @@ async def _put_merge_partial(
             body[field] = partial[field]
         elif field in current:
             body[field] = current[field]
-    return await c._request("PUT", f"/api/{kind_path}/{entity_id}", json=body)
+    headers: dict[str, str] | None = None
+    if "current_version" in current:
+        headers = {"If-Match": str(current["current_version"])}
+    return await c._request(
+        "PUT", f"/api/{kind_path}/{entity_id}", json=body, headers=headers,
+    )
 
 
 _COLLECTION_UPDATE_FIELDS = (
@@ -610,8 +622,10 @@ async def _update_element(c: IrisClient, args: dict[str, Any]) -> str:
                 elif field in current:
                     body[field] = current[field]
             body["package_id"] = args["package_id"]
+            headers = {"If-Match": str(current.get("current_version", 1))}
             resp = await c._request(
-                "PUT", f"/api/elements/{args['element_id']}", json=body,
+                "PUT", f"/api/elements/{args['element_id']}",
+                json=body, headers=headers,
             )
         else:
             resp = await _put_merge_partial(

--- a/mcp/tests/test_update_tools.py
+++ b/mcp/tests/test_update_tools.py
@@ -200,3 +200,102 @@ class TestUpdateElement:
         )
         body = json.loads(result[0].text)
         assert body["description"] == "el desc"
+
+
+class TestIfMatchHeader:
+    """Versioned update endpoints (elements / diagrams / packages)
+    require an ``If-Match`` header — backend returns HTTP 428 without
+    it. Regression guard for v6.7.3 / issue #158."""
+
+    @pytest.mark.asyncio
+    async def test_update_element_sends_if_match(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/elements/el-1").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="el-1", current_version=7),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/elements/el-1").mock(
+            return_value=httpx.Response(200, json=_entity(id="el-1")),
+        )
+        await tools.dispatch(
+            "update_element", client,
+            {"element_id": "el-1", "description": "x"},
+        )
+        assert put_route.calls[0].request.headers.get("If-Match") == "7"
+
+    @pytest.mark.asyncio
+    async def test_update_element_package_id_sends_if_match(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        """The package_id special-case path takes a different branch
+        than the standard helper — it must also send If-Match."""
+        respx_mock.get(f"{BASE}/api/elements/el-2").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="el-2", current_version=3),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/elements/el-2").mock(
+            return_value=httpx.Response(200, json=_entity(id="el-2")),
+        )
+        await tools.dispatch(
+            "update_element", client,
+            {"element_id": "el-2", "package_id": "pkg-a"},
+        )
+        assert put_route.calls[0].request.headers.get("If-Match") == "3"
+
+    @pytest.mark.asyncio
+    async def test_update_diagram_sends_if_match(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/diagrams/d-1").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="d-1", current_version=4),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/diagrams/d-1").mock(
+            return_value=httpx.Response(200, json=_entity(id="d-1")),
+        )
+        await tools.dispatch(
+            "update_diagram", client,
+            {"diagram_id": "d-1", "description": "x"},
+        )
+        assert put_route.calls[0].request.headers.get("If-Match") == "4"
+
+    @pytest.mark.asyncio
+    async def test_update_package_sends_if_match(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/packages/pk-1").mock(
+            return_value=httpx.Response(
+                200, json=_entity(id="pk-1", current_version=2),
+            ),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/packages/pk-1").mock(
+            return_value=httpx.Response(200, json=_entity(id="pk-1")),
+        )
+        await tools.dispatch(
+            "update_package", client,
+            {"package_id": "pk-1", "description": "x"},
+        )
+        assert put_route.calls[0].request.headers.get("If-Match") == "2"
+
+    @pytest.mark.asyncio
+    async def test_update_set_omits_if_match(
+        self, client: IrisClient, respx_mock: respx.Router,
+    ) -> None:
+        """Unversioned endpoints (sets, collections) don't include
+        ``current_version`` in their GET response — no If-Match header
+        should be sent (backend would 400 on a stray header anyway)."""
+        respx_mock.get(f"{BASE}/api/sets/s-1").mock(
+            return_value=httpx.Response(200, json=_entity(id="s-1")),
+        )
+        put_route = respx_mock.put(f"{BASE}/api/sets/s-1").mock(
+            return_value=httpx.Response(200, json=_entity(id="s-1")),
+        )
+        await tools.dispatch(
+            "update_set", client,
+            {"set_id": "s-1", "description": "x"},
+        )
+        assert "If-Match" not in put_route.calls[0].request.headers


### PR DESCRIPTION
Closes #158.

## Summary

- Backend update routes for elements / diagrams / packages require `If-Match` for optimistic concurrency (HTTP 428 without). Both the MCP `_put_merge_partial` helper and its CLI mirror did GET → merge → PUT but never sent the header, so every MCP `update_element`/`update_diagram`/`update_package` call (and the matching CLI commands) 428'd in production.
- Both helpers now inject `If-Match: <current_version>` from the GET response. Unversioned endpoints (collections, sets) keep working unchanged — their GET responses don't include `current_version` so no header is sent.
- The `_update_element` package_id special-case branch in MCP had the same bug — also fixed.
- Regression guards added in `mcp/tests/test_update_tools.py::TestIfMatchHeader` and `cli/tests/test_write_commands.py::TestUpdateIfMatch` — the previous tests used `respx` mocks that didn't validate request headers, which is why this slipped past CI.

## Test plan

- [x] `cd mcp && uv run pytest` — 222 passed
- [x] `cd cli && uv run pytest` — 28 passed in targeted, all green in full
- [ ] After deploy: `update_element` with `package_id` from MCP succeeds (the original repro from the v6.7.0 Claude.ai session)
- [ ] After deploy: `iris update package <id> --description x` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)