### PR TITLE
fix(v6.8.1): five next-label issues — #162, #164, #165, #166, #167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.1] - 2026-05-17
+
+### Fixed
+
+- **Dynamic List view crashes with `marked(): input parameter is
+  undefined or null`** (issue
+  [#167](https://github.com/cgbarlow/iris/issues/167)). Two-part
+  fix: `DynamicListCanvas` now passes the markdown content under
+  the prop name `MarkdownView` actually declares (`source`, not
+  `markdown`); `renderMarkdown()` coalesces `undefined` / `null`
+  to `''` defensively so the same class of bug can't bite other
+  callers. DOMPurify still runs after `marked` per Protocol §7.
+- **Class element attributes inconsistent across diagrams** (ADR-192,
+  SPEC-192-A, issue
+  [#164](https://github.com/cgbarlow/iris/issues/164)). The canvas
+  used to mint nodes with only `label / entityType / description /
+  entityId / notation`, dropping class attributes, operations,
+  literals and visual overrides. Three near-identical mini-builders
+  on `views/[id]/+page.svelte` now route through a new shared
+  `elementToNodeData()` helper, so the renderer always sees a
+  complete shape and `refreshNodeDescriptions` carries
+  backend-authored attributes forward.
+- **Package Relationships tab always empty** (issue
+  [#166](https://github.com/cgbarlow/iris/issues/166)). The
+  frontend asked for `?page_size=200` on
+  `GET /api/packages/{id}/elements`; the router capped at
+  `le=100`, so every request 422'd and the silent catch on the
+  frontend hid the failure as "No elements in this package."
+  Backend cap raised to `le=500`; frontend surfaces fetch errors
+  in a banner instead of swallowing them.
+
+### Changed
+
+- **Hierarchy sidebar uniformity** (ADR-194, SPEC-194-A, issue
+  [#162](https://github.com/cgbarlow/iris/issues/162)).
+  `HierarchyControls` defaults shrunk to compact density
+  (`px-2 py-1 text-xs` triggers; `px-3 py-1 text-xs` menu items).
+  The packages-detail sidebar drops its bespoke "+ Child" dropdown
+  and inline `Diagrams` toggle and adopts the shared
+  `HierarchyControls` + `showDiagrams` / `showText` model that
+  Dashboard / Views list / View detail already use. All four
+  hierarchy surfaces now read visually identical.
+- **"Save as template" dialog clarifies the `Data` field** (issue
+  [#165](https://github.com/cgbarlow/iris/issues/165)). The
+  ambiguous "Data payload" label is renamed to "Data (attributes,
+  operations, visual…)" and the dialog gains help text explaining
+  what `Data` vs `Metadata` capture — class element attributes
+  already round-tripped through templates via the `data` field;
+  users couldn't tell from the old label.
+
 ## [6.8.0] - 2026-05-17
 
 ### Added

--- a/backend/app/packages/router.py
+++ b/backend/app/packages/router.py
@@ -188,7 +188,10 @@ async def get_package_elements_route(
     package_id: str,
     request: Request,
     page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=50, ge=1, le=100),
+    # Issue #166: cap raised from 100 → 500 so callers (notably the
+    # /packages/[id] Relationships tab) can request a comfortable
+    # page_size without 422-ing.
+    page_size: int = Query(default=50, ge=1, le=500),
     _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
 ) -> ElementListResponse:
     """List elements that belong to this package (ADR-184)."""

--- a/backend/tests/test_element_templates/test_crud_and_apply.py
+++ b/backend/tests/test_element_templates/test_crud_and_apply.py
@@ -498,3 +498,66 @@ class TestApplyTemplate:
             headers=h,
         )
         assert r.status_code == 404
+
+    async def test_template_captures_class_attributes(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Issue #165: class element ``attributes`` are part of
+        ``element_versions.data`` JSON, so checking the 'data' field
+        in the dialog must round-trip them through the template into
+        a new element.
+        """
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        attrs = [
+            {"name": "price", "type": "string", "scope": "Private"},
+            {"name": "qty", "type": "int"},
+        ]
+        # Source element: a UML class with structured attributes.
+        src = await client.post(
+            "/api/elements",
+            json={
+                "set_id": set_id,
+                "element_type": "class",
+                "notation": "uml",
+                "name": "Order",
+                "data": {"attributes": attrs, "operations": ["ship()"]},
+            },
+            headers=h,
+        )
+        assert src.status_code == 201, src.text
+        src_id = src.json()["id"]
+
+        # Build a template that captures the data field only.
+        tpl = await client.post(
+            "/api/element-templates",
+            json={
+                "source_element_id": src_id,
+                "name": "Class with attrs",
+                "included_fields": ["element_type", "notation", "data"],
+                "set_id": set_id,
+                "is_global": False,
+            },
+            headers=h,
+        )
+        assert tpl.status_code == 201, tpl.text
+        tpl_data = tpl.json()["template_data"]
+        assert tpl_data["data"]["attributes"] == attrs
+        assert tpl_data["data"]["operations"] == ["ship()"]
+
+        # Create a new element from the template — attributes carry through.
+        new_el = await client.post(
+            "/api/elements",
+            json={
+                "set_id": set_id,
+                "template_id": tpl.json()["id"],
+                "name": "Order Copy",
+            },
+            headers=h,
+        )
+        assert new_el.status_code == 201, new_el.text
+        body = new_el.json()
+        assert body["element_type"] == "class"
+        assert body["notation"] == "uml"
+        assert body["data"]["attributes"] == attrs
+        assert body["data"]["operations"] == ["ship()"]

--- a/backend/tests/test_elements/test_package_membership.py
+++ b/backend/tests/test_elements/test_package_membership.py
@@ -364,6 +364,56 @@ class TestPackageElementsEndpoint:
         assert in_b["body"]["id"] not in ids
         assert body["total"] == 1
 
+    async def test_empty_package_returns_empty_list(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Issue #166: empty package returns 200 + [], not an error."""
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        pkg = await _create_package(client, headers, set_id=set_id)
+
+        resp = await client.get(f"/api/packages/{pkg}/elements")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    async def test_page_size_200_accepted(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Issue #166 root cause: frontend asked page_size=200 and the
+        router's ``le=100`` cap returned 422. The cap is now ``le=500``
+        so the relationships tab loads.
+        """
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        pkg = await _create_package(client, headers, set_id=set_id)
+        await _create_element(
+            client, headers, set_id=set_id, package_id=pkg, name="Only",
+        )
+
+        resp = await client.get(
+            f"/api/packages/{pkg}/elements?page_size=200",
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["page_size"] == 200
+        assert body["total"] == 1
+        assert len(body["items"]) == 1
+
+    async def test_page_size_over_cap_returns_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Cap is raised to 500 — anything beyond still 422."""
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        pkg = await _create_package(client, headers, set_id=set_id)
+
+        resp = await client.get(
+            f"/api/packages/{pkg}/elements?page_size=501",
+        )
+        assert resp.status_code == 422
+
 
 class TestDiagramRelationshipsAugmentation:
     """GET /api/diagrams/{id}/relationships gains element_package_memberships."""

--- a/docs/adrs/ADR-192-Canvas-Node-Hydration-From-Element.md
+++ b/docs/adrs/ADR-192-Canvas-Node-Hydration-From-Element.md
@@ -1,0 +1,120 @@
+# ADR-192: Canvas node hydration from element
+
+Status: Accepted (2026-05-17)
+Extends: [ADR-184](ADR-184-Element-Package-Membership.md), [ADR-190](ADR-190-Class-Diagram-Type-Under-Simple-Notation.md)
+Implements: Issue [#164](https://github.com/cgbarlow/iris/issues/164)
+Spec: [SPEC-192-A](specs/SPEC-192-A-Canvas-Node-Hydration.md)
+
+## Context
+
+Issue [#164](https://github.com/cgbarlow/iris/issues/164) — two
+class-UML elements ("rankedtrajectory" and "test ingredient") rendered
+inconsistently on the canvas. Same `notation=uml`, same
+`element_type=class`, same theme, but one showed its attribute
+compartment populated while the other showed only the name with no
+visible attributes.
+
+Investigation traced the divergence to **how each element's canvas
+node was minted**, not to the renderer:
+
+- `frontend/src/lib/canvas/renderers/UmlRenderer.svelte` reads
+  `data.attributes` off the node and renders the compartment under
+  `{#if attributes && attributes.length > 0}`. The renderer is
+  innocent — given the right data, it renders correctly.
+- The view-detail page (`frontend/src/routes/views/[id]/+page.svelte`)
+  had **three** places that built `node.data` from an `Element`:
+  1. `handleAddElement` (create new element on canvas) — populated
+     only `label / entityType / description / entityId / notation`.
+  2. `handleLinkElement` (link an existing element onto canvas) —
+     same shape; dropped any class attributes the source element had.
+  3. `refreshNodeDescriptions` (post-load sync from the backend) —
+     synced `label / description / diagramUsageCount` only.
+
+So if a user authored class attributes on `/elements/[id]` after the
+node was placed, the canvas node never picked them up. Two class
+elements created on different paths would render with totally
+different completeness.
+
+This is also a Protocol §13 (DRY) violation: three near-identical
+mini-builders that drifted apart in subtle ways.
+
+## Decision
+
+Introduce a single source of truth for "given a backend `Element`,
+produce the canvas node `data` payload":
+
+```ts
+// frontend/src/lib/canvas/elementToNodeData.ts
+export function elementToNodeData(element: Element): ElementNodeData {
+  const data = (element.data ?? {}) as Record<string, unknown>;
+  return {
+    label: element.name,
+    entityType: element.element_type as SimpleEntityType,
+    description: element.description ?? '',
+    entityId: element.id,
+    notation: element.notation ?? 'simple',
+    attributes:  data.attributes,
+    operations:  data.operations,
+    literals:    data.literals,
+    stereotype:  data.stereotype,
+    qualifier:   data.qualifier,
+    visual:      data.visual as NodeVisualOverrides | undefined,
+    diagramUsageCount: element.diagram_usage_count ?? 0,
+  };
+}
+```
+
+All three call sites on `views/[id]/+page.svelte` are refactored to
+use this helper. `refreshNodeDescriptions` keeps its description
+"starts-with-label" trim for BPMN-style payloads, but otherwise
+performs a wholesale merge of the hydrated fields.
+
+`ElementNodeData` declares an open index signature `[key: string]:
+unknown` so it remains assignable to `CanvasNodeData`.
+
+## Why not bake this into the renderer
+
+The renderer's contract is to read from `node.data`. Making it fetch
+the element on the fly would mean a network call per render — bad
+for canvases with dozens of nodes — and would break the
+dirty-tracking model that powers undo/redo. The canvas-stored copy
+of `data` remains the source of truth for the canvas; the helper
+just ensures the copy is *complete* the moment it's minted and
+*refreshed* whenever `refreshNodeDescriptions` runs.
+
+## Why not store attributes on the canvas
+
+The element's `data` payload already lives in `element_versions.data`
+on the backend. Duplicating it in the diagram's `nodes[].data` would
+diverge two sources of truth (which is what caused #164 in the first
+place). The helper closes the loop: every time the canvas reads, it
+hydrates from the element; every time the user navigates back, it
+re-hydrates.
+
+## Consequences
+
+- New file: `frontend/src/lib/canvas/elementToNodeData.ts`.
+- Refactor: three call sites on
+  `frontend/src/routes/views/[id]/+page.svelte` use the helper.
+- Tests: `frontend/tests/unit/elementToNodeData.test.ts` — 9 shape
+  cases covering class attributes, operations, literals, visual
+  overrides, missing data, default diagramUsageCount.
+- No backend changes; no migration; no MCP / CLI changes.
+- CHANGELOG `[6.8.1]` Fixed entry referencing #164.
+
+## Verification
+
+- `npx vitest run tests/unit/elementToNodeData.test.ts` — 9 green.
+- `npx vitest run tests/unit/markdownView.test.ts tests/unit/packageRelationshipsTab.test.ts tests/unit/elementTemplates.test.ts tests/unit/hierarchyControls.test.ts` — full suite remains green.
+- Manual smoke on `./scripts/dev.sh start`: edit a class element's
+  attributes on `/elements/[id]`, return to a diagram containing
+  that element, attributes appear in the compartment after
+  `refreshNodeDescriptions` fires.
+
+## See also
+
+- Issue [#164](https://github.com/cgbarlow/iris/issues/164).
+- [ADR-190](ADR-190-Class-Diagram-Type-Under-Simple-Notation.md) —
+  the prior class-under-simple work that surfaced this gap.
+- `frontend/src/lib/canvas/renderers/UmlRenderer.svelte:75` — the
+  consumer of the hydrated shape.

--- a/docs/adrs/ADR-194-Hierarchy-Sidebar-Uniformity.md
+++ b/docs/adrs/ADR-194-Hierarchy-Sidebar-Uniformity.md
@@ -1,0 +1,138 @@
+# ADR-194: Hierarchy sidebar uniformity across Dashboard / Views / Packages
+
+Status: Accepted (2026-05-17)
+Extends: [ADR-189](ADR-189-Package-Relationships-Tab.md)
+Implements: Issue [#162](https://github.com/cgbarlow/iris/issues/162)
+Spec: [SPEC-194-A](specs/SPEC-194-A-Hierarchy-Sidebar-Uniformity.md)
+
+## Context
+
+Issue [#162](https://github.com/cgbarlow/iris/issues/162) — the
+hierarchy panel on the views page had buttons that were too large
+after the v5.6.1 DRY refactor (which unified Dashboard and Views to
+the shared `HierarchyControls.svelte`). The packages-detail page,
+on the other hand, had a bespoke inline dropdown ("+ Child" → Diagram
+/ Package) and a "Diagrams" toggle button that the user liked
+visually but did **not** use the shared component.
+
+So the actual state in v6.8.0 was:
+
+| Surface | Hierarchy controls source |
+|---|---|
+| Dashboard (`/+page.svelte`) | `<HierarchyControls>` (large buttons) |
+| Views list (`/views/+page.svelte`) | `<HierarchyControls>` (large buttons) |
+| View detail (`/views/[id]/+page.svelte`) | `<HierarchyControls>` (large buttons) |
+| Package detail (`/packages/[id]/+page.svelte`) | **Bespoke inline dropdown + Diagrams toggle** (compact buttons) |
+
+Two failure modes:
+1. **Visual inconsistency** — the shared component's `px-3 py-1.5
+   text-sm` buttons read large compared to the surrounding UI on the
+   detail pages, while the bespoke packages compact controls felt
+   right.
+2. **DRY drift** — packages detail re-implemented the "+ New →
+   Package | Diagram" dropdown UI logic the shared component already
+   owned. The packages page also passed `showDiagramsOnly` to
+   `TreeNode` while the other surfaces passed `showDiagrams` /
+   `showText`.
+
+The user's brief: "use the same code from dashboard for hierarchy
+area on view page, but styling that the size of the buttons and
+text uses is as per the 'packages' screen, which is as it used to
+be on the view screen, and is perfect. Then make 'packages' screen
+consistent with the 'view' page."
+
+## Decision
+
+Two changes, paired:
+
+1. **Shrink `HierarchyControls` defaults to compact** —
+   `px-2 py-1 text-xs` on the two trigger buttons; `px-3 py-1
+   text-xs` on the dropdown menu items and Show checkboxes. No
+   `size` prop — every existing caller wants the smaller density;
+   YAGNI on the larger variant.
+2. **Replace the packages-detail bespoke dropdown with
+   `<HierarchyControls>`** — the same component, the same compact
+   styling, the same prop shape. The component's `oncreatepackage`
+   handler maps to the packages page's `showCreateChildPackageDialog`
+   flag; `oncreateview` maps to `showCreateChildDiagramDialog`. The
+   packages page drops its `showChildMenu` local state entirely.
+3. **Normalise TreeNode props on the packages page** — replace the
+   `treeDiagramsOnly` boolean and `showDiagramsOnly` prop with
+   `showDiagrams` / `showText` driven by the shared component's
+   checkboxes. `TreeNode` already accepts both shapes (it has
+   carried `showDiagrams` / `showText` since #27), so this is a
+   prop-rename, not a TreeNode change.
+
+After this change, all four surfaces use the same component and the
+same prop names. Future hierarchy work should never reintroduce a
+parallel implementation.
+
+## Why not add a size prop
+
+Every existing caller wants the smaller density (the user
+explicitly cited packages-page styling as "perfect"). Adding a
+size prop would create configuration surface without a real
+consumer. If a future surface needs larger buttons it can be added
+then, behind a real requirement.
+
+## Why drop `showDiagramsOnly`
+
+The boolean was packages-page-specific and meant "hide packages
+that have no descendant diagrams." Its behaviour was strictly a
+subset of the more flexible `showDiagrams` / `showText` model: with
+both flags on (the default), packages are always shown, and only
+text-class diagrams can be hidden. The original use case was
+"declutter when looking for diagrams," which is satisfied by
+`showText=false`.
+
+## Consequences
+
+- `frontend/src/lib/components/HierarchyControls.svelte` — class
+  strings shrunk; no API change.
+- `frontend/src/routes/packages/[id]/+page.svelte` — imports
+  `HierarchyControls`; drops `showChildMenu` state, drops
+  `treeDiagramsOnly` state, adds `showDiagrams` / `showText` state;
+  the sidebar header renders `<HierarchyControls>` instead of the
+  inline dropdown; `<TreeNode>` invocation uses the new props.
+- Existing tests pass without change: Dashboard, Views list and
+  View detail already used the shared component — only the visual
+  density changes.
+- New tests:
+  - `frontend/tests/unit/hierarchyControls.test.ts` — three
+    assertions for compact class strings.
+  - `frontend/tests/unit/packagesPageHierarchy.test.ts` — five
+    assertions for the packages-page DRY refactor.
+- No backend changes; no migration; no MCP / CLI changes.
+- CHANGELOG `[6.8.1]`.
+
+## Verification
+
+```
+npx vitest run \
+  tests/unit/hierarchyControls.test.ts \
+  tests/unit/packagesPageHierarchy.test.ts \
+  tests/unit/hierarchyControlsViews.test.ts \
+  tests/unit/dashboardHierarchy.test.ts \
+  tests/unit/packageRelationshipsTab.test.ts
+```
+
+All green.
+
+Manual:
+
+1. `./scripts/dev.sh start`
+2. Visit `/` (Dashboard), `/views`, `/views/{id}`, and
+   `/packages/{id}`.
+3. The "+ New" / "Show" controls in each hierarchy area read
+   visually identical and use the compact density.
+4. On `/packages/{id}`, click "+ New" — the dropdown lists
+   `Package` and `View` (creating children under the current
+   package via the existing dialogs).
+5. The Show checkboxes (`Diagrams`, `Text`) drive `TreeNode`'s
+   filtering identically across surfaces.
+
+## See also
+
+- Issue [#162](https://github.com/cgbarlow/iris/issues/162).
+- [ADR-189](ADR-189-Package-Relationships-Tab.md) — the prior
+  packages-detail work that left the hierarchy refactor unfinished.

--- a/docs/adrs/specs/SPEC-192-A-Canvas-Node-Hydration.md
+++ b/docs/adrs/specs/SPEC-192-A-Canvas-Node-Hydration.md
@@ -1,0 +1,115 @@
+# SPEC-192-A: Canvas node hydration from element
+
+Implements: [ADR-192](../ADR-192-Canvas-Node-Hydration-From-Element.md)
+Resolves: Issue [#164](https://github.com/cgbarlow/iris/issues/164)
+Status: Living
+
+## Surface
+
+Single helper exported from `frontend/src/lib/canvas/elementToNodeData.ts`:
+
+```ts
+export interface ElementNodeData {
+  label: string;
+  entityType: SimpleEntityType;
+  description: string;
+  entityId: string;
+  notation: string;
+  attributes?: unknown;
+  operations?: unknown;
+  literals?: unknown;
+  stereotype?: unknown;
+  qualifier?: unknown;
+  visual?: NodeVisualOverrides;
+  diagramUsageCount: number;
+  [key: string]: unknown;            // mirror CanvasNodeData
+}
+
+export function elementToNodeData(element: Element): ElementNodeData;
+```
+
+The open index signature keeps the helper assignable directly to
+`CanvasNodeData` without a cast.
+
+## Call sites
+
+| File:line | Function | Behaviour |
+|---|---|---|
+| `frontend/src/routes/views/[id]/+page.svelte:~1156` | `handleAddElement` (non-BPMN branch) | New node's `data` is `elementToNodeData(created)` from the POST response. |
+| `frontend/src/routes/views/[id]/+page.svelte:~1556` | `handleLinkElement` (non-BPMN branch) | Same shape when binding an existing element to a fresh canvas node. |
+| `frontend/src/routes/views/[id]/+page.svelte:~614` | `refreshNodeDescriptions` | For each node with `entityId`, fetch the element, hydrate via the helper, merge over existing data (preserves canvas-specific keys), keep the description "starts-with-label" trim for BPMN. |
+
+`refreshNodeDescriptions` diff-checks the hydrated fields
+(`label / description / diagramUsageCount / attributes / operations /
+literals / stereotype / qualifier`) and only triggers a state update
+when at least one has changed.
+
+## Fields hydrated and their sources
+
+| Field on node.data | Source on Element | Default |
+|---|---|---|
+| `label` | `element.name` | (required) |
+| `entityType` | `element.element_type` cast to `SimpleEntityType` | (required) |
+| `description` | `element.description` | `''` |
+| `entityId` | `element.id` | (required) |
+| `notation` | `element.notation` | `'simple'` |
+| `attributes` | `element.data.attributes` | `undefined` |
+| `operations` | `element.data.operations` | `undefined` |
+| `literals` | `element.data.literals` | `undefined` |
+| `stereotype` | `element.data.stereotype` | `undefined` |
+| `qualifier` | `element.data.qualifier` | `undefined` |
+| `visual` | `element.data.visual` | `undefined` |
+| `diagramUsageCount` | `element.diagram_usage_count` | `0` |
+
+BPMN-specific shape (`bpmnDefaultDiscriminators`) is **not** routed
+through this helper — BPMN nodes have a different `data` contract
+(see `handleAddElement` BPMN branch). Future refactor could collapse
+the BPMN branch too, but is out of scope for issue #164.
+
+## Tests
+
+`frontend/tests/unit/elementToNodeData.test.ts` — 9 cases:
+
+1. Carries label, entityType, entityId, description, notation.
+2. Coerces missing description to empty string.
+3. Defaults notation to "simple".
+4. Hydrates class attributes from `data.attributes`.
+5. Hydrates operations + literals + stereotype + qualifier.
+6. Passes through `visual` overrides.
+7. Handles an element with no `data` field.
+8. Reads `diagramUsageCount` from `diagram_usage_count`.
+9. Defaults `diagramUsageCount` to 0.
+
+## Acceptance criteria
+
+- Class elements show their attributes on every diagram they appear
+  on, including after attributes are added/edited via
+  `/elements/[id]` (without a hard reload — `refreshNodeDescriptions`
+  picks them up on next navigation back to the diagram).
+- No regression to BPMN flow, which still uses
+  `bpmnDefaultDiscriminators` for `data.data`.
+- No regression to undo/redo — node `data` remains canvas-state of
+  record; the helper just keeps it complete and refreshed.
+
+## Verification
+
+```
+cd frontend
+npx vitest run tests/unit/elementToNodeData.test.ts \
+                tests/unit/markdownView.test.ts \
+                tests/unit/packageRelationshipsTab.test.ts \
+                tests/unit/elementTemplates.test.ts \
+                tests/unit/hierarchyControls.test.ts \
+                tests/unit/packagesPageHierarchy.test.ts
+```
+
+All green.
+
+Manual:
+
+1. `./scripts/dev.sh restart`
+2. Browse to a class element. Add 2 attributes; save.
+3. Open a diagram that contains the element. Attributes show in the
+   class compartment.
+4. Add the same element to a new diagram via "Link Element" — the
+   new node also renders with the attributes.

--- a/docs/adrs/specs/SPEC-194-A-Hierarchy-Sidebar-Uniformity.md
+++ b/docs/adrs/specs/SPEC-194-A-Hierarchy-Sidebar-Uniformity.md
@@ -1,0 +1,91 @@
+# SPEC-194-A: Hierarchy sidebar uniformity
+
+Implements: [ADR-194](../ADR-194-Hierarchy-Sidebar-Uniformity.md)
+Resolves: Issue [#162](https://github.com/cgbarlow/iris/issues/162)
+Status: Living
+
+## Shared component
+
+`frontend/src/lib/components/HierarchyControls.svelte`
+
+```svelte
+interface Props {
+  showDiagrams: boolean;
+  showText: boolean;
+  onShowDiagrams: (v: boolean) => void;
+  onShowText:     (v: boolean) => void;
+  oncreateview:    () => void;
+  oncreatepackage: () => void;
+}
+```
+
+Density: trigger buttons `px-2 py-1 text-xs`; dropdown menu items
+`px-3 py-1 text-xs`; Show checkboxes `px-3 py-1 text-xs`. No `size`
+prop — single density.
+
+## Call sites
+
+| File:line | Wires |
+|---|---|
+| `frontend/src/routes/+page.svelte:631` | Dashboard root — creates top-level packages and views |
+| `frontend/src/routes/views/+page.svelte:390` | Views list — creates top-level packages and views |
+| `frontend/src/routes/views/[id]/+page.svelte:2088` | View detail sidebar — creates *child* of current diagram's package |
+| `frontend/src/routes/packages/[id]/+page.svelte:~514` | Packages detail sidebar — creates *child* of current package |
+
+All four pass `{showDiagrams}` / `{showText}` (Svelte 5 shorthand).
+On the two detail pages, the `oncreatepackage` / `oncreateview`
+handlers open the page-specific child-creation dialogs.
+
+## TreeNode prop normalisation
+
+`TreeNode` accepts both `showDiagrams` / `showText` (issue #27 era)
+and the older `showDiagramsOnly` boolean. The packages-detail page
+historically used `showDiagramsOnly`; this spec drops that path so
+all surfaces drive `TreeNode` the same way. `showDiagramsOnly`
+remains in `TreeNode`'s prop list because no caller uses it after
+this change — a future cleanup can delete the dead branch.
+
+## Tests
+
+`frontend/tests/unit/hierarchyControls.test.ts` — adds 3 cases:
+
+1. Trigger buttons use compact `px-2 py-1 text-xs`.
+2. Dropdown items use compact `px-3 py-1 text-xs`.
+3. The old larger `px-3 py-1.5 text-sm` / `px-4 py-1.5 text-sm`
+   strings are gone.
+
+`frontend/tests/unit/packagesPageHierarchy.test.ts` (new) — 5 cases:
+
+1. `HierarchyControls` is imported.
+2. It's mounted in the sidebar.
+3. `oncreatepackage` and `oncreateview` wire to the existing
+   child-creation dialog flags.
+4. The old bespoke `showChildMenu` / `+ Child` dropdown is gone.
+5. `TreeNode` receives `showDiagrams` / `showText`, not
+   `showDiagramsOnly`.
+
+## Acceptance criteria
+
+- Visual density across Dashboard / Views / View detail / Packages
+  detail is identical.
+- "+ New" dropdown on every surface offers the same Package / View
+  pair (sub-meanings differ — root vs child).
+- Show checkboxes (`Diagrams`, `Text`) drive `TreeNode` filtering
+  identically on every surface.
+- No regression to the existing keyboard/aria affordances on
+  `HierarchyControls`.
+
+## Verification
+
+```
+npx vitest run \
+  tests/unit/hierarchyControls.test.ts \
+  tests/unit/packagesPageHierarchy.test.ts \
+  tests/unit/hierarchyControlsViews.test.ts \
+  tests/unit/dashboardHierarchy.test.ts \
+  tests/unit/packageRelationshipsTab.test.ts
+```
+
+All green.
+
+Manual smoke per ADR-194.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.0",
+	"version": "6.8.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/elementToNodeData.ts
+++ b/frontend/src/lib/canvas/elementToNodeData.ts
@@ -1,0 +1,56 @@
+/**
+ * Builds the canvas-node ``data`` payload from a backend Element
+ * (ADR-192, issue #164).
+ *
+ * The view-detail page used to mint nodes with only label / entityType /
+ * description / entityId / notation, dropping class attributes,
+ * operations, literals and any visual overrides. That caused
+ * inconsistencies on /views/[id] for class elements whose structured
+ * payload was edited via /elements/[id] — the canvas node never
+ * picked the change up.
+ *
+ * Single source of truth: every call site that turns an Element into
+ * a node payload goes through here so the renderer (``UmlRenderer``
+ * et al.) gets a complete data shape. Protocol §13 (DRY).
+ */
+import type { Element } from '$lib/types/api';
+import type { NodeVisualOverrides, SimpleEntityType } from '$lib/types/canvas';
+
+/** Shape consumed by the canvas renderers — compatible with CanvasNodeData. */
+export interface ElementNodeData {
+	label: string;
+	entityType: SimpleEntityType;
+	description: string;
+	entityId: string;
+	notation: string;
+	attributes?: unknown;
+	operations?: unknown;
+	literals?: unknown;
+	stereotype?: unknown;
+	qualifier?: unknown;
+	visual?: NodeVisualOverrides;
+	diagramUsageCount: number;
+	// CanvasNodeData has an open index signature — mirror it so this
+	// type is assignable directly without a cast.
+	[key: string]: unknown;
+}
+
+export function elementToNodeData(element: Element): ElementNodeData {
+	const data = (element.data ?? {}) as Record<string, unknown>;
+	return {
+		label: element.name,
+		// Backend ``element_type`` is the string form of SimpleEntityType;
+		// the cast mirrors the explicit cast at the historical call sites.
+		entityType: element.element_type as SimpleEntityType,
+		description: element.description ?? '',
+		entityId: element.id,
+		notation: element.notation ?? 'simple',
+		attributes: data.attributes,
+		operations: data.operations,
+		literals: data.literals,
+		stereotype: data.stereotype,
+		qualifier: data.qualifier,
+		visual: data.visual as NodeVisualOverrides | undefined,
+		diagramUsageCount: element.diagram_usage_count ?? 0,
+	};
+}

--- a/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
+++ b/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
@@ -89,7 +89,7 @@
 
 <div class="dynamic-list-canvas" style="padding: 1rem">
 	<MarkdownView
-		markdown={content}
+		source={content}
 		{textDiagramIds}
 		{onheadings}
 	/>

--- a/frontend/src/lib/components/CreateTemplateDialog.svelte
+++ b/frontend/src/lib/components/CreateTemplateDialog.svelte
@@ -11,12 +11,16 @@
 	import DOMPurify from 'dompurify';
 	import { apiFetch, ApiError } from '$lib/utils/api';
 
+	// Issue #165: the original "Data payload" label hid the fact that
+	// class elements' attributes / operations / literals all live
+	// inside element.data. Users assumed they had to be promoted
+	// individually and gave up. The expanded label spells it out.
 	const FIELD_OPTIONS: { value: string; label: string }[] = [
 		{ value: 'name', label: 'Name' },
 		{ value: 'description', label: 'Description' },
 		{ value: 'element_type', label: 'Type' },
 		{ value: 'notation', label: 'Notation' },
-		{ value: 'data', label: 'Data payload' },
+		{ value: 'data', label: 'Data (attributes, operations, visual…)' },
 		{ value: 'metadata', label: 'Metadata' },
 		{ value: 'package_id', label: 'Package membership' },
 		{ value: 'tags', label: 'Tags' },
@@ -159,6 +163,10 @@
 						</label>
 					{/each}
 				</div>
+				<p class="mt-2 text-xs" style="color: var(--color-muted)">
+					'Data' captures the element's structured contents — for class elements that includes its
+					attributes and operations. 'Metadata' is admin info like timestamps and author.
+				</p>
 			</fieldset>
 
 			<label class="flex items-center gap-2 text-sm">

--- a/frontend/src/lib/components/HierarchyControls.svelte
+++ b/frontend/src/lib/components/HierarchyControls.svelte
@@ -44,7 +44,7 @@
 		<button
 			type="button"
 			onclick={() => { newOpen = !newOpen; showOpen = false; }}
-			class="whitespace-nowrap rounded px-3 py-1.5 text-sm text-white"
+			class="whitespace-nowrap rounded px-2 py-1 text-xs text-white"
 			style="background-color: var(--color-primary)"
 			aria-haspopup="menu"
 			aria-expanded={newOpen}
@@ -62,7 +62,7 @@
 				<button
 					role="menuitem"
 					onclick={() => { oncreatepackage(); closeAll(); }}
-					class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
+					class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
 					style="color: var(--color-fg)"
 				>
 					Package
@@ -70,7 +70,7 @@
 				<button
 					role="menuitem"
 					onclick={() => { oncreateview(); closeAll(); }}
-					class="block w-full px-4 py-1.5 text-left text-sm hover:opacity-80"
+					class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
 					style="color: var(--color-fg); padding-left: 2rem"
 				>
 					View
@@ -83,7 +83,7 @@
 		<button
 			type="button"
 			onclick={() => { showOpen = !showOpen; newOpen = false; }}
-			class="whitespace-nowrap rounded border px-3 py-1.5 text-sm"
+			class="whitespace-nowrap rounded border px-2 py-1 text-xs"
 			style="border-color: var(--color-border); color: var(--color-fg)"
 			aria-haspopup="menu"
 			aria-expanded={showOpen}
@@ -107,7 +107,7 @@
 					Views
 				</div>
 				<label
-					class="flex cursor-pointer items-center gap-2 px-4 py-1.5 text-sm hover:opacity-80"
+					class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
 					style="color: var(--color-fg)"
 				>
 					<input
@@ -118,7 +118,7 @@
 					Diagrams
 				</label>
 				<label
-					class="flex cursor-pointer items-center gap-2 px-4 py-1.5 text-sm hover:opacity-80"
+					class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
 					style="color: var(--color-fg)"
 				>
 					<input

--- a/frontend/src/lib/components/markdownHelpers.ts
+++ b/frontend/src/lib/components/markdownHelpers.ts
@@ -86,7 +86,9 @@ export interface RenderedMarkdown {
  * caller's CSS can apply muted colour (issue #26).
  */
 export function renderMarkdown(source: string, textDiagramIds?: Set<string>): RenderedMarkdown {
-	const raw = marked.parse(source, { async: false }) as string;
+	// Issue #167: defend against undefined/null. Fresh Dynamic List views
+	// can arrive with no body yet; marked throws on non-string input.
+	const raw = marked.parse(source ?? '', { async: false }) as string;
 
 	// Issue #32 reopen: User Guide images use absolute paths (e.g.
 	// `/guide/dashboard.png`) — those have no scheme so the original

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -4,6 +4,7 @@
 	import { apiFetch, ApiError } from '$lib/utils/api';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import DiagramDialog from '$lib/components/DiagramDialog.svelte';
+	import HierarchyControls from '$lib/components/HierarchyControls.svelte';
 	import PackagePicker from '$lib/components/PackagePicker.svelte';
 	import TreeNode from '$lib/components/TreeNode.svelte';
 	import VersionHistory from '$lib/components/VersionHistory.svelte';
@@ -61,6 +62,7 @@
 	let packageElementsLoading = $state(false);
 	let packageElementsTotal = $state(0);
 	let packageElementsLoaded = $state(false);
+	let packageElementsError = $state<string | null>(null);
 	let showDeleteDialog = $state(false);
 	let deleteMessage = $state('Are you sure you want to delete this package? This action cannot be undone.');
 	let cloneLoading = $state(false);
@@ -71,7 +73,6 @@
 	let contextItems = $derived(getAiContextItems());
 	let isInContext = $derived(pkg ? contextItems.some((i) => i.id === pkg!.id) : false);
 	let showParentPicker = $state(false);
-	let showChildMenu = $state(false);
 	let showCreateChildDiagramDialog = $state(false);
 	let showCreateChildPackageDialog = $state(false);
 	let childPackageName = $state('');
@@ -94,7 +95,12 @@
 	let hierarchyTree = $state<DiagramHierarchyNode[]>([]);
 	let hierarchyLoading = $state(false);
 	let treeSearchQuery = $state('');
-	let treeDiagramsOnly = $state(false);
+	// ADR-194 / issue #162: align tree filters with the shared
+	// HierarchyControls model (showDiagrams / showText). The earlier
+	// ``treeDiagramsOnly`` boolean only filtered packages with content,
+	// which was inconsistent with Dashboard / Views detail.
+	let showDiagrams = $state(true);
+	let showText = $state(true);
 	let treeExpandedIds = $state(new Set<string>());
 
 	$effect(() => {
@@ -158,7 +164,14 @@
 		// Lazy-loaded the first time the Relationships tab is opened
 		// (issue #157, ADR-188). Uses the existing
 		// GET /api/packages/{id}/elements endpoint from ADR-184.
+		//
+		// Issue #166: the previous ``?page_size=200`` violated the
+		// router's old ``le=100`` cap and 422'd silently — every
+		// package looked empty. Backend cap is now ``le=500`` and the
+		// frontend asks for 200; errors surface in
+		// ``packageElementsError`` instead of being swallowed.
 		packageElementsLoading = true;
+		packageElementsError = null;
 		try {
 			const resp = await apiFetch<{
 				items: PackageElement[];
@@ -168,9 +181,10 @@
 			}>(`/api/packages/${id}/elements?page_size=200`);
 			packageElements = resp.items;
 			packageElementsTotal = resp.total;
-		} catch {
+		} catch (e) {
 			packageElements = [];
 			packageElementsTotal = 0;
+			packageElementsError = e instanceof ApiError ? e.message : 'Failed to load package elements';
 		}
 		packageElementsLoaded = true;
 		packageElementsLoading = false;
@@ -503,55 +517,19 @@
 			>
 				<div class="flex items-center justify-between p-3" style="border-bottom: 1px solid var(--color-border)">
 					<span class="text-sm font-semibold" style="color: var(--color-fg)">Hierarchy</span>
-					<div class="flex items-center gap-1">
-						<button
-							onclick={() => (treeDiagramsOnly = !treeDiagramsOnly)}
-							class="rounded px-2 py-1 text-xs"
-							style="border: 1px solid {treeDiagramsOnly ? 'var(--color-primary)' : 'var(--color-border)'}; color: {treeDiagramsOnly ? 'var(--color-primary)' : 'var(--color-fg)'}; background: {treeDiagramsOnly ? 'var(--color-surface, transparent)' : 'transparent'}"
-							title="Show only items with child diagrams"
-							aria-pressed={treeDiagramsOnly}
-						>
-							Diagrams
-						</button>
-						<div style="position: relative">
-							<button
-								onclick={() => (showChildMenu = !showChildMenu)}
-								class="rounded px-2 py-1 text-xs"
-								style="background: var(--color-primary); color: white"
-								title="Create child item"
-							>
-								+ Child
-							</button>
-							{#if showChildMenu}
-								<!-- svelte-ignore a11y_no_static_element_interactions -->
-								<div
-									style="position: fixed; inset: 0; z-index: 9"
-									onclick={() => (showChildMenu = false)}
-									onkeydown={(e) => { if (e.key === 'Escape') showChildMenu = false; }}
-								></div>
-								<div
-									style="position: absolute; top: 100%; right: 0; z-index: 10; min-width: 120px"
-									class="mt-1 rounded border shadow-md"
-									style:border-color="var(--color-border)"
-									style:background-color="var(--color-surface)"
-								>
-									<button
-										onclick={() => { showCreateChildDiagramDialog = true; showChildMenu = false; }}
-										class="block w-full px-3 py-2 text-left text-xs hover:opacity-80"
-										style="color: var(--color-fg)"
-									>
-										Diagram
-									</button>
-									<button
-										onclick={() => { showCreateChildPackageDialog = true; showChildMenu = false; }}
-										class="block w-full px-3 py-2 text-left text-xs hover:opacity-80"
-										style="color: var(--color-fg); border-top: 1px solid var(--color-border)"
-									>
-										Package
-									</button>
-								</div>
-							{/if}
-						</div>
+					<div class="flex items-center gap-2">
+						<!-- ADR-194 (issue #162): shared HierarchyControls so the
+							 toolbar matches Dashboard / Views detail. + New here
+							 creates a CHILD of the current package, hence the
+							 packages-page-specific dialog handlers. -->
+						<HierarchyControls
+							{showDiagrams}
+							{showText}
+							onShowDiagrams={(v) => (showDiagrams = v)}
+							onShowText={(v) => (showText = v)}
+							oncreateview={() => (showCreateChildDiagramDialog = true)}
+							oncreatepackage={() => (showCreateChildPackageDialog = true)}
+						/>
 						<button
 							onclick={() => { sidebarOpen = false; localStorage.setItem('iris-hierarchy-sidebar-open', 'false'); }}
 							class="rounded p-1 text-xs"
@@ -580,7 +558,7 @@
 					{:else}
 						<ul role="tree">
 							{#each hierarchyTree as node (node.id)}
-								<TreeNode {node} currentDiagramId={pkg.id} searchQuery={treeSearchQuery} showDiagramsOnly={treeDiagramsOnly} expandedIds={treeExpandedIds} />
+								<TreeNode {node} currentDiagramId={pkg.id} searchQuery={treeSearchQuery} {showDiagrams} {showText} expandedIds={treeExpandedIds} />
 							{/each}
 						</ul>
 					{/if}
@@ -868,6 +846,11 @@
 				</h2>
 				{#if packageElementsLoading}
 					<p class="text-sm" style="color: var(--color-muted)">Loading elements…</p>
+				{:else if packageElementsError}
+					<p class="rounded border px-3 py-2 text-sm" role="alert"
+						style="color: var(--color-danger); border-color: var(--color-danger); background: var(--color-surface)">
+						Failed to load package elements: {packageElementsError}
+					</p>
 				{:else if packageElements.length === 0}
 					<p class="text-sm" style="color: var(--color-muted)">No elements in this package.</p>
 				{:else}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -46,6 +46,7 @@
 	import { getActiveThemeId, loadThemes, areThemesLoaded, resolveNodeVisual } from '$lib/stores/themeStore.svelte';
 	import { Accordion } from 'bits-ui';
 	import { createCanvasHistory } from '$lib/canvas/useCanvasHistory.svelte';
+	import { elementToNodeData } from '$lib/canvas/elementToNodeData';
 	import { createLockManager } from '$lib/utils/locks.svelte';
 	import DOMPurify from 'dompurify';
 	import type { Element, DiagramHierarchyNode, Package } from '$lib/types/api';
@@ -610,7 +611,10 @@
 		loading = false;
 	}
 
-	/** Sync node descriptions from linked elements (WP-5). */
+	/** Sync node data from linked elements. Originally label+description
+	 *  only (WP-5); now hydrates via elementToNodeData() so class
+	 *  attributes/operations/literals authored later on /elements/[id]
+	 *  appear on the canvas without a hard reload (ADR-192, issue #164). */
 	async function refreshNodeDescriptions() {
 		let updated = false;
 		const refreshed = await Promise.all(
@@ -619,19 +623,26 @@
 				if (!entityId) return node;
 				try {
 					const element = await apiFetch<Element>(`/api/elements/${entityId}`);
-					const rawDesc = element.description ?? '';
-					const desc = rawDesc.startsWith(node.data.label) ? rawDesc.slice(rawDesc.indexOf('\n') + 1).replace(/^\r?\n/, '') : rawDesc;
-					if (desc !== node.data.description || element.name !== node.data.label || (node.data as Record<string, unknown>).diagramUsageCount !== (element.diagram_usage_count ?? 0)) {
+					const hydrated = elementToNodeData(element);
+					// Keep the description's "starts-with-label" trim so
+					// BPMN-style payloads don't double-show the title.
+					const rawDesc = hydrated.description;
+					const desc = rawDesc.startsWith(hydrated.label)
+						? rawDesc.slice(rawDesc.indexOf('\n') + 1).replace(/^\r?\n/, '')
+						: rawDesc;
+					const prev = node.data as Record<string, unknown>;
+					const next: Record<string, unknown> = { ...node.data, ...hydrated, description: desc };
+					const diffKeys = [
+						'label', 'description', 'diagramUsageCount',
+						'attributes', 'operations', 'literals',
+						'stereotype', 'qualifier',
+					];
+					const changed = diffKeys.some((k) =>
+						JSON.stringify(next[k]) !== JSON.stringify(prev[k]),
+					);
+					if (changed) {
 						updated = true;
-						return {
-							...node,
-							data: {
-								...node.data,
-								label: element.name,
-								description: desc,
-								diagramUsageCount: element.diagram_usage_count ?? 0,
-							},
-						};
+						return { ...node, data: next as typeof node.data };
 					}
 				} catch { /* element may be deleted */ }
 				return node;
@@ -1159,13 +1170,12 @@
 				type: elementType,
 				position: findOpenPosition(),
 				width: 200,
-				data: {
-					label: name,
-					entityType: elementType,
-					description,
-					entityId: created.id,
-					notation: effectiveNotation,
-				},
+				// ADR-192 (issue #164): hydrate the node from the backend
+				// element so class compartments / visuals / stereotypes
+				// stay in sync. New elements still arrive with empty
+				// data, but any future enrichment is picked up by
+				// refreshNodeDescriptions.
+				data: elementToNodeData(created),
 			};
 			history.pushState(canvasNodes, canvasEdges);
 			canvasNodes = [...canvasNodes, newNode];
@@ -1559,13 +1569,10 @@
 			type: elementType,
 			position: findOpenPosition(),
 			width: 200,
-			data: {
-				label: element.name,
-				entityType: elementType,
-				description: element.description ?? '',
-				entityId: element.id,
-				notation: element.notation ?? 'simple',
-			},
+			// ADR-192 (issue #164): use the shared hydrator so class
+			// attributes/operations/literals authored on /elements/[id]
+			// show up the moment the element is linked onto the canvas.
+			data: elementToNodeData(element),
 		};
 		history.pushState(canvasNodes, canvasEdges);
 		canvasNodes = [...canvasNodes, newNode];

--- a/frontend/tests/unit/descriptionSync.test.ts
+++ b/frontend/tests/unit/descriptionSync.test.ts
@@ -30,9 +30,11 @@ describe('Node description sync', () => {
 	it('fetches element data for nodes with entityId', () => {
 		// The function should fetch element data for nodes with entityId
 		expect(pageSrc).toContain("node.data?.entityId");
-		// And update label and description
-		expect(pageSrc).toContain('element.name');
-		expect(pageSrc).toContain('element.description');
+		// ADR-192 (issue #164): label + description (and all other
+		// renderer-visible fields) now flow through the shared
+		// elementToNodeData() helper.
+		expect(pageSrc).toContain('elementToNodeData(element)');
+		expect(pageSrc).toMatch(/hydrated\.(label|description)/);
 	});
 
 	it('uses Promise.all for parallel entity fetching', () => {

--- a/frontend/tests/unit/elementTemplates.test.ts
+++ b/frontend/tests/unit/elementTemplates.test.ts
@@ -117,6 +117,18 @@ describe('CreateTemplateDialog — field whitelist + scoping', () => {
 	it('flips set_id to null when promoting to global', () => {
 		expect(createTemplateDialogSrc).toContain('set_id: isGlobal ? null : setId');
 	});
+
+	it("clarifies the 'data' label so users know it covers class attributes (issue #165)", () => {
+		// The opaque "Data payload" label hid the fact that class
+		// attributes / operations / literals all live in element.data.
+		expect(createTemplateDialogSrc).not.toMatch(/label:\s*'Data payload'/);
+		expect(createTemplateDialogSrc).toMatch(/label:\s*'Data \(attributes, operations, visual…\)'/);
+	});
+
+	it('renders help text explaining what Data vs Metadata capture', () => {
+		expect(createTemplateDialogSrc).toContain('class elements');
+		expect(createTemplateDialogSrc).toContain('attributes and operations');
+	});
 });
 
 describe('Element template detail page', () => {

--- a/frontend/tests/unit/elementToNodeData.test.ts
+++ b/frontend/tests/unit/elementToNodeData.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for the shared elementToNodeData() helper (ADR-192, issue #164).
+ *
+ * Backstory: canvas nodes were minted with only label/entityType/
+ * description/entityId/notation. Class element attributes / operations /
+ * literals lived on the backend ``element.data`` JSON but never made
+ * it onto the node — so a class element whose attributes were edited
+ * via the element-detail page showed empty compartments on diagrams.
+ *
+ * The helper is the single source of truth for "given a backend
+ * Element, produce the canvas node ``data`` payload". Used by
+ * handleAddElement, handleLinkElement, and refreshNodeDescriptions
+ * on /views/[id]/+page.svelte.
+ */
+import { describe, it, expect } from 'vitest';
+import { elementToNodeData } from '$lib/canvas/elementToNodeData';
+import type { Element } from '$lib/types/api';
+
+const base: Element = {
+	id: 'el-1',
+	element_type: 'class',
+	current_version: 1,
+	name: 'Order',
+	description: 'An order placed by a customer.',
+	data: {},
+	created_at: '2026-05-17T00:00:00Z',
+	created_by: 'u1',
+	updated_at: '2026-05-17T00:00:00Z',
+	is_deleted: false,
+};
+
+describe('elementToNodeData', () => {
+	it('carries label, entityType, entityId, description, notation from the element', () => {
+		const node = elementToNodeData({ ...base, notation: 'uml' });
+		expect(node.label).toBe('Order');
+		expect(node.entityType).toBe('class');
+		expect(node.entityId).toBe('el-1');
+		expect(node.description).toBe('An order placed by a customer.');
+		expect(node.notation).toBe('uml');
+	});
+
+	it('coerces missing description to empty string', () => {
+		const node = elementToNodeData({ ...base, description: null });
+		expect(node.description).toBe('');
+	});
+
+	it('defaults notation to "simple" when the element does not set one', () => {
+		const node = elementToNodeData({ ...base, notation: undefined });
+		expect(node.notation).toBe('simple');
+	});
+
+	it('hydrates class attributes from element.data.attributes', () => {
+		const attributes = [
+			{ name: 'id', type: 'string', scope: 'Private' as const },
+			{ name: 'total', type: 'number' },
+		];
+		const node = elementToNodeData({ ...base, data: { attributes } });
+		expect(node.attributes).toEqual(attributes);
+	});
+
+	it('hydrates operations + literals + stereotype + qualifier from element.data', () => {
+		const node = elementToNodeData({
+			...base,
+			data: {
+				operations: ['ship()', 'cancel()'],
+				literals: ['ACTIVE', 'CLOSED'],
+				stereotype: 'entity',
+				qualifier: 'inventory',
+			},
+		});
+		expect(node.operations).toEqual(['ship()', 'cancel()']);
+		expect(node.literals).toEqual(['ACTIVE', 'CLOSED']);
+		expect(node.stereotype).toBe('entity');
+		expect(node.qualifier).toBe('inventory');
+	});
+
+	it('passes through visual overrides on element.data.visual', () => {
+		const visual = { width: 300, height: 120, icon: 'box' };
+		const node = elementToNodeData({ ...base, data: { visual } });
+		expect(node.visual).toEqual(visual);
+	});
+
+	it('handles an element with no data field (treats as empty)', () => {
+		const node = elementToNodeData({ ...base, data: undefined as unknown as Record<string, unknown> });
+		expect(node.attributes).toBeUndefined();
+		expect(node.operations).toBeUndefined();
+		expect(node.label).toBe('Order');
+	});
+
+	it('reads diagramUsageCount from the element', () => {
+		const node = elementToNodeData({ ...base, diagram_usage_count: 7 });
+		expect(node.diagramUsageCount).toBe(7);
+	});
+
+	it('defaults diagramUsageCount to 0 when not provided', () => {
+		const node = elementToNodeData(base);
+		expect(node.diagramUsageCount).toBe(0);
+	});
+});

--- a/frontend/tests/unit/hierarchyControls.test.ts
+++ b/frontend/tests/unit/hierarchyControls.test.ts
@@ -65,3 +65,25 @@ describe('HierarchyControls (issue #27)', () => {
 		expect(src).toMatch(/isPackage \|\| /);
 	});
 });
+
+describe('HierarchyControls — compact sizing (issue #162)', () => {
+	it('the "+ New" and "Show" trigger buttons use compact px-2 py-1 text-xs', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		// Both top-level buttons render at the smaller density now.
+		const triggers = src.match(/whitespace-nowrap rounded[^"]*px-2 py-1 text-xs/g) ?? [];
+		expect(triggers.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('the dropdown menu items use compact px-3 py-1 text-xs', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		const items = src.match(/block w-full px-3 py-1 text-left text-xs/g) ?? [];
+		// Two top-level menus + Diagrams/Text checkboxes use the compact style.
+		expect(items.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it('does not use the old larger px-3 py-1.5 text-sm sizing anywhere', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		expect(src).not.toMatch(/px-3 py-1\.5 text-sm/);
+		expect(src).not.toMatch(/px-4 py-1\.5 text-sm/);
+	});
+});

--- a/frontend/tests/unit/markdownView.test.ts
+++ b/frontend/tests/unit/markdownView.test.ts
@@ -12,6 +12,26 @@ import {
 	urlIsAllowed,
 } from '$lib/components/markdownHelpers';
 
+describe('renderMarkdown — null/empty input safety (issue #167)', () => {
+	it('returns empty html when source is undefined', () => {
+		const { html, links } = renderMarkdown(undefined as unknown as string);
+		expect(html).toBe('');
+		expect(links).toEqual([]);
+	});
+
+	it('returns empty html when source is null', () => {
+		const { html, links } = renderMarkdown(null as unknown as string);
+		expect(html).toBe('');
+		expect(links).toEqual([]);
+	});
+
+	it('returns empty html when source is the empty string', () => {
+		const { html, links } = renderMarkdown('');
+		expect(html).toBe('');
+		expect(links).toEqual([]);
+	});
+});
+
 describe('renderMarkdown — sanitisation (protocol #7)', () => {
 	it('strips <script> tags from the source', () => {
 		const { html } = renderMarkdown('# Heading\n\n<script>window.__pwned = true;</script>\n\nBody.');

--- a/frontend/tests/unit/packageRelationshipsTab.test.ts
+++ b/frontend/tests/unit/packageRelationshipsTab.test.ts
@@ -70,3 +70,25 @@ describe('Package detail relationships tab — UI affordance', () => {
 		expect(pkgPageSrc).toContain('!packageElementsLoaded');
 	});
 });
+
+describe('Package detail relationships tab — fetch error handling (issue #166)', () => {
+	it('declares packageElementsError state', () => {
+		expect(pkgPageSrc).toContain('packageElementsError');
+	});
+
+	it('captures the error in loadPackageElements catch instead of swallowing it', () => {
+		// The earlier "catch {…}" silently hid the 422 produced by the
+		// page_size cap mismatch. Verify the new shape captures e.message.
+		expect(pkgPageSrc).toMatch(/catch\s*\(e\)/);
+		expect(pkgPageSrc).toContain('packageElementsError = e instanceof ApiError');
+	});
+
+	it("renders an alert banner when packageElementsError is set", () => {
+		expect(pkgPageSrc).toContain('Failed to load package elements');
+		expect(pkgPageSrc).toMatch(/role="alert"/);
+	});
+
+	it('clears any prior error at the start of a new load', () => {
+		expect(pkgPageSrc).toContain('packageElementsError = null');
+	});
+});

--- a/frontend/tests/unit/packagesPageHierarchy.test.ts
+++ b/frontend/tests/unit/packagesPageHierarchy.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Packages-detail hierarchy sidebar uniformity (ADR-194, issue #162).
+ *
+ * The packages-detail page used to roll its own "+ Child" dropdown +
+ * "Diagrams" toggle inside the hierarchy sidebar — different look,
+ * different prop shape on TreeNode — while Dashboard and View-detail
+ * used the shared HierarchyControls component. Issue #162 closes that
+ * DRY gap.
+ *
+ * Static-parser style for parity with hierarchyControls.test.ts and
+ * packageRelationshipsTab.test.ts.
+ */
+// @ts-nocheck — Node.js imports (fs, path) not typed under SvelteKit tsconfig; Vitest resolves at runtime.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(import.meta.dirname, '../..');
+const PKG_DETAIL = resolve(ROOT, 'src/routes/packages/[id]/+page.svelte');
+
+describe('Packages detail page hierarchy — uses shared HierarchyControls', () => {
+	it('imports HierarchyControls', () => {
+		const src = readFileSync(PKG_DETAIL, 'utf-8');
+		expect(src).toMatch(/import HierarchyControls from '\$lib\/components\/HierarchyControls\.svelte'/);
+	});
+
+	it('mounts HierarchyControls in the hierarchy sidebar', () => {
+		const src = readFileSync(PKG_DETAIL, 'utf-8');
+		expect(src).toContain('<HierarchyControls');
+	});
+
+	it("wires the dropdown's create handlers to the existing child-creation dialogs", () => {
+		const src = readFileSync(PKG_DETAIL, 'utf-8');
+		// The shared component takes oncreatepackage / oncreateview; the
+		// packages page maps them to its child-creation dialog flags.
+		expect(src).toMatch(/oncreatepackage=\{[^}]*showCreateChildPackageDialog\s*=\s*true/);
+		expect(src).toMatch(/oncreateview=\{[^}]*showCreateChildDiagramDialog\s*=\s*true/);
+	});
+
+	it('removes the bespoke "+ Child" dropdown trigger that used to live inline', () => {
+		const src = readFileSync(PKG_DETAIL, 'utf-8');
+		// The old inline dropdown was driven by a ``showChildMenu`` flag —
+		// HierarchyControls owns its own menu state now.
+		expect(src).not.toMatch(/showChildMenu\s*=\s*\$state/);
+		expect(src).not.toMatch(/\+ Child/);
+	});
+
+	it('normalises the TreeNode props to showDiagrams / showText (drops showDiagramsOnly)', () => {
+		const src = readFileSync(PKG_DETAIL, 'utf-8');
+		// Either the explicit ``showDiagrams={showDiagrams}`` form or
+		// the Svelte 5 ``{showDiagrams}`` shorthand is accepted.
+		expect(src).toMatch(/<TreeNode[^/>]*(showDiagrams=|\{showDiagrams\})/);
+		expect(src).toMatch(/<TreeNode[^/>]*(showText=|\{showText\})/);
+		expect(src).not.toMatch(/showDiagramsOnly=\{treeDiagramsOnly\}/);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.0"
+version = "6.8.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Five UAT defects of v6.7–v6.8 surfaced after the packages-as-membership / class-under-simple / element-templates / dynamic-list wave. All resolved in one patch release.

| # | Title | Fix shape |
|---|---|---|
| [#167](https://github.com/cgbarlow/iris/issues/167) | Dynamic List view throws `marked(): input parameter is undefined or null` | Prop-name typo (`markdown`→`source`) + `marked.parse(source ?? '')` defensive guard |
| [#164](https://github.com/cgbarlow/iris/issues/164) | Class attributes inconsistent across diagrams | ADR-192 / SPEC-192-A — new `elementToNodeData()` helper hydrates renderer-visible shape; three call sites refactored (Protocol §13 DRY) |
| [#166](https://github.com/cgbarlow/iris/issues/166) | Package Relationships tab always empty | Backend cap `le=100`→`le=500`; frontend surfaces fetch errors in a banner instead of silent catch |
| [#162](https://github.com/cgbarlow/iris/issues/162) | Hierarchy sidebar inconsistent | ADR-194 / SPEC-194-A — `HierarchyControls` defaults shrunk to compact; packages-detail adopts shared component (drops bespoke "+ Child" dropdown) |
| [#165](https://github.com/cgbarlow/iris/issues/165) | "Save as template" doesn't surface class attributes | Rename `Data payload`→`Data (attributes, operations, visual…)` + help text. Capability already worked via `data` field — the label hid it. |

## What's in this PR

**Code**
- `frontend/src/lib/canvas/elementToNodeData.ts` (new) — shared helper
- `frontend/src/routes/views/[id]/+page.svelte` — three call sites use the helper
- `frontend/src/routes/packages/[id]/+page.svelte` — adopts `HierarchyControls`, surfaces fetch errors
- `frontend/src/lib/components/HierarchyControls.svelte` — compact density
- `frontend/src/lib/components/CreateTemplateDialog.svelte` — clearer label + help text
- `frontend/src/lib/canvas/text/DynamicListCanvas.svelte` — prop name fix
- `frontend/src/lib/components/markdownHelpers.ts` — null guard
- `backend/app/packages/router.py` — `page_size` cap raised

**Docs**
- ADR-192 + SPEC-192-A (canvas node hydration)
- ADR-194 + SPEC-194-A (hierarchy sidebar uniformity)
- CHANGELOG `[6.8.1]` — Fixed + Changed

**Versions**
- `frontend/package.json` → 6.8.1
- `mcp/pyproject.toml` → 6.8.1

## Tests added

**Frontend (vitest)** — 28 new assertions across 7 files:
- `tests/unit/elementToNodeData.test.ts` (NEW, 9) — shape variants
- `tests/unit/packagesPageHierarchy.test.ts` (NEW, 5) — DRY refactor assertions
- `tests/unit/markdownView.test.ts` (+3) — null/undefined/empty input safety
- `tests/unit/packageRelationshipsTab.test.ts` (+4) — error banner + state
- `tests/unit/hierarchyControls.test.ts` (+3) — compact-class assertions
- `tests/unit/elementTemplates.test.ts` (+2) — label/help text
- `tests/unit/descriptionSync.test.ts` — updated to assert new helper-driven shape

**Backend (pytest)** — 5 new cases:
- `test_package_membership.py::TestPackageElementsEndpoint::test_empty_package_returns_empty_list`
- `…::test_page_size_200_accepted` (was the failing case before the fix)
- `…::test_page_size_over_cap_returns_422`
- `test_element_templates/test_crud_and_apply.py::TestApplyTemplate::test_template_captures_class_attributes`

## Test plan

- [x] `cd frontend && npx vitest run` — 1071/1074 pass (3 remaining failures pre-existing baseline, unrelated)
- [x] `cd backend && pytest tests/test_packages tests/test_elements tests/test_element_templates tests/test_migrations` — 292/294 pass (2 pre-existing baseline failures, unrelated)
- [x] `cd mcp && pytest` — 237/238 pass (1 pre-existing baseline failure, unrelated)
- [x] `cd cli && pytest` — 56/56 pass
- [x] `python scripts/check_surface_parity.py` — clean
- [ ] **Manual smoke** (record outcomes here):
  - [ ] `#167` Create a new Dynamic List view → load it → no console error.
  - [ ] `#164` Edit a class element's attributes on `/elements/[id]`; open a diagram containing it; attributes render.
  - [ ] `#166` Open `/packages/{id}` Relationships tab; element list now appears; force a 422 (e.g. invalid id) → banner shows.
  - [ ] `#162` Visually compare Dashboard / Views list / View detail / Packages detail — same compact hierarchy controls.
  - [ ] `#165` "Save as template" on a class element → checkbox reads "Data (attributes, operations, visual…)"; help text visible; new element from template carries attributes.

## Protocol checklist

- §1/§2: ADR-192 + SPEC-192-A and ADR-194 + SPEC-194-A. #166/#167/#165 are contract/UX fixes without architectural decisions — CHANGELOG only.
- §3: TDD throughout — RED → GREEN on every fix.
- §4: Single feature branch `fix/v6.8.1-next-label-issues`.
- §5/§6: CHANGELOG `[6.8.1]`; tag + GH release after merge.
- §7: DOMPurify still wraps `marked.parse`. Null guard preserves the sanitiser pipeline.
- §9: Production code only — no stubs.
- §13 (DRY): elementToNodeData centralises node hydration; packages-detail now uses HierarchyControls.
- §14: surface parity green.
- §15: no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)