### PR TITLE
fix(v6.8.5): elements page search race condition (#173 item 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.5] - 2026-05-18
+
+### Fixed
+
+- **Elements page search "flashed away" after typing**  (issue
+  [#173](https://github.com/cgbarlow/iris/issues/173) item 7,
+  ADR-196). Typing "grocery" briefly showed the matching element,
+  then it disappeared as a slower earlier-typed request returned
+  and overwrote the result. Root cause: the search input fired
+  `loadElements()` synchronously on every keystroke with no
+  debounce and no `AbortController`. The fix mirrors the
+  dashboard's pattern — 300 ms debounce, an `AbortController` so
+  newer requests cancel older in-flight ones, and a request-time
+  query capture as a belt-and-braces race guard. Aborted requests
+  no longer surface as a generic "Failed to load elements".
+
 ## [6.8.4] - 2026-05-18
 
 ### Fixed

--- a/docs/adrs/ADR-196-Elements-Search-Debounce-Abort.md
+++ b/docs/adrs/ADR-196-Elements-Search-Debounce-Abort.md
@@ -1,0 +1,99 @@
+# ADR-196: Elements page search uses debounced abortable fetch
+
+Status: Accepted (2026-05-18)
+Related: dashboard search at `frontend/src/routes/+page.svelte:460-464`
+
+## Context
+
+Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 7 —
+on the elements page, typing "grocery" in the search box shows the
+matching "Grocery item template source" element briefly, then it
+"flashes away" and the user sees nothing. The same search on the
+dashboard works perfectly. The user observation: *"learn from the
+dashboard view."*
+
+Cause. The elements page wired its search input to
+`oninput={() => { page = 1; loadElements(); }}` — synchronous fetch
+on every keystroke, no debounce, no `AbortController`. Typing
+"grocery" fires 7 requests in rapid succession; the network does
+not guarantee they return in order. When a slower earlier request
+for `"grocer"` lands *after* the faster `"grocery"` request, the
+later response is overwritten by the earlier one and the matching
+result vanishes.
+
+The dashboard's search has had a 300ms debounce since at least
+v5.x (`onSearchInput` at `frontend/src/routes/+page.svelte:461-464`).
+Debounce alone fixes most cases — keystrokes within 300ms of each
+other don't fire — but a long tail of slow networks can still
+inject a stale response, so we add an `AbortController` and a
+request-time query capture as a belt-and-braces guard.
+
+## Decision
+
+`frontend/src/routes/elements/+page.svelte` adopts the pattern:
+
+1. **Debounce** the search input with `onSearchInput`,
+   `setTimeout(..., 300)`, mirroring the dashboard's cadence.
+2. **AbortController** — `loadElements` aborts the previous
+   in-flight request before issuing the next one, passing
+   `{ signal }` to `apiFetch` (which already forwards `RequestInit`
+   to `fetch`).
+3. **Request-time query capture** — capture `searchQuery.trim()`
+   into `requestedQuery` at fetch-time, and compare against the
+   current `searchQuery` when the response resolves. Drop stale
+   results. This catches the case where a response begins
+   resolving in the JS event loop before `AbortController` fires.
+4. **AbortError silencing** — a deliberately-aborted request must
+   not surface as "Failed to load elements".
+
+## Why mirror the dashboard rather than refactor both
+
+DRY tension (Protocol §13). Two ways to spell this:
+
+- **Inline (chosen).** Same pattern in both files. ~15 lines each.
+  No new abstraction. Anyone reading either page sees the whole
+  story locally.
+- **Shared helper.** Extract a `debouncedFetch` / `useDebouncedLoad`
+  utility into `frontend/src/lib/utils/`. Two callers today;
+  third caller would push us over the DRY threshold.
+
+The shared-helper version costs more than it saves at two callers,
+because Svelte 5's `$state` is reactive at the source-file level —
+the helper would have to take callbacks to read/write the page's
+state, which is more indirection than the duplication. We commit
+to revisiting this if a third search input needs the same shape;
+the spec calls out the threshold explicitly.
+
+## Why 300ms
+
+Matches the dashboard. Subjectively responsive; long enough to
+collapse the keystrokes of "grocery" (typed in <1s on most
+keyboards) into one or two requests. Not a number worth
+re-deriving.
+
+## Consequences
+
+- `frontend/src/routes/elements/+page.svelte` — module-level
+  `searchTimeout` + `loadController`, new `onSearchInput`,
+  `loadElements` aborts the previous controller and discards
+  stale responses; search input `oninput` wired to
+  `onSearchInput`.
+- `frontend/tests/unit/elementsSearchRaceCondition.test.ts` —
+  new static-parser test (10 assertions) covers debounce, abort,
+  signal forwarding, AbortError handling, and the race-guard.
+- No backend changes; no MCP / CLI changes.
+- CHANGELOG `[6.8.5]`.
+
+## Verification
+
+- `npx vitest run tests/unit/elementsSearchRaceCondition.test.ts`
+  — 10 green.
+- Browser smoke: dev.sh, navigate to /elements, type "grocery"
+  in the search box, confirm the matching element stays rendered.
+  Confirm the dashboard search (which already worked) is unchanged.
+
+## See also
+
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 7.
+- Dashboard search reference:
+  `frontend/src/routes/+page.svelte:400-418,460-464`.

--- a/docs/adrs/specs/SPEC-196-A-Elements-Search-Debounce-Abort.md
+++ b/docs/adrs/specs/SPEC-196-A-Elements-Search-Debounce-Abort.md
@@ -1,0 +1,99 @@
+# SPEC-196-A: Elements page search debounce + abort
+
+Implements: [ADR-196](../ADR-196-Elements-Search-Debounce-Abort.md)
+Resolves: Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 7
+Status: Living
+
+## Shape
+
+`frontend/src/routes/elements/+page.svelte`:
+
+```ts
+let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+let loadController: AbortController | undefined;
+
+function onSearchInput() {
+  clearTimeout(searchTimeout);
+  searchTimeout = setTimeout(() => {
+    page = 1;
+    loadElements();
+  }, 300);
+}
+
+async function loadElements() {
+  loadController?.abort();
+  loadController = new AbortController();
+  const controller = loadController;
+  const requestedQuery = searchQuery.trim();
+  loading = true;
+  try {
+    // …build params…
+    const data = await apiFetch<…>(`/api/elements?${params}`, { signal: controller.signal });
+    if (requestedQuery !== searchQuery.trim()) return;  // race guard
+    elements = data.items;
+    total = data.total;
+    loadAvailableTags();
+  } catch (e) {
+    if (e instanceof DOMException && e.name === 'AbortError') return;
+    error = 'Failed to load elements';
+  } finally {
+    if (controller === loadController) loading = false;
+  }
+}
+```
+
+Search input markup:
+```svelte
+<input id="element-search" bind:value={searchQuery} oninput={onSearchInput} type="search" … />
+```
+
+The `loading = false` is guarded by `controller === loadController`
+so an aborted older controller doesn't clear the spinner while the
+newer request is still in-flight.
+
+## Acceptance criteria
+
+1. Typing a single character that matches an element shows the
+   element and it stays rendered.
+2. Typing "grocery" character-by-character within ~1s yields the
+   final result set rendered exactly once, with no flash of stale
+   results.
+3. Rapidly toggling between search and filter (notation /
+   collection / set) does not leave the spinner stuck on; loading
+   reflects the newest request.
+4. Network errors on the newest request still surface as "Failed
+   to load elements".
+5. The dashboard search at `frontend/src/routes/+page.svelte` is
+   not modified — its behaviour is reference-only.
+
+## DRY threshold (revisit trigger)
+
+Two callers (dashboard + elements page) use this pattern inline.
+**On the third caller**, extract to
+`frontend/src/lib/utils/debounced-fetch.ts` with a generic
+`createDebouncedLoader<T>(...)` and refactor both existing call
+sites in the same PR. The signature should accept (a) a request
+builder, (b) a response handler, (c) a debounce ms, (d) an
+identity check for the race guard.
+
+## Tests
+
+`frontend/tests/unit/elementsSearchRaceCondition.test.ts` —
+10 cases:
+
+1-5. **Debounce.** `searchTimeout` declared, `onSearchInput`
+   exists, `setTimeout(..., 300)`, `clearTimeout(searchTimeout)`,
+   input wired to `onSearchInput`.
+6-9. **Abort.** `loadController` declared, `abort()` called at
+   start of `loadElements`, `signal` passed to `apiFetch`,
+   `AbortError` handled.
+10. **Race guard.** A `requestedQuery` / `searchAtRequest` /
+   `capturedQuery` local is compared on response.
+
+## Verification
+
+```
+npx vitest run tests/unit/elementsSearchRaceCondition.test.ts
+```
+
+Green. Manual smoke per ADR-196 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.4",
+	"version": "6.8.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -63,7 +63,29 @@
 		}
 	});
 
+	// Issue #173 item 7: search-race fix. Each keystroke previously
+	// fired loadElements() synchronously with no debounce or abort, so
+	// late responses overwrote recent ones (the "grocery" flash). We
+	// mirror the dashboard's 300ms debounce and add an AbortController
+	// so the newest request cancels older in-flight ones. A captured
+	// requestedQuery is compared against the current searchQuery at
+	// response time as a belt-and-braces guard.
+	let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+	let loadController: AbortController | undefined;
+
+	function onSearchInput() {
+		clearTimeout(searchTimeout);
+		searchTimeout = setTimeout(() => {
+			page = 1;
+			loadElements();
+		}, 300);
+	}
+
 	async function loadElements() {
+		loadController?.abort();
+		loadController = new AbortController();
+		const controller = loadController;
+		const requestedQuery = searchQuery.trim();
 		loading = true;
 		try {
 			const params = new URLSearchParams();
@@ -72,15 +94,19 @@
 			if (currentSetId) params.set('set_id', currentSetId);
 			else if (currentCollectionId) params.set('collection_id', currentCollectionId);
 			if (notationFilter) params.set('notation', notationFilter);
-			if (searchQuery.trim()) params.set('search', searchQuery.trim());
-			const data = await apiFetch<PaginatedResponse<Element>>(`/api/elements?${params}`);
+			if (requestedQuery) params.set('search', requestedQuery);
+			const data = await apiFetch<PaginatedResponse<Element>>(`/api/elements?${params}`, { signal: controller.signal });
+			// Race guard: drop the result if the user has typed past this query.
+			if (requestedQuery !== searchQuery.trim()) return;
 			elements = data.items;
 			total = data.total;
 			loadAvailableTags();
-		} catch {
+		} catch (e) {
+			if (e instanceof DOMException && e.name === 'AbortError') return;
 			error = 'Failed to load elements';
+		} finally {
+			if (controller === loadController) loading = false;
 		}
-		loading = false;
 	}
 
 	async function loadAvailableTags() {
@@ -337,7 +363,7 @@
 		<input
 			id="element-search"
 			bind:value={searchQuery}
-			oninput={() => { page = 1; loadElements(); }}
+			oninput={onSearchInput}
 			type="search"
 			placeholder="Search elements..."
 			class="rounded border px-3 py-2 text-sm"

--- a/frontend/tests/unit/elementsSearchRaceCondition.test.ts
+++ b/frontend/tests/unit/elementsSearchRaceCondition.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Elements page search race condition (v6.8.5, ADR-196, issue #173 item 7).
+ *
+ * Bug: the search input fired `loadElements()` synchronously on every
+ * keystroke with no debounce and no abort handling. Late responses
+ * overwrote recent ones — typing "grocery" showed the matching
+ * "Grocery item template source" result, then it flashed away when an
+ * earlier in-flight request for "grocer" returned with a different
+ * result set.
+ *
+ * Fix: mirror the dashboard's debounce (300ms) and add an
+ * AbortController so later searches cancel earlier in-flight ones.
+ * Also discard responses whose query no longer matches the current
+ * `searchQuery` as a belt-and-braces guard against the rare case
+ * where AbortController fires after a response has already begun
+ * resolving in the JS event loop.
+ *
+ * Static-parser style to match the rest of this suite.
+ */
+
+const src = readFileSync(
+	resolve(__dirname, '../../src/routes/elements/+page.svelte'),
+	'utf-8',
+);
+
+describe('Elements page search — debounce', () => {
+	it('declares a module-level searchTimeout', () => {
+		expect(src).toMatch(/let\s+searchTimeout\s*:\s*ReturnType<typeof setTimeout>/);
+	});
+
+	it('declares a debounced onSearchInput handler', () => {
+		expect(src).toMatch(/function\s+onSearchInput/);
+	});
+
+	it('debounces with setTimeout(..., 300)', () => {
+		expect(src).toMatch(/setTimeout\([^,]+,\s*300\)/);
+	});
+
+	it('clears the pending timeout on each keystroke', () => {
+		expect(src).toMatch(/clearTimeout\(searchTimeout\)/);
+	});
+
+	it('search input wires oninput to onSearchInput, not loadElements', () => {
+		// The buggy version had `oninput={() => { page = 1; loadElements(); }}`.
+		// The fix routes through the debounced handler.
+		expect(src).toMatch(/id="element-search"[\s\S]{0,200}?oninput=\{onSearchInput\}/);
+	});
+});
+
+describe('Elements page search — abort', () => {
+	it('declares a module-level AbortController slot', () => {
+		expect(src).toMatch(/let\s+loadController\s*:\s*AbortController\s*\|\s*undefined/);
+	});
+
+	it('aborts the previous controller at the start of loadElements', () => {
+		expect(src).toMatch(/loadController\?\.abort\(\)/);
+	});
+
+	it('passes the new controller signal to apiFetch', () => {
+		expect(src).toMatch(/apiFetch[^(]*\([^)]*signal[^)]*\)/);
+	});
+
+	it('swallows AbortError so it does not surface as a generic load failure', () => {
+		expect(src).toMatch(/AbortError/);
+	});
+});
+
+describe('Elements page search — race guard', () => {
+	it('discards stale responses whose query no longer matches', () => {
+		// Belt-and-braces: after a debounce window, the in-flight query
+		// is captured in a local at fetch-time and compared against the
+		// current searchQuery on response.
+		expect(src).toMatch(/requestedQuery|searchAtRequest|capturedQuery/);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.4"
+version = "6.8.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes part of #173 — item 7 (elements page search "flashes away").

- 300ms debounce on the search input (mirrors the dashboard's pattern at `frontend/src/routes/+page.svelte:460-464`).
- `AbortController` so newer requests cancel older in-flight ones; aborted requests no longer surface as "Failed to load elements".
- Request-time query capture as a belt-and-braces race guard: drop responses whose query no longer matches the current `searchQuery`.

## Why this happened

The elements page wired `oninput={() => { page = 1; loadElements(); }}` — synchronous fetch on every keystroke. Typing "grocery" fires 7 requests; when a slower earlier request returns after the matching one, the later state-write wins and the result vanishes.

DRY decision documented in SPEC-196-A: kept the pattern inline in both pages for now (two callers), with an explicit revisit threshold at three callers.

## Test plan

- [x] `npx vitest run tests/unit/elementsSearchRaceCondition.test.ts` — 10 green.
- [ ] Browser smoke (post-deploy on iris-uat): /elements, type "grocery", confirm the matching element stays put.
- [ ] Bonus: verify dashboard search (unchanged) still works the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)