### PR TITLE
fix(v6.8.2): HierarchyControls dropdowns escape overflow containers (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.2] - 2026-05-17
+
+### Fixed
+
+- **HierarchyControls "Show" / "+ New" dropdowns clipped inside narrow
+  sidebars** (issue
+  [#169](https://github.com/cgbarlow/iris/issues/169)). On the
+  packages-detail page (and any other surface where the hierarchy
+  panel sits inside an `overflow-y: auto` / `overflow: hidden`
+  container), the dropdown menus were anchored with Tailwind
+  `absolute left-0`, so they got clipped at the ancestor's right
+  edge — the "Packages are always shown." footer ran off the visible
+  area. The menus now render with `position: fixed`, with viewport
+  coordinates computed from the trigger button's
+  `getBoundingClientRect()`. Fixed-position menus stay anchored to
+  the viewport, so they close on any scroll.
+
 ## [6.8.1] - 2026-05-17
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.1",
+	"version": "6.8.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/HierarchyControls.svelte
+++ b/frontend/src/lib/components/HierarchyControls.svelte
@@ -7,11 +7,19 @@
 	 *  - "+ New"  → create View | create Package
 	 *  - "Show"   → toggle Diagrams / Text visibility (Packages always shown)
 	 *
-	 * Issue #30: dropdowns anchor `left-0` so the menu extends rightwards
-	 * from the button. `right-0` clipped under the AppShell on the
-	 * Dashboard hierarchy panel because that panel sits flush-left and
-	 * a leftward menu had nowhere to go.
+	 * Issue #169: the menus used `position: absolute` anchored `left-0`
+	 * against a `<div class="relative">` parent. On the packages-detail
+	 * sidebar (and other callers whose ancestor sets `overflow-y: auto`
+	 * or `overflow: hidden`), the menu got clipped at the container's
+	 * right edge. Switching to `position: fixed` with viewport-anchored
+	 * coordinates from `getBoundingClientRect()` lets the menu escape
+	 * any ancestor overflow.
+	 *
+	 * Fixed-position menus do not follow the page when it scrolls, so
+	 * we close them on scroll — the user can re-open with one click.
 	 */
+	import { onMount } from 'svelte';
+
 	interface Props {
 		showDiagrams: boolean;
 		showText: boolean;
@@ -32,18 +40,50 @@
 
 	let newOpen = $state(false);
 	let showOpen = $state(false);
+	let newButtonEl = $state<HTMLButtonElement | undefined>(undefined);
+	let showButtonEl = $state<HTMLButtonElement | undefined>(undefined);
+	let newMenuPos = $state({ top: 0, left: 0 });
+	let showMenuPos = $state({ top: 0, left: 0 });
+
+	function positionFor(btn: HTMLButtonElement | undefined) {
+		if (!btn) return { top: 0, left: 0 };
+		const r = btn.getBoundingClientRect();
+		return { top: r.bottom + 4, left: r.left };
+	}
+
+	function toggleNew() {
+		if (!newOpen) newMenuPos = positionFor(newButtonEl);
+		newOpen = !newOpen;
+		showOpen = false;
+	}
+
+	function toggleShow() {
+		if (!showOpen) showMenuPos = positionFor(showButtonEl);
+		showOpen = !showOpen;
+		newOpen = false;
+	}
 
 	function closeAll() {
 		newOpen = false;
 		showOpen = false;
 	}
+
+	onMount(() => {
+		// Fixed-position menus stay glued to the viewport while the page
+		// scrolls under them — close on any scroll to keep the menu
+		// visually attached to its trigger.
+		const handler = () => { if (newOpen || showOpen) closeAll(); };
+		window.addEventListener('scroll', handler, true);
+		return () => window.removeEventListener('scroll', handler, true);
+	});
 </script>
 
 <div class="flex items-center gap-2">
-	<div class="relative">
+	<div>
 		<button
+			bind:this={newButtonEl}
 			type="button"
-			onclick={() => { newOpen = !newOpen; showOpen = false; }}
+			onclick={toggleNew}
 			class="whitespace-nowrap rounded px-2 py-1 text-xs text-white"
 			style="background-color: var(--color-primary)"
 			aria-haspopup="menu"
@@ -51,38 +91,13 @@
 		>
 			+ New ▾
 		</button>
-		{#if newOpen}
-			<!-- v5.4.1 (#46 item #3): Package above View, with View indented to
-				 visually convey the package → view containment relationship. -->
-			<div
-				role="menu"
-				class="absolute left-0 z-50 mt-1 min-w-[160px] rounded border py-1 shadow-lg"
-				style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
-			>
-				<button
-					role="menuitem"
-					onclick={() => { oncreatepackage(); closeAll(); }}
-					class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
-					style="color: var(--color-fg)"
-				>
-					Package
-				</button>
-				<button
-					role="menuitem"
-					onclick={() => { oncreateview(); closeAll(); }}
-					class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
-					style="color: var(--color-fg); padding-left: 2rem"
-				>
-					View
-				</button>
-			</div>
-		{/if}
 	</div>
 
-	<div class="relative">
+	<div>
 		<button
+			bind:this={showButtonEl}
 			type="button"
-			onclick={() => { showOpen = !showOpen; newOpen = false; }}
+			onclick={toggleShow}
 			class="whitespace-nowrap rounded border px-2 py-1 text-xs"
 			style="border-color: var(--color-border); color: var(--color-fg)"
 			aria-haspopup="menu"
@@ -90,51 +105,79 @@
 		>
 			Show ▾
 		</button>
-		{#if showOpen}
-			<div
-				role="menu"
-				class="absolute left-0 z-50 mt-1 min-w-[180px] rounded border py-1 shadow-lg"
-				style="background-color: var(--color-bg, #fff); border-color: var(--color-border)"
-			>
-				<!-- v5.4.1 (#46 item #2): "Views" section header above the
-					 Diagrams checkbox. Greyed and non-interactive — informs the
-					 user that "Diagrams" is a kind of View, since the data model
-					 calls them diagrams but the UI calls them Views. -->
-				<div
-					class="px-4 pb-0.5 pt-1 text-xs uppercase tracking-wide"
-					style="color: var(--color-muted); pointer-events: none"
-				>
-					Views
-				</div>
-				<label
-					class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
-					style="color: var(--color-fg)"
-				>
-					<input
-						type="checkbox"
-						checked={showDiagrams}
-						onchange={(e) => onShowDiagrams((e.target as HTMLInputElement).checked)}
-					/>
-					Diagrams
-				</label>
-				<label
-					class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
-					style="color: var(--color-fg)"
-				>
-					<input
-						type="checkbox"
-						checked={showText}
-						onchange={(e) => onShowText((e.target as HTMLInputElement).checked)}
-					/>
-					Text
-				</label>
-				<p class="mt-1 px-4 py-1 text-xs" style="color: var(--color-muted)">
-					Packages are always shown.
-				</p>
-			</div>
-		{/if}
 	</div>
 </div>
+
+{#if newOpen}
+	<!-- v5.4.1 (#46 item #3): Package above View, with View indented to
+	     visually convey the package → view containment relationship. -->
+	<div
+		role="menu"
+		class="z-50 min-w-[160px] rounded border py-1 shadow-lg"
+		style="position: fixed; top: {newMenuPos.top}px; left: {newMenuPos.left}px; background-color: var(--color-bg, #fff); border-color: var(--color-border)"
+	>
+		<button
+			role="menuitem"
+			onclick={() => { oncreatepackage(); closeAll(); }}
+			class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
+			style="color: var(--color-fg)"
+		>
+			Package
+		</button>
+		<button
+			role="menuitem"
+			onclick={() => { oncreateview(); closeAll(); }}
+			class="block w-full px-3 py-1 text-left text-xs hover:opacity-80"
+			style="color: var(--color-fg); padding-left: 2rem"
+		>
+			View
+		</button>
+	</div>
+{/if}
+
+{#if showOpen}
+	<div
+		role="menu"
+		class="z-50 min-w-[180px] rounded border py-1 shadow-lg"
+		style="position: fixed; top: {showMenuPos.top}px; left: {showMenuPos.left}px; background-color: var(--color-bg, #fff); border-color: var(--color-border)"
+	>
+		<!-- v5.4.1 (#46 item #2): "Views" section header above the
+		     Diagrams checkbox. Greyed and non-interactive — informs the
+		     user that "Diagrams" is a kind of View, since the data model
+		     calls them diagrams but the UI calls them Views. -->
+		<div
+			class="px-4 pb-0.5 pt-1 text-xs uppercase tracking-wide"
+			style="color: var(--color-muted); pointer-events: none"
+		>
+			Views
+		</div>
+		<label
+			class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
+			style="color: var(--color-fg)"
+		>
+			<input
+				type="checkbox"
+				checked={showDiagrams}
+				onchange={(e) => onShowDiagrams((e.target as HTMLInputElement).checked)}
+			/>
+			Diagrams
+		</label>
+		<label
+			class="flex cursor-pointer items-center gap-2 px-3 py-1 text-xs hover:opacity-80"
+			style="color: var(--color-fg)"
+		>
+			<input
+				type="checkbox"
+				checked={showText}
+				onchange={(e) => onShowText((e.target as HTMLInputElement).checked)}
+			/>
+			Text
+		</label>
+		<p class="mt-1 px-4 py-1 text-xs" style="color: var(--color-muted)">
+			Packages are always shown.
+		</p>
+	</div>
+{/if}
 
 {#if newOpen || showOpen}
 	<!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/frontend/tests/unit/hierarchyControls.test.ts
+++ b/frontend/tests/unit/hierarchyControls.test.ts
@@ -66,6 +66,40 @@ describe('HierarchyControls (issue #27)', () => {
 	});
 });
 
+describe('HierarchyControls — dropdowns escape overflow containers (issue #169)', () => {
+	it('binds the trigger buttons so the dropdown can read their bounding box', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		// Both trigger buttons get a `bind:this` so we can call
+		// getBoundingClientRect() on them before opening the menu.
+		expect(src).toMatch(/bind:this=\{newButtonEl\}/);
+		expect(src).toMatch(/bind:this=\{showButtonEl\}/);
+	});
+
+	it('positions each dropdown with position: fixed so it escapes overflow ancestors', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		// The Tailwind `absolute` positioning was being clipped by
+		// `overflow-y: auto` / `overflow: hidden` on the parent asides
+		// (Dashboard, View detail, Packages detail). Switching to
+		// `position: fixed` removes that constraint.
+		const fixedHits = src.match(/position:\s*fixed/g) ?? [];
+		expect(fixedHits.length).toBeGreaterThanOrEqual(2);
+		// The old absolute classes should no longer be on the menu containers.
+		expect(src).not.toMatch(/<div\s+role="menu"\s+class="absolute/);
+	});
+
+	it('computes the menu position from the trigger button rect on open', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		expect(src).toMatch(/getBoundingClientRect\(\)/);
+	});
+
+	it('closes the dropdowns on scroll so they do not detach from the trigger', () => {
+		const src = readFileSync(COMPONENT, 'utf-8');
+		// Fixed-position menus stay glued to the viewport; close on
+		// scroll so the user never sees a floating orphan.
+		expect(src).toMatch(/addEventListener\(['"]scroll['"]/);
+	});
+});
+
 describe('HierarchyControls — compact sizing (issue #162)', () => {
 	it('the "+ New" and "Show" trigger buttons use compact px-2 py-1 text-xs', () => {
 		const src = readFileSync(COMPONENT, 'utf-8');

--- a/frontend/tests/unit/hierarchyControlsAlignment.test.ts
+++ b/frontend/tests/unit/hierarchyControlsAlignment.test.ts
@@ -4,35 +4,42 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 /**
- * Issue #30: dropdowns previously used `absolute right-0`, which on the
- * Dashboard's left-aligned hierarchy panel pushed the menu under the
- * AppShell nav. They now use `left-0` so the menu extends rightwards
- * from the button — visible in both the Dashboard panel (panel sits on
- * the page-content left edge) and the Views toolbar (button sits among
- * other toolbar items with room to the right).
+ * Issue #30 (original): dropdowns previously used `absolute right-0`,
+ * which on the Dashboard's left-aligned hierarchy panel pushed the
+ * menu under the AppShell nav. They were switched to `left-0` so the
+ * menu extends rightwards from the button.
+ *
+ * Issue #169 (this rev): the menus are now `position: fixed` with
+ * coordinates computed from `getBoundingClientRect()` of the trigger.
+ * Same visual outcome (menu opens *right and down* from the trigger,
+ * never to the left) but escapes any overflow ancestor.
  */
 const SRC = readFileSync(
 	resolve(import.meta.dirname, '../../src/lib/components/HierarchyControls.svelte'),
 	'utf-8',
 );
 
-describe('HierarchyControls dropdown alignment (issue #30)', () => {
-	it('the + New menu opens to the right (left-anchored)', () => {
+describe('HierarchyControls dropdown alignment (issues #30, #169)', () => {
+	it('the + New menu is positioned from the trigger button rect', () => {
 		expect(SRC).toMatch(/min-w-\[160px\]/);
-		const newMenu = SRC.match(/class="([^"]*min-w-\[160px\][^"]*)"/)?.[1] ?? '';
-		expect(newMenu).toContain('left-0');
-		expect(newMenu).not.toContain('right-0');
+		// New shape: inline style sets `left: {newMenuPos.left}px`, anchored
+		// to the trigger's bounding rect left edge (matches the prior left-0
+		// intent, but works across overflow contexts).
+		expect(SRC).toMatch(/left: \{newMenuPos\.left\}px/);
 	});
 
-	it('the Show menu opens to the right (left-anchored)', () => {
+	it('the Show menu is positioned from the trigger button rect', () => {
 		expect(SRC).toMatch(/min-w-\[180px\]/);
-		const showMenu = SRC.match(/class="([^"]*min-w-\[180px\][^"]*)"/)?.[1] ?? '';
-		expect(showMenu).toContain('left-0');
-		expect(showMenu).not.toContain('right-0');
+		expect(SRC).toMatch(/left: \{showMenuPos\.left\}px/);
 	});
 
-	it('regression guard — neither menu uses right-0', () => {
-		const occurrences = SRC.match(/absolute right-0/g) ?? [];
-		expect(occurrences).toHaveLength(0);
+	it('regression guard — neither menu opens to the LEFT of the trigger', () => {
+		// The original #30 guard: never `right-0` (which would left-align
+		// the menu and clip under the AppShell nav). The new positioning
+		// uses `r.left` (button's left edge), so a right-aligned variant
+		// would manifest as `r.right - menuWidth`. Neither pattern should
+		// appear.
+		expect(SRC).not.toMatch(/right-0/);
+		expect(SRC).not.toMatch(/right:\s*\{[^}]*\}px/);
 	});
 });

--- a/frontend/tests/unit/hierarchyControlsViews.test.ts
+++ b/frontend/tests/unit/hierarchyControlsViews.test.ts
@@ -38,9 +38,11 @@ describe('HierarchyControls (v5.4.1, issue #46 items #2 + #3)', () => {
 	});
 
 	it('+New dropdown lists Package above View, with View indented', () => {
-		// Locate the +New menu block (between "+ New ▾" and the closing
-		// Show ▾ trigger).
-		const newMenuMatch = SRC.match(/\+\s*New\s*▾[\s\S]*?Show\s*▾/);
+		// Issue #169: the menu now lives in a top-level {#if newOpen}
+		// block (separate from the trigger button) because it's
+		// position:fixed. Locate it by its min-w-[160px] signature and
+		// the closing </div> of that menu.
+		const newMenuMatch = SRC.match(/min-w-\[160px\][\s\S]*?<\/div>\s*\{\/if\}/);
 		expect(newMenuMatch, '+New menu block found').not.toBeNull();
 		const newBlock = newMenuMatch![0];
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.1"
+version = "6.8.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes [#169](https://github.com/cgbarlow/iris/issues/169) — the "Show" dropdown on the packages-detail Hierarchy panel was getting clipped (the footer text "Packages are always shown." was running off the visible area).

Root cause: the menus used Tailwind `absolute left-0` against a `<div class="relative">` parent. The packages-detail sidebar's `<aside class="overflow-y-auto">` clipped the absolute-positioned menu at the sidebar's right edge (CSS spec: when `overflow-y` is non-visible, `overflow-x: visible` computes to `auto`). The same latent bug existed in any HierarchyControls caller whose ancestor sets `overflow: hidden` (view-detail page) or `overflow-y: auto` (Dashboard hierarchy wrapper).

## Fix

Switch both menus to `position: fixed` with viewport coordinates from each trigger button's `getBoundingClientRect()`. Fixed-position elements escape every ancestor overflow context. To prevent the menu from floating away when the page scrolls, close all open menus on scroll (capture phase so it catches inner scroll containers too).

## Tests

- **+4 vitest cases** on `hierarchyControls.test.ts` asserting:
  - `bind:this` on both trigger buttons
  - `position: fixed` on both menu divs (and no remaining `<div role="menu" class="absolute …">`)
  - `getBoundingClientRect()` is called
  - `addEventListener('scroll', …)` closes the menus
- **Updated** `hierarchyControlsAlignment.test.ts` and `hierarchyControlsViews.test.ts` to match the new structure (menus now live in top-level `{#if}` blocks separate from the trigger buttons).

## Test plan

- [x] `npx vitest run` — 1075/1078 pass (3 pre-existing baseline failures unrelated)
- [x] `npx svelte-check` — clean for HierarchyControls
- [x] `python scripts/check_surface_parity.py` — clean
- [ ] **Manual smoke** on UAT once Render redeploys:
  - [ ] Open `/packages/{id}` → sidebar → click "Show ▾". Dropdown renders fully outside the sidebar's right edge; "Packages are always shown." is fully visible.
  - [ ] Same on Dashboard / Views list / View detail — menus open identically and don't get clipped.
  - [ ] Scroll the page while a menu is open — menu closes cleanly.

## Files

- `frontend/src/lib/components/HierarchyControls.svelte` — menus → `position: fixed` + `getBoundingClientRect` + scroll close
- `frontend/tests/unit/hierarchyControls.test.ts` — +4 new cases
- `frontend/tests/unit/hierarchyControlsAlignment.test.ts` — updated for new shape
- `frontend/tests/unit/hierarchyControlsViews.test.ts` — updated for new shape
- `CHANGELOG.md` — `[6.8.2]` Fixed entry
- `frontend/package.json`, `mcp/pyproject.toml` — 6.8.1 → 6.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)