### PR TITLE
fix(v6.8.7): single-element clone preserves source set (#173 item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.8.7] - 2026-05-18
+
+### Fixed
+
+- **Cloning an element from /elements/{id} dropped it into the
+  default set** (issue
+  [#173](https://github.com/cgbarlow/iris/issues/173) item 1,
+  ADR-198). The detail-page Clone button POSTed to
+  `/api/elements` without `set_id`, so the backend's
+  `create_element` fell back to `DEFAULT_SET_ID`. Now passes
+  `set_id: entity.set_id`. Batch clone path
+  (`POST /api/batch/elements/clone`) was already correct; a
+  regression test now locks in that invariant explicitly.
+
 ## [6.8.6] - 2026-05-18
 
 ### Fixed

--- a/backend/tests/test_batch/test_clone_preserves_set.py
+++ b/backend/tests/test_batch/test_clone_preserves_set.py
@@ -1,0 +1,113 @@
+"""Regression test: batch clone preserves source element's set_id.
+
+Issue #173 item 1, ADR-198 — locks in the invariant that
+`batch_clone_elements` reads the source element's `set_id` and
+re-uses it on the clone. The frontend single-element clone path
+on /elements/{id} had a separate but related bug (didn't pass
+set_id in the request) which is fixed in the same PR; this test
+guards the backend side so we don't regress that too.
+
+Same fixture pattern as test_operations.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+class TestBatchCloneSetPreservation:
+    async def test_clone_inherits_source_set_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+
+        set_resp = await client.post(
+            "/api/sets", json={"name": "TargetSet"}, headers=h,
+        )
+        assert set_resp.status_code == 201
+        target_set_id = set_resp.json()["id"]
+
+        src_resp = await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "SourceInSet",
+                "data": {},
+                "set_id": target_set_id,
+            },
+            headers=h,
+        )
+        assert src_resp.status_code == 201
+        src_id = src_resp.json()["id"]
+
+        clone_resp = await client.post(
+            "/api/batch/elements/clone",
+            json={"ids": [src_id]},
+            headers=h,
+        )
+        assert clone_resp.status_code == 200
+        assert clone_resp.json()["succeeded"] == 1
+
+        list_resp = await client.get(
+            f"/api/elements?set_id={target_set_id}", headers=h,
+        )
+        items = list_resp.json()["items"]
+        names = [e["name"] for e in items]
+        assert "SourceInSet" in names
+        assert "SourceInSet (Copy)" in names, (
+            "Clone must land in the source's set, not the default set "
+            "(issue #173 item 1)."
+        )

--- a/docs/adrs/ADR-198-Clone-Element-Preserves-Set.md
+++ b/docs/adrs/ADR-198-Clone-Element-Preserves-Set.md
@@ -1,0 +1,95 @@
+# ADR-198: Cloning an element preserves its source's set
+
+Status: Accepted (2026-05-18)
+
+## Context
+
+Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 1
+— the user reported that cloning an element did not put the clone
+in the same set as the original. Plan-time research suggested
+this might be a no-op (the backend's `batch_clone_elements` reads
+and re-uses the source's `set_id`, see
+`backend/app/batch/service.py:308,331`). Reproduce-first turned up
+a real bug — but in a different code path.
+
+### Two clone paths
+
+1. **Batch clone** — `POST /api/batch/elements/clone`, called
+   from the elements list page's bulk-action toolbar
+   (`frontend/src/routes/elements/+page.svelte:223-234`). Backend
+   `batch_clone_elements` selects `e.set_id` from the source and
+   passes it back in the INSERT. **Correct.**
+2. **Single-element clone** — the "Clone" button on the element
+   detail page (`/elements/{id}`,
+   `frontend/src/routes/elements/[id]/+page.svelte:320-336`).
+   Sends `POST /api/elements` with only `element_type`, `name`,
+   `description`, `data` — **no `set_id`**. The backend's
+   `create_element` falls back to `DEFAULT_SET_ID` when the body
+   omits `set_id`, so the clone lands in the default set rather
+   than the source's. **The bug.**
+
+The user's clone button on a per-element detail page hit path #2;
+the symptom matched their report exactly.
+
+## Decision
+
+`handleClone` in
+`frontend/src/routes/elements/[id]/+page.svelte` includes
+`set_id: entity.set_id` in the POST body. The fix is intentionally
+narrow — `set_id` only, matching the field the issue calls out.
+Other attributes (`notation`, `metadata`, `package_id`, tags) are
+left to follow-up if the user reports they should also propagate;
+this matches the batch path, which also doesn't copy those fields
+into the clone today.
+
+We also add a backend regression test
+(`backend/tests/test_batch/test_clone_preserves_set.py`) that
+locks in the batch-path invariant explicitly — the existing
+`test_clone_elements` only asserts the clone name appears in the
+list, not which set it lives in.
+
+## Why not generalise the clone to copy everything
+
+The existing batch clone path is the historical "shallow copy"
+shape (element_type + set_id + name + description + data + tags).
+The user reported a narrow problem ("same set"); the surgical fix
+keeps the behaviour consistent across both paths without expanding
+clone semantics in a UAT patch release. If the user wants notation
+/ metadata / package_id preserved, that's an ADR-198 follow-up.
+
+## Why not move the single-clone path through `batch_clone_elements`
+
+Reasonable suggestion — eliminates the duplication and the bug at
+the same time. Skipped for this PR because (a) the batch endpoint
+returns a `BatchResult` envelope that the detail-page UX would
+have to unwrap, and (b) it would change the response shape that
+`apiFetch<Element>` expects, requiring a typed wrapper change.
+Bigger blast radius than a one-line body addition. Filed as a
+candidate refactor; not done here.
+
+## Consequences
+
+- `frontend/src/routes/elements/[id]/+page.svelte:320-336` —
+  `handleClone` includes `set_id: entity.set_id` in the POST body.
+- `frontend/tests/unit/elementClonePreservesSet.test.ts` — new
+  static-parser test (3 assertions).
+- `backend/tests/test_batch/test_clone_preserves_set.py` — new
+  pytest module, 1 case, locks in the batch-path invariant.
+- No backend code change; no migration; no MCP / CLI changes.
+- CHANGELOG `[6.8.7]`.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_batch/test_clone_preserves_set.py backend/tests/test_batch/test_operations.py
+cd frontend && npx vitest run tests/unit/elementClonePreservesSet.test.ts
+```
+
+All green. Manual smoke: navigate to an element in a non-default
+set, click "Clone", confirm the new element appears in the same
+set's listing.
+
+## See also
+
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 1.
+- Batch clone backend: `backend/app/batch/service.py:295-364`.

--- a/docs/adrs/specs/SPEC-198-A-Clone-Element-Preserves-Set.md
+++ b/docs/adrs/specs/SPEC-198-A-Clone-Element-Preserves-Set.md
@@ -1,0 +1,86 @@
+# SPEC-198-A: Clone element preserves source set
+
+Implements: [ADR-198](../ADR-198-Clone-Element-Preserves-Set.md)
+Resolves: Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 1
+Status: Living
+
+## Invariant
+
+For every code path that creates an element from another element
+(clone), the new element's `set_id` equals the source's `set_id`.
+
+Two paths today:
+
+| Path | Surface | Behaviour |
+|---|---|---|
+| Batch clone | `POST /api/batch/elements/clone` | `batch_clone_elements` selects source `set_id` and re-inserts it. **Was already correct.** Regression test added in this PR. |
+| Single clone (detail page) | `POST /api/elements` from `/elements/{id}` Clone button | Frontend body now includes `set_id: entity.set_id`. **Was the bug.** |
+
+## Frontend shape
+
+`frontend/src/routes/elements/[id]/+page.svelte`:
+
+```ts
+async function handleClone() {
+  if (!entity) return;
+  try {
+    const created = await apiFetch<Element>('/api/elements', {
+      method: 'POST',
+      body: JSON.stringify({
+        element_type: entity.element_type,
+        name: `${entity.name} (Copy)`,
+        description: entity.description ?? '',
+        data: entity.data ?? {},
+        set_id: entity.set_id,   // ← added
+      }),
+    });
+    await goto(`/elements/${created.id}`);
+  } catch (e) {
+    error = e instanceof ApiError ? e.message : 'Failed to clone element';
+  }
+}
+```
+
+## Out of scope
+
+Notation, metadata, package_id, and tags are not propagated.
+Matches the batch path's existing behaviour. Filed for follow-up
+if a user wants those preserved too.
+
+## Acceptance criteria
+
+1. Cloning an element from `/elements/{id}` produces an element
+   whose `set_id` equals the source's `set_id`.
+2. Cloning an element via the batch endpoint
+   (`POST /api/batch/elements/clone`) produces a clone in the
+   source's set (preserved invariant — backed by a new regression
+   test).
+3. The clone name remains `"{source.name} (Copy)"` on both paths.
+4. No other fields change behaviour.
+
+## Tests
+
+Frontend — `frontend/tests/unit/elementClonePreservesSet.test.ts`:
+
+1. `handleClone` still POSTs to `/api/elements`.
+2. Body includes `set_id: entity.set_id`.
+3. Basic fields (element_type, name with `(Copy)`, data) still
+   present.
+
+Backend — `backend/tests/test_batch/test_clone_preserves_set.py`:
+
+1. `test_clone_inherits_source_set_id` — create a set, create an
+   element in that set, batch-clone it, list elements filtered by
+   that set, assert both source and clone appear.
+
+## Verification
+
+```
+.venv/bin/python -m pytest \
+  backend/tests/test_batch/test_clone_preserves_set.py \
+  backend/tests/test_batch/test_operations.py
+
+cd frontend && npx vitest run tests/unit/elementClonePreservesSet.test.ts
+```
+
+Green. Manual smoke per ADR-198 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.6",
+	"version": "6.8.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -320,6 +320,9 @@
 	async function handleClone() {
 		if (!entity) return;
 		try {
+			// Issue #173 item 1: explicitly pass set_id so the clone lands in
+			// the source's set, not the default. The backend's create_element
+			// defaults set_id when absent, which is what produced the bug.
 			const created = await apiFetch<Element>('/api/elements', {
 				method: 'POST',
 				body: JSON.stringify({
@@ -327,6 +330,7 @@
 					name: `${entity.name} (Copy)`,
 					description: entity.description ?? '',
 					data: entity.data ?? {},
+					set_id: entity.set_id,
 				}),
 			});
 			await goto(`/elements/${created.id}`);

--- a/frontend/tests/unit/elementClonePreservesSet.test.ts
+++ b/frontend/tests/unit/elementClonePreservesSet.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Element clone preserves source set_id (v6.8.7, ADR-198, issue #173 item 1).
+ *
+ * Bug: the single-element clone button on /elements/{id} sent a
+ * `POST /api/elements` body containing only `element_type`, `name`,
+ * `description`, `data` — but not `set_id`. The backend's
+ * `create_element` defaults to `DEFAULT_SET_ID` when `set_id` is
+ * absent, so the "(Copy)" landed in the default set rather than the
+ * source's set.
+ *
+ * (The batch-clone path at /api/batch/elements/clone is unaffected —
+ * `batch_clone_elements` in the backend reads and re-inserts the
+ * source's `set_id`. The bug is purely the detail-page handler.)
+ *
+ * Fix: include `set_id: entity.set_id` in the clone POST body.
+ *
+ * Static-parser style to match the rest of this suite.
+ */
+
+const src = readFileSync(
+	resolve(__dirname, '../../src/routes/elements/[id]/+page.svelte'),
+	'utf-8',
+);
+
+function handleCloneBody(): string {
+	const start = src.indexOf('async function handleClone(');
+	expect(start, 'handleClone not found').toBeGreaterThan(-1);
+	const braceStart = src.indexOf('{', start);
+	let depth = 0;
+	let i = braceStart;
+	for (; i < src.length; i++) {
+		const ch = src[i];
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) break;
+		}
+	}
+	return src.slice(braceStart, i + 1);
+}
+
+describe('Element detail — handleClone preserves source set_id (#173 item 1)', () => {
+	const body = handleCloneBody();
+
+	it('still POSTs to /api/elements', () => {
+		expect(body).toContain("'/api/elements'");
+	});
+
+	it('includes set_id: entity.set_id in the request body', () => {
+		expect(body).toMatch(/set_id:\s*entity\.set_id/);
+	});
+
+	it('still includes the basic fields', () => {
+		expect(body).toMatch(/element_type:\s*entity\.element_type/);
+		expect(body).toMatch(/name:\s*`\$\{entity\.name\}\s*\(Copy\)`/);
+		expect(body).toMatch(/data:\s*entity\.data/);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.6"
+version = "6.8.7"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes part of #173 — item 1 (cloned element should land in same set as original).

Reproduce-first turned up a real bug, but in a different code path than the plan suspected:

- **Batch clone** (`POST /api/batch/elements/clone`) — already correct. Backend `batch_clone_elements` reads source `set_id` and re-uses it. Added a regression test that explicitly asserts this.
- **Single-element clone** (Clone button on `/elements/{id}`) — was the bug. POST body omitted `set_id`, so the backend's `create_element` fell back to `DEFAULT_SET_ID`. Fix: include `set_id: entity.set_id`.

## Scope

Narrow on purpose. Only `set_id` is propagated (the field the issue calls out). Notation, metadata, package_id, and tags are not — that matches the existing batch-clone behaviour. ADR-198 documents the rationale and flags the candidate refactor of routing the single-clone path through `batch_clone_elements` for a future PR.

## Test plan

- [x] `.venv/bin/python -m pytest backend/tests/test_batch/test_clone_preserves_set.py backend/tests/test_batch/test_operations.py` — green.
- [x] `npx vitest run tests/unit/elementClonePreservesSet.test.ts` — green.
- [ ] Browser smoke (post-deploy on iris-uat): navigate to an element in a non-default set, click "Clone", confirm the copy appears in the same set's listing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)