### PR TITLE
fix(v6.8.3): templates 500 on Supabase + dynamic list tweaks (#170)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.3] - 2026-05-17
+
+### Fixed
+
+- **HTTP 500 on `POST /api/element-templates` in Supabase** (the
+  surfaced as CORS error in the UAT browser because the failure
+  short-circuited the CORS middleware). The `INSERT INTO
+  element_templates` statement embedded a literal `0` for
+  `is_deleted` in the `VALUES` clause — PostgreSQL rejects integer
+  literals for `BOOLEAN` columns (Protocol §15). The adapter's
+  retry-with-bool-coercion only fires for *bound* int parameters,
+  and the `is_xxx = 0/1` regex rewrite doesn't catch bare literals
+  inside `VALUES`. `is_deleted` is dropped from the INSERT column
+  list — both schemas default it correctly (`0` on SQLite, `FALSE`
+  on Supabase).
+- **Dynamic List bullet missing closing `**`** (issue
+  [#170](https://github.com/cgbarlow/iris/issues/170)). When
+  `show_description=False`, `_bullet` emitted `- **{name}` (no
+  closing `**`), so markdown rendered the literal asterisks instead
+  of bolding the name. Now emits `- **{name}**`.
+
+### Changed
+
+- **Dynamic List defaults to enclosing-package contents** (issue
+  [#170](https://github.com/cgbarlow/iris/issues/170)). A fresh
+  `dynamic_list` diagram created inside a package now defaults to
+  `mode='package_elements'` with `package_id` = the diagram's
+  `parent_package_id`. Diagrams without a parent package fall back
+  to the previous `diagram_relationships` default. The synthesised
+  `data.dynamic_source` is echoed on read so the frontend picker
+  reflects the applied defaults. The auto-generated footer
+  ("(Dynamic list — auto-generated)") is removed from the
+  rendered markdown. The mode dropdown labels are simplified to
+  "Package elements" and "Diagram relationships" (no "Default" prefix).
+
 ## [6.8.2] - 2026-05-17
 
 ### Fixed

--- a/backend/app/diagrams/dynamic_list.py
+++ b/backend/app/diagrams/dynamic_list.py
@@ -23,13 +23,15 @@ if TYPE_CHECKING:
 
 
 _PLACEHOLDER = "_No items yet._"
-_FOOTER = "###### (Dynamic list — auto-generated)"
 
 
 def _bullet(name: str, description: str | None, show_description: bool) -> str:
     if show_description and description is not None and description.strip() != "":
         return f"- **{name}** ({description})"
-    return f"- **{name}"
+    # Issue #170: previously emitted ``- **{name}`` with no closing
+    # ``**`` — markdown rendered the literal asterisks instead of bolding
+    # the name when descriptions were hidden.
+    return f"- **{name}**"
 
 
 async def _fetch_diagram_header(
@@ -168,4 +170,6 @@ async def compute_dynamic_list_content(
         body = await _diagram_relationships_body(
             db, diagram_id, show_description=show_description,
         )
-    return f"{header}\n\n{body}\n\n{_FOOTER}\n"
+    # Issue #170(a): no auto-generated footer — the markdown now ends at
+    # the body so the user-visible content is uncluttered.
+    return f"{header}\n\n{body}\n"

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -215,18 +215,38 @@ async def _maybe_synthesise_content(
     src = data.get("dynamic_source") or {}
     if not isinstance(src, dict):
         src = {}
-    mode = src.get("mode") or "diagram_relationships"
+
+    # Issue #170(c): when ``dynamic_source`` is unset, default to
+    # listing the elements of the diagram's enclosing package. Falls
+    # back to the original ``diagram_relationships`` mode when the
+    # diagram has no parent package.
+    parent_pkg = diagram.get("parent_package_id")
+    parent_pkg = parent_pkg if isinstance(parent_pkg, str) else None
+    mode = src.get("mode")
+    if not mode:
+        mode = "package_elements" if parent_pkg else "diagram_relationships"
     package_id = src.get("package_id")
+    if not isinstance(package_id, str):
+        package_id = parent_pkg if mode == "package_elements" else None
     show_description = bool(src.get("show_description", False))
+
     rendered = await compute_dynamic_list_content(
         db,
         str(diagram["id"]),
         mode=str(mode),
-        package_id=package_id if isinstance(package_id, str) else None,
+        package_id=package_id,
         show_description=show_description,
     )
     data["content"] = rendered
     data["is_content_locked"] = True
+    # Echo the resolved source so the frontend picker shows the defaults
+    # that were applied (instead of an empty dropdown that mismatches
+    # the rendered content).
+    data["dynamic_source"] = {
+        "mode": mode,
+        "package_id": package_id,
+        "show_description": show_description,
+    }
     diagram["data"] = data
 
 

--- a/backend/app/element_templates/service.py
+++ b/backend/app/element_templates/service.py
@@ -127,12 +127,18 @@ async def create_element_template(
     template_data = _project_template_data(src, filtered)
     template_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
+    # Literal ``, 0)`` for is_deleted caused HTTP 500 on Supabase —
+    # PostgreSQL BOOLEAN columns reject integer literals (Protocol §15).
+    # The adapter rewrites ``is_xxx = 0/1`` equality and retries int
+    # params as booleans, but cannot rewrite a bare literal in VALUES.
+    # Both schemas DEFAULT is_deleted to the correct false value, so
+    # omit the column entirely and let the default apply.
     await db.execute(
         "INSERT INTO element_templates "
         "(id, name, description, set_id, is_global, source_element_id, "
         "included_fields, template_data, created_by, created_at, "
-        "updated_at, is_deleted) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)",
+        "updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             template_id, name, description, set_id, 1 if is_global else 0,
             source_element_id, json.dumps(filtered),

--- a/backend/tests/test_dynamic_list_compute.py
+++ b/backend/tests/test_dynamic_list_compute.py
@@ -303,6 +303,184 @@ class TestPackageElementsMode:
         assert "_No items yet._" in body
 
 
+class TestCosmeticTweaks:
+    """Issue #170 — three small Dynamic List polish fixes."""
+
+    async def test_no_auto_generated_footer(
+        self,
+        client_db: tuple[httpx.AsyncClient, DatabaseManager],
+    ) -> None:
+        """The '(Dynamic list — auto-generated)' footer is removed."""
+        client, db_manager = client_db
+        from app.diagrams.dynamic_list import compute_dynamic_list_content
+
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        a = await _create_element(client, h, name="A", set_id=set_id)
+        b = await _create_element(client, h, name="B", set_id=set_id)
+        await _create_relationship(client, h, source=a, target=b)
+        diagram_id = await _create_dynamic_list_diagram(
+            client, h, set_id=set_id, elements_on_canvas=[a, b],
+            dynamic_source={"mode": "diagram_relationships"},
+        )
+
+        db = db_manager.main_db
+        body = await compute_dynamic_list_content(
+            db, diagram_id, mode="diagram_relationships",
+            package_id=None, show_description=False,
+        )
+        assert "Dynamic list" not in body
+        assert "auto-generated" not in body
+
+    async def test_bullets_have_closing_bold_marker(
+        self,
+        client_db: tuple[httpx.AsyncClient, DatabaseManager],
+    ) -> None:
+        """With ``show_description=False`` the bullet was '- **Name' with
+        no closing ``**`` (rendered as literal '**Name' in markdown).
+        Every bullet must have a matching closing marker.
+        """
+        client, db_manager = client_db
+        from app.diagrams.dynamic_list import compute_dynamic_list_content
+
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        pkg = await _create_package(client, h, set_id=set_id, name="Pantry")
+        await _create_element(
+            client, h, name="Caster sugar", set_id=set_id, package_id=pkg,
+        )
+        diagram_id = await _create_dynamic_list_diagram(
+            client, h, set_id=set_id, elements_on_canvas=[],
+            dynamic_source={"mode": "package_elements", "package_id": pkg},
+        )
+
+        db = db_manager.main_db
+        for show_desc in (False, True):
+            body = await compute_dynamic_list_content(
+                db, diagram_id, mode="package_elements",
+                package_id=pkg, show_description=show_desc,
+            )
+            bullets = [line for line in body.splitlines() if line.startswith("- ")]
+            assert bullets
+            for line in bullets:
+                # Each bullet should have an even (matching) count of
+                # ``**`` markers — i.e. every opening has a closing.
+                assert line.count("**") % 2 == 0, (
+                    f"unmatched **: {line!r} (show_description={show_desc})"
+                )
+            # Specifically the name renders as ``**Caster sugar**``.
+            assert "**Caster sugar**" in body
+
+
+class TestParentPackageDefault:
+    """Issue #170(c): a fresh dynamic_list diagram inside a package
+    defaults to mode='package_elements' with package_id = the diagram's
+    parent_package_id.
+    """
+
+    async def test_no_source_in_data_defaults_to_parent_package_elements(
+        self,
+        client_db: tuple[httpx.AsyncClient, DatabaseManager],
+    ) -> None:
+        client, db_manager = client_db
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        pkg = await _create_package(client, h, set_id=set_id, name="Pantry")
+        await _create_element(
+            client, h, name="Caster sugar", set_id=set_id, package_id=pkg,
+        )
+
+        # Diagram created WITH parent_package_id but WITHOUT dynamic_source.
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "dynamic_list",
+                "notation": "markdown",
+                "name": "Pantry list",
+                "set_id": set_id,
+                "parent_package_id": pkg,
+                "data": {"nodes": [], "edges": []},
+            },
+            headers=h,
+        )
+        assert resp.status_code == 201, resp.text
+        diagram_id = resp.json()["id"]
+
+        # On read, the synthesised content reflects package_elements
+        # with the parent package.
+        read = await client.get(f"/api/diagrams/{diagram_id}", headers=h)
+        assert read.status_code == 200
+        data = read.json()["data"]
+        assert "**Caster sugar**" in data["content"]
+        # The resolved dynamic_source is echoed on read so the frontend
+        # picker shows the right state.
+        src = data.get("dynamic_source") or {}
+        assert src.get("mode") == "package_elements"
+        assert src.get("package_id") == pkg
+
+    async def test_no_parent_package_falls_back_to_diagram_relationships(
+        self,
+        client_db: tuple[httpx.AsyncClient, DatabaseManager],
+    ) -> None:
+        client, db_manager = client_db
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "dynamic_list",
+                "notation": "markdown",
+                "name": "Orphan list",
+                "set_id": set_id,
+                "data": {"nodes": [], "edges": []},
+            },
+            headers=h,
+        )
+        assert resp.status_code == 201, resp.text
+        diagram_id = resp.json()["id"]
+
+        read = await client.get(f"/api/diagrams/{diagram_id}", headers=h)
+        src = read.json()["data"].get("dynamic_source") or {}
+        assert src.get("mode") == "diagram_relationships"
+
+    async def test_explicit_source_overrides_defaults(
+        self,
+        client_db: tuple[httpx.AsyncClient, DatabaseManager],
+    ) -> None:
+        """An explicit ``dynamic_source`` in the stored data wins over
+        the parent-package fallback.
+        """
+        client, db_manager = client_db
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+        pkg = await _create_package(client, h, set_id=set_id, name="Pantry")
+
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "dynamic_list",
+                "notation": "markdown",
+                "name": "Explicit",
+                "set_id": set_id,
+                "parent_package_id": pkg,
+                "data": {
+                    "nodes": [],
+                    "edges": [],
+                    "dynamic_source": {
+                        "mode": "diagram_relationships",
+                        "show_description": True,
+                    },
+                },
+            },
+            headers=h,
+        )
+        diagram_id = resp.json()["id"]
+        read = await client.get(f"/api/diagrams/{diagram_id}", headers=h)
+        src = read.json()["data"].get("dynamic_source") or {}
+        assert src.get("mode") == "diagram_relationships"
+
+
 class TestReadTimeSynthesis:
     async def test_get_diagram_populates_content_and_lock_flag(
         self,

--- a/backend/tests/test_element_templates/test_crud_and_apply.py
+++ b/backend/tests/test_element_templates/test_crud_and_apply.py
@@ -216,6 +216,35 @@ class TestCreate:
         assert r.status_code == 201, r.text
         assert r.json()["included_fields"] == ["name"]
 
+    async def test_insert_statement_has_no_literal_boolean_integers(
+        self, client: httpx.AsyncClient,  # noqa: ARG002
+    ) -> None:
+        """Protocol §15: PostgreSQL rejects integer literals for
+        BOOLEAN columns. The adapter rewrites bound integer params and
+        ``is_xxx = 0/1`` equality patterns, but cannot rewrite literal
+        integers inside ``VALUES (..., 0)``. Regression test for the
+        v6.8.0 → v6.8.x production 500 on POST /api/element-templates.
+        """
+        from pathlib import Path
+        svc = Path(__file__).resolve().parents[2] / "app" / "element_templates" / "service.py"
+        src = svc.read_text(encoding="utf-8")
+        # The INSERT statement for element_templates must not embed a
+        # literal ``0`` for ``is_deleted`` (the column has DEFAULT 0 /
+        # DEFAULT FALSE in both DBs — let the default apply).
+        insert_block_start = src.index("INSERT INTO element_templates")
+        insert_block_end = src.index("await db.commit()", insert_block_start)
+        insert_block = src[insert_block_start:insert_block_end]
+        # No literal boolean integers in the column list or VALUES.
+        assert ", 0)" not in insert_block.replace("\n", " "), (
+            f"INSERT for element_templates still has a literal 0 — "
+            f"Supabase BOOLEAN columns will reject this. Block:\n{insert_block}"
+        )
+        assert "is_deleted" not in insert_block, (
+            "is_deleted should be omitted from the INSERT — let the "
+            "column DEFAULT apply (0 on SQLite, FALSE on Supabase). "
+            f"Block:\n{insert_block}"
+        )
+
     async def test_create_rejects_unknown_source_element(
         self, client: httpx.AsyncClient,
     ) -> None:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.2",
+	"version": "6.8.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
+++ b/frontend/src/lib/canvas/text/DynamicListCanvas.svelte
@@ -118,8 +118,11 @@
 						class="rounded border px-2 py-1 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 					>
-						<option value="diagram_relationships">Default (diagram relationships)</option>
+						<!-- Issue #170(c): default mode is now Package elements
+							 when the diagram is inside a package; "Default" no
+							 longer maps to one option, so the labels are plain. -->
 						<option value="package_elements">Package elements</option>
+						<option value="diagram_relationships">Diagram relationships</option>
 					</select>
 				</label>
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.2"
+version = "6.8.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Two fixes bundled into a single patch release:

1. **Templates 500 (production blocker)** — `POST /api/element-templates` returned HTTP 500 on Supabase. The browser saw it as a CORS error because the failure short-circuited the CORS middleware before headers could be added. Root cause: literal `, 0)` for `is_deleted` in the INSERT — PostgreSQL `BOOLEAN` rejects integer literals (Protocol §15). The adapter's int→bool retry only fires for bound parameters; the regex rewrite only catches `is_xxx = 0/1` equality patterns. Fix: drop `is_deleted` from the INSERT column list (both schemas default it correctly).
2. **Dynamic List tweaks ([#170](https://github.com/cgbarlow/iris/issues/170))** — three small UX fixes:
   - Remove the `(Dynamic list — auto-generated)` footer
   - Fix bullet missing closing `**` when `show_description=false` (was `- **Caster sugar`, now `- **Caster sugar**`)
   - Default mode to `package_elements` with `package_id = parent_package_id` for diagrams inside a package; fall back to `diagram_relationships` otherwise; echo the resolved `dynamic_source` on read

## Why bundled

The templates 500 is a production blocker; #170 was already in-flight. Both touch only backend service code + the dynamic-list frontend canvas — independent diff areas — and shipping together avoids a second deploy. Bundling matches the v6.8.1 precedent.

## Tests

- **backend** `test_dynamic_list_compute.py`: +5 cases (footer removed, bullets closed, parent-package default, no-parent fallback, explicit source wins)
- **backend** `test_element_templates/test_crud_and_apply.py`: +1 static regression case asserting no literal `0` or `is_deleted` column in the INSERT — catches the bug since the test suite runs SQLite-only and previously didn't notice
- 29/29 templates + dynamic_list tests green
- `python scripts/check_surface_parity.py` clean

## Test plan

- [x] `pytest backend/tests/test_element_templates backend/tests/test_dynamic_list_compute.py` (29 passed)
- [x] `python scripts/check_surface_parity.py` (clean)
- [ ] **Manual prod smoke** once Render redeploys:
  - [ ] On UAT, create an element template via the dialog → no CORS / 500 error; template appears
  - [ ] Open a dynamic_list view inside a package → renders the package's elements by default; bullets bold cleanly; no "auto-generated" footer
  - [ ] Toggle `show_description` on/off — bullets bold both ways
  - [ ] Change mode to "Diagram relationships" — old behavior preserved

## Element templates surface parity (per user question)

Confirmed available on all three surfaces (per ADR-191 / v6.8.0):

- **REST**: `POST/GET/PUT/DELETE /api/element-templates`, `POST /api/element-templates/{id}`, plus `template_id` parameter on `POST /api/elements`
- **MCP**: `create_element_template`, `list_element_templates`, `get_element_template`, `update_element_template`, `delete_element_template`, plus `template_id` parameter on `create_element` (mcp/src/iris_mcp/tools.py:1411-1534)
- **CLI**: `iris create/get/update/delete element-template …`, `iris list element-templates …`, plus `--template-id` on `iris create element` (cli/src/iris_cli/main.py:1037-1083, 784-815)

🤖 Generated with [Claude Code](https://claude.com/claude-code)