### PR TITLE
feat(v6.8.0): element templates (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.0] - 2026-05-17
+
+### Added
+
+- **Element Templates** (ADR-191, SPEC-191-A, issue
+  [#153](https://github.com/cgbarlow/iris/issues/153)). Capture a
+  user-selected subset of fields from an existing element into a
+  reusable template, then pre-fill new elements from any template via
+  REST, MCP, or CLI.
+  - Set-scoped by default; opt-in `is_global` flag for templates that
+    should be reusable across sets. A CHECK constraint enforces that
+    exactly one of "scoped to a set" or "global" is true at any time.
+  - Field whitelist of eight keys (`name`, `description`,
+    `element_type`, `notation`, `data`, `metadata`, `package_id`,
+    `tags`) — anything outside the whitelist is silently dropped at
+    write time.
+  - Full CRUD on three surfaces (per Protocol §14 / ADR-182): REST
+    routes under `/api/element-templates`, five MCP tools
+    (`create_*` / `list_*` / `get_*` / `update_*` /
+    `delete_element_template`), and a new `element-template` entity
+    on the CLI. `POST /api/elements` and the matching MCP / CLI
+    create surfaces gain an optional `template_id` parameter that
+    pre-fills whitelisted fields server-side (explicit fields always
+    win).
+  - Frontend: **Templates** button on `/elements` opens a
+    `TemplatesListDialog` (set-scoped + global) with per-row
+    "Use" buttons; **Save as template** on `/elements/[id]` opens a
+    `CreateTemplateDialog` with field checkboxes and a "Make
+    global" toggle; new `/element-templates/[id]` detail page renders
+    the captured snapshot with a "Create element from template"
+    affordance and Delete.
+  - 74 new tests across backend (34), MCP (12), CLI (8), and frontend
+    (20).
+  - `scripts/check_surface_parity.py` updated to register the new
+    `element_template` entity and to accept kebab-case CLI entity
+    names (normalised to underscore for the cross-surface compare).
+    `delete_element_template` joins the documented
+    "delete deferred — needs audit/undo ADR" asymmetry list.
+
+### Migrations
+
+- SQLite `m067_element_templates.py` — table + CHECK + two partial
+  indexes. Wired into `backend/app/startup.py:_initialize_sqlite`.
+- Supabase mirror `m071_element_templates.sql` — same shape with
+  `BOOLEAN` `is_global` / `is_deleted` (Protocol §15 boolean literal
+  convention; `m067_*.sql` was already taken by the
+  doview_analysis pointer fix, so the Supabase numbering steps to
+  `m071`). Applied via `scripts/supabase-migrate.sh` **before** the
+  Render code deploy.
+
 ## [6.7.4] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ A hand-written user guide at `/guide` covers every user-facing capability across
 - **Auto-membership** — saving a view's canvas automatically moves referenced entities into the view's set
 - **Set Selector** — dropdown on views, entities, and import pages for filtering and assignment
 
+### Element Templates
+
+- **Save as template** on the element detail page captures a user-chosen subset of fields (name, description, element_type, notation, data, metadata, package_id, tags) into a reusable template (v6.8.0, ADR-191)
+- **Templates** browser on the elements list shows set-scoped and global templates; "Use" pre-fills a new element from the template's snapshot (server-side merge — explicit fields always win)
+- Templates are set-scoped by default with an optional Make Global flag; full CRUD on REST (`/api/element-templates`), MCP (`create_element_template` / `list_element_templates` / `get_element_template` / `update_element_template` / `delete_element_template`), and CLI (`iris create element-template …`, etc.). `create_element` on all three surfaces accepts an optional `template_id`
+
 ### Batch Operations
 
 - Select mode toggle on views and entities list pages with checkboxes on each item

--- a/backend/app/element_templates/__init__.py
+++ b/backend/app/element_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Element Templates module (ADR-191, v6.8.0, issue #153)."""

--- a/backend/app/element_templates/models.py
+++ b/backend/app/element_templates/models.py
@@ -1,0 +1,80 @@
+"""Pydantic models for element templates (ADR-191, issue #153)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# Whitelist of element fields that may be captured into a template.
+# Anything outside this set is dropped from `included_fields` at write
+# time (so attackers can't smuggle arbitrary keys into `template_data`).
+INCLUDED_FIELD_WHITELIST: frozenset[str] = frozenset({
+    "name",
+    "description",
+    "element_type",
+    "notation",
+    "data",
+    "metadata",
+    "package_id",
+    "tags",
+})
+
+
+class ElementTemplateCreate(BaseModel):
+    """Request body for creating an element template.
+
+    ``source_element_id`` is required: v1 templates are always captured
+    from an existing element. ``set_id`` and ``is_global`` are
+    mutually exclusive — exactly one must produce a non-null scope
+    (enforced by the DB CHECK constraint and the service layer).
+    """
+
+    source_element_id: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    included_fields: list[str] = Field(min_length=1)
+    set_id: str | None = None
+    is_global: bool = False
+
+
+class ElementTemplateUpdate(BaseModel):
+    """Request body for editing an element template.
+
+    All fields optional; absent fields are not touched. ``set_id`` and
+    ``is_global`` can be flipped to promote a template global or
+    demote it back (the CHECK constraint validates the resulting
+    state).
+    """
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    included_fields: list[str] | None = None
+    set_id: str | None = None
+    is_global: bool | None = None
+
+
+class ElementTemplateResponse(BaseModel):
+    """Response model for an element template."""
+
+    id: str
+    name: str
+    description: str | None = None
+    set_id: str | None = None
+    set_name: str | None = None
+    is_global: bool = False
+    source_element_id: str | None = None
+    source_element_name: str | None = None
+    included_fields: list[str]
+    template_data: dict[str, object]
+    created_by: str
+    created_by_username: str = "Unknown"
+    created_at: str
+    updated_at: str
+
+
+class ElementTemplateListResponse(BaseModel):
+    """Paginated list of element templates."""
+
+    items: list[ElementTemplateResponse]
+    total: int
+    page: int
+    page_size: int

--- a/backend/app/element_templates/router.py
+++ b/backend/app/element_templates/router.py
@@ -1,0 +1,140 @@
+"""Element template API routes (ADR-191, issue #153)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from app.auth.dependencies import get_current_user, get_optional_user
+from app.element_templates.models import (
+    ElementTemplateCreate,
+    ElementTemplateListResponse,
+    ElementTemplateResponse,
+    ElementTemplateUpdate,
+)
+from app.element_templates.service import (
+    ElementTemplateNotFoundError,
+    ElementTemplateScopeError,
+    create_element_template,
+    delete_element_template,
+    get_element_template,
+    list_element_templates,
+    update_element_template,
+)
+
+router = APIRouter(prefix="/api/element-templates", tags=["element-templates"])
+
+
+@router.post("", response_model=ElementTemplateResponse, status_code=201)
+async def create(
+    body: ElementTemplateCreate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> ElementTemplateResponse:
+    """Create a template from an existing element."""
+    db = request.app.state.db_manager.main_db
+    try:
+        result = await create_element_template(
+            db,
+            source_element_id=body.source_element_id,
+            name=body.name,
+            description=body.description,
+            included_fields=body.included_fields,
+            set_id=body.set_id,
+            is_global=body.is_global,
+            created_by=current_user["id"],
+        )
+    except ElementTemplateScopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    except ElementTemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))  # noqa: B904
+    return ElementTemplateResponse(**result)
+
+
+@router.get("", response_model=ElementTemplateListResponse)
+async def list_all(
+    request: Request,
+    set_id: str | None = None,
+    include_global: bool = True,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=100),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ElementTemplateListResponse:
+    """List element templates with set-scope + global filter."""
+    db = request.app.state.db_manager.main_db
+    items, total = await list_element_templates(
+        db,
+        set_id=set_id,
+        include_global=include_global,
+        page=page,
+        page_size=page_size,
+    )
+    return ElementTemplateListResponse(
+        items=[ElementTemplateResponse(**item) for item in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/{template_id}", response_model=ElementTemplateResponse)
+async def get_one(
+    template_id: str,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ElementTemplateResponse:
+    """Get a single template by ID."""
+    db = request.app.state.db_manager.main_db
+    result = await get_element_template(db, template_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return ElementTemplateResponse(**result)
+
+
+@router.put("/{template_id}", response_model=ElementTemplateResponse)
+async def update(
+    template_id: str,
+    body: ElementTemplateUpdate,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> ElementTemplateResponse:
+    """Edit a template. Templates are not versioned — no If-Match."""
+    db = request.app.state.db_manager.main_db
+    # The model uses None to mean "leave untouched" for everything
+    # except set_id; for set_id, we need a tri-state because None is
+    # the legitimate value for globals. The Pydantic model's set_id
+    # default is None, so we differentiate via the request body's
+    # explicit keys.
+    raw = body.model_dump(exclude_unset=True)
+    kwargs: dict[str, Any] = {}
+    if "name" in raw:
+        kwargs["name"] = raw["name"]
+    if "description" in raw:
+        kwargs["description"] = raw["description"]
+    if "included_fields" in raw:
+        kwargs["included_fields"] = raw["included_fields"]
+    if "is_global" in raw:
+        kwargs["is_global"] = raw["is_global"]
+    if "set_id" in raw:
+        kwargs["set_id"] = raw["set_id"]  # may be None
+    try:
+        result = await update_element_template(db, template_id, **kwargs)
+    except ElementTemplateScopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    if result is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return ElementTemplateResponse(**result)
+
+
+@router.delete("/{template_id}", status_code=204)
+async def delete(
+    template_id: str,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> None:
+    """Soft-delete a template."""
+    db = request.app.state.db_manager.main_db
+    ok = await delete_element_template(db, template_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Template not found")

--- a/backend/app/element_templates/service.py
+++ b/backend/app/element_templates/service.py
@@ -1,0 +1,375 @@
+"""Element template CRUD service (ADR-191, issue #153).
+
+Templates capture a snapshot of selected fields from a source element
+so later element creation can be pre-filled. Set-scoped by default;
+``is_global`` promotes a template across sets. ``included_fields`` is
+filtered against ``INCLUDED_FIELD_WHITELIST`` to keep the surface
+narrow.
+
+Row access is positional throughout (Protocol §15) so the same code
+runs on SQLite and Supabase.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.element_templates.models import INCLUDED_FIELD_WHITELIST
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+class ElementTemplateScopeError(ValueError):
+    """Raised when (set_id, is_global) are inconsistent.
+
+    Router maps to HTTP 422. The DB CHECK constraint enforces the same
+    invariant — this gives callers a clearer error than a generic
+    constraint-violation 500.
+    """
+
+
+class ElementTemplateNotFoundError(LookupError):
+    """Raised when a template can't be located (e.g. soft-deleted or
+    missing). Router maps to 404.
+    """
+
+
+def _validate_scope(*, set_id: str | None, is_global: bool) -> None:
+    """is_global=True ↔ set_id is None. Otherwise reject."""
+    if is_global and set_id is not None:
+        msg = "is_global templates must not have a set_id"
+        raise ElementTemplateScopeError(msg)
+    if not is_global and set_id is None:
+        msg = "non-global templates require a set_id"
+        raise ElementTemplateScopeError(msg)
+
+
+def _filter_included_fields(fields: list[str]) -> list[str]:
+    """Drop unknown fields silently, preserving caller-supplied order
+    for the subset that survives."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for f in fields:
+        if f in INCLUDED_FIELD_WHITELIST and f not in seen:
+            out.append(f)
+            seen.add(f)
+    return out
+
+
+async def _load_source_element(
+    db: DatabasePort, element_id: str,
+) -> dict[str, Any]:
+    """Pull just the columns/JSON we may snapshot. Positional access."""
+    cursor = await db.execute(
+        "SELECT e.id, e.element_type, e.notation, ev.name, ev.description, "
+        "ev.data, ev.metadata, e.package_id "
+        "FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "AND e.current_version = ev.version "
+        "WHERE e.id = ? AND e.is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        msg = f"Source element {element_id} not found"
+        raise ElementTemplateNotFoundError(msg)
+    src: dict[str, Any] = {
+        "element_type": row[1],
+        "notation": row[2] or "simple",
+        "name": row[3],
+        "description": row[4],
+        "data": json.loads(row[5]) if row[5] else {},
+        "metadata": json.loads(row[6]) if row[6] else None,
+        "package_id": row[7],
+    }
+    # Pull tags positionally
+    tag_cursor = await db.execute(
+        "SELECT tag FROM element_tags WHERE element_id = ? ORDER BY tag",
+        (element_id,),
+    )
+    tag_rows = await tag_cursor.fetchall()
+    src["tags"] = [r[0] for r in tag_rows]
+    return src
+
+
+def _project_template_data(
+    src: dict[str, Any], included_fields: list[str],
+) -> dict[str, Any]:
+    """Snapshot only the included fields from the source element."""
+    return {k: src.get(k) for k in included_fields}
+
+
+async def create_element_template(
+    db: DatabasePort,
+    *,
+    source_element_id: str,
+    name: str,
+    description: str | None,
+    included_fields: list[str],
+    set_id: str | None,
+    is_global: bool,
+    created_by: str,
+) -> dict[str, Any]:
+    """Create a new template by snapshotting an element."""
+    _validate_scope(set_id=set_id, is_global=is_global)
+    filtered = _filter_included_fields(included_fields)
+    if not filtered:
+        msg = (
+            "included_fields must contain at least one whitelisted "
+            f"field. Whitelist: {sorted(INCLUDED_FIELD_WHITELIST)}"
+        )
+        raise ElementTemplateScopeError(msg)
+    src = await _load_source_element(db, source_element_id)
+    template_data = _project_template_data(src, filtered)
+    template_id = str(uuid.uuid4())
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO element_templates "
+        "(id, name, description, set_id, is_global, source_element_id, "
+        "included_fields, template_data, created_by, created_at, "
+        "updated_at, is_deleted) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        (
+            template_id, name, description, set_id, 1 if is_global else 0,
+            source_element_id, json.dumps(filtered),
+            json.dumps(template_data), created_by, now, now,
+        ),
+    )
+    await db.commit()
+    return await get_element_template(db, template_id)  # type: ignore[return-value]
+
+
+async def get_element_template(
+    db: DatabasePort, template_id: str,
+) -> dict[str, Any] | None:
+    """Fetch a single template, enriched with denormalised names."""
+    cursor = await db.execute(
+        "SELECT t.id, t.name, t.description, t.set_id, s.name, "
+        "t.is_global, t.source_element_id, "
+        "(SELECT ev.name FROM element_versions ev "
+        "  JOIN elements e ON e.id = ev.element_id "
+        "  WHERE e.id = t.source_element_id "
+        "  AND e.current_version = ev.version) AS source_name, "
+        "t.included_fields, t.template_data, t.created_by, "
+        "u.username, t.created_at, t.updated_at "
+        "FROM element_templates t "
+        "LEFT JOIN sets s ON s.id = t.set_id "
+        "LEFT JOIN users u ON u.id = t.created_by "
+        "WHERE t.id = ? AND t.is_deleted = 0",
+        (template_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "name": row[1],
+        "description": row[2],
+        "set_id": row[3],
+        "set_name": row[4],
+        "is_global": bool(row[5]),
+        "source_element_id": row[6],
+        "source_element_name": row[7],
+        "included_fields": json.loads(row[8]) if row[8] else [],
+        "template_data": json.loads(row[9]) if row[9] else {},
+        "created_by": row[10],
+        "created_by_username": row[11] or "Unknown",
+        "created_at": row[12],
+        "updated_at": row[13],
+    }
+
+
+async def list_element_templates(
+    db: DatabasePort,
+    *,
+    set_id: str | None = None,
+    include_global: bool = True,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict[str, Any]], int]:
+    """List templates. Returns (items, total).
+
+    Scoping:
+      - set_id=None, include_global=True → all globals only.
+      - set_id="<uuid>", include_global=True → templates in that set
+        plus all globals.
+      - set_id="<uuid>", include_global=False → only that set.
+    """
+    where_parts = ["t.is_deleted = 0"]
+    params: list[Any] = []
+    if set_id is not None and include_global:
+        where_parts.append("(t.set_id = ? OR t.is_global = 1)")
+        params.append(set_id)
+    elif set_id is not None:
+        where_parts.append("t.set_id = ?")
+        params.append(set_id)
+    elif include_global:
+        where_parts.append("t.is_global = 1")
+    else:
+        # set_id None and not include_global → empty result.
+        return [], 0
+    where_sql = " AND ".join(where_parts)
+
+    count_cursor = await db.execute(
+        f"SELECT COUNT(*) FROM element_templates t WHERE {where_sql}",
+        tuple(params),
+    )
+    count_row = await count_cursor.fetchone()
+    total: int = count_row[0] if count_row else 0
+
+    offset = (page - 1) * page_size
+    list_cursor = await db.execute(
+        "SELECT t.id, t.name, t.description, t.set_id, s.name, "
+        "t.is_global, t.source_element_id, "
+        "(SELECT ev.name FROM element_versions ev "
+        "  JOIN elements e ON e.id = ev.element_id "
+        "  WHERE e.id = t.source_element_id "
+        "  AND e.current_version = ev.version) AS source_name, "
+        "t.included_fields, t.template_data, t.created_by, "
+        "u.username, t.created_at, t.updated_at "
+        "FROM element_templates t "
+        "LEFT JOIN sets s ON s.id = t.set_id "
+        "LEFT JOIN users u ON u.id = t.created_by "
+        f"WHERE {where_sql} "
+        "ORDER BY t.is_global DESC, t.name ASC "
+        "LIMIT ? OFFSET ?",
+        (*params, page_size, offset),
+    )
+    rows = await list_cursor.fetchall()
+    items = [
+        {
+            "id": r[0],
+            "name": r[1],
+            "description": r[2],
+            "set_id": r[3],
+            "set_name": r[4],
+            "is_global": bool(r[5]),
+            "source_element_id": r[6],
+            "source_element_name": r[7],
+            "included_fields": json.loads(r[8]) if r[8] else [],
+            "template_data": json.loads(r[9]) if r[9] else {},
+            "created_by": r[10],
+            "created_by_username": r[11] or "Unknown",
+            "created_at": r[12],
+            "updated_at": r[13],
+        }
+        for r in rows
+    ]
+    return items, total
+
+
+async def update_element_template(
+    db: DatabasePort,
+    template_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    included_fields: list[str] | None = None,
+    set_id: str | None | type[Ellipsis] = ...,  # ... = "not touched"
+    is_global: bool | None = None,
+) -> dict[str, Any] | None:
+    """Edit a template's mutable fields.
+
+    Re-projects ``template_data`` from the source element when
+    ``included_fields`` changes AND the source element is still alive.
+    If the source has been deleted, the existing ``template_data`` is
+    filtered down to the intersection with the new ``included_fields``.
+    """
+    existing = await get_element_template(db, template_id)
+    if existing is None:
+        return None
+
+    new_name = name if name is not None else existing["name"]
+    new_description = (
+        description if description is not None else existing["description"]
+    )
+    new_is_global = (
+        is_global if is_global is not None else existing["is_global"]
+    )
+    new_set_id: str | None
+    if set_id is ...:
+        new_set_id = existing["set_id"]
+    else:
+        new_set_id = set_id  # may be None or a string
+    _validate_scope(set_id=new_set_id, is_global=new_is_global)
+
+    new_included = (
+        _filter_included_fields(included_fields)
+        if included_fields is not None
+        else list(existing["included_fields"])
+    )
+    if not new_included:
+        msg = "included_fields must contain at least one whitelisted field"
+        raise ElementTemplateScopeError(msg)
+
+    new_data = existing["template_data"]
+    if included_fields is not None:
+        # Re-project: prefer fresh data from the source element if it
+        # still exists; otherwise keep the prior snapshot for fields
+        # that survived the included_fields filter.
+        try:
+            src = await _load_source_element(
+                db, existing["source_element_id"],
+            ) if existing.get("source_element_id") else None
+        except ElementTemplateNotFoundError:
+            src = None
+        if src is not None:
+            new_data = _project_template_data(src, new_included)
+        else:
+            new_data = {k: existing["template_data"].get(k) for k in new_included}
+
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "UPDATE element_templates SET "
+        "name = ?, description = ?, set_id = ?, is_global = ?, "
+        "included_fields = ?, template_data = ?, updated_at = ? "
+        "WHERE id = ? AND is_deleted = 0",
+        (
+            new_name, new_description, new_set_id,
+            1 if new_is_global else 0,
+            json.dumps(new_included), json.dumps(new_data), now,
+            template_id,
+        ),
+    )
+    await db.commit()
+    return await get_element_template(db, template_id)
+
+
+async def delete_element_template(
+    db: DatabasePort, template_id: str,
+) -> bool:
+    """Soft-delete a template. Returns True if a row was updated."""
+    cursor = await db.execute(
+        "UPDATE element_templates SET is_deleted = 1 "
+        "WHERE id = ? AND is_deleted = 0",
+        (template_id,),
+    )
+    await db.commit()
+    return (cursor.rowcount or 0) > 0
+
+
+def apply_template_to_create_body(
+    template: dict[str, Any], request_body: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge ``template.template_data`` under explicit request fields.
+
+    Used by ``POST /api/elements`` when the caller supplies
+    ``template_id``. Rules:
+      - Only fields in ``template.included_fields`` are eligible.
+      - Explicit request fields ALWAYS win (the user's typed values
+        are not overwritten by template defaults).
+      - Tags are merged separately by the caller via the tags table —
+        we just pass the list through.
+    """
+    merged = dict(request_body)
+    data: dict[str, Any] = template.get("template_data") or {}
+    for key in template.get("included_fields") or []:
+        if key in merged and merged[key] is not None:
+            continue
+        if key in data:
+            merged[key] = data[key]
+    return merged

--- a/backend/app/elements/models.py
+++ b/backend/app/elements/models.py
@@ -14,16 +14,22 @@ _UNSET: Any = object()
 
 
 class ElementCreate(BaseModel):
-    """Request body for creating an element."""
+    """Request body for creating an element.
 
-    element_type: str = Field(min_length=1)
-    name: str = Field(min_length=1, max_length=255)
+    ``template_id`` (v6.8.0, ADR-191) pre-fills any whitelisted fields
+    from the named template. Explicit fields on the request always
+    win over template defaults.
+    """
+
+    element_type: str = Field(default="", min_length=0)
+    name: str = Field(default="", min_length=0, max_length=255)
     description: str | None = None
     data: dict[str, object] = Field(default_factory=dict)
     set_id: str | None = None
     package_id: str | None = None
     metadata: dict[str, object] | None = None
     notation: str = "simple"
+    template_id: str | None = None
 
 
 class ElementUpdate(BaseModel):

--- a/backend/app/elements/router.py
+++ b/backend/app/elements/router.py
@@ -17,6 +17,10 @@ from app.elements.models import (
     ElementVersionResponse,
 )
 from app.elements.models import _UNSET as _ELEMENT_UPDATE_UNSET
+from app.element_templates.service import (
+    apply_template_to_create_body,
+    get_element_template,
+)
 from app.elements.service import (
     ElementPackageInvariantError,
     cascade_delete_element,
@@ -39,23 +43,74 @@ async def create(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> ElementResponse:
-    """Create a new element."""
+    """Create a new element. When ``template_id`` is supplied, the
+    named template pre-fills whitelisted fields (ADR-191) — explicit
+    request fields always win over template defaults.
+    """
     db = request.app.state.db_manager.main_db
+    fields = body.model_dump(exclude_unset=True)
+    template_id = fields.pop("template_id", None)
+    template_tags: list[str] = []
+    if template_id:
+        template = await get_element_template(db, template_id)
+        if template is None:
+            raise HTTPException(
+                status_code=404, detail=f"Template {template_id} not found",
+            )
+        fields = apply_template_to_create_body(template, fields)
+        # Tags are written to a separate table after the element is
+        # created; pop them off the create body so they don't reach
+        # the service signature.
+        template_tags = list(fields.pop("tags", None) or [])
+
+    # Post-merge required-field validation.
+    element_type = fields.get("element_type") or ""
+    name = fields.get("name") or ""
+    if not element_type:
+        raise HTTPException(
+            status_code=422,
+            detail="element_type is required (provide explicitly or via template)",
+        )
+    if not name:
+        raise HTTPException(
+            status_code=422,
+            detail="name is required (provide explicitly or via template)",
+        )
+
     try:
         result = await create_element(
             db,
-            element_type=body.element_type,
-            name=body.name,
-            description=body.description,
-            data=body.data,
+            element_type=element_type,
+            name=name,
+            description=fields.get("description"),
+            data=fields.get("data") or {},
             created_by=current_user["id"],
-            set_id=body.set_id,
-            package_id=body.package_id,
-            metadata=body.metadata,
-            notation=body.notation,
+            set_id=fields.get("set_id"),
+            package_id=fields.get("package_id"),
+            metadata=fields.get("metadata"),
+            notation=fields.get("notation") or "simple",
         )
     except ElementPackageInvariantError as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+
+    # Apply template-supplied tags (if any) to the element_tags table.
+    if template_tags:
+        now = datetime.now(tz=UTC).isoformat()
+        for tag in template_tags:
+            tag = str(tag).strip()
+            if not tag or len(tag) > 50:
+                continue
+            try:
+                await db.execute(
+                    "INSERT INTO element_tags (element_id, tag, "
+                    "created_at, created_by) VALUES (?, ?, ?, ?)",
+                    (result["id"], tag, now, current_user["id"]),
+                )
+            except Exception:
+                # Tag already exists — skip silently.
+                pass
+        await db.commit()
+
     # Re-read so we pick up package_name/set_name without re-issuing joins
     # in the create path.
     fresh = await get_element(db, result["id"])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from app.diagrams.router import admin_router as admin_thumbnails_router
 from app.diagrams.router import diagram_rel_router
 from app.diagrams.router import router as diagrams_router
 from app.docref.router import router as docref_router
+from app.element_templates.router import router as element_templates_router
 from app.elements.router import router as elements_router
 from app.artefacts.router import router as artefacts_router
 from app.export.router import router as export_router
@@ -175,6 +176,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(auth_router)
     app.include_router(oauth_router)  # ADR-164, v6.0.0
     app.include_router(elements_router)
+    app.include_router(element_templates_router)  # ADR-191, v6.8.0
     app.include_router(relationships_router)
     app.include_router(diagrams_router)
     app.include_router(diagram_rel_router)

--- a/backend/app/migrations/m067_element_templates.py
+++ b/backend/app/migrations/m067_element_templates.py
@@ -1,0 +1,52 @@
+"""Migration 067: Element Templates table (ADR-191, issue #153).
+
+Captures a snapshot of selected fields from an existing element so
+later element creation can be pre-filled from the template. Templates
+are set-scoped by default with an optional ``is_global`` promotion
+flag; the CHECK constraint enforces scoping consistency.
+
+No back-fill — existing elements never appear in this table; users
+must explicitly create templates from them.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m067_element_templates"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — CREATE TABLE IF NOT EXISTS."""
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS element_templates (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            set_id TEXT REFERENCES sets(id),
+            is_global INTEGER NOT NULL DEFAULT 0,
+            source_element_id TEXT REFERENCES elements(id),
+            included_fields TEXT NOT NULL,
+            template_data TEXT NOT NULL,
+            created_by TEXT REFERENCES users(id),
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            CHECK (
+                (is_global = 1 AND set_id IS NULL) OR
+                (is_global = 0 AND set_id IS NOT NULL)
+            )
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_element_templates_set "
+        "ON element_templates(set_id) WHERE is_deleted = 0"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_element_templates_global "
+        "ON element_templates(is_global) WHERE is_global = 1 AND is_deleted = 0"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m071_element_templates.sql
+++ b/backend/app/migrations/supabase/m071_element_templates.sql
@@ -1,0 +1,36 @@
+-- Migration 071: Element Templates table (ADR-191, issue #153).
+--
+-- Mirrors SQLite m067. Captures a snapshot of selected fields from an
+-- existing element so later element creation can be pre-filled from
+-- the template. Set-scoped by default with optional is_global
+-- promotion; CHECK constraint enforces scoping consistency.
+--
+-- Idempotent. Protocol §15: booleans use TRUE/FALSE literals on
+-- Postgres (NOT integer 0/1 — `is_global` and `is_deleted` are
+-- declared BOOLEAN here).
+
+CREATE TABLE IF NOT EXISTS public.element_templates (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    set_id TEXT REFERENCES public.sets(id),
+    is_global BOOLEAN NOT NULL DEFAULT FALSE,
+    source_element_id TEXT REFERENCES public.elements(id),
+    included_fields TEXT NOT NULL,
+    template_data TEXT NOT NULL,
+    created_by TEXT REFERENCES public.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    CONSTRAINT element_templates_scoping_consistent CHECK (
+        (is_global = TRUE AND set_id IS NULL) OR
+        (is_global = FALSE AND set_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_element_templates_set
+    ON public.element_templates(set_id) WHERE is_deleted = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_element_templates_global
+    ON public.element_templates(is_global)
+    WHERE is_global = TRUE AND is_deleted = FALSE;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -70,6 +70,7 @@ from app.migrations.m063_doview_analysis_creation_format_pointer import up as m0
 from app.migrations.m064_element_package_membership import up as m064_up
 from app.migrations.m065_dynamic_list_diagram_type import up as m065_up
 from app.migrations.m066_class_for_simple_notation import up as m066_up
+from app.migrations.m067_element_templates import up as m067_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -167,6 +168,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m064_up(main)  # issue #149, v6.7.0: elements.package_id column (ADR-184)
     await m065_up(main)  # issue #147, v6.7.0: dynamic_list diagram_type (ADR-186)
     await m066_up(main)  # issue #160, v6.7.4: register (class, simple) diagram_type_notations pair (ADR-188)
+    await m067_up(main)  # issue #153, v6.8.0: element_templates table (ADR-191)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_element_templates/test_crud_and_apply.py
+++ b/backend/tests/test_element_templates/test_crud_and_apply.py
@@ -1,0 +1,500 @@
+"""Integration tests for element templates (ADR-191, issue #153).
+
+Covers:
+
+- CRUD on /api/element-templates (create/get/list/update/delete).
+- Scoping: set-scoped, global, and the CHECK constraint that ties
+  is_global to set_id.
+- Field whitelisting: non-whitelisted fields are dropped from
+  included_fields silently.
+- Re-projection on update when included_fields changes.
+- ``POST /api/elements?template_id=…`` pre-fill with explicit request
+  fields winning.
+- Tags are written through to element_tags when included.
+
+All tests use the real FastAPI app + a temp SQLite database
+(no mocks — Protocol §9). TDD: written before / alongside the
+implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _create_set(c: httpx.AsyncClient, h: dict, name: str = "S") -> str:
+    r = await c.post("/api/sets", json={"name": name}, headers=h)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _create_element(
+    c: httpx.AsyncClient, h: dict, *, set_id: str, **extra,
+) -> dict:
+    body = {
+        "element_type": "component",
+        "name": "Source Element",
+        "description": "from-element description",
+        "data": {"k": "v"},
+        "metadata": {"author": "me"},
+        "notation": "simple",
+        "set_id": set_id,
+        **extra,
+    }
+    r = await c.post("/api/elements", json=body, headers=h)
+    assert r.status_code == 201, r.text
+    # Add a tag so we can test the tags path.
+    el_id = r.json()["id"]
+    await c.post(
+        f"/api/elements/{el_id}/tags",
+        json={"tag": "alpha"}, headers=h,
+    )
+    return r.json()
+
+
+class TestCreate:
+    async def test_create_template_from_element_set_scoped(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"],
+                "name": "Tpl A",
+                "description": "first template",
+                "included_fields": ["name", "description", "data", "tags"],
+                "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["name"] == "Tpl A"
+        assert body["is_global"] is False
+        assert body["set_id"] == set_id
+        assert set(body["included_fields"]) == {
+            "name", "description", "data", "tags",
+        }
+        assert body["template_data"]["name"] == "Source Element"
+        assert body["template_data"]["tags"] == ["alpha"]
+        assert body["source_element_id"] == el["id"]
+
+    async def test_create_global_template(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"],
+                "name": "Global Tpl",
+                "included_fields": ["name", "element_type"],
+                "set_id": None,
+                "is_global": True,
+            },
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["is_global"] is True
+        assert body["set_id"] is None
+
+    async def test_create_rejects_global_with_set_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"],
+                "name": "Bad Tpl",
+                "included_fields": ["name"],
+                "set_id": set_id,
+                "is_global": True,
+            },
+            headers=h,
+        )
+        assert r.status_code == 422
+
+    async def test_create_rejects_non_global_without_set_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"],
+                "name": "Bad Tpl",
+                "included_fields": ["name"],
+                "set_id": None,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert r.status_code == 422
+
+    async def test_create_drops_non_whitelisted_fields_silently(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"],
+                "name": "Tpl Filtered",
+                "included_fields": ["name", "id", "current_version", "evil"],
+                "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+        assert r.json()["included_fields"] == ["name"]
+
+    async def test_create_rejects_unknown_source_element(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": "does-not-exist",
+                "name": "Tpl",
+                "included_fields": ["name"],
+                "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert r.status_code == 404
+
+
+class TestListAndGet:
+    async def test_list_set_scoped_plus_globals(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_a = await _create_set(client, h, name="A")
+        set_b = await _create_set(client, h, name="B")
+        el_a = await _create_element(client, h, set_id=set_a)
+        el_b = await _create_element(client, h, set_id=set_b)
+        # Two templates in A, one in B, one global.
+        for n in ("A1", "A2"):
+            r = await client.post(
+                "/api/element-templates",
+                json={
+                    "source_element_id": el_a["id"], "name": n,
+                    "included_fields": ["name"], "set_id": set_a,
+                    "is_global": False,
+                },
+                headers=h,
+            )
+            assert r.status_code == 201
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el_b["id"], "name": "B1",
+                "included_fields": ["name"], "set_id": set_b,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert r.status_code == 201
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el_a["id"], "name": "G1",
+                "included_fields": ["name"], "set_id": None,
+                "is_global": True,
+            },
+            headers=h,
+        )
+        assert r.status_code == 201
+
+        # set_id=A + include_global → A's 2 + 1 global = 3
+        r = await client.get(
+            f"/api/element-templates?set_id={set_a}&include_global=true",
+            headers=h,
+        )
+        assert r.status_code == 200
+        names = sorted(t["name"] for t in r.json()["items"])
+        assert names == ["A1", "A2", "G1"]
+
+        # set_id=A + include_global=false → A's 2 only
+        r = await client.get(
+            f"/api/element-templates?set_id={set_a}&include_global=false",
+            headers=h,
+        )
+        names = sorted(t["name"] for t in r.json()["items"])
+        assert names == ["A1", "A2"]
+
+        # set_id absent + include_global → globals only
+        r = await client.get(
+            "/api/element-templates?include_global=true", headers=h,
+        )
+        names = sorted(t["name"] for t in r.json()["items"])
+        assert names == ["G1"]
+
+    async def test_get_one_returns_full_template(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": ["name", "data"], "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+        r = await client.get(
+            f"/api/element-templates/{tid}", headers=h,
+        )
+        assert r.status_code == 200
+        assert r.json()["template_data"]["data"] == {"k": "v"}
+
+    async def test_get_missing_template_returns_404(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        r = await client.get(
+            "/api/element-templates/no-such-id", headers=h,
+        )
+        assert r.status_code == 404
+
+
+class TestUpdate:
+    async def test_update_reprojects_template_data(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": ["name"], "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+        # Expand included_fields to include description; expect a
+        # fresh snapshot from the source element.
+        r = await client.put(
+            f"/api/element-templates/{tid}",
+            json={"included_fields": ["name", "description"]},
+            headers=h,
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["included_fields"] == ["name", "description"]
+        assert body["template_data"]["description"] == "from-element description"
+
+    async def test_promote_to_global(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": ["name"], "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+        r = await client.put(
+            f"/api/element-templates/{tid}",
+            json={"is_global": True, "set_id": None},
+            headers=h,
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["is_global"] is True
+        assert r.json()["set_id"] is None
+
+
+class TestDelete:
+    async def test_delete_soft_deletes(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": ["name"], "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+        r = await client.delete(
+            f"/api/element-templates/{tid}", headers=h,
+        )
+        assert r.status_code == 204
+        # Subsequent get → 404
+        r = await client.get(f"/api/element-templates/{tid}", headers=h)
+        assert r.status_code == 404
+
+
+class TestApplyTemplate:
+    async def test_create_element_with_template_pre_fills_fields(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": [
+                    "name", "description", "element_type", "data", "tags",
+                ],
+                "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+
+        # Create a new element supplying only set_id + template_id;
+        # template fills name, description, element_type, data, tags.
+        r = await client.post(
+            "/api/elements",
+            json={"set_id": set_id, "template_id": tid},
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+        new_el = r.json()
+        assert new_el["name"] == "Source Element"
+        assert new_el["description"] == "from-element description"
+        assert new_el["element_type"] == "component"
+        assert new_el["data"] == {"k": "v"}
+        assert new_el["tags"] == ["alpha"]
+
+    async def test_explicit_fields_win_over_template(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        el = await _create_element(client, h, set_id=set_id)
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": el["id"], "name": "T",
+                "included_fields": ["name", "description"],
+                "set_id": set_id, "is_global": False,
+            },
+            headers=h,
+        )
+        tid = r.json()["id"]
+        r = await client.post(
+            "/api/elements",
+            json={
+                "set_id": set_id,
+                "template_id": tid,
+                "element_type": "component",
+                "name": "Override Name",
+            },
+            headers=h,
+        )
+        assert r.status_code == 201, r.text
+        new_el = r.json()
+        assert new_el["name"] == "Override Name"
+        # Description was not overridden → comes from template.
+        assert new_el["description"] == "from-element description"
+
+    async def test_missing_template_returns_404(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        r = await client.post(
+            "/api/elements",
+            json={
+                "set_id": set_id,
+                "template_id": "no-such-template",
+                "element_type": "component",
+                "name": "X",
+            },
+            headers=h,
+        )
+        assert r.status_code == 404

--- a/backend/tests/test_migrations/test_element_templates_schema.py
+++ b/backend/tests/test_migrations/test_element_templates_schema.py
@@ -1,0 +1,122 @@
+"""v6.8.0 (ADR-191, issue #153): static-parser tests asserting that
+SQLite m067 and Supabase m071 create the ``element_templates`` table
+with the expected columns, indexes, and scoping consistency CHECK
+constraint.
+
+Pattern follows test_response_format_prompts_schema.py /
+test_cascade_ux_polish_schema.py — readonly file inspection, no DB
+spin-up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m067 ─────────────────────────────────────────────────────────
+
+
+def test_sqlite_m067_creates_element_templates_table() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    assert "CREATE TABLE IF NOT EXISTS element_templates" in py
+
+
+def test_sqlite_m067_has_required_columns() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    for col in (
+        "id TEXT PRIMARY KEY",
+        "name TEXT NOT NULL",
+        "set_id TEXT REFERENCES sets(id)",
+        "is_global INTEGER NOT NULL DEFAULT 0",
+        "source_element_id TEXT REFERENCES elements(id)",
+        "included_fields TEXT NOT NULL",
+        "template_data TEXT NOT NULL",
+        "is_deleted INTEGER NOT NULL DEFAULT 0",
+    ):
+        assert col in py, f"missing column declaration: {col!r}"
+
+
+def test_sqlite_m067_enforces_scoping_check_constraint() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    # The CHECK constraint guarantees set_id ↔ is_global consistency.
+    assert "CHECK" in py
+    assert "(is_global = 1 AND set_id IS NULL)" in py
+    assert "(is_global = 0 AND set_id IS NOT NULL)" in py
+
+
+def test_sqlite_m067_creates_indexes() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    assert "CREATE INDEX IF NOT EXISTS idx_element_templates_set" in py
+    assert "CREATE INDEX IF NOT EXISTS idx_element_templates_global" in py
+
+
+def test_sqlite_m067_is_idempotent() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    assert "CREATE TABLE IF NOT EXISTS" in py
+    assert "CREATE INDEX IF NOT EXISTS" in py
+
+
+def test_sqlite_m067_has_migration_id() -> None:
+    py = _read("app/migrations/m067_element_templates.py")
+    assert 'MIGRATION_ID = "m067_element_templates"' in py
+
+
+# ── Supabase m071 ───────────────────────────────────────────────────────
+
+
+def test_supabase_m071_creates_element_templates_table() -> None:
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    assert "CREATE TABLE IF NOT EXISTS public.element_templates" in sql
+
+
+def test_supabase_m071_uses_boolean_literals_for_is_global() -> None:
+    """Protocol §15: BOOLEAN columns on Postgres must use TRUE/FALSE
+    literals, not 0/1. is_global and is_deleted are both BOOLEAN
+    here. Regression guard pattern from
+    test_response_format_prompts_schema.py.
+    """
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    # Column declarations
+    assert "is_global BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    assert "is_deleted BOOLEAN NOT NULL DEFAULT FALSE" in sql
+    # CHECK constraint references
+    assert "is_global = TRUE" in sql
+    assert "is_global = FALSE" in sql
+    # No integer-literal slip-ups
+    assert "is_global = 1" not in sql
+    assert "is_global = 0" not in sql
+    assert "is_global INTEGER" not in sql
+
+
+def test_supabase_m071_check_constraint_uses_boolean_literals() -> None:
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    assert (
+        "CONSTRAINT element_templates_scoping_consistent CHECK ("
+        in sql
+    )
+    assert "(is_global = TRUE AND set_id IS NULL)" in sql
+    assert "(is_global = FALSE AND set_id IS NOT NULL)" in sql
+
+
+def test_supabase_m071_creates_indexes_with_boolean_predicate() -> None:
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    assert "idx_element_templates_set" in sql
+    assert "WHERE is_deleted = FALSE" in sql
+    assert "idx_element_templates_global" in sql
+
+
+def test_supabase_m071_is_idempotent() -> None:
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    assert sql.count("CREATE TABLE IF NOT EXISTS") >= 1
+    assert sql.count("CREATE INDEX IF NOT EXISTS") >= 2
+
+
+def test_supabase_m071_documents_pairing() -> None:
+    sql = _read("app/migrations/supabase/m071_element_templates.sql")
+    assert "Mirrors SQLite m067" in sql

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -37,6 +37,10 @@ app = typer.Typer(
 
 diagrams_app = typer.Typer(help="Diagram commands.", no_args_is_help=True)
 elements_app = typer.Typer(help="Element commands.", no_args_is_help=True)
+element_templates_app = typer.Typer(
+    help="Element template commands (v6.8.0, ADR-191).",
+    no_args_is_help=True,
+)
 packages_app = typer.Typer(help="Package commands.", no_args_is_help=True)
 sets_app = typer.Typer(help="Set commands.", no_args_is_help=True)
 collections_app = typer.Typer(help="Collection commands.", no_args_is_help=True)
@@ -46,11 +50,16 @@ conversations_app = typer.Typer(help="Conversation commands.", no_args_is_help=T
 # v6.4.0 (ADR-180): write-tool parity with MCP.
 create_app = typer.Typer(help="Create new entities.", no_args_is_help=True)
 update_app = typer.Typer(help="Update entity metadata (partial).", no_args_is_help=True)
+delete_app = typer.Typer(
+    help="Delete entities (currently: element-template only — ADR-191).",
+    no_args_is_help=True,
+)
 move_app = typer.Typer(help="Re-parent entities (diagram / package / set).", no_args_is_help=True)
 render_app = typer.Typer(help="Render diagrams or markdown to md/docx/pdf artefacts.", no_args_is_help=True)
 
 app.add_typer(diagrams_app, name="diagrams")
 app.add_typer(elements_app, name="elements")
+app.add_typer(element_templates_app, name="element-templates")
 app.add_typer(packages_app, name="packages")
 app.add_typer(sets_app, name="sets")
 app.add_typer(collections_app, name="collections")
@@ -58,6 +67,7 @@ app.add_typer(export_app, name="export")
 app.add_typer(conversations_app, name="conversations")
 app.add_typer(create_app, name="create")
 app.add_typer(update_app, name="update")
+app.add_typer(delete_app, name="delete")
 app.add_typer(move_app, name="move")
 app.add_typer(render_app, name="render")
 
@@ -339,6 +349,66 @@ def elements_get(element_id: str) -> None:
         d = element.model_dump()
         for k in ("id", "name", "element_type", "notation", "current_version"):
             typer.echo(f"{k}: {d.get(k)}")
+
+
+# --- Element templates (v6.8.0, ADR-191) ------------------------------------
+
+
+@element_templates_app.command("list")
+def element_templates_list(
+    set_id: str | None = typer.Option(None, "--set-id"),
+    include_global: bool = typer.Option(
+        True, "--include-global/--no-include-global",
+    ),
+    page: int = typer.Option(1, "--page", min=1),
+    page_size: int = typer.Option(50, "--page-size", min=1, max=100),
+) -> None:
+    async def _do() -> list[Any]:
+        async with _client() as c:
+            params: dict[str, Any] = {
+                "page": page, "page_size": page_size,
+                "include_global": include_global,
+            }
+            if set_id is not None:
+                params["set_id"] = set_id
+            resp = await c._request(
+                "GET", "/api/element-templates", params=params,
+            )
+            return resp.json().get("items", [])
+
+    rows = _run(_do())
+    if state.as_json:
+        output.print_json(rows)
+    else:
+        output.print_table(
+            rows,
+            columns=["id", "name", "set_name", "is_global", "updated_at"],
+            title=f"Element Templates ({len(rows)})",
+        )
+
+
+@element_templates_app.command("get")
+def element_templates_get(template_id: str) -> None:
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "GET", f"/api/element-templates/{template_id}",
+            )
+            return resp.json()
+
+    output.print_json(_run(_do()))
+
+
+@element_templates_app.command("delete")
+def element_templates_delete(template_id: str) -> None:
+    """Soft-delete an element template."""
+    async def _do() -> Any:
+        async with _client() as c:
+            await c._request(
+                "DELETE", f"/api/element-templates/{template_id}",
+            )
+            return {"deleted": True, "template_id": template_id}
+    output.print_json(_run(_do()))
 
 
 # --- Packages / Sets / Collections ------------------------------------------
@@ -700,8 +770,8 @@ def create_package_cmd(
 
 @create_app.command("element")
 def create_element_cmd(
-    name: str = typer.Option(..., "--name"),
-    element_type: str = typer.Option(..., "--element-type"),
+    name: str | None = typer.Option(None, "--name"),
+    element_type: str | None = typer.Option(None, "--element-type"),
     set_id: str | None = typer.Option(None, "--set-id"),
     package_id: str | None = typer.Option(
         None, "--package-id",
@@ -711,17 +781,28 @@ def create_element_cmd(
     description: str | None = typer.Option(None, "--description"),
     data_json: str | None = typer.Option(None, "--data-json"),
     metadata_json: str | None = typer.Option(None, "--metadata-json"),
+    template_id: str | None = typer.Option(
+        None, "--template-id",
+        help=(
+            "Optional element template (v6.8.0, ADR-191) to "
+            "pre-fill whitelisted fields. Explicit options always win."
+        ),
+    ),
 ) -> None:
     """Create a standalone Element in a set's element pool.
 
     For drawing elements onto a diagram in one step, use
     `iris diagrams ...` flows or the API/MCP `apply_diagram_creation`
     tool instead.
+
+    When ``--template-id`` is supplied, ``--name`` and
+    ``--element-type`` are optional (the template can provide them).
     """
-    body: dict[str, Any] = {
-        "element_type": element_type,
-        "name": name,
-    }
+    body: dict[str, Any] = {}
+    if element_type is not None:
+        body["element_type"] = element_type
+    if name is not None:
+        body["name"] = name
     if set_id is not None:
         body["set_id"] = set_id
     if package_id is not None:
@@ -730,6 +811,8 @@ def create_element_cmd(
         body["notation"] = notation
     if description is not None:
         body["description"] = description
+    if template_id is not None:
+        body["template_id"] = template_id
     data = _parse_json_opt(data_json, "--data-json")
     if data is not None:
         body["data"] = data
@@ -934,6 +1017,136 @@ def update_element_cmd(
                 "PUT", f"/api/elements/{element_id}", json=body, headers=headers,
             )
             return resp.json()
+    output.print_json(_run(_do()))
+
+
+# ── iris create / update element-template (v6.8.0, ADR-191) ───────────────
+
+
+def _parse_csv_opt(raw: str | None, flag: str) -> list[str] | None:
+    if raw is None:
+        return None
+    items = [s.strip() for s in raw.split(",") if s.strip()]
+    if not items:
+        raise typer.BadParameter(
+            f"{flag} must contain at least one field name",
+        )
+    return items
+
+
+@create_app.command("element-template")
+def create_element_template_cmd(
+    source_element: str = typer.Option(..., "--source-element"),
+    name: str = typer.Option(..., "--name"),
+    include: str = typer.Option(
+        ..., "--include",
+        help=(
+            "Comma-separated whitelist of element fields to carry "
+            "into the template (e.g. name,description,data,tags). "
+            "Non-whitelisted fields are dropped silently."
+        ),
+    ),
+    set_id: str | None = typer.Option(
+        None, "--set-id",
+        help=(
+            "Set to scope the template under. Required for "
+            "non-global templates; omit when --global is passed."
+        ),
+    ),
+    is_global: bool = typer.Option(
+        False, "--global/--no-global",
+        help="Promote the template to global (visible from any set).",
+    ),
+    description: str | None = typer.Option(None, "--description"),
+) -> None:
+    """Capture an element template from an existing element."""
+    body: dict[str, Any] = {
+        "source_element_id": source_element,
+        "name": name,
+        "included_fields": _parse_csv_opt(include, "--include"),
+        "is_global": is_global,
+    }
+    if description is not None:
+        body["description"] = description
+    if set_id is not None:
+        body["set_id"] = set_id
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/element-templates", json=body,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@update_app.command("element-template")
+def update_element_template_cmd(
+    template_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    include: str | None = typer.Option(
+        None, "--include",
+        help=(
+            "Replacement comma-separated field list. Triggers a "
+            "template_data re-projection if the source element is "
+            "still alive."
+        ),
+    ),
+    set_id: str | None = typer.Option(
+        None, "--set-id",
+        help=(
+            "New set scope. Pass the literal 'null' to clear (when "
+            "promoting to global)."
+        ),
+    ),
+    is_global: bool | None = typer.Option(
+        None, "--global/--no-global",
+        help="Promote to global or demote back.",
+    ),
+) -> None:
+    """Update an element template (no versioning — no If-Match)."""
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if description is not None:
+        body["description"] = description
+    fields = _parse_csv_opt(include, "--include")
+    if fields is not None:
+        body["included_fields"] = fields
+    if set_id is not None:
+        body["set_id"] = _resolve_null(set_id)
+    if is_global is not None:
+        body["is_global"] = is_global
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "PUT", f"/api/element-templates/{template_id}", json=body,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@delete_app.command("element-template")
+def delete_element_template_cmd(
+    template_id: str = typer.Argument(...),
+) -> None:
+    """Soft-delete an element template (v6.8.0, ADR-191).
+
+    Mirrors the `iris element-templates delete` sibling command for
+    parity with `iris create element-template` and
+    `iris update element-template`. Required under Protocol §14 /
+    ADR-182 (see scripts/check_surface_parity.py) — `delete_*`
+    parity is NOT under the issue-#133 deferral blanket for new
+    entities introduced after that blanket was written.
+    """
+    async def _do() -> Any:
+        async with _client() as c:
+            await c._request(
+                "DELETE", f"/api/element-templates/{template_id}",
+            )
+            return {"deleted": True, "template_id": template_id}
     output.print_json(_run(_do()))
 
 

--- a/cli/tests/test_element_templates.py
+++ b/cli/tests/test_element_templates.py
@@ -1,0 +1,198 @@
+"""CLI tests for element templates surface (ADR-191, v6.8.0).
+
+Covers:
+- ``iris create element-template`` body forwarding (set-scoped + global).
+- ``iris update element-template`` partial-update body wiring.
+- ``iris element-templates list / get / delete`` round-trips.
+- ``iris create element --template-id`` extending the existing
+  element-create command.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import respx
+from typer.testing import CliRunner
+
+from iris_cli.main import app
+
+runner = CliRunner()
+BASE = "http://iris.test"
+
+
+def _invoke(*args: str) -> tuple[int, str, str]:
+    result = runner.invoke(app, list(args), catch_exceptions=False)
+    return result.exit_code, result.stdout, result.stderr
+
+
+def _template(**overrides) -> dict:
+    base = {
+        "id": "t-1",
+        "name": "Tpl",
+        "description": None,
+        "set_id": "s-1",
+        "set_name": "S",
+        "is_global": False,
+        "source_element_id": "el-1",
+        "source_element_name": "El",
+        "included_fields": ["name", "description"],
+        "template_data": {"name": "El", "description": "d"},
+        "created_by": "u",
+        "created_by_username": "user",
+        "created_at": "2026-05-17T00:00:00+00:00",
+        "updated_at": "2026-05-17T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCreateTemplate:
+    def test_create_set_scoped_template(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(201, json=_template()),
+        )
+        code, out, _ = _invoke(
+            "create", "element-template",
+            "--source-element", "el-1",
+            "--name", "Tpl",
+            "--include", "name,description,data",
+            "--set-id", "s-1",
+        )
+        assert code == 0, out
+        body = json.loads(route.calls[0].request.content)
+        assert body["source_element_id"] == "el-1"
+        assert body["name"] == "Tpl"
+        assert body["included_fields"] == ["name", "description", "data"]
+        assert body["set_id"] == "s-1"
+        assert body["is_global"] is False
+
+    def test_create_global_template(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(
+                201, json=_template(set_id=None, set_name=None, is_global=True),
+            ),
+        )
+        code, out, _ = _invoke(
+            "create", "element-template",
+            "--source-element", "el-1",
+            "--name", "Tpl",
+            "--include", "name",
+            "--global",
+        )
+        assert code == 0, out
+        body = json.loads(route.calls[0].request.content)
+        assert body["is_global"] is True
+        assert "set_id" not in body
+
+
+class TestListGetDelete:
+    def test_list_forwards_filters(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "items": [_template()], "total": 1,
+                    "page": 1, "page_size": 50,
+                },
+            ),
+        )
+        code, _out, _ = _invoke(
+            "--json", "element-templates", "list",
+            "--set-id", "s-1", "--include-global",
+        )
+        assert code == 0
+        url = str(route.calls[0].request.url)
+        assert "set_id=s-1" in url
+        assert "include_global=True" in url or "include_global=true" in url
+
+    def test_get_returns_template(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(200, json=_template()),
+        )
+        code, out, _ = _invoke("element-templates", "get", "t-1")
+        assert code == 0
+        assert "t-1" in out
+
+    def test_delete_calls_delete_endpoint(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.delete(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(204),
+        )
+        code, out, _ = _invoke("element-templates", "delete", "t-1")
+        assert code == 0, out
+        assert route.called
+
+
+class TestUpdateTemplate:
+    def test_update_forwards_only_supplied_fields(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.put(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(
+                200, json=_template(name="Renamed"),
+            ),
+        )
+        code, _out, _ = _invoke(
+            "update", "element-template", "t-1", "--name", "Renamed",
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"name": "Renamed"}
+
+    def test_update_promote_to_global_with_null_set(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.put(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(
+                200, json=_template(set_id=None, is_global=True),
+            ),
+        )
+        code, _out, _ = _invoke(
+            "update", "element-template", "t-1",
+            "--global", "--set-id", "null",
+        )
+        assert code == 0
+        body = json.loads(route.calls[0].request.content)
+        assert body["is_global"] is True
+        assert body["set_id"] is None
+
+
+class TestCreateElementWithTemplate:
+    def test_template_id_forwards_to_create_element(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(201, json={
+                "id": "el-new", "element_type": "component",
+                "current_version": 1, "name": "Templated",
+                "description": None, "data": {}, "set_id": "s-1",
+                "package_id": None, "package_name": None,
+                "notation": "simple",
+                "created_at": "2026-05-17T00:00:00+00:00",
+                "created_by": "u",
+                "updated_at": "2026-05-17T00:00:00+00:00",
+            }),
+        )
+        code, out, _ = _invoke(
+            "create", "element",
+            "--set-id", "s-1",
+            "--template-id", "t-1",
+        )
+        assert code == 0, out
+        body = json.loads(route.calls[0].request.content)
+        assert body["template_id"] == "t-1"
+        assert body["set_id"] == "s-1"
+        # name and element_type omitted — template provides them.
+        assert "name" not in body
+        assert "element_type" not in body

--- a/docs/adrs/ADR-191-Element-Templates.md
+++ b/docs/adrs/ADR-191-Element-Templates.md
@@ -1,0 +1,232 @@
+# ADR-191: Element Templates
+
+Status: Accepted (2026-05-17)
+Extends: [ADR-184](ADR-184-Element-Package-Membership.md) (element→package membership), [ADR-182](ADR-182-Surface-Parity-Discipline.md) (surface parity)
+Implements: Issue [#153](https://github.com/cgbarlow/iris/issues/153)
+Spec: [SPEC-191-A](specs/SPEC-191-A-Element-Templates.md)
+
+## Context
+
+Issue [#153](https://github.com/cgbarlow/iris/issues/153) — "Feature:
+element templates." Users repeatedly create elements that follow the
+same shape (FIXM Arrival/Departure pairs, DoView outcome boxes,
+ArchiMate stakeholder profiles…). Each one is a manual recreation
+of the same attributes, metadata, and notation. The user asked for:
+
+1. A "create template" action on the element screen that captures a
+   user-chosen subset of fields from an existing element.
+2. A "templates" button on the elements list that opens a browser.
+3. From the template browser, a "use this template" affordance that
+   creates a new element with the captured fields pre-filled.
+4. An optional "use template" dropdown on the regular new-element
+   flow.
+5. Coverage on REST, MCP, and CLI surfaces (Protocol §14 / ADR-182).
+
+Plan-time clarifications (recorded in `docs/plans/humming-marinating-dusk.md`):
+
+- **Scope** — set-scoped by default with an optional `is_global` flag.
+  Most templates belong to a workspace; some (FIXM, DoView base
+  shapes) should be reusable across sets.
+- **Lifecycle** — full CRUD: editable + deletable. No versioning.
+- **Field whitelist** — the user picks which of `name`, `description`,
+  `element_type`, `notation`, `data`, `metadata`, `package_id`, `tags`
+  are captured. Anything else is dropped at write time.
+- **Surface coverage** — REST + MCP + CLI all gain the five
+  CRUD endpoints plus a `template_id` parameter on `create_element`.
+
+## Decision
+
+### Data model
+
+New table `element_templates` (migration m067 SQLite, m071 Supabase):
+
+```sql
+CREATE TABLE element_templates (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    set_id TEXT REFERENCES sets(id),
+    is_global INTEGER NOT NULL DEFAULT 0,     -- BOOLEAN on Postgres (Protocol §15)
+    source_element_id TEXT REFERENCES elements(id),
+    included_fields TEXT NOT NULL,            -- JSON array
+    template_data TEXT NOT NULL,              -- JSON snapshot
+    created_by TEXT REFERENCES users(id),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    CHECK (
+        (is_global = 1 AND set_id IS NULL) OR
+        (is_global = 0 AND set_id IS NOT NULL)
+    )
+)
+```
+
+Two partial indexes (`idx_element_templates_set` on `set_id WHERE
+is_deleted=0`, `idx_element_templates_global` on `is_global WHERE
+is_global=1 AND is_deleted=0`). The CHECK constraint guarantees
+exactly one of "scoped to a set" or "global" is true at any time.
+
+### Field whitelist
+
+```python
+INCLUDED_FIELD_WHITELIST = frozenset({
+    "name", "description", "element_type", "notation",
+    "data", "metadata", "package_id", "tags",
+})
+```
+
+Enforced at create time in `element_templates/service.py`. Anything
+outside this list is silently dropped from `included_fields` / not
+captured into `template_data`. Prevents callers from smuggling
+arbitrary keys (e.g. `is_deleted`, `created_by`) into the snapshot.
+
+### Surface coverage
+
+| Surface | Tools / endpoints |
+|---|---|
+| REST | `POST /api/element-templates`, `GET /api/element-templates`, `GET /api/element-templates/{id}`, `PUT /api/element-templates/{id}`, `DELETE /api/element-templates/{id}` |
+| REST (existing) | `POST /api/elements` gains optional `template_id` param |
+| MCP | `create_element_template`, `list_element_templates`, `get_element_template`, `update_element_template`, `delete_element_template` |
+| MCP (existing) | `create_element` gains optional `template_id` |
+| CLI | `iris create element-template …`, `iris list element-template …`, `iris get element-template …`, `iris update element-template …`, `iris delete element-template …` |
+| CLI (existing) | `iris create element … --template-id` |
+
+`scripts/check_surface_parity.py` learns the new entity:
+
+- `_KNOWN_ENTITIES` adds `"element_template"`.
+- CLI parser accepts kebab-case (`"element-template"`) and normalises
+  to underscore for the cross-surface comparison.
+
+Delete is exempted from MCP/CLI parity under the existing "deferred
+delete needs ADR (audit, undo)" exception. The script lists
+`delete_element_template` alongside the other delete asymmetries.
+
+### `template_id` on `create_element`
+
+When `template_id` is supplied, `apply_template_to_create_body` reads
+the named template and merges its `template_data` into the request
+body field-by-field for every key in `included_fields ∩ INCLUDED_FIELD_WHITELIST`.
+Explicit request fields always win — the template fills only what the
+caller didn't provide. After merge, required fields (`element_type`,
+`name`) are re-validated; if neither the request nor the template
+supplies them, the API returns 422.
+
+### Frontend UX
+
+Three new surfaces in the Svelte app:
+
+1. **Elements list** (`/elements`): a new **Templates** button next
+   to **New Element**. Opens `TemplatesListDialog.svelte`, which
+   lists set-scoped + global templates and provides a per-row "Use"
+   button. On Use, the dialog asks for the new element's name, then
+   POSTs to `/api/elements` with `{ template_id, name, set_id }`.
+2. **Element detail** (`/elements/[id]`): a new **Save as template**
+   button next to Clone/Delete. Opens
+   `CreateTemplateDialog.svelte` with name, description, eight field
+   checkboxes (matching the backend whitelist), and a
+   "Make global" toggle. Posts to `/api/element-templates`.
+3. **Template detail** (`/element-templates/[id]`): renders scope
+   badge, source element link, captured fields table (`field` →
+   pretty-printed `template_data[field]`), "Create element from
+   template" form, and Delete affordance.
+
+The new-element dialog (`EntityDialog.svelte`) is intentionally
+**not** modified for v1 — adding a template dropdown there would
+require pre-filling its internal state across five notations and
+their per-diagram-type sub-filters. The same outcome is reachable
+today via the **Templates** button: it lives next to **New
+Element** in the same toolbar. A follow-up issue may merge the two
+flows once the basic UX has been validated.
+
+## Why no versioning
+
+Templates are user-authored shortcuts, not authoritative records.
+Editing in place matches how users think about saved configurations
+(closer to a browser bookmark than to an element). Versioning would
+introduce a table doubling, a versions endpoint per surface, and a
+rollback story that nobody has asked for. If demand surfaces later,
+the existing `element_versions`-style table is the obvious add.
+
+## Why set-scoped + global, not "global only" or "set-only"
+
+Set-only would force every project to re-author the same baseline
+templates. Global-only would mix workspace-specific shapes (FIXM
+extension X for set A) into every set's pool. The two-level model
+mirrors how tags are scoped in Iris (per-set) but adds an explicit
+opt-in for shared shapes via `is_global`.
+
+## Why the field whitelist
+
+Without a whitelist, a malicious or buggy caller could snapshot
+`created_by`, `id`, `is_deleted` or similar fields into `template_data`
+and have them write back during `apply_template_to_create_body`. The
+whitelist makes the captured surface a small, audited set and
+documents (in code) the public element schema.
+
+## Why no template dropdown on EntityDialog in v1
+
+`EntityDialog.svelte` carries five notation-specific sub-filters
+(`SIMPLE_DIAGRAM_TYPE_FILTER`, `UML_DIAGRAM_TYPE_FILTER`,
+`ARCHIMATE_DIAGRAM_TYPE_LAYERS`, `C4_DIAGRAM_TYPE_LEVELS`,
+`BPMN_DIAGRAM_TYPE_FILTER`) plus a C4 picker, a layer reset on
+notation change, and a `showAllTypes` toggle. Pre-filling its state
+from a template's `template_data` would require mapping every
+notation's `element_type` representation into the dialog's
+`SimpleEntityType` union and stabilising the cross-notation reset
+logic. The Templates button on the same toolbar is a clean separate
+flow that covers the user's stated need without touching that
+codepath. v2 of templates can merge the two flows once the baseline
+ships.
+
+## Consequences
+
+- New module `backend/app/element_templates/` (models, service,
+  router).
+- Migrations: SQLite `m067_element_templates.py`, Supabase mirror
+  `m071_element_templates.sql` (`m067_*.sql` was already taken by
+  the doview_analysis pointer fix, so the Supabase numbering jumps
+  to `m071`).
+- `backend/app/elements/{models,router}.py` gain `template_id` on
+  `ElementCreate` and apply-template logic on `POST /api/elements`.
+- `mcp/src/iris_mcp/tools.py` gains five `*_element_template` tools
+  and a `template_id` parameter on `create_element`.
+- `cli/src/iris_cli/main.py` gains the matching subcommands and the
+  `--template-id` flag.
+- `scripts/check_surface_parity.py` learns the entity and kebab-case
+  CLI normalisation.
+- New Svelte components `TemplatesListDialog.svelte`,
+  `CreateTemplateDialog.svelte`; new route
+  `frontend/src/routes/element-templates/[id]/+page.svelte`.
+- Existing elements-list and element-detail routes gain the two new
+  buttons.
+- Tests: backend (27 + 7 schema), MCP (12), CLI (8), frontend (20).
+  56 new tests.
+- CHANGELOG `[6.8.0]`; README gains a short Templates subsection;
+  version bumps to `6.8.0` in `frontend/package.json` and
+  `mcp/pyproject.toml`.
+
+## Verification
+
+- `pytest backend/tests/test_element_templates/ backend/tests/test_migrations/test_element_templates_schema.py` — 34 green.
+- `pytest mcp/tests/test_element_templates.py` — 12 green.
+- `pytest cli/tests/test_element_templates.py` — 8 green.
+- `npx vitest run tests/unit/elementTemplates.test.ts` — 20 green.
+- `python scripts/check_surface_parity.py` — green; `element_template`
+  is a known entity with all three create/update surfaces present
+  and `delete_element_template` listed under the deferred-delete
+  exception.
+- Browser smoke: create a template from an existing element via
+  Save as template; open the Templates dialog from the elements
+  list; use a template to create a new element; verify pre-fill via
+  the detail page.
+- Supabase migrate: apply `m071_element_templates.sql` before the
+  v6.8.0 code deploy (Protocol §15 release ordering).
+
+## See also
+
+- [SPEC-191-A](specs/SPEC-191-A-Element-Templates.md) — implementation spec.
+- [ADR-184](ADR-184-Element-Package-Membership.md) — package_id
+  is one of the eight whitelisted fields.
+- [ADR-182](ADR-182-Surface-Parity-Discipline.md) — parity rules.
+- Protocol §14 (Surface Parity) and §15 (SQLite ↔ Supabase parity).
+- Issue [#153](https://github.com/cgbarlow/iris/issues/153).

--- a/docs/adrs/specs/SPEC-191-A-Element-Templates.md
+++ b/docs/adrs/specs/SPEC-191-A-Element-Templates.md
@@ -1,0 +1,164 @@
+# SPEC-191-A: Element Templates
+
+Implements [ADR-191](../ADR-191-Element-Templates.md).
+Spec status: Living. Last revised 2026-05-17.
+
+## 1. Data model
+
+### 1.1 Table `element_templates`
+
+| Column | Type (SQLite) | Type (Supabase) | Notes |
+|---|---|---|---|
+| `id` | TEXT PRIMARY KEY | TEXT PRIMARY KEY | UUID, supplied by service |
+| `name` | TEXT NOT NULL | TEXT NOT NULL | 1..255 chars; sanitised in service via `escape()` |
+| `description` | TEXT | TEXT | optional |
+| `set_id` | TEXT REFERENCES sets(id) | TEXT REFERENCES public.sets(id) | nullable iff `is_global=1` |
+| `is_global` | INTEGER NOT NULL DEFAULT 0 | BOOLEAN NOT NULL DEFAULT FALSE | Protocol §15: TRUE/FALSE on Postgres |
+| `source_element_id` | TEXT REFERENCES elements(id) | TEXT REFERENCES public.elements(id) | nullable (element may be deleted) |
+| `included_fields` | TEXT NOT NULL | TEXT NOT NULL | JSON array of whitelist keys |
+| `template_data` | TEXT NOT NULL | TEXT NOT NULL | JSON snapshot of captured fields |
+| `created_by` | TEXT REFERENCES users(id) | TEXT REFERENCES public.users(id) | |
+| `created_at` | TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP | TIMESTAMPTZ NOT NULL DEFAULT now() | |
+| `updated_at` | TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP | TIMESTAMPTZ NOT NULL DEFAULT now() | |
+| `is_deleted` | INTEGER NOT NULL DEFAULT 0 | BOOLEAN NOT NULL DEFAULT FALSE | soft delete |
+
+CHECK constraint (both halves):
+
+```
+(is_global = 1 AND set_id IS NULL) OR
+(is_global = 0 AND set_id IS NOT NULL)
+```
+
+### 1.2 Indexes
+
+- `idx_element_templates_set ON element_templates(set_id) WHERE is_deleted = 0`.
+- `idx_element_templates_global ON element_templates(is_global) WHERE is_global = 1 AND is_deleted = 0`.
+
+### 1.3 Field whitelist
+
+```python
+INCLUDED_FIELD_WHITELIST = frozenset({
+    "name", "description", "element_type", "notation",
+    "data", "metadata", "package_id", "tags",
+})
+```
+
+Anything outside this set is silently dropped from
+`included_fields` and never written into `template_data`.
+
+## 2. REST endpoints
+
+Prefix: `/api/element-templates`.
+
+| Method | Path | Body / Query | Response | Auth |
+|---|---|---|---|---|
+| POST | `` | `ElementTemplateCreate` | 201 `ElementTemplateResponse` | get_current_user |
+| GET | `` | `set_id?`, `include_global=true`, `page=1`, `page_size=50` | `ElementTemplateListResponse` | get_optional_user |
+| GET | `/{template_id}` | — | `ElementTemplateResponse` | get_optional_user |
+| PUT | `/{template_id}` | `ElementTemplateUpdate` | `ElementTemplateResponse` | get_current_user |
+| DELETE | `/{template_id}` | — | 204 | get_current_user |
+
+Update is partial: only keys present in the JSON body are touched. `set_id` may be null to demote a global template back to a set (the CHECK constraint validates the resulting state). 422 on scope violations; 404 on missing template.
+
+### 2.1 Extension to `POST /api/elements`
+
+`ElementCreate` gains optional `template_id`. Pre-merge flow:
+
+```
+fields = request.model_dump(exclude_unset=True)
+template_id = fields.pop("template_id", None)
+template_tags = []
+if template_id:
+    template = await get_element_template(db, template_id)
+    if not template: raise 404
+    fields = apply_template_to_create_body(template, fields)
+    template_tags = fields.pop("tags", None) or []
+# re-validate required (element_type + name), then create_element(...)
+# write template_tags to element_tags table after creation
+```
+
+`apply_template_to_create_body` merges `template_data[k]` into `fields[k]` for every `k ∈ included_fields ∩ INCLUDED_FIELD_WHITELIST` where `fields.get(k)` is absent. Explicit request fields always win.
+
+## 3. MCP tools
+
+Five new tools mirror the REST surface plus `template_id` on `create_element`:
+
+- `create_element_template(source_element_id, name, description?, included_fields, set_id?, is_global=false)`
+- `list_element_templates(set_id?, include_global=true, page=1, page_size=50)`
+- `get_element_template(template_id)`
+- `update_element_template(template_id, name?, description?, included_fields?, set_id?, is_global?)`
+- `delete_element_template(template_id)`
+- `create_element` gains `template_id` (optional)
+
+Tests in `mcp/tests/test_element_templates.py`.
+
+## 4. CLI subcommands
+
+CLI uses kebab-case entity names; the parity script normalises to underscores. New subcommands under the existing `create`/`update`/`delete`/`get`/`list` apps:
+
+- `iris create element-template --from-element ID --name … --include name,description,data --global/--set-id`
+- `iris list element-template [--set-id … | --global]`
+- `iris get element-template ID`
+- `iris update element-template ID --name … --include … --global`
+- `iris delete element-template ID`
+- `iris create element` gains `--template-id`
+
+Tests in `cli/tests/test_element_templates.py`.
+
+## 5. Frontend
+
+### 5.1 Routes / components
+
+| File | Purpose |
+|---|---|
+| `frontend/src/lib/components/TemplatesListDialog.svelte` | Browse + Use |
+| `frontend/src/lib/components/CreateTemplateDialog.svelte` | Capture from current element |
+| `frontend/src/routes/element-templates/[id]/+page.svelte` | Template detail |
+| `frontend/src/routes/elements/+page.svelte` | (modified) Templates button + dialog mount |
+| `frontend/src/routes/elements/[id]/+page.svelte` | (modified) Save-as-template button + dialog mount |
+
+### 5.2 Use-from-template flow
+
+1. User clicks **Templates** on `/elements` → dialog opens, fetches `GET /api/element-templates?set_id=…&include_global=true&page_size=100`.
+2. User picks a template, clicks **Use** → inline mini-form asks for `name`.
+3. Submit → `POST /api/elements` with `{ template_id, name, set_id }`. Backend pre-fills whitelisted fields server-side.
+4. `goto(/elements/{newId})`.
+
+### 5.3 Save-as-template flow
+
+1. User opens `/elements/{id}`, clicks **Save as template** → dialog opens.
+2. Form: name (default = `"{element.name} template"`), description (optional), 8 field checkboxes (defaults: name + description + element_type + notation + data + tags), "Make global" toggle (default off).
+3. Submit → `POST /api/element-templates` with `source_element_id` = current element, `included_fields` = checked boxes, `set_id` or `is_global` depending on toggle.
+4. `goto(/element-templates/{templateId})`.
+
+### 5.4 Detail page
+
+- Header: name, scope badge (Global or set name).
+- Source element link (or "(source element deleted)" if `source_element_id` is null).
+- Captured-fields table: each `included_fields` entry + pretty-printed JSON of `template_data[field]`.
+- Action buttons: **Create element from template** (inline form), **Delete** (confirm dialog).
+
+## 6. Security / sanitisation
+
+- All user-supplied strings rendered into Svelte templates flow through `{expression}` (Svelte's default escaping). No `{@html}` is used — Protocol §7.
+- DOMPurify sanitises `name` / `description` in the Create-element-from-template form before submission (belt-and-braces; backend also re-sanitises via `escape()`).
+- `INCLUDED_FIELD_WHITELIST` is the trust boundary for which element fields can leave `elements` and enter `element_templates.template_data`.
+
+## 7. Tests
+
+| Suite | Path | Count |
+|---|---|---|
+| Backend schema | `backend/tests/test_migrations/test_element_templates_schema.py` | 7 |
+| Backend CRUD + apply | `backend/tests/test_element_templates/test_crud_and_apply.py` | 27 |
+| MCP | `mcp/tests/test_element_templates.py` | 12 |
+| CLI | `cli/tests/test_element_templates.py` | 8 |
+| Frontend | `frontend/tests/unit/elementTemplates.test.ts` | 20 |
+
+Total: 74. (Earlier in development the count was lower; this is the final delta.)
+
+## 8. Rollout
+
+1. Merge feature branch.
+2. Apply Supabase `m071_element_templates.sql` via `scripts/supabase-migrate.sh` (Protocol §15: migration before app deploy).
+3. Render auto-deploys on push to main → tag `v6.8.0` → GitHub release.
+4. Spot-check production: create a template, list templates, use a template, delete a template — once on the live frontend, once via MCP, once via CLI.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.7.4",
+	"version": "6.8.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/CreateTemplateDialog.svelte
+++ b/frontend/src/lib/components/CreateTemplateDialog.svelte
@@ -1,0 +1,193 @@
+<script lang="ts">
+	/**
+	 * "Save as template" dialog (v6.8.0, ADR-191, issue #153).
+	 *
+	 * Captures a snapshot of the current element with user-chosen
+	 * fields. Whitelist matches `INCLUDED_FIELD_WHITELIST` in
+	 * `backend/app/element_templates/models.py`. The user can promote
+	 * the template to global; otherwise it is scoped to the element's
+	 * current set.
+	 */
+	import DOMPurify from 'dompurify';
+	import { apiFetch, ApiError } from '$lib/utils/api';
+
+	const FIELD_OPTIONS: { value: string; label: string }[] = [
+		{ value: 'name', label: 'Name' },
+		{ value: 'description', label: 'Description' },
+		{ value: 'element_type', label: 'Type' },
+		{ value: 'notation', label: 'Notation' },
+		{ value: 'data', label: 'Data payload' },
+		{ value: 'metadata', label: 'Metadata' },
+		{ value: 'package_id', label: 'Package membership' },
+		{ value: 'tags', label: 'Tags' },
+	];
+
+	interface Props {
+		open: boolean;
+		sourceElementId: string;
+		sourceElementName: string;
+		setId: string | null;
+		oncancel: () => void;
+		oncreated: (templateId: string) => void;
+	}
+
+	let { open, sourceElementId, sourceElementName, setId, oncancel, oncreated }: Props = $props();
+
+	let dialogEl: HTMLDialogElement | undefined = $state();
+	let name = $state('');
+	let description = $state('');
+	let isGlobal = $state(false);
+	let includedSet = $state<Set<string>>(new Set(['name', 'description', 'element_type', 'notation', 'data', 'tags']));
+	let submitting = $state(false);
+	let error = $state<string | null>(null);
+
+	$effect(() => {
+		if (open && dialogEl && !dialogEl.open) {
+			name = sourceElementName ? `${sourceElementName} template` : '';
+			description = '';
+			isGlobal = false;
+			includedSet = new Set(['name', 'description', 'element_type', 'notation', 'data', 'tags']);
+			error = null;
+			dialogEl.showModal();
+		} else if (!open && dialogEl?.open) {
+			dialogEl.close();
+		}
+	});
+
+	function toggleField(value: string, checked: boolean) {
+		const next = new Set(includedSet);
+		if (checked) next.add(value);
+		else next.delete(value);
+		includedSet = next;
+	}
+
+	async function handleSubmit(event: SubmitEvent) {
+		event.preventDefault();
+		if (submitting) return;
+		error = null;
+		const trimmed = name.trim();
+		if (!trimmed) {
+			error = 'Template name is required.';
+			return;
+		}
+		const included = [...includedSet];
+		if (included.length === 0) {
+			error = 'Pick at least one field to capture.';
+			return;
+		}
+		if (!isGlobal && !setId) {
+			error = 'Source element has no set — only Global scope is available.';
+			return;
+		}
+		submitting = true;
+		try {
+			const body: Record<string, unknown> = {
+				source_element_id: sourceElementId,
+				name: DOMPurify.sanitize(trimmed),
+				description: description.trim() ? DOMPurify.sanitize(description.trim()) : null,
+				included_fields: included,
+				is_global: isGlobal,
+				set_id: isGlobal ? null : setId,
+			};
+			const created = await apiFetch<{ id: string }>('/api/element-templates', {
+				method: 'POST',
+				body: JSON.stringify(body),
+			});
+			oncreated(created.id);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : 'Failed to create template';
+		}
+		submitting = false;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			oncancel();
+		}
+	}
+</script>
+
+{#if open}
+	<dialog
+		bind:this={dialogEl}
+		onkeydown={handleKeydown}
+		aria-labelledby="create-template-title"
+		class="rounded-lg p-6 shadow-lg backdrop:bg-black/50"
+		style="background-color: var(--color-surface); color: var(--color-fg); border: 1px solid var(--color-border); min-width: 460px; max-width: 90vw"
+	>
+		<h2 id="create-template-title" class="text-lg font-bold">Save as template</h2>
+		<p class="mt-1 text-sm" style="color: var(--color-muted)">
+			Capture selected fields from <strong style="color: var(--color-fg)">{sourceElementName}</strong>
+			so later elements can be pre-filled from this template.
+		</p>
+
+		<form onsubmit={handleSubmit} class="mt-4 flex flex-col gap-4">
+			<div>
+				<label for="template-name" class="block text-sm font-medium">Template name</label>
+				<input
+					id="template-name"
+					bind:value={name}
+					required
+					autocomplete="off"
+					class="mt-1 w-full rounded border px-3 py-2 text-sm"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+				/>
+			</div>
+
+			<div>
+				<label for="template-description" class="block text-sm font-medium">Description (optional)</label>
+				<textarea
+					id="template-description"
+					bind:value={description}
+					rows="2"
+					class="mt-1 w-full rounded border px-3 py-2 text-sm"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+				></textarea>
+			</div>
+
+			<fieldset>
+				<legend class="text-sm font-medium">Fields to capture</legend>
+				<div class="mt-1 grid grid-cols-2 gap-1">
+					{#each FIELD_OPTIONS as field (field.value)}
+						<label class="flex items-center gap-2 text-sm">
+							<input
+								type="checkbox"
+								checked={includedSet.has(field.value)}
+								onchange={(e) => toggleField(field.value, (e.currentTarget as HTMLInputElement).checked)}
+							/>
+							{field.label}
+						</label>
+					{/each}
+				</div>
+			</fieldset>
+
+			<label class="flex items-center gap-2 text-sm">
+				<input type="checkbox" bind:checked={isGlobal} />
+				Make template global (visible from any set)
+			</label>
+
+			{#if error}
+				<p class="text-sm" role="alert" style="color: var(--color-danger)">{error}</p>
+			{/if}
+
+			<div class="flex justify-end gap-3">
+				<button
+					type="button"
+					onclick={oncancel}
+					class="rounded px-4 py-2 text-sm"
+					style="border: 1px solid var(--color-border); color: var(--color-fg)"
+				>
+					Cancel
+				</button>
+				<button
+					type="submit"
+					disabled={submitting}
+					class="rounded px-4 py-2 text-sm text-white disabled:opacity-50"
+					style="background-color: var(--color-primary)"
+				>
+					{submitting ? 'Saving…' : 'Save template'}
+				</button>
+			</div>
+		</form>
+	</dialog>
+{/if}

--- a/frontend/src/lib/components/TemplatesListDialog.svelte
+++ b/frontend/src/lib/components/TemplatesListDialog.svelte
@@ -1,0 +1,250 @@
+<script lang="ts">
+	/**
+	 * Element template browser (v6.8.0, ADR-191, issue #153).
+	 *
+	 * Lists set-scoped + global element templates and lets the user
+	 * either inspect one (link to `/element-templates/{id}`) or
+	 * instantiate a new element from it. The "use template" flow asks
+	 * for a name in a follow-up prompt and POSTs to
+	 * `/api/elements` with `{ name, set_id, template_id }` — the
+	 * backend applies the template's whitelisted fields server-side
+	 * (ADR-191 §"apply_template_to_create_body").
+	 */
+	import DOMPurify from 'dompurify';
+	import { apiFetch, ApiError } from '$lib/utils/api';
+
+	interface ElementTemplate {
+		id: string;
+		name: string;
+		description: string | null;
+		set_id: string | null;
+		set_name: string | null;
+		is_global: boolean;
+		source_element_id: string | null;
+		source_element_name: string | null;
+		included_fields: string[];
+		template_data: Record<string, unknown>;
+		created_at: string;
+		updated_at: string;
+		created_by_username: string;
+	}
+
+	interface PaginatedTemplates {
+		items: ElementTemplate[];
+		total: number;
+		page: number;
+		page_size: number;
+	}
+
+	interface Props {
+		open: boolean;
+		setId: string;
+		oncancel: () => void;
+		onuse: (createdElementId: string) => void;
+	}
+
+	let { open, setId, oncancel, onuse }: Props = $props();
+
+	let dialogEl: HTMLDialogElement | undefined = $state();
+	let templates = $state<ElementTemplate[]>([]);
+	let loading = $state(false);
+	let error = $state<string | null>(null);
+
+	// Inline "use template" mini-form state
+	let useTarget = $state<ElementTemplate | null>(null);
+	let newName = $state('');
+	let useSubmitting = $state(false);
+
+	async function loadTemplates() {
+		loading = true;
+		error = null;
+		try {
+			const params = new URLSearchParams();
+			if (setId) params.set('set_id', setId);
+			params.set('include_global', 'true');
+			params.set('page_size', '100');
+			const data = await apiFetch<PaginatedTemplates>(
+				`/api/element-templates?${params}`,
+			);
+			templates = data.items;
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : 'Failed to load templates';
+			templates = [];
+		}
+		loading = false;
+	}
+
+	$effect(() => {
+		if (open && dialogEl && !dialogEl.open) {
+			loadTemplates();
+			useTarget = null;
+			newName = '';
+			dialogEl.showModal();
+		} else if (!open && dialogEl?.open) {
+			dialogEl.close();
+		}
+	});
+
+	function startUse(t: ElementTemplate) {
+		useTarget = t;
+		newName = '';
+	}
+
+	function cancelUse() {
+		useTarget = null;
+		newName = '';
+	}
+
+	async function confirmUse(event: SubmitEvent) {
+		event.preventDefault();
+		if (!useTarget || !newName.trim()) return;
+		useSubmitting = true;
+		const sanitizedName = DOMPurify.sanitize(newName.trim());
+		try {
+			const body: Record<string, unknown> = {
+				template_id: useTarget.id,
+				name: sanitizedName,
+			};
+			if (setId) body.set_id = setId;
+			const created = await apiFetch<{ id: string }>('/api/elements', {
+				method: 'POST',
+				body: JSON.stringify(body),
+			});
+			useTarget = null;
+			newName = '';
+			onuse(created.id);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : 'Failed to create from template';
+		}
+		useSubmitting = false;
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			if (useTarget) {
+				cancelUse();
+			} else {
+				oncancel();
+			}
+		}
+	}
+</script>
+
+{#if open}
+	<dialog
+		bind:this={dialogEl}
+		onkeydown={handleKeydown}
+		aria-labelledby="templates-dialog-title"
+		class="rounded-lg p-6 shadow-lg backdrop:bg-black/50"
+		style="background-color: var(--color-surface); color: var(--color-fg); border: 1px solid var(--color-border); min-width: 560px; max-width: 90vw; max-height: 80vh; overflow: auto"
+	>
+		<div class="flex items-start justify-between gap-4">
+			<div>
+				<h2 id="templates-dialog-title" class="text-lg font-bold">Element Templates</h2>
+				<p class="mt-1 text-sm" style="color: var(--color-muted)">
+					Choose a template to create a new element with pre-filled fields.
+				</p>
+			</div>
+			<button
+				type="button"
+				onclick={oncancel}
+				aria-label="Close"
+				class="rounded p-1"
+				style="color: var(--color-muted)"
+			>
+				✕
+			</button>
+		</div>
+
+		{#if error}
+			<p class="mt-4 text-sm" role="alert" style="color: var(--color-danger)">{error}</p>
+		{/if}
+
+		{#if loading}
+			<p class="mt-6 text-sm" style="color: var(--color-muted)">Loading templates…</p>
+		{:else if templates.length === 0}
+			<p class="mt-6 text-sm" style="color: var(--color-muted)">
+				No templates available. Open an element and choose "Save as template" to create one.
+			</p>
+		{:else if useTarget}
+			<form onsubmit={confirmUse} class="mt-6 flex flex-col gap-4">
+				<div>
+					<p class="text-sm" style="color: var(--color-muted)">
+						Creating an element from <strong style="color: var(--color-fg)">{useTarget.name}</strong>.
+						Pre-filled fields: {useTarget.included_fields.join(', ')}.
+					</p>
+				</div>
+				<div>
+					<label for="template-new-name" class="block text-sm font-medium">Element name</label>
+					<input
+						id="template-new-name"
+						bind:value={newName}
+						required
+						autocomplete="off"
+						class="mt-1 w-full rounded border px-3 py-2 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					/>
+				</div>
+				<div class="flex justify-end gap-3">
+					<button
+						type="button"
+						onclick={cancelUse}
+						class="rounded px-4 py-2 text-sm"
+						style="border: 1px solid var(--color-border); color: var(--color-fg)"
+					>
+						Back
+					</button>
+					<button
+						type="submit"
+						disabled={useSubmitting || !newName.trim()}
+						class="rounded px-4 py-2 text-sm text-white disabled:opacity-50"
+						style="background-color: var(--color-primary)"
+					>
+						{useSubmitting ? 'Creating…' : 'Create element'}
+					</button>
+				</div>
+			</form>
+		{:else}
+			<table class="mt-6 w-full text-sm">
+				<thead>
+					<tr style="border-bottom: 1px solid var(--color-border)">
+						<th class="py-2 pr-4 text-left font-medium" style="color: var(--color-muted)">Name</th>
+						<th class="py-2 pr-4 text-left font-medium" style="color: var(--color-muted)">Scope</th>
+						<th class="py-2 pr-4 text-left font-medium" style="color: var(--color-muted)">Captured fields</th>
+						<th class="py-2 text-left font-medium" style="color: var(--color-muted)">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each templates as t (t.id)}
+						<tr style="border-bottom: 1px solid var(--color-border)">
+							<td class="py-2 pr-4">
+								<a href="/element-templates/{t.id}" class="underline" style="color: var(--color-primary)">{t.name}</a>
+								{#if t.description}
+									<div class="mt-0.5 text-xs" style="color: var(--color-muted)">{t.description}</div>
+								{/if}
+							</td>
+							<td class="py-2 pr-4">
+								{#if t.is_global}
+									<span class="rounded px-2 py-0.5 text-xs" style="background: var(--color-surface); border: 1px solid var(--color-border)">Global</span>
+								{:else}
+									<span class="text-xs" style="color: var(--color-muted)">{t.set_name ?? t.set_id ?? ''}</span>
+								{/if}
+							</td>
+							<td class="py-2 pr-4 text-xs" style="color: var(--color-muted)">{t.included_fields.join(', ')}</td>
+							<td class="py-2">
+								<button
+									type="button"
+									onclick={() => startUse(t)}
+									class="rounded px-3 py-1 text-xs text-white"
+									style="background-color: var(--color-primary)"
+								>
+									Use
+								</button>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
+	</dialog>
+{/if}

--- a/frontend/src/routes/element-templates/[id]/+page.svelte
+++ b/frontend/src/routes/element-templates/[id]/+page.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+	/**
+	 * Element template detail page (v6.8.0, ADR-191, issue #153).
+	 *
+	 * Shows scope, source element, captured fields, and the snapshot
+	 * of the data that will be applied to new elements. Provides a
+	 * "Create element from template" affordance that mirrors the
+	 * one in the elements-list Templates dialog.
+	 */
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import DOMPurify from 'dompurify';
+	import { apiFetch, ApiError } from '$lib/utils/api';
+
+	interface ElementTemplate {
+		id: string;
+		name: string;
+		description: string | null;
+		set_id: string | null;
+		set_name: string | null;
+		is_global: boolean;
+		source_element_id: string | null;
+		source_element_name: string | null;
+		included_fields: string[];
+		template_data: Record<string, unknown>;
+		created_at: string;
+		updated_at: string;
+		created_by_username: string;
+	}
+
+	let tpl = $state<ElementTemplate | null>(null);
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let useFormOpen = $state(false);
+	let newName = $state('');
+	let submitting = $state(false);
+	let deleting = $state(false);
+	let showConfirmDelete = $state(false);
+
+	$effect(() => {
+		const id = page.params.id;
+		if (id) load(id);
+	});
+
+	async function load(id: string) {
+		loading = true;
+		error = null;
+		try {
+			tpl = await apiFetch<ElementTemplate>(`/api/element-templates/${id}`);
+		} catch (e) {
+			error = e instanceof ApiError && e.status === 404
+				? 'Template not found'
+				: 'Failed to load template';
+		}
+		loading = false;
+	}
+
+	async function createFromTemplate(event: SubmitEvent) {
+		event.preventDefault();
+		if (!tpl || !newName.trim() || submitting) return;
+		submitting = true;
+		try {
+			const body: Record<string, unknown> = {
+				template_id: tpl.id,
+				name: DOMPurify.sanitize(newName.trim()),
+			};
+			if (tpl.set_id) body.set_id = tpl.set_id;
+			const created = await apiFetch<{ id: string }>('/api/elements', {
+				method: 'POST',
+				body: JSON.stringify(body),
+			});
+			goto(`/elements/${created.id}`);
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : 'Failed to create element';
+		}
+		submitting = false;
+	}
+
+	async function handleDelete() {
+		if (!tpl) return;
+		deleting = true;
+		try {
+			await apiFetch(`/api/element-templates/${tpl.id}`, { method: 'DELETE' });
+			goto('/elements');
+		} catch (e) {
+			error = e instanceof ApiError ? e.message : 'Failed to delete template';
+			deleting = false;
+		}
+	}
+
+	function renderValue(value: unknown): string {
+		if (value === null || value === undefined) return '—';
+		if (typeof value === 'string') return value;
+		if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+		try {
+			return JSON.stringify(value, null, 2);
+		} catch {
+			return String(value);
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{tpl?.name ?? 'Element Template'} — Iris</title>
+</svelte:head>
+
+{#if loading}
+	<div class="p-8" role="status"><p style="color: var(--color-muted)">Loading template…</p></div>
+{:else if error}
+	<div class="p-8" role="alert">
+		<p style="color: var(--color-danger)">{error}</p>
+		<button onclick={() => goto('/elements')} class="mt-4 rounded px-4 py-2 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+			Back to Elements
+		</button>
+	</div>
+{:else if tpl}
+	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
+		<ol class="flex items-baseline gap-1">
+			<li><a href="/elements" style="color: var(--color-primary)">Elements</a></li>
+			<li><span aria-hidden="true">/</span></li>
+			<li>Templates</li>
+			<li><span aria-hidden="true">/</span></li>
+			<li aria-current="page">{tpl.name}</li>
+		</ol>
+	</nav>
+
+	<div class="flex items-start justify-between gap-4">
+		<div>
+			<div class="flex flex-wrap items-center gap-3">
+				<h1 class="text-2xl font-bold" style="color: var(--color-fg)">{tpl.name}</h1>
+				{#if tpl.is_global}
+					<span class="rounded px-2 py-0.5 text-sm" style="background: var(--color-surface); color: var(--color-fg); border: 1px solid var(--color-border)">Global</span>
+				{:else if tpl.set_name}
+					<span class="rounded px-2 py-0.5 text-sm" style="background: var(--color-surface); color: var(--color-muted); border: 1px solid var(--color-border)">{tpl.set_name}</span>
+				{/if}
+			</div>
+			<p class="mt-1 text-sm" style="color: var(--color-muted)">Element template</p>
+		</div>
+		<div class="flex gap-2">
+			<button
+				onclick={() => { useFormOpen = true; newName = ''; }}
+				class="rounded px-4 py-2 text-sm text-white"
+				style="background-color: var(--color-primary)"
+			>
+				Create element from template
+			</button>
+			<button
+				onclick={() => (showConfirmDelete = true)}
+				class="rounded px-4 py-2 text-sm text-white"
+				style="background-color: var(--color-danger)"
+			>
+				Delete
+			</button>
+		</div>
+	</div>
+
+	{#if tpl.description}
+		<p class="mt-3 text-sm" style="color: var(--color-fg)">{tpl.description}</p>
+	{/if}
+
+	{#if useFormOpen}
+		<form onsubmit={createFromTemplate} class="mt-6 rounded border p-4" style="border-color: var(--color-border); background: var(--color-surface)">
+			<label for="new-from-template" class="block text-sm font-medium" style="color: var(--color-fg)">New element name</label>
+			<input
+				id="new-from-template"
+				bind:value={newName}
+				required
+				autocomplete="off"
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			/>
+			<div class="mt-3 flex justify-end gap-2">
+				<button type="button" onclick={() => (useFormOpen = false)} class="rounded px-4 py-2 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+					Cancel
+				</button>
+				<button type="submit" disabled={submitting || !newName.trim()} class="rounded px-4 py-2 text-sm text-white disabled:opacity-50" style="background-color: var(--color-primary)">
+					{submitting ? 'Creating…' : 'Create'}
+				</button>
+			</div>
+		</form>
+	{/if}
+
+	<section class="mt-8">
+		<h2 class="text-base font-semibold" style="color: var(--color-fg)">Metadata</h2>
+		<dl class="mt-3 grid gap-3" style="grid-template-columns: auto 1fr">
+			<dt class="text-sm font-medium" style="color: var(--color-muted)">Source element</dt>
+			<dd class="text-sm" style="color: var(--color-fg)">
+				{#if tpl.source_element_id}
+					<a href="/elements/{tpl.source_element_id}" style="color: var(--color-primary)">
+						{tpl.source_element_name ?? tpl.source_element_id}
+					</a>
+				{:else}
+					<span style="color: var(--color-muted)">(source element deleted)</span>
+				{/if}
+			</dd>
+			<dt class="text-sm font-medium" style="color: var(--color-muted)">Created by</dt>
+			<dd class="text-sm" style="color: var(--color-fg)">{tpl.created_by_username}</dd>
+			<dt class="text-sm font-medium" style="color: var(--color-muted)">Created</dt>
+			<dd class="text-sm" style="color: var(--color-fg)">{tpl.created_at}</dd>
+			<dt class="text-sm font-medium" style="color: var(--color-muted)">Updated</dt>
+			<dd class="text-sm" style="color: var(--color-fg)">{tpl.updated_at}</dd>
+		</dl>
+	</section>
+
+	<section class="mt-8">
+		<h2 class="text-base font-semibold" style="color: var(--color-fg)">Captured fields</h2>
+		<p class="mt-1 text-xs" style="color: var(--color-muted)">
+			These values will be used to pre-fill new elements created from this template. Explicit fields on the create request override these defaults.
+		</p>
+		<div class="mt-3 overflow-x-auto">
+			<table class="w-full text-sm" style="color: var(--color-fg)">
+				<thead>
+					<tr style="border-bottom: 1px solid var(--color-border)">
+						<th class="py-2 pr-4 text-left font-medium" style="color: var(--color-muted)">Field</th>
+						<th class="py-2 text-left font-medium" style="color: var(--color-muted)">Value</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each tpl.included_fields as f (f)}
+						<tr style="border-bottom: 1px solid var(--color-border)">
+							<td class="py-2 pr-4 font-mono text-xs">{f}</td>
+							<td class="py-2"><pre class="whitespace-pre-wrap text-xs" style="color: var(--color-fg)">{renderValue(tpl.template_data[f])}</pre></td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	</section>
+
+	{#if showConfirmDelete}
+		<div style="position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.4)">
+			<div class="rounded-lg p-6 shadow-lg" style="background: var(--color-bg); border: 1px solid var(--color-border); width: 420px; max-width: 90vw">
+				<h3 class="text-lg font-semibold" style="color: var(--color-fg)">Delete template</h3>
+				<p class="mt-2 text-sm" style="color: var(--color-muted)">
+					Delete '{tpl.name}'? Elements already created from this template are unaffected.
+				</p>
+				<div class="mt-4 flex justify-end gap-2">
+					<button onclick={() => (showConfirmDelete = false)} class="rounded px-4 py-2 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+						Cancel
+					</button>
+					<button onclick={handleDelete} disabled={deleting} class="rounded px-4 py-2 text-sm text-white disabled:opacity-50" style="background-color: var(--color-danger)">
+						{deleting ? 'Deleting…' : 'Delete'}
+					</button>
+				</div>
+			</div>
+		</div>
+	{/if}
+{/if}

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -13,6 +13,8 @@
 	import BatchSetDialog from '$lib/components/BatchSetDialog.svelte';
 	import BatchTagDialog from '$lib/components/BatchTagDialog.svelte';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
+	import TemplatesListDialog from '$lib/components/TemplatesListDialog.svelte';
+	import { goto } from '$app/navigation';
 
 	let elements = $state<Element[]>([]);
 	let loading = $state(true);
@@ -24,6 +26,7 @@
 	let availableTags = $state<string[]>([]);
 	let sortField = $state<'name' | 'element_type' | 'updated_at'>('name');
 	let showCreateDialog = $state(false);
+	let showTemplatesDialog = $state(false);
 	let groupMode = $state<'none' | 'type' | 'tag'>(
 		(typeof window !== 'undefined' &&
 			(localStorage.getItem('iris-elements-group') as 'none' | 'type' | 'tag')) ||
@@ -309,6 +312,13 @@
 			{selectMode ? 'Cancel Select' : 'Select'}
 		</button>
 		<button
+			onclick={() => (showTemplatesDialog = true)}
+			class="rounded px-4 py-2 text-sm"
+			style="border: 1px solid var(--color-border); color: var(--color-fg)"
+		>
+			Templates
+		</button>
+		<button
 			onclick={() => (showCreateDialog = true)}
 			class="rounded px-4 py-2 text-sm text-white"
 			style="background-color: var(--color-primary)"
@@ -562,6 +572,16 @@
 	mode="create"
 	onsave={handleCreate}
 	oncancel={() => (showCreateDialog = false)}
+/>
+
+<TemplatesListDialog
+	open={showTemplatesDialog}
+	setId={currentSetId}
+	oncancel={() => (showTemplatesDialog = false)}
+	onuse={(newId) => {
+		showTemplatesDialog = false;
+		goto(`/elements/${newId}`);
+	}}
 />
 
 <BatchSetDialog

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -18,6 +18,7 @@
 	import TagInput from '$lib/components/TagInput.svelte';
 	import CommentsPanel from '$lib/components/CommentsPanel.svelte';
 	import VersionHistory from '$lib/components/VersionHistory.svelte';
+	import CreateTemplateDialog from '$lib/components/CreateTemplateDialog.svelte';
 	import { Accordion } from 'bits-ui';
 	import DOMPurify from 'dompurify';
 	import {
@@ -39,6 +40,7 @@
 	let error = $state<string | null>(null);
 	let activeTab = $state<'details' | 'versions' | 'relationships' | 'diagrams'>('details');
 	let showDeleteDialog = $state(false);
+	let showSaveTemplateDialog = $state(false);
 	let isBookmarked = $state(false);
 	let bookmarkLoading = $state(false);
 
@@ -408,6 +410,13 @@
 				style="border: 1px solid var(--color-border); color: var(--color-fg)"
 			>
 				Clone
+			</button>
+			<button
+				onclick={() => (showSaveTemplateDialog = true)}
+				class="rounded px-4 py-2 text-sm"
+				style="border: 1px solid var(--color-border); color: var(--color-fg)"
+			>
+				Save as template
 			</button>
 			<button
 				onclick={() => (showDeleteDialog = true)}
@@ -915,5 +924,17 @@
 		confirmLabel="Delete"
 		onconfirm={handleDelete}
 		oncancel={() => (showDeleteDialog = false)}
+	/>
+
+	<CreateTemplateDialog
+		open={showSaveTemplateDialog}
+		sourceElementId={entity.id}
+		sourceElementName={entity.name}
+		setId={entity.set_id ?? null}
+		oncancel={() => (showSaveTemplateDialog = false)}
+		oncreated={(templateId) => {
+			showSaveTemplateDialog = false;
+			goto(`/element-templates/${templateId}`);
+		}}
 	/>
 {/if}

--- a/frontend/tests/unit/elementTemplates.test.ts
+++ b/frontend/tests/unit/elementTemplates.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Element templates frontend wiring tests (v6.8.0, ADR-191, issue
+ * #153). Static-parser style — mirrors the dashboardHierarchy /
+ * packageRelationshipsTab patterns. Verifies that the three new
+ * affordances exist and reach the right backend endpoints.
+ */
+
+const elementsListSrc = readFileSync(
+	resolve(__dirname, '../../src/routes/elements/+page.svelte'),
+	'utf-8',
+);
+const elementDetailSrc = readFileSync(
+	resolve(__dirname, '../../src/routes/elements/[id]/+page.svelte'),
+	'utf-8',
+);
+const templateDetailSrc = readFileSync(
+	resolve(__dirname, '../../src/routes/element-templates/[id]/+page.svelte'),
+	'utf-8',
+);
+const templatesListDialogSrc = readFileSync(
+	resolve(__dirname, '../../src/lib/components/TemplatesListDialog.svelte'),
+	'utf-8',
+);
+const createTemplateDialogSrc = readFileSync(
+	resolve(__dirname, '../../src/lib/components/CreateTemplateDialog.svelte'),
+	'utf-8',
+);
+
+describe('Elements list — Templates button + dialog', () => {
+	it('imports TemplatesListDialog', () => {
+		expect(elementsListSrc).toContain('TemplatesListDialog');
+	});
+
+	it('exposes a Templates button next to New Element', () => {
+		// The button toggles a state flag — verify both.
+		expect(elementsListSrc).toContain('showTemplatesDialog = true');
+		expect(elementsListSrc).toMatch(/>\s*Templates\s*</);
+	});
+
+	it('passes the current set_id to the dialog', () => {
+		expect(elementsListSrc).toContain('setId={currentSetId}');
+	});
+
+	it('navigates to the created element after Use', () => {
+		expect(elementsListSrc).toContain('goto(`/elements/${newId}`)');
+	});
+});
+
+describe('Element detail — Save as template action', () => {
+	it('imports CreateTemplateDialog', () => {
+		expect(elementDetailSrc).toContain('CreateTemplateDialog');
+	});
+
+	it('has a Save-as-template button that opens the dialog', () => {
+		expect(elementDetailSrc).toContain('showSaveTemplateDialog = true');
+		expect(elementDetailSrc).toContain('Save as template');
+	});
+
+	it('routes to the new template detail page on creation', () => {
+		expect(elementDetailSrc).toContain('goto(`/element-templates/${templateId}`)');
+	});
+});
+
+describe('TemplatesListDialog — API contract', () => {
+	it('calls GET /api/element-templates with set_id + include_global', () => {
+		expect(templatesListDialogSrc).toContain('/api/element-templates?');
+		expect(templatesListDialogSrc).toContain("params.set('include_global', 'true')");
+		expect(templatesListDialogSrc).toContain("params.set('set_id', setId)");
+	});
+
+	it('POSTs to /api/elements with template_id when Use is confirmed', () => {
+		expect(templatesListDialogSrc).toContain("'/api/elements'");
+		expect(templatesListDialogSrc).toContain('template_id: useTarget.id');
+	});
+
+	it('sanitises the new element name with DOMPurify before sending', () => {
+		expect(templatesListDialogSrc).toContain('DOMPurify');
+		expect(templatesListDialogSrc).toContain('DOMPurify.sanitize(newName.trim())');
+	});
+
+	it('shows an empty-state when no templates exist', () => {
+		expect(templatesListDialogSrc).toContain('No templates available');
+	});
+});
+
+describe('CreateTemplateDialog — field whitelist + scoping', () => {
+	it('lists the eight whitelisted fields from INCLUDED_FIELD_WHITELIST', () => {
+		// Mirrors backend/app/element_templates/models.py:INCLUDED_FIELD_WHITELIST.
+		for (const f of [
+			'name',
+			'description',
+			'element_type',
+			'notation',
+			'data',
+			'metadata',
+			'package_id',
+			'tags',
+		]) {
+			expect(createTemplateDialogSrc).toContain(`value: '${f}'`);
+		}
+	});
+
+	it('POSTs to /api/element-templates with source_element_id + included_fields', () => {
+		expect(createTemplateDialogSrc).toContain("'/api/element-templates'");
+		expect(createTemplateDialogSrc).toContain('source_element_id: sourceElementId');
+		expect(createTemplateDialogSrc).toContain('included_fields: included');
+	});
+
+	it('blocks save when global is off and no set_id is supplied', () => {
+		expect(createTemplateDialogSrc).toContain('only Global scope is available');
+	});
+
+	it('flips set_id to null when promoting to global', () => {
+		expect(createTemplateDialogSrc).toContain('set_id: isGlobal ? null : setId');
+	});
+});
+
+describe('Element template detail page', () => {
+	it('loads template by id from GET /api/element-templates/{id}', () => {
+		expect(templateDetailSrc).toContain('/api/element-templates/${id}');
+	});
+
+	it('has a Create-element-from-template form that POSTs to /api/elements', () => {
+		expect(templateDetailSrc).toContain('template_id: tpl.id');
+		expect(templateDetailSrc).toContain("'/api/elements'");
+	});
+
+	it('has a Delete affordance calling DELETE /api/element-templates/{id}', () => {
+		expect(templateDetailSrc).toContain('/api/element-templates/${tpl.id}');
+		expect(templateDetailSrc).toContain("method: 'DELETE'");
+	});
+
+	it('renders included_fields against template_data in a table', () => {
+		expect(templateDetailSrc).toContain('Captured fields');
+		expect(templateDetailSrc).toContain('tpl.included_fields');
+		expect(templateDetailSrc).toContain('tpl.template_data');
+	});
+
+	it('shows a Global badge for global templates and the set name otherwise', () => {
+		expect(templateDetailSrc).toMatch(/>\s*Global\s*</);
+		expect(templateDetailSrc).toContain('tpl.set_name');
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.7.4"
+version = "6.8.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -380,12 +380,20 @@ async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
     `apply_diagram_creation` (which materialises elements + their
     diagram representation atomically) or create the diagram with an
     inline element via `create_diagram` data payload.
+
+    v6.8.0 (ADR-191): when ``template_id`` is supplied, the named
+    template pre-fills any whitelisted fields that the caller hasn't
+    set explicitly.
     """
-    body: dict[str, Any] = {
-        "element_type": args["element_type"],
-        "name": args["name"],
-    }
-    for key in ("description", "data", "set_id", "metadata", "notation", "package_id"):
+    body: dict[str, Any] = {}
+    if args.get("element_type") is not None:
+        body["element_type"] = args["element_type"]
+    if args.get("name") is not None:
+        body["name"] = args["name"]
+    for key in (
+        "description", "data", "set_id", "metadata", "notation",
+        "package_id", "template_id",
+    ):
         if args.get(key) is not None:
             body[key] = args[key]
     try:
@@ -393,6 +401,102 @@ async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
     except IrisAuthError:
         return _auth_required_payload("Create element")
     return with_web_url(json.dumps(resp.json()), "element")
+
+
+# ── Element templates (v6.8.0, ADR-191) ──────────────────────────────
+
+
+async def _create_element_template(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.8.0 (ADR-191): capture a template from an existing element.
+
+    ``included_fields`` selects which element fields the template
+    carries (whitelist: name, description, element_type, notation,
+    data, metadata, package_id, tags). Templates are set-scoped by
+    default; pass ``is_global=true`` to make a template visible from
+    any set (in which case omit ``set_id``).
+    """
+    body: dict[str, Any] = {
+        "source_element_id": args["source_element_id"],
+        "name": args["name"],
+        "included_fields": args["included_fields"],
+        "is_global": bool(args.get("is_global", False)),
+    }
+    if args.get("description") is not None:
+        body["description"] = args["description"]
+    if args.get("set_id") is not None:
+        body["set_id"] = args["set_id"]
+    try:
+        resp = await c._request(
+            "POST", "/api/element-templates", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create element template")
+    return with_web_url(json.dumps(resp.json()), "element-template")
+
+
+async def _list_element_templates(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.8.0 (ADR-191): list element templates with set + global scope."""
+    params: dict[str, Any] = {
+        "page": int(args.get("page", 1)),
+        "page_size": int(args.get("limit", 50)),
+        "include_global": bool(args.get("include_global", True)),
+    }
+    if args.get("set_id") is not None:
+        params["set_id"] = args["set_id"]
+    try:
+        resp = await c._request(
+            "GET", "/api/element-templates", params=params,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("List element templates")
+    return with_web_urls_list(
+        json.dumps(resp.json().get("items", [])), "element-template",
+    )
+
+
+async def _get_element_template(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.8.0 (ADR-191): fetch a single template by ID."""
+    try:
+        resp = await c._request(
+            "GET", f"/api/element-templates/{args['template_id']}",
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Get element template")
+    return with_web_url(json.dumps(resp.json()), "element-template")
+
+
+async def _update_element_template(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.8.0 (ADR-191): edit a template (no If-Match — templates are
+    not versioned). Only the keys present in ``args`` are sent."""
+    template_id = args["template_id"]
+    body: dict[str, Any] = {}
+    for key in ("name", "description", "included_fields", "is_global"):
+        if key in args and args[key] is not None:
+            body[key] = args[key]
+    # set_id is tri-state-friendly: caller may pass None to mean
+    # "clear" (for a global template), or a string to set.
+    if "set_id" in args:
+        body["set_id"] = args["set_id"]
+    try:
+        resp = await c._request(
+            "PUT", f"/api/element-templates/{template_id}", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Update element template")
+    return with_web_url(json.dumps(resp.json()), "element-template")
+
+
+async def _delete_element_template(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.8.0 (ADR-191): soft-delete a template."""
+    try:
+        await c._request(
+            "DELETE", f"/api/element-templates/{args['template_id']}",
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Delete element template")
+    return json.dumps({
+        "success": True, "template_id": args["template_id"], "deleted": True,
+    })
 
 
 async def _create_diagram(c: IrisClient, args: dict[str, Any]) -> str:
@@ -1304,17 +1408,25 @@ TOOLS: list[Tool] = [
             "elements onto a diagram in one step, prefer "
             "`apply_diagram_creation` (atomic element + canvas "
             "materialisation) or `create_diagram` with an inline data "
-            "payload."
+            "payload. v6.8.0 (ADR-191): supply `template_id` to pre-"
+            "fill whitelisted fields from a saved element template; "
+            "explicit fields always win over template defaults."
         ),
         input_schema=_schema({
             "element_type": _str_arg(
                 "element_type",
                 "Element type (e.g. 'component', 'class', "
                 "'outcome_box') — must be a registered type for the "
-                "chosen notation",
+                "chosen notation. Optional only when `template_id` is "
+                "supplied and the template includes element_type.",
+                required=False,
             ),
             "name": _str_arg(
-                "name", "Display name for the element",
+                "name",
+                "Display name for the element. Optional only when "
+                "`template_id` is supplied and the template includes "
+                "name.",
+                required=False,
             ),
             "set_id": _str_arg(
                 "set_id",
@@ -1352,8 +1464,188 @@ TOOLS: list[Tool] = [
                 {"type": "object", "additionalProperties": True},
                 False,
             ),
+            "template_id": _str_arg(
+                "template_id",
+                "Optional element template (v6.8.0, ADR-191) to "
+                "pre-fill whitelisted fields. Explicit request fields "
+                "always win over template defaults.",
+                required=False,
+            ),
         }),
         handler=_create_element,
+    ),
+    # ── Element templates (v6.8.0, ADR-191, issue #153) ────────────────
+    Tool(
+        name="create_element_template",
+        description=(
+            "Capture a saved template from an existing element. The "
+            "template snapshots a user-chosen subset of the element's "
+            "fields (whitelist: name, description, element_type, "
+            "notation, data, metadata, package_id, tags) so future "
+            "`create_element` calls can pre-fill from it via "
+            "`template_id`. Set-scoped by default; pass "
+            "`is_global=true` to share across sets (and omit "
+            "`set_id`). v6.8.0, ADR-191, issue #153."
+        ),
+        input_schema=_schema({
+            "source_element_id": _str_arg(
+                "source_element_id",
+                "ID of the element to snapshot the template from",
+            ),
+            "name": _str_arg(
+                "name", "Display name for the template",
+            ),
+            "included_fields": (
+                {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Element fields to carry into the template. "
+                        "Anything outside the whitelist is dropped "
+                        "silently. At least one whitelisted field is "
+                        "required."
+                    ),
+                },
+                True,
+            ),
+            "description": _str_arg(
+                "description", "Optional template description",
+                required=False,
+            ),
+            "set_id": _str_arg(
+                "set_id",
+                "Set to scope the template to. Required when "
+                "`is_global` is false; must be omitted when "
+                "`is_global` is true.",
+                required=False,
+            ),
+            "is_global": (
+                {
+                    "type": "boolean",
+                    "description": (
+                        "Promote the template to global (visible from "
+                        "every set). Default false."
+                    ),
+                    "default": False,
+                },
+                False,
+            ),
+        }),
+        handler=_create_element_template,
+    ),
+    Tool(
+        name="list_element_templates",
+        description=(
+            "List element templates with set + global scope. "
+            "v6.8.0, ADR-191."
+        ),
+        input_schema=_schema({
+            "set_id": _str_arg(
+                "set_id",
+                "Scope to a single set. Combine with "
+                "`include_global=true` to also include global "
+                "templates.",
+                required=False,
+            ),
+            "include_global": (
+                {
+                    "type": "boolean",
+                    "description": (
+                        "When true (default), global templates are "
+                        "included in the result."
+                    ),
+                    "default": True,
+                },
+                False,
+            ),
+            "page": (
+                {"type": "integer", "description": "Page (1-based)",
+                 "default": 1},
+                False,
+            ),
+            "limit": (
+                {"type": "integer", "description": "Page size",
+                 "default": 50},
+                False,
+            ),
+        }),
+        handler=_list_element_templates,
+    ),
+    Tool(
+        name="get_element_template",
+        description=(
+            "Fetch a single element template by ID. v6.8.0, ADR-191."
+        ),
+        input_schema=_schema({
+            "template_id": _str_arg(
+                "template_id", "Template ID",
+            ),
+        }),
+        handler=_get_element_template,
+    ),
+    Tool(
+        name="update_element_template",
+        description=(
+            "Edit an element template's name, description, included "
+            "fields, or scope (promote to/from global). Templates "
+            "are not versioned — no If-Match. When "
+            "`included_fields` changes and the source element is "
+            "still alive, `template_data` is re-projected from the "
+            "source; otherwise the prior snapshot is filtered down "
+            "to the intersection with the new fields. v6.8.0, "
+            "ADR-191."
+        ),
+        input_schema=_schema({
+            "template_id": _str_arg(
+                "template_id", "Template ID",
+            ),
+            "name": _str_arg(
+                "name", "New name", required=False,
+            ),
+            "description": _str_arg(
+                "description", "New description", required=False,
+            ),
+            "included_fields": (
+                {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Replacement included_fields. Triggers a "
+                        "re-projection of template_data."
+                    ),
+                },
+                False,
+            ),
+            "set_id": _str_arg(
+                "set_id",
+                "New set scope. Pass null to clear (when promoting "
+                "to global).",
+                required=False,
+            ),
+            "is_global": (
+                {
+                    "type": "boolean",
+                    "description": (
+                        "Promote to global (set_id must be null) or "
+                        "demote back."
+                    ),
+                },
+                False,
+            ),
+        }),
+        handler=_update_element_template,
+    ),
+    Tool(
+        name="delete_element_template",
+        description=(
+            "Soft-delete an element template. v6.8.0, ADR-191."
+        ),
+        input_schema=_schema({
+            "template_id": _str_arg(
+                "template_id", "Template ID",
+            ),
+        }),
+        handler=_delete_element_template,
     ),
     # ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────
     Tool(

--- a/mcp/tests/test_element_templates.py
+++ b/mcp/tests/test_element_templates.py
@@ -1,0 +1,245 @@
+"""MCP tests for element templates surface (ADR-191, v6.8.0,
+issue #153).
+
+Covers:
+
+- Five new tools registered: create/list/get/update/delete
+  element_template.
+- create_element gains optional ``template_id`` parameter and forwards
+  it to the REST POST body.
+- Body forwarding for create/update template (included_fields,
+  is_global, set_id semantics).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+def _template_response(**overrides):
+    base = {
+        "id": "t-1",
+        "name": "Tpl",
+        "description": None,
+        "set_id": "s-1",
+        "set_name": "S",
+        "is_global": False,
+        "source_element_id": "el-1",
+        "source_element_name": "El",
+        "included_fields": ["name", "description"],
+        "template_data": {"name": "El", "description": "from-source"},
+        "created_by": "u",
+        "created_by_username": "user",
+        "created_at": "2026-05-17T00:00:00+00:00",
+        "updated_at": "2026-05-17T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestInventory:
+    def test_five_new_tools_registered(self) -> None:
+        names = {t.name for t in tools.tool_definitions()}
+        expected = {
+            "create_element_template",
+            "list_element_templates",
+            "get_element_template",
+            "update_element_template",
+            "delete_element_template",
+        }
+        assert expected <= names
+
+    def test_create_element_schema_includes_template_id(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        props = defs["create_element"].inputSchema["properties"]
+        assert "template_id" in props
+
+    def test_create_element_required_relaxed(self) -> None:
+        """When template_id is supplied, element_type and name may
+        come from the template — they must not be required at the
+        MCP schema level."""
+        defs = {t.name: t for t in tools.tool_definitions()}
+        required = defs["create_element"].inputSchema.get("required", [])
+        assert "element_type" not in required
+        assert "name" not in required
+
+    def test_create_element_template_required_fields(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        required = defs["create_element_template"].inputSchema["required"]
+        assert "source_element_id" in required
+        assert "name" in required
+        assert "included_fields" in required
+
+
+class TestCreateElementTemplateForward:
+    @pytest.mark.anyio
+    async def test_forwards_full_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(201, json=_template_response()),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._create_element_template(c, {
+                "source_element_id": "el-1",
+                "name": "Tpl",
+                "description": "d",
+                "included_fields": ["name", "description"],
+                "set_id": "s-1",
+                "is_global": False,
+            })
+        body = json.loads(route.calls[0].request.content)
+        assert body == {
+            "source_element_id": "el-1",
+            "name": "Tpl",
+            "description": "d",
+            "included_fields": ["name", "description"],
+            "set_id": "s-1",
+            "is_global": False,
+        }
+
+    @pytest.mark.anyio
+    async def test_global_omits_set_id(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(
+                201, json=_template_response(set_id=None, is_global=True),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._create_element_template(c, {
+                "source_element_id": "el-1",
+                "name": "Tpl",
+                "included_fields": ["name"],
+                "is_global": True,
+            })
+        body = json.loads(route.calls[0].request.content)
+        assert body["is_global"] is True
+        assert "set_id" not in body
+
+
+class TestListGetUpdateDelete:
+    @pytest.mark.anyio
+    async def test_list_forwards_filters(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.get(f"{BASE}/api/element-templates").mock(
+            return_value=httpx.Response(
+                200, json={
+                    "items": [_template_response()],
+                    "total": 1, "page": 1, "page_size": 50,
+                },
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._list_element_templates(c, {
+                "set_id": "s-1", "include_global": False,
+                "page": 2, "limit": 10,
+            })
+        url = str(route.calls[0].request.url)
+        assert "set_id=s-1" in url
+        assert "include_global=False" in url or "include_global=false" in url
+        assert "page=2" in url
+        assert "page_size=10" in url
+
+    @pytest.mark.anyio
+    async def test_get_returns_template(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(200, json=_template_response()),
+        )
+        async with IrisClient(BASE) as c:
+            result = await tools._get_element_template(c, {"template_id": "t-1"})
+        assert "t-1" in result
+
+    @pytest.mark.anyio
+    async def test_update_forwards_only_supplied_fields(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.put(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(
+                200, json=_template_response(name="Renamed"),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._update_element_template(c, {
+                "template_id": "t-1", "name": "Renamed",
+            })
+        body = json.loads(route.calls[0].request.content)
+        assert body == {"name": "Renamed"}
+
+    @pytest.mark.anyio
+    async def test_update_promote_to_global_forwards_null_set_id(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.put(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(
+                200, json=_template_response(set_id=None, is_global=True),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._update_element_template(c, {
+                "template_id": "t-1",
+                "is_global": True,
+                "set_id": None,
+            })
+        body = json.loads(route.calls[0].request.content)
+        assert body["is_global"] is True
+        assert body["set_id"] is None
+
+    @pytest.mark.anyio
+    async def test_delete_returns_success_payload(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.delete(f"{BASE}/api/element-templates/t-1").mock(
+            return_value=httpx.Response(204),
+        )
+        async with IrisClient(BASE) as c:
+            result = await tools._delete_element_template(
+                c, {"template_id": "t-1"},
+            )
+        body = json.loads(result)
+        assert body["success"] is True
+        assert body["template_id"] == "t-1"
+        assert body["deleted"] is True
+
+
+class TestCreateElementWithTemplate:
+    @pytest.mark.anyio
+    async def test_forwards_template_id_to_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(201, json={
+                "id": "el-new", "element_type": "component",
+                "current_version": 1, "name": "Templated",
+                "description": None, "data": {}, "set_id": "s-1",
+                "package_id": None, "package_name": None,
+                "notation": "simple",
+                "created_at": "2026-05-17T00:00:00+00:00",
+                "created_by": "u",
+                "updated_at": "2026-05-17T00:00:00+00:00",
+            }),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._create_element(c, {
+                "set_id": "s-1",
+                "template_id": "t-1",
+            })
+        body = json.loads(route.calls[0].request.content)
+        assert body["template_id"] == "t-1"
+        assert body["set_id"] == "s-1"
+        # element_type / name are absent (template fills them).
+        assert "element_type" not in body
+        assert "name" not in body

--- a/scripts/check_surface_parity.py
+++ b/scripts/check_surface_parity.py
@@ -40,7 +40,19 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 DOCUMENTED_ASYMMETRIES: tuple[tuple[str, str, str], ...] = (
     ("cli_only", "ask", "ADR-168 — MCP clients bring their own LLM"),
-    ("deferred_write", "delete_*",
+    # delete_* deferred ONLY for the original five entities (issue #133
+    # scope). New entities (e.g. element_template, ADR-191) are
+    # expected to expose delete on every surface — they're not
+    # eligible for the deferred-write blanket.
+    ("deferred_write", "delete_collection",
+     "out-of-scope for issue #133; needs a future ADR (audit, undo)"),
+    ("deferred_write", "delete_set",
+     "out-of-scope for issue #133; needs a future ADR (audit, undo)"),
+    ("deferred_write", "delete_package",
+     "out-of-scope for issue #133; needs a future ADR (audit, undo)"),
+    ("deferred_write", "delete_diagram",
+     "out-of-scope for issue #133; needs a future ADR (audit, undo)"),
+    ("deferred_write", "delete_element",
      "out-of-scope for issue #133; needs a future ADR (audit, undo)"),
     ("design_invariant", "move_element",
      "ADR-178 invariant — elements travel with their parent diagram"),
@@ -105,17 +117,20 @@ def parse_cli_writes() -> set[WriteOp]:
     """Scan CLI for write subcommand groups.
 
     Looks for `@{create,update,move,delete}_app.command("entity")`
-    decorators in cli/src/iris_cli/main.py.
+    decorators in cli/src/iris_cli/main.py. Entity names may be
+    kebab-case in the CLI (e.g. ``"element-template"``) — we
+    normalise to underscores for cross-surface comparison.
     """
     results: set[WriteOp] = set()
     cli_path = REPO_ROOT / "cli/src/iris_cli/main.py"
     text = cli_path.read_text(encoding="utf-8")
     pat = re.compile(
-        r'@(create|update|move|delete)_app\.command\(\s*"([a-z_]+)"',
+        r'@(create|update|move|delete)_app\.command\(\s*"([a-z_-]+)"',
     )
     for verb, entity in pat.findall(text):
-        if entity in _KNOWN_ENTITIES:
-            results.add(WriteOp("cli", verb, entity))
+        normalised = entity.replace("-", "_")
+        if normalised in _KNOWN_ENTITIES:
+            results.add(WriteOp("cli", verb, normalised))
     return results
 
 
@@ -124,6 +139,8 @@ def parse_cli_writes() -> set[WriteOp]:
 
 _KNOWN_ENTITIES = frozenset({
     "collection", "set", "package", "diagram", "element",
+    # v6.8.0 (ADR-191) — element templates have full write parity.
+    "element_template",
 })
 
 


### PR DESCRIPTION
## Summary

First-class **element templates** (ADR-191, [#153](https://github.com/cgbarlow/iris/issues/153)) — capture a user-selected subset of fields from any existing element, then pre-fill new elements from any template via REST, MCP, CLI, or the new UI affordances. Full surface parity per Protocol §14.

### Data model

- New table `element_templates` with paired migrations: SQLite **m067** and Supabase **m071** (mirror — `m067_*.sql` was already taken by the doview_analysis pointer fix).
- CHECK constraint enforces "set-scoped XOR global". Two partial indexes for the two list paths.
- Whitelist of 8 capturable fields: `name`, `description`, `element_type`, `notation`, `data`, `metadata`, `package_id`, `tags`. Anything outside is dropped at write time (security boundary).

### Surfaces

| Surface | What's new |
|---|---|
| REST | 5 endpoints under `/api/element-templates` + `template_id` on `POST /api/elements` (server-side merge — explicit fields win) |
| MCP | `create_element_template` / `list_element_templates` / `get_element_template` / `update_element_template` / `delete_element_template` + `template_id` on `create_element` |
| CLI | `iris create element-template …`, `iris update`/`delete`/`get`/`list element-template`, `iris create element --template-id` |
| Frontend | **Templates** button on `/elements` (opens `TemplatesListDialog`); **Save as template** on `/elements/[id]` (opens `CreateTemplateDialog`); new `/element-templates/[id]` detail page with Create-element-from-template flow + Delete |

`scripts/check_surface_parity.py` learns the new entity, accepts kebab-case CLI entity names (normalised to underscore), and treats `delete_element_template` as required on every surface — new entities are NOT under the issue-#133 deferred-delete blanket. ✅ Parity clean.

### Tests

**74 new tests, all green**:
- Backend: 27 CRUD/apply + 7 schema (`backend/tests/test_element_templates/`, `test_element_templates_schema.py`)
- MCP: 12 (`mcp/tests/test_element_templates.py`)
- CLI: 8 (`cli/tests/test_element_templates.py`)
- Frontend: 20 (`frontend/tests/unit/elementTemplates.test.ts`)

## Test plan

- [x] `pytest backend/tests/test_element_templates/ backend/tests/test_migrations/test_element_templates_schema.py` (34 passed)
- [x] `pytest mcp/tests/test_element_templates.py` (12 passed)
- [x] `pytest cli/tests/test_element_templates.py` (8 passed)
- [x] `npx vitest run tests/unit/elementTemplates.test.ts tests/unit/packageRelationshipsTab.test.ts` (29 passed)
- [x] `python scripts/check_surface_parity.py` — clean
- [x] `./scripts/dev.sh restart` smoke — m067 applied at startup, `element_templates` table present with the 12 expected columns
- [ ] **Release ordering**: apply Supabase `m071_element_templates.sql` via `scripts/supabase-migrate.sh` **before** the Render code deploy (Protocol §15).
- [ ] Spot-check production end-to-end: create template → use template → delete template; once via UI, once via MCP, once via CLI.

## Docs

- **ADR-191** — Element Templates (full WH(Y), with rejected alternatives and dependency chain into ADR-184 / ADR-182 / Protocol §14 + §15)
- **SPEC-191-A** — implementation spec (schema, surface contracts, frontend wiring, sanitisation, test inventory, rollout)
- **CHANGELOG `[6.8.0]`** — Added + Migrations sections
- **README** — new Element Templates subsection
- **Version bump** — `frontend/package.json` and `mcp/pyproject.toml` → `6.8.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)