### PR TITLE
feat(v6.9.0): KG settings tab split + element-package edges (#173 items 4, 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.9.0] - 2026-05-18
+
+### Added
+
+- **Knowledge graph models element ↔ package membership as a
+  first-class edge** (issue
+  [#173](https://github.com/cgbarlow/iris/issues/173) item 5,
+  ADR-199). For every element with a non-null `package_id`, the
+  graph now emits a `package → element` edge (direction matches
+  `set_membership` and `hierarchy`). Default visibility ON;
+  toggle lives under the new Relationships tab → Package group →
+  "Elements (membership)".
+
+### Changed
+
+- **KG settings: Visibility tab split into Nodes + Relationships**
+  (issue [#173](https://github.com/cgbarlow/iris/issues/173) item 4,
+  ADR-199). The previous combined column mixed node-type toggles
+  and relationship-type toggles; finding the one you wanted was
+  fiddly. The settings dialog now has three tabs (Nodes /
+  Relationships / Display). Per-tab Reset semantics: each tab
+  resets only its own concern.
+
 ## [6.8.7] - 2026-05-18
 
 ### Fixed

--- a/backend/app/graph/models.py
+++ b/backend/app/graph/models.py
@@ -43,6 +43,10 @@ class GraphDisplaySettings(BaseModel):
         "collection_membership": True, "set_membership": True, "direct_diagram_links": True,
         "hierarchy": True, "diagram_element": True, "diagram_package": True,
         "diagram_link": True, "package_relationship": True, "element_relationship": True,
+        # Issue #173 item 5 — elements that belong to packages get a
+        # package → element edge so the KG can render package membership
+        # alongside set membership and diagram containment.
+        "element_package": True,
     })
     label_density: int = Field(default=10, ge=1, le=50)
     node_spacing: float = Field(default=1.0, ge=0.2, le=3.0)

--- a/backend/app/graph/service.py
+++ b/backend/app/graph/service.py
@@ -208,7 +208,7 @@ async def get_graph_data(
 
     # 1. Elements
     cursor = await db.execute(
-        "SELECT e.id, ev.name, e.element_type, ev.description, e.set_id "
+        "SELECT e.id, ev.name, e.element_type, ev.description, e.set_id, e.package_id "
         "FROM elements e "
         "JOIN element_versions ev ON e.id = ev.element_id AND e.current_version = ev.version "
         f"WHERE e.is_deleted = 0 {entity_filter.format(a='e')}",  # noqa: S608
@@ -375,6 +375,19 @@ async def get_graph_data(
                 "label": None,
                 "edge_type": "set_membership",
             })
+
+    # 8b. Package → Element membership (#173 item 5, ADR-199).
+    # element_rows columns: 0=id, 1=name, 2=type, 3=desc, 4=set_id, 5=package_id
+    for row in element_rows:
+        eid, pkg_id = row[0], row[5]
+        if pkg_id and pkg_id in package_ids:
+            edges.append({
+                "id": str(uuid.uuid4()),
+                "source": pkg_id, "target": eid,
+                "relationship_type": "contains",
+                "label": None,
+                "edge_type": "element_package",
+            })
     for row in diagram_rows:
         did, sid = row[0], row[6]
         if sid and sid in set_ids:
@@ -447,6 +460,7 @@ GRAPH_SETTINGS_DEFAULTS: dict[str, Any] = {
         "diagram_element": True, "diagram_package": True,
         "diagram_link": True, "package_relationship": True,
         "element_relationship": True,
+        "element_package": True,
     },
     "label_density": 10,
     "node_spacing": 1.0,

--- a/backend/tests/test_graph/test_element_package_edges.py
+++ b/backend/tests/test_graph/test_element_package_edges.py
@@ -1,0 +1,197 @@
+"""Tests for the element ↔ package edge type in the knowledge graph.
+
+Issue #173 item 5, ADR-199 — elements can belong to packages
+(`element.package_id` per m064_element_package_membership), but the
+graph service did not previously emit edges for that relationship,
+and the KG visibility settings had no toggle for it.
+
+This module covers the backend invariants:
+
+- `GET /api/graph?set_id=...` includes `element_package` edges for
+  every element whose `package_id` is in the scoped package set.
+- Edge direction is package → element (consistent with set_membership
+  and hierarchy: containers point at their contents).
+- Default settings include `element_package: True` so the edges are
+  visible out of the box.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.graph.models import GraphDisplaySettings
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+class TestDefaults:
+    def test_element_package_default_visible(self) -> None:
+        defaults = GraphDisplaySettings()
+        assert "element_package" in defaults.edges, (
+            "element_package must appear in the defaults dict so the "
+            "settings UI can render its toggle"
+        )
+        assert defaults.edges["element_package"] is True, (
+            "default visibility for element_package should be ON"
+        )
+
+
+class TestGraphEmitsElementPackageEdges:
+    async def test_edge_emitted_for_element_with_package_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+
+        set_resp = await client.post(
+            "/api/sets", json={"name": "GraphSet"}, headers=h,
+        )
+        assert set_resp.status_code == 201
+        set_id = set_resp.json()["id"]
+
+        pkg_resp = await client.post(
+            "/api/packages",
+            json={"name": "Pantry", "set_id": set_id},
+            headers=h,
+        )
+        assert pkg_resp.status_code == 201
+        pkg_id = pkg_resp.json()["id"]
+
+        el_resp = await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "Tinned Tomatoes",
+                "data": {},
+                "set_id": set_id,
+                "package_id": pkg_id,
+            },
+            headers=h,
+        )
+        assert el_resp.status_code == 201, el_resp.text
+        el_id = el_resp.json()["id"]
+
+        graph_resp = await client.get(f"/api/graph?set_id={set_id}", headers=h)
+        assert graph_resp.status_code == 200
+        body = graph_resp.json()
+
+        ep_edges = [e for e in body["edges"] if e["edge_type"] == "element_package"]
+        assert len(ep_edges) == 1, (
+            f"expected 1 element_package edge, got {len(ep_edges)} "
+            f"(all edges: {[e['edge_type'] for e in body['edges']]})"
+        )
+        edge = ep_edges[0]
+        assert edge["source"] == pkg_id, "edge direction should be package → element"
+        assert edge["target"] == el_id
+
+    async def test_no_edge_when_element_has_no_package(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "GraphSet"}, headers=h,
+        )
+        set_id = set_resp.json()["id"]
+
+        await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "FreeFloating",
+                "data": {},
+                "set_id": set_id,
+            },
+            headers=h,
+        )
+
+        graph_resp = await client.get(f"/api/graph?set_id={set_id}", headers=h)
+        body = graph_resp.json()
+        ep_edges = [e for e in body["edges"] if e["edge_type"] == "element_package"]
+        assert ep_edges == []
+
+    async def test_node_type_remains_element_not_package(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Sanity: adding the edge doesn't change node typing."""
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "GraphSet"}, headers=h,
+        )
+        set_id = set_resp.json()["id"]
+
+        pkg_resp = await client.post(
+            "/api/packages",
+            json={"name": "Pantry", "set_id": set_id},
+            headers=h,
+        )
+        pkg_id = pkg_resp.json()["id"]
+
+        el_resp = await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "Tinned Tomatoes",
+                "data": {},
+                "set_id": set_id,
+                "package_id": pkg_id,
+            },
+            headers=h,
+        )
+        el_id = el_resp.json()["id"]
+
+        graph_resp = await client.get(f"/api/graph?set_id={set_id}", headers=h)
+        body = graph_resp.json()
+
+        el_node = next(n for n in body["nodes"] if n["id"] == el_id)
+        pkg_node = next(n for n in body["nodes"] if n["id"] == pkg_id)
+        assert el_node["node_type"] == "element"
+        assert pkg_node["node_type"] == "package"

--- a/docs/adrs/ADR-199-KG-Settings-Tab-Split-And-Element-Package-Edge.md
+++ b/docs/adrs/ADR-199-KG-Settings-Tab-Split-And-Element-Package-Edge.md
@@ -1,0 +1,139 @@
+# ADR-199: KG settings split + first-class element ↔ package edges
+
+Status: Accepted (2026-05-18)
+Bundles: issue [#173](https://github.com/cgbarlow/iris/issues/173) items 4 and 5.
+
+## Context
+
+Two pieces of UAT feedback that hit the same component and the
+same user mental model, so they ship as one release:
+
+**Item 4.** The KG Visibility tab mixed node-type toggles and
+relationship-type toggles in a single column. With twelve toggles
+in one panel, finding the one you want — particularly toggling a
+single relationship without touching node visibility — was
+fiddly.
+
+**Item 5.** Elements can belong to packages
+(`element.package_id` per `m064_element_package_membership`,
+ADR-184), but the graph service did not emit edges for that
+relationship. The KG showed elements floating, with no visual
+link to the package they belong to, even though packages and
+elements were both rendered as nodes in the same view.
+
+The two are coupled in practice: item 5 adds a new toggle to the
+relationship-types list, and the natural place for it is the new
+"Relationships" tab from item 4. Shipping them in two separate
+PRs would either land the new toggle in the old combined tab
+(worse UX) or block item 5 on item 4.
+
+## Decision
+
+One PR. Two coordinated changes:
+
+### Tab split (item 4)
+
+`KnowledgeGraphSettings.svelte` widens its `activeTab` union from
+`'visibility' | 'display'` to `'nodes' | 'relationships' |
+'display'`. The body of the former Visibility tab is split: node
+toggles live under "Nodes", edge toggles live under
+"Relationships". Display tab is unchanged.
+
+Default tab on first open: `'nodes'` (preserves the
+"node-type-first" mental model of the previous Visibility tab —
+that section's heading was at the top).
+
+The `onResetToDefaults` prop signature widens to the new union.
+The dashboard's caller switches to per-tab reset semantics: each
+tab resets only its own concern (nodes resets `nodes`,
+relationships resets `edges`, display resets physics). This was
+already the user's intent — the old code reset both nodes and
+edges from the single "Visibility" tab because there was nowhere
+finer-grained to reset from. Now there is.
+
+### Element ↔ package edge (item 5)
+
+`get_graph_data` selects `e.package_id` alongside the existing
+element columns, and emits one `package → element` edge per
+element whose `package_id` resolves to a package in the scoped
+set. Edge direction matches the existing `set_membership` and
+`hierarchy` conventions: containers point at their contents.
+
+`element_package` is added to `GraphDisplaySettings.edges` and to
+`GRAPH_SETTINGS_DEFAULTS` with default `True`. The frontend
+exposes the toggle in `EDGE_GROUPS` under the **Package** group
+(alongside `hierarchy` and `package_relationship`).
+
+## Why this edge direction (package → element)
+
+Consistency. Every other "containment" edge in the graph points
+container → contents:
+
+| Edge | Direction |
+|---|---|
+| `collection_membership` | collection → set |
+| `set_membership` | set → element / diagram / package |
+| `hierarchy` | parent_package → child_package / diagram |
+| `diagram_element` | diagram → element |
+| `element_package` (this PR) | **package → element** |
+
+Reversing for elements alone would be a needless inconsistency.
+
+## Why default ON
+
+Symmetric with the other containment edges. Users who don't want
+to see package membership can turn it off; users who never opened
+the settings dialog should see the most informative view by
+default.
+
+## Why no per-element-type granularity
+
+Out of scope. The toggle is one boolean for "show element-to-
+package edges at all". Per-type filtering (only show
+`component → package` but not `interface → package`, say) is a
+separate feature with no current user demand.
+
+## Consequences
+
+- `backend/app/graph/models.py:36-51` — `element_package: True` in
+  `GraphDisplaySettings.edges` default.
+- `backend/app/graph/service.py:211,367-397,444-451` — element
+  SELECT adds `package_id`, new edge-generation block emits
+  `element_package` edges, `GRAPH_SETTINGS_DEFAULTS` includes the
+  key.
+- `backend/tests/test_graph/test_element_package_edges.py` — new
+  pytest module, 4 cases (defaults, emit-with-package,
+  no-emit-without-package, node typing sanity).
+- `frontend/src/lib/components/KnowledgeGraphSettings.svelte` —
+  `activeTab` union widened, three tab buttons, two `{#if}`
+  branches for the split, `element_package` toggle added to the
+  Package group in `EDGE_GROUPS`.
+- `frontend/src/lib/components/KnowledgeGraph.svelte:17` — prop
+  signature widened to match.
+- `frontend/src/routes/+page.svelte:690-702` — `onResetToDefaults`
+  caller switches to per-tab reset semantics.
+- `frontend/tests/unit/kgSettingsTabSplit.test.ts` — new static-
+  parser test (12 assertions) covers tab structure, body gating,
+  edge toggle placement, prop signature.
+- CHANGELOG `[6.9.0]`. Minor bump — new feature surface.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_graph/
+cd frontend && npx vitest run tests/unit/kgSettingsTabSplit.test.ts
+```
+
+Both green. Manual smoke: open KG with a set that has elements
+assigned to packages; confirm package→element edges render; open
+settings, confirm three tabs (Nodes / Relationships / Display);
+toggle the new "Elements (membership)" item under the Package
+group and confirm the edges hide.
+
+## See also
+
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) items 4, 5.
+- [ADR-184](ADR-184-Element-Package-Membership.md) — the
+  `element.package_id` column this edge surfaces.
+- [ADR-189](ADR-189-Package-Relationships-Tab.md) — the table
+  view of the same relationship on the package detail page.

--- a/docs/adrs/specs/SPEC-199-A-KG-Settings-Tab-Split-And-Element-Package-Edge.md
+++ b/docs/adrs/specs/SPEC-199-A-KG-Settings-Tab-Split-And-Element-Package-Edge.md
@@ -1,0 +1,139 @@
+# SPEC-199-A: KG settings tab split + element-package edges
+
+Implements: [ADR-199](../ADR-199-KG-Settings-Tab-Split-And-Element-Package-Edge.md)
+Resolves: Issue [#173](https://github.com/cgbarlow/iris/issues/173) items 4, 5
+Status: Living
+
+## Frontend tab structure
+
+`frontend/src/lib/components/KnowledgeGraphSettings.svelte`:
+
+```ts
+let activeTab = $state<'nodes' | 'relationships' | 'display'>('nodes');
+```
+
+Three tab buttons in order: **Nodes** | **Relationships** |
+**Display**. Each branch renders only its own controls:
+
+| Tab | Renders |
+|---|---|
+| Nodes | `{#each Object.entries(NODE_TYPE_LABELS)}` node checkboxes with colour swatches |
+| Relationships | `{#each EDGE_GROUPS}` group → items, with tri-state group toggle |
+| Display | Label density, spread, size contrast sliders |
+
+## EDGE_GROUPS structure (Relationships tab)
+
+```ts
+const EDGE_GROUPS = [
+  { label: 'Containment', items: [
+    { key: 'collection_membership', label: 'Collection → Sets' },
+    { key: 'set_membership',         label: 'Set → Contents' },
+    { key: 'direct_diagram_links',   label: 'Direct diagram links' },
+  ]},
+  { label: 'Package', items: [
+    { key: 'hierarchy',            label: 'Nesting' },
+    { key: 'package_relationship', label: 'Relationships' },
+    { key: 'element_package',      label: 'Elements (membership)' },  // ← new
+  ]},
+  { label: 'Diagram', items: [
+    { key: 'diagram_element', label: 'Elements' },
+    { key: 'diagram_package', label: 'References' },
+    { key: 'diagram_link',    label: 'Navigation' },
+  ]},
+  { label: 'Element', items: [
+    { key: 'element_relationship', label: 'Relationships' },
+  ]},
+];
+```
+
+## Backend graph emission
+
+`backend/app/graph/service.py`:
+
+- Element SELECT now grabs `e.package_id` as `row[5]`.
+- New edge-generation block (section 8b):
+
+```python
+for row in element_rows:
+    eid, pkg_id = row[0], row[5]
+    if pkg_id and pkg_id in package_ids:
+        edges.append({
+            "id": str(uuid.uuid4()),
+            "source": pkg_id, "target": eid,
+            "relationship_type": "contains",
+            "label": None,
+            "edge_type": "element_package",
+        })
+```
+
+Edge direction: **package → element** (container → contents, matching
+`set_membership` and `hierarchy`).
+
+## Defaults
+
+Both `GraphDisplaySettings.edges` (pydantic model) and
+`GRAPH_SETTINGS_DEFAULTS` (service-layer settings store) include:
+
+```python
+"element_package": True
+```
+
+## Per-tab reset semantics
+
+`frontend/src/routes/+page.svelte` `onResetToDefaults` handler:
+
+```ts
+if (tab === 'nodes') {
+  graphSettings = { ...graphSettings, nodes: { ...defaults.nodes } };
+} else if (tab === 'relationships') {
+  graphSettings = { ...graphSettings, edges: { ...defaults.edges } };
+} else {
+  graphSettings = { ...graphSettings, label_density: ..., node_spacing: ..., size_contrast: ..., link_length: ... };
+}
+```
+
+## Acceptance criteria
+
+1. Opening KG settings shows three tab buttons; Nodes is active
+   by default.
+2. Switching to Relationships shows only edge toggles (with group
+   tri-state); switching to Nodes shows only node toggles.
+3. Resetting from the Relationships tab restores edge defaults
+   without disturbing node toggles, and vice versa.
+4. Opening KG for a set with elements assigned to packages shows
+   `package → element` edges by default.
+5. Toggling "Elements (membership)" off in the Package group
+   hides those edges.
+6. No other edge type's visibility, default, or rendering changes.
+
+## Tests
+
+Backend — `backend/tests/test_graph/test_element_package_edges.py`:
+
+1. `element_package` appears in `GraphDisplaySettings.edges`
+   defaults with value `True`.
+2. `GET /api/graph?set_id=...` emits one `element_package` edge
+   per element with a `package_id` resolving to a package in
+   scope (correct source/target).
+3. Element with no `package_id` produces no edge.
+4. Edge addition doesn't change node typing.
+
+Frontend — `frontend/tests/unit/kgSettingsTabSplit.test.ts`:
+
+1-6. Tab structure: union is widened; default is `'nodes'`; three
+   tab buttons present; old `'visibility'` key gone.
+7. Nodes branch gated on `activeTab === 'nodes'`.
+8-9. Relationships branch gated on `activeTab === 'relationships'`;
+   `EDGE_GROUPS` still iterated.
+10-11. `element_package` toggle key exists and sits under the
+   Package group.
+12. `onResetToDefaults` prop widened to the new union.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_graph/
+cd frontend && npx vitest run tests/unit/kgSettingsTabSplit.test.ts
+```
+
+Both green. Manual smoke per ADR-199 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.8.7",
+	"version": "6.9.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/KnowledgeGraph.svelte
+++ b/frontend/src/lib/components/KnowledgeGraph.svelte
@@ -14,7 +14,7 @@
 		highlightNodeId?: string | null;
 		isAdmin?: boolean;
 		onSaveDefault?: (settings: GraphSettings) => void | Promise<void>;
-		onResetToDefaults?: (tab: 'visibility' | 'display') => void;
+		onResetToDefaults?: (tab: 'nodes' | 'relationships' | 'display') => void;
 	}
 
 	let { nodes, edges, settings, onSettingsChange, onNodeClick, onNodeHover, highlightNodeId = null, isAdmin = false, onSaveDefault, onResetToDefaults }: Props = $props();

--- a/frontend/src/lib/components/KnowledgeGraphSettings.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphSettings.svelte
@@ -7,12 +7,16 @@
 		onchange: (settings: GraphSettings) => void;
 		isAdmin?: boolean;
 		onSaveDefault?: (settings: GraphSettings) => void | Promise<void>;
-		onResetToDefaults?: (tab: 'visibility' | 'display') => void;
+		onResetToDefaults?: (tab: 'nodes' | 'relationships' | 'display') => void;
 	}
 
 	let { settings, onchange, isAdmin = false, onSaveDefault, onResetToDefaults }: Props = $props();
 
-	let activeTab = $state<'visibility' | 'display'>('visibility');
+	// Issue #173 item 4: split former 'visibility' tab into 'nodes' and
+	// 'relationships' so node-type and relationship-type toggles each
+	// own their own column. Default opens on 'nodes' (preserves the
+	// "first thing you see" behaviour).
+	let activeTab = $state<'nodes' | 'relationships' | 'display'>('nodes');
 
 	const EDGE_GROUPS: { label: string; items: { key: string; label: string }[] }[] = [
 		{
@@ -28,6 +32,10 @@
 			items: [
 				{ key: 'hierarchy', label: 'Nesting' },
 				{ key: 'package_relationship', label: 'Relationships' },
+				// Issue #173 item 5: elements belonging to packages get
+				// their own toggle here so users can hide membership
+				// edges without losing package-to-package relationships.
+				{ key: 'element_package', label: 'Elements (membership)' },
 			],
 		},
 		{
@@ -74,13 +82,18 @@
 <div
 	style="position: absolute; top: 100%; right: 0; z-index: 20; margin-top: 4px; min-width: 220px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 4px 16px rgba(0,0,0,0.18); padding: 0"
 >
-	<!-- Tabs -->
+	<!-- Tabs (issue #173 item 4: Nodes / Relationships / Display) -->
 	<div class="flex" style="border-bottom: 1px solid var(--color-border)">
 		<button
-			onclick={() => (activeTab = 'visibility')}
+			onclick={() => (activeTab = 'nodes')}
 			class="flex-1 px-3 py-2 text-xs font-medium"
-			style="color: {activeTab === 'visibility' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'visibility' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
-		>Visibility</button>
+			style="color: {activeTab === 'nodes' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'nodes' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
+		>Nodes</button>
+		<button
+			onclick={() => (activeTab = 'relationships')}
+			class="flex-1 px-3 py-2 text-xs font-medium"
+			style="color: {activeTab === 'relationships' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'relationships' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
+		>Relationships</button>
 		<button
 			onclick={() => (activeTab = 'display')}
 			class="flex-1 px-3 py-2 text-xs font-medium"
@@ -89,7 +102,7 @@
 	</div>
 
 	<div style="padding: 12px">
-		{#if activeTab === 'visibility'}
+		{#if activeTab === 'nodes'}
 			<!-- Node Types -->
 			<h4 class="mb-2 text-xs font-semibold uppercase" style="color: var(--color-muted)">Node Types</h4>
 			{#each Object.entries(NODE_TYPE_LABELS) as [key, label]}
@@ -99,9 +112,7 @@
 					{label}
 				</label>
 			{/each}
-
-			<hr class="my-2" style="border-color: var(--color-border)" />
-
+		{:else if activeTab === 'relationships'}
 			<!-- Relationship Types -->
 			<h4 class="mb-2 text-xs font-semibold uppercase" style="color: var(--color-muted)">Relationship Types</h4>
 			{#each EDGE_GROUPS as group}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -690,8 +690,12 @@
 								onResetToDefaults={async (tab) => {
 									const defaults = await fetchAdminDefaults(setId || undefined, collectionId || undefined);
 									adminDefaults = defaults;
-									if (tab === 'visibility') {
-										graphSettings = { ...graphSettings, nodes: { ...defaults.nodes }, edges: { ...defaults.edges } };
+									// Issue #173 item 4: per-tab reset — each tab resets only its own concern
+									// (Nodes resets node toggles, Relationships resets edge toggles, Display resets physics).
+									if (tab === 'nodes') {
+										graphSettings = { ...graphSettings, nodes: { ...defaults.nodes } };
+									} else if (tab === 'relationships') {
+										graphSettings = { ...graphSettings, edges: { ...defaults.edges } };
 									} else {
 										graphSettings = { ...graphSettings, label_density: defaults.label_density, node_spacing: defaults.node_spacing, size_contrast: defaults.size_contrast, link_length: defaults.link_length };
 									}

--- a/frontend/tests/unit/kgSettingsTabSplit.test.ts
+++ b/frontend/tests/unit/kgSettingsTabSplit.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * KG settings tab split: Visibility → Nodes + Relationships
+ * (v6.9.0, ADR-199, issue #173 items 4 + 5).
+ *
+ * The previous Visibility tab mixed node-type toggles and relationship-type
+ * toggles in one column. We split into three tabs:
+ *
+ *   Nodes  |  Relationships  |  Display
+ *
+ * Item 5 also adds the new `element_package` edge type, which lands in
+ * the Package group under the Relationships tab.
+ *
+ * Static-parser style to match the rest of this suite.
+ */
+
+const src = readFileSync(
+	resolve(__dirname, '../../src/lib/components/KnowledgeGraphSettings.svelte'),
+	'utf-8',
+);
+
+describe('KG settings — tab structure', () => {
+	it("widens activeTab to 'nodes' | 'relationships' | 'display'", () => {
+		expect(src).toMatch(/\$state<'nodes'\s*\|\s*'relationships'\s*\|\s*'display'>/);
+	});
+
+	it("defaults activeTab to 'nodes'", () => {
+		expect(src).toMatch(/\$state<'nodes'\s*\|\s*'relationships'\s*\|\s*'display'>\('nodes'\)/);
+	});
+
+	it('renders a Nodes tab button', () => {
+		expect(src).toMatch(/onclick=\{[^}]*activeTab\s*=\s*'nodes'[^}]*\}[^>]*>[^<]*Nodes/);
+	});
+
+	it('renders a Relationships tab button', () => {
+		expect(src).toMatch(/onclick=\{[^}]*activeTab\s*=\s*'relationships'[^}]*\}[^>]*>[^<]*Relationships/);
+	});
+
+	it('renders a Display tab button', () => {
+		expect(src).toMatch(/onclick=\{[^}]*activeTab\s*=\s*'display'[^}]*\}[^>]*>[^<]*Display/);
+	});
+
+	it("no longer references the old 'visibility' tab key", () => {
+		expect(src).not.toMatch(/activeTab\s*===\s*'visibility'/);
+		expect(src).not.toMatch(/'visibility'\s*\|\s*'display'/);
+	});
+});
+
+describe('KG settings — Nodes tab body', () => {
+	it('Node-Types section is gated on activeTab === "nodes"', () => {
+		// The section heading or content sits inside an {#if activeTab === 'nodes'} branch.
+		expect(src).toMatch(/activeTab\s*===\s*'nodes'[\s\S]*?Node Types/);
+	});
+});
+
+describe('KG settings — Relationships tab body', () => {
+	it('Relationship-Types section is gated on activeTab === "relationships"', () => {
+		expect(src).toMatch(/activeTab\s*===\s*'relationships'[\s\S]*?Relationship Types/);
+	});
+
+	it('still iterates EDGE_GROUPS in the Relationships branch', () => {
+		// Sanity: edge group rendering is preserved, just moved.
+		expect(src).toContain('EDGE_GROUPS');
+	});
+});
+
+describe('KG settings — element ↔ package edge toggle (#173 item 5)', () => {
+	it('exposes an element_package toggle key in EDGE_GROUPS', () => {
+		expect(src).toMatch(/key:\s*'element_package'/);
+	});
+
+	it('places the element_package toggle under the Package group', () => {
+		// Slice from the start of the Package group to the start of the
+		// next *group-level* label (Diagram). That window contains every
+		// `key: 'foo'` entry for the Package group's items.
+		const packageGroupStart = src.indexOf("label: 'Package'");
+		expect(packageGroupStart, "'Package' group not found").toBeGreaterThan(-1);
+		const diagramGroupStart = src.indexOf("label: 'Diagram'", packageGroupStart);
+		expect(diagramGroupStart, "'Diagram' group not found").toBeGreaterThan(-1);
+		const packageGroupSlice = src.slice(packageGroupStart, diagramGroupStart);
+		expect(packageGroupSlice).toMatch(/key:\s*'element_package'/);
+	});
+});
+
+describe('KG settings — onResetToDefaults prop signature', () => {
+	it("widens onResetToDefaults to accept the new 3-tab union", () => {
+		expect(src).toMatch(
+			/onResetToDefaults\?:\s*\(tab:\s*'nodes'\s*\|\s*'relationships'\s*\|\s*'display'\)\s*=>\s*void/,
+		);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.8.7"
+version = "6.9.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes parts of #173 — items 4 and 5, bundled because they share the same component and user mental model.

- **Item 4**: KG settings "Visibility" tab splits into **Nodes** and **Relationships**. Per-tab Reset semantics — each tab resets only its own concern (Nodes resets node toggles, Relationships resets edge toggles, Display resets physics). Default tab on open: Nodes.
- **Item 5**: Knowledge graph now models element ↔ package membership as a first-class edge. For every element with a non-null `package_id`, a \`package → element\` edge is emitted (direction matches \`set_membership\` and \`hierarchy\`). New \`element_package\` edge type added to defaults (visible ON). Toggle lives under the new Relationships tab → Package group → "Elements (membership)".

## Why bundled

Item 5 adds a new toggle that lands under the new Relationships tab from item 4. Shipping separately would either land the new toggle in the old combined tab (worse UX) or block item 5 on item 4. One PR, one release.

## Test plan

- [x] \`.venv/bin/python -m pytest backend/tests/test_graph/\` — 30 passed (4 new + 26 existing).
- [x] \`npx vitest run tests/unit/kgSettingsTabSplit.test.ts\` — 12 passed.
- [ ] Browser smoke (post-deploy on iris-uat):
  - Open KG, click settings cog — confirm 3 tabs (Nodes / Relationships / Display) with Nodes active by default.
  - Switch to Relationships — confirm edge toggles render, Package group shows "Elements (membership)".
  - Open KG for a set with elements assigned to packages — confirm \`package → element\` edges render.
  - Toggle "Elements (membership)" off — confirm those edges hide.
  - Reset on each tab — confirm it only resets that tab's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)