### PR TITLE
fix(v6.8.4): package Relationships tab stale data (#173 item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.4] - 2026-05-18
+
+### Fixed
+
+- **Stale elements rendered on package Relationships tab after
+  navigation** (issue
+  [#173](https://github.com/cgbarlow/iris/issues/173) item 3,
+  ADR-195). Navigating from package A to package B left A's
+  elements visible on B's Relationships tab until a hard browser
+  refresh. Root cause: `loadPackage` reset top-level state
+  (`pkg`, `error`, `parentPackageName`) but not the lazy-loaded
+  relationships state (`packageElementsLoaded`, `packageElements`,
+  `packageElementsTotal`, `packageElementsLoading`,
+  `packageElementsError`), so the activation-side guard
+  short-circuited the re-fetch. Also resets inline edit state
+  (`editingDetails`, `detailsDirty`) so edit mode doesn't bleed
+  across packages.
+
 ## [6.8.3] - 2026-05-17
 
 ### Fixed

--- a/docs/adrs/ADR-195-Package-Detail-State-Reset-On-Navigation.md
+++ b/docs/adrs/ADR-195-Package-Detail-State-Reset-On-Navigation.md
@@ -1,0 +1,100 @@
+# ADR-195: Package detail page resets per-package state on navigation
+
+Status: Accepted (2026-05-18)
+Extends: [ADR-189](ADR-189-Package-Relationships-Tab.md)
+
+## Context
+
+Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 3 —
+when a user viewed package A's Relationships tab (hydrating the
+elements list), then navigated to package B and opened its
+Relationships tab, B's tab showed A's elements. A hard browser
+refresh fixed it; in-app navigation did not.
+
+ADR-189 introduced lazy hydration on the Relationships tab via a
+`packageElementsLoaded` boolean — first activation fetches, later
+activations short-circuit. The short-circuit was sound for repeat
+opens of the same package's tab, but the page's navigation handler
+(`$effect` keyed on `page.params.id`) only re-ran `loadPackage(id)`,
+which reset `pkg`, `parentPackageName`, `error`, and `loading` but
+left `packageElements*` untouched. When `activateRelationshipsTab`
+then asked "is it loaded?" the answer was "yes — for the previous
+package". The fetch never re-fired; the old data rendered against
+the new package's heading.
+
+The same latching pattern affected the inline edit state
+(`editingDetails`, `detailsDirty`) — a user who left edit mode
+active and navigated would see edit mode persist on the new
+package, with the previous package's field values still in the
+inputs.
+
+## Decision
+
+`loadPackage(id)` resets *all* per-package derived state at the top
+of the function — before the network call returns. The bug pattern
+is general (any cached `*Loaded` flag held against the page's
+package identity), so the reset is general: every piece of state
+whose meaning is "about package P" gets cleared.
+
+Concretely, before the fetch:
+
+```ts
+packageElementsLoaded = false;
+packageElementsLoading = false;
+packageElements = [];
+packageElementsTotal = 0;
+packageElementsError = null;
+editingDetails = false;
+detailsDirty = false;
+```
+
+The activation-side guard
+(`!packageElementsLoaded && !packageElementsLoading`) is unchanged —
+opening the tab twice without navigation still skips the redundant
+fetch. The reset moves the invalidation responsibility to the
+identity-change boundary, which is where it should have lived from
+the start.
+
+## Why reset in `loadPackage` rather than in the `$effect`
+
+`loadPackage` is the single chokepoint reached by every navigation,
+the first mount, and every post-mutation refresh (`saveDetails`,
+`handleSetParent`, `handleRemoveParent`). Resetting there means
+every path that loads a new package identity benefits, including
+the in-place "refresh after mutation" paths where the state has
+intentionally not changed and the cached elements *should* be
+re-fetched to reflect the mutation.
+
+## Why not invalidate on `params.id` change directly
+
+The `$effect` could compare previous and current `id`s and only
+reset on a real navigation, leaving in-place refreshes alone.
+Skipped: it would preserve a stale relationships list across edits
+that don't touch package membership, but it would *also* preserve
+stale data across edits that do. Always-reset is the safer default
+for a tab that fetches in <100ms.
+
+## Consequences
+
+- `frontend/src/routes/packages/[id]/+page.svelte` — seven lines of
+  resets inside `loadPackage` (lines ~132-141).
+- `frontend/tests/unit/packageDetailStateReset.test.ts` — new
+  static-parser test (8 assertions) asserts every reset is present
+  and that the activation-side guard still works.
+- No backend changes, no migration, no MCP / CLI changes.
+- CHANGELOG `[6.8.4]`.
+
+## Verification
+
+- `npx vitest run tests/unit/packageDetailStateReset.test.ts
+  tests/unit/packageRelationshipsTab.test.ts` — 21 green.
+- Browser smoke: visit `/packages/{A}` → Relationships, open the
+  tab to hydrate, navigate to `/packages/{B}` (where B's element
+  set differs), open Relationships — B's elements render without
+  a hard refresh.
+
+## See also
+
+- [ADR-189](ADR-189-Package-Relationships-Tab.md) — the lazy
+  hydration mechanism whose invalidation gap this ADR closes.
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 3.

--- a/docs/adrs/specs/SPEC-195-A-Package-Detail-State-Reset.md
+++ b/docs/adrs/specs/SPEC-195-A-Package-Detail-State-Reset.md
@@ -1,0 +1,86 @@
+# SPEC-195-A: Package detail state reset on navigation
+
+Implements: [ADR-195](../ADR-195-Package-Detail-State-Reset-On-Navigation.md)
+Resolves: Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 3
+Status: Living
+
+## Per-package state inventory
+
+State declared in `frontend/src/routes/packages/[id]/+page.svelte`
+whose meaning is "about the currently-viewed package". Every entry
+in the **Reset** column is cleared at the top of `loadPackage(id)`.
+
+| State | Meaning | Reset |
+|---|---|---|
+| `pkg` | The package record itself | implicit (overwritten by fetch) |
+| `parentPackageName` | Parent package's display name | yes (set to `null`) |
+| `versions` | Version history list | implicit (`loadVersions` overwrites) |
+| `loading` / `error` | Page-level fetch state | yes |
+| `packageElements` | Relationships tab — elements list | **yes** (was the bug) |
+| `packageElementsLoaded` | Relationships tab — hydration flag | **yes** (was the bug) |
+| `packageElementsLoading` | Relationships tab — in-flight flag | **yes** |
+| `packageElementsTotal` | Relationships tab — total count | **yes** |
+| `packageElementsError` | Relationships tab — fetch error | **yes** |
+| `editingDetails` | Inline edit mode flag | **yes** |
+| `detailsDirty` | Inline edit unsaved-changes flag | **yes** |
+| `editName` / `editDescription` | Edit-mode field buffers | implicit (re-seeded by `enterDetailsEdit`) |
+| `isBookmarked` | Bookmark indicator | reset by `loadBookmarkStatus` |
+| `hierarchyTree` | Sidebar hierarchy (keyed on `set_id`) | not reset — sidebar lives across packages within a set; refresh handled by `loadHierarchyTree` calls in mutation handlers |
+| `showDeleteDialog` / `showParentPicker` / `showCreateChild*Dialog` | Transient modal flags | not reset — modals are user-initiated actions, not derived state |
+| `cloneLoading` | In-flight clone indicator | not reset — clone navigates away on success |
+
+The reset block sits *before* the `try { ... }` to ensure it fires
+even if the network call throws.
+
+## Reset block
+
+```ts
+// Issue #173 item 3
+packageElementsLoaded = false;
+packageElementsLoading = false;
+packageElements = [];
+packageElementsTotal = 0;
+packageElementsError = null;
+editingDetails = false;
+detailsDirty = false;
+```
+
+## Acceptance criteria
+
+1. After viewing package A's Relationships tab, navigating to
+   package B and opening its Relationships tab shows B's elements
+   without a hard refresh.
+2. A user editing details on A who navigates to B sees B's read-
+   only Details view (not A's edit-mode buffers).
+3. Repeat-opening the same package's Relationships tab without
+   navigation still skips the redundant fetch
+   (`!packageElementsLoaded && !packageElementsLoading` guard
+   preserved).
+4. Mutation handlers that call `loadPackage(pkg.id)` to refresh
+   after a save (`saveDetails`, `handleSetParent`,
+   `handleRemoveParent`) will re-fetch the relationships list,
+   which is the desired behaviour — these are usually triggered by
+   changes that may affect membership.
+
+## Tests
+
+`frontend/tests/unit/packageDetailStateReset.test.ts` — 8 cases:
+
+1-5. Each of the five `packageElements*` flags is reset in
+   `loadPackage`'s body.
+6-7. `editingDetails` and `detailsDirty` reset in the same place.
+8. Activation-side guard `!packageElementsLoaded &&
+   !packageElementsLoading` remains in `activateRelationshipsTab`.
+
+Also re-runs `tests/unit/packageRelationshipsTab.test.ts` to
+confirm no regression to the existing ADR-189 behaviour.
+
+## Verification
+
+```
+npx vitest run \
+  tests/unit/packageDetailStateReset.test.ts \
+  tests/unit/packageRelationshipsTab.test.ts
+```
+
+Both files green. Manual smoke per ADR-195 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.3",
+	"version": "6.8.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -130,6 +130,16 @@
 		loading = true;
 		error = null;
 		parentPackageName = null;
+		// Issue #173 item 3: reset per-package derived state so navigating
+		// from package A → B doesn't leave A's relationships / edit state
+		// rendered until a hard refresh.
+		packageElementsLoaded = false;
+		packageElementsLoading = false;
+		packageElements = [];
+		packageElementsTotal = 0;
+		packageElementsError = null;
+		editingDetails = false;
+		detailsDirty = false;
 		try {
 			pkg = await apiFetch<Package>(`/api/packages/${id}`);
 			recordVisit({ id: pkg.id, type: 'package', name: pkg.name, setId: pkg.set_id ?? undefined, setName: pkg.set_name ?? undefined, description: pkg.description ?? undefined, href: `/packages/${pkg.id}` });

--- a/frontend/tests/unit/packageDetailStateReset.test.ts
+++ b/frontend/tests/unit/packageDetailStateReset.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Package detail per-package state reset (v6.8.4, ADR-195, issue #173 item 3).
+ *
+ * Bug: the relationships tab cached its elements in `packageElements*`
+ * state with `packageElementsLoaded` latched to `true` after first
+ * hydration. Navigating to a different package re-ran `loadPackage`
+ * but did not reset those flags, so the previous package's elements
+ * stayed rendered until a hard browser refresh.
+ *
+ * Reproduction: visit /packages/A → Relationships tab (hydrates A's
+ * elements) → navigate to /packages/B → Relationships tab. B's tab
+ * shows A's elements.
+ *
+ * Fix: reset per-package derived state at the top of `loadPackage`
+ * so each navigation starts from a clean slate. Static-parser style
+ * to match the rest of this suite.
+ */
+
+const pkgPageSrc = readFileSync(
+	resolve(__dirname, '../../src/routes/packages/[id]/+page.svelte'),
+	'utf-8',
+);
+
+function loadPackageBody(): string {
+	const start = pkgPageSrc.indexOf('async function loadPackage(');
+	expect(start, 'loadPackage function not found').toBeGreaterThan(-1);
+	const braceStart = pkgPageSrc.indexOf('{', start);
+	let depth = 0;
+	let i = braceStart;
+	for (; i < pkgPageSrc.length; i++) {
+		const ch = pkgPageSrc[i];
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) break;
+		}
+	}
+	return pkgPageSrc.slice(braceStart, i + 1);
+}
+
+describe('Package detail — loadPackage resets per-package state (issue #173 item 3)', () => {
+	const body = loadPackageBody();
+
+	it('resets packageElementsLoaded', () => {
+		expect(body).toMatch(/packageElementsLoaded\s*=\s*false/);
+	});
+
+	it('resets packageElementsLoading', () => {
+		expect(body).toMatch(/packageElementsLoading\s*=\s*false/);
+	});
+
+	it('clears packageElements array', () => {
+		expect(body).toMatch(/packageElements\s*=\s*\[\]/);
+	});
+
+	it('resets packageElementsTotal to 0', () => {
+		expect(body).toMatch(/packageElementsTotal\s*=\s*0/);
+	});
+
+	it('clears packageElementsError', () => {
+		expect(body).toMatch(/packageElementsError\s*=\s*null/);
+	});
+
+	it('exits any in-progress inline edit (editingDetails)', () => {
+		// If the user was editing Frozen's details and navigated to
+		// Pantry, edit-mode would persist with stale field values.
+		expect(body).toMatch(/editingDetails\s*=\s*false/);
+	});
+
+	it('resets detailsDirty flag', () => {
+		expect(body).toMatch(/detailsDirty\s*=\s*false/);
+	});
+});
+
+describe('Package detail — activateRelationshipsTab guard still in place', () => {
+	it('continues to short-circuit when state is hydrated for current package', () => {
+		// Behaviour unchanged on the activation side — the reset is in
+		// loadPackage, so a tab re-open without navigation still skips
+		// the redundant fetch.
+		expect(pkgPageSrc).toContain('!packageElementsLoaded && !packageElementsLoading');
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.3"
+version = "6.8.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes part of #173 — item 3 (stale items in package Relationships tabs).

- Reset `packageElements*` and inline-edit state at the top of `loadPackage` so navigating from package A → B no longer leaves A's elements (or A's edit-mode buffers) rendered until a hard browser refresh.
- ADR-195 / SPEC-195-A document the invariant: every piece of state whose meaning is "about the currently-viewed package" is cleared at the navigation boundary.
- Activation-side guard (`!packageElementsLoaded && !packageElementsLoading`) preserved — repeat-opening the same package's tab still skips the redundant fetch.

## Why this happened

ADR-189 added lazy hydration on the Relationships tab via a `packageElementsLoaded` flag. The activation-side guard was sound for repeat opens of the same package, but the navigation handler reset top-level state (`pkg`, `error`, `parentPackageName`) and left `packageElements*` untouched. The fetch never re-fired against the new package's id.

## Test plan

- [x] `npx vitest run tests/unit/packageDetailStateReset.test.ts tests/unit/packageRelationshipsTab.test.ts` — 21 green.
- [ ] Browser smoke (post-deploy on iris-uat): visit a package with elements → Relationships → navigate to a different package → Relationships → confirm correct elements without hard refresh.
- [ ] Bonus check: enter edit mode on one package, navigate to another, confirm edit mode does not bleed across.

## Notes

Pre-existing test failures in `extensionManagerFields`, `importIdempotency`, `importPageAcceptsArchimate` are unrelated to this change (confirmed by re-running against `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)