### PR TITLE
feat(v6.10.0): batch element create + update tools (#173 item 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.10.0] - 2026-05-18
+
+### Added
+
+- **Batch element create + update across REST, MCP, CLI** (issue
+  [#173](https://github.com/cgbarlow/iris/issues/173) item 6,
+  ADR-200). Creating or updating long lists of elements via the
+  singular `create_element` / `update_element` MCP tools required
+  N round-trips. New plural tools handle up to 100 items in one
+  call:
+  - REST: `POST /api/batch/elements/create`,
+    `POST /api/batch/elements/update`. Both return
+    `BatchResultWithIds { succeeded, failed, errors, ids }`.
+  - MCP: `create_elements`, `update_elements`. Per-item schema
+    is open so callers can construct any subset of the singular
+    fields.
+  - CLI: `iris create elements --from-json <path|->`,
+    `iris update elements --from-json <path|->`. JSON-only input
+    via file or stdin.
+  - Per-item failure isolation — a bad row reports an
+    index-tagged error without sinking the rest of the batch.
+    Per-item optimistic concurrency on update (each item carries
+    its own `expected_version`).
+  - Surface parity (`scripts/check_surface_parity.py`) verified
+    clean.
+
 ## [6.9.0] - 2026-05-18
 
 ### Added

--- a/backend/app/batch/models.py
+++ b/backend/app/batch/models.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
+
+from app.elements.models import _UNSET
 
 
 class BatchIds(BaseModel):
@@ -32,3 +36,66 @@ class BatchResult(BaseModel):
     succeeded: int = 0
     failed: int = 0
     errors: list[str] = Field(default_factory=list)
+
+
+# ── v6.10.0 / ADR-200 / issue #173 item 6 ────────────────────────────
+# Bulk element create + update so MCP clients can ship many items in
+# one call. Per-item failure isolation; the response envelope includes
+# the ids of items that succeeded so callers can chase up the failures
+# by index.
+
+
+class BatchElementCreateItem(BaseModel):
+    """Per-item element create payload for batch create.
+
+    Mirrors ``ElementCreate`` but with all fields optional at the model
+    boundary so we can surface validation failures as per-item errors
+    rather than rejecting the whole batch on one bad row.
+    """
+
+    element_type: str = ""
+    name: str = Field(default="", max_length=255)
+    description: str | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+    set_id: str | None = None
+    package_id: str | None = None
+    metadata: dict[str, Any] | None = None
+    notation: str = "simple"
+
+
+class BatchElementsCreate(BaseModel):
+    """Request body for POST /api/batch/elements/create."""
+
+    elements: list[BatchElementCreateItem] = Field(min_length=1, max_length=100)
+
+
+class BatchElementUpdateItem(BaseModel):
+    """Per-item element update payload.
+
+    ``element_id`` and ``expected_version`` are the per-item analogues
+    of the URL path arg + ``If-Match`` header on the singular endpoint.
+    ``package_id`` is tri-state: omit to leave untouched, send null to
+    clear, send a UUID to set (uses the same _UNSET sentinel as
+    ElementUpdate).
+    """
+
+    element_id: str
+    expected_version: int = Field(ge=1)
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
+    change_summary: str | None = None
+    metadata: dict[str, Any] | None = None
+    package_id: Any = _UNSET
+
+
+class BatchElementsUpdate(BaseModel):
+    """Request body for POST /api/batch/elements/update."""
+
+    updates: list[BatchElementUpdateItem] = Field(min_length=1, max_length=100)
+
+
+class BatchResultWithIds(BatchResult):
+    """Response for batch operations that return the ids of successful items."""
+
+    ids: list[str] = Field(default_factory=list)

--- a/backend/app/batch/router.py
+++ b/backend/app/batch/router.py
@@ -7,16 +7,26 @@ from typing import Any
 from fastapi import APIRouter, Depends, Request
 
 from app.auth.dependencies import get_current_user
-from app.batch.models import BatchIds, BatchModifySet, BatchModifyTags, BatchResult
+from app.batch.models import (
+    BatchElementsCreate,
+    BatchElementsUpdate,
+    BatchIds,
+    BatchModifySet,
+    BatchModifyTags,
+    BatchResult,
+    BatchResultWithIds,
+)
 from app.batch.service import (
     batch_clone_elements,
     batch_clone_diagrams,
+    batch_create_elements,
     batch_delete_elements,
     batch_delete_diagrams,
     batch_set_elements,
     batch_set_diagrams,
     batch_tags_elements,
     batch_tags_diagrams,
+    batch_update_elements,
 )
 
 router = APIRouter(prefix="/api/batch", tags=["batch"])
@@ -132,3 +142,38 @@ async def tags_elements(
         modified_by=current_user["id"],
     )
     return BatchResult(**result)
+
+
+# --- Bulk create / update (v6.10.0, ADR-200, #173 item 6) ---
+
+
+@router.post("/elements/create", response_model=BatchResultWithIds)
+async def create_elements(
+    body: BatchElementsCreate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> BatchResultWithIds:
+    """Bulk create elements. Per-item failure isolation."""
+    db = request.app.state.db_manager.main_db
+    items = [el.model_dump() for el in body.elements]
+    result = await batch_create_elements(
+        db, items, created_by=current_user["id"],
+    )
+    return BatchResultWithIds(**result)
+
+
+@router.post("/elements/update", response_model=BatchResultWithIds)
+async def update_elements(
+    body: BatchElementsUpdate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> BatchResultWithIds:
+    """Bulk update elements. Per-item expected_version; per-item failure isolation."""
+    db = request.app.state.db_manager.main_db
+    # ``exclude_unset`` preserves the tri-state semantics of package_id —
+    # only items whose payload explicitly included the key get it forwarded.
+    items = [u.model_dump(exclude_unset=True) for u in body.updates]
+    result = await batch_update_elements(
+        db, items, updated_by=current_user["id"],
+    )
+    return BatchResultWithIds(**result)

--- a/backend/app/batch/service.py
+++ b/backend/app/batch/service.py
@@ -292,6 +292,116 @@ async def batch_delete_elements(
     return {"succeeded": succeeded, "failed": failed, "errors": errors}
 
 
+async def batch_create_elements(
+    db: DatabasePort,
+    elements: list[dict[str, Any]],
+    created_by: str,
+) -> dict[str, Any]:
+    """Bulk create elements with per-item failure isolation (ADR-200, #173)."""
+    from app.elements.models import _UNSET
+    from app.elements.service import create_element, ElementPackageInvariantError
+
+    succeeded = 0
+    failed = 0
+    errors: list[str] = []
+    created_ids: list[str] = []
+
+    for idx, item in enumerate(elements):
+        try:
+            element_type = item.get("element_type") or ""
+            name = item.get("name") or ""
+            if not element_type:
+                raise ValueError("element_type is required")
+            if not name:
+                raise ValueError("name is required")
+            result = await create_element(
+                db,
+                element_type=element_type,
+                name=name,
+                description=item.get("description"),
+                data=item.get("data") or {},
+                created_by=created_by,
+                set_id=item.get("set_id"),
+                package_id=item.get("package_id"),
+                metadata=item.get("metadata"),
+                notation=item.get("notation") or "simple",
+            )
+            created_ids.append(str(result["id"]))
+            succeeded += 1
+        except ElementPackageInvariantError as exc:
+            failed += 1
+            errors.append(f"Element at index {idx}: {exc}")
+        except Exception as exc:
+            failed += 1
+            errors.append(f"Element at index {idx}: {exc}")
+
+    return {
+        "succeeded": succeeded, "failed": failed,
+        "errors": errors, "ids": created_ids,
+    }
+
+
+async def batch_update_elements(
+    db: DatabasePort,
+    updates: list[dict[str, Any]],
+    updated_by: str,
+) -> dict[str, Any]:
+    """Bulk update elements (ADR-200, #173).
+
+    Each item carries its own ``expected_version``; version conflicts
+    surface as per-item failures (not a whole-batch 409).
+    """
+    from app.elements.models import _UNSET
+    from app.elements.service import update_element, ElementPackageInvariantError
+
+    succeeded = 0
+    failed = 0
+    errors: list[str] = []
+    updated_ids: list[str] = []
+
+    for idx, item in enumerate(updates):
+        try:
+            element_id = item.get("element_id")
+            expected_version = item.get("expected_version")
+            if not element_id:
+                raise ValueError("element_id is required")
+            if expected_version is None:
+                raise ValueError("expected_version is required")
+
+            update_kwargs: dict[str, Any] = {
+                "name": item["name"],
+                "description": item.get("description"),
+                "data": item.get("data") or {},
+                "change_summary": item.get("change_summary"),
+                "updated_by": updated_by,
+                "expected_version": int(expected_version),
+                "metadata": item.get("metadata"),
+            }
+            # Tri-state package_id: only forward when the client
+            # explicitly included the key (which exclude_unset captures).
+            if "package_id" in item and item["package_id"] is not _UNSET:
+                update_kwargs["package_id"] = item["package_id"]
+
+            result = await update_element(db, element_id, **update_kwargs)
+            if result is None:
+                raise ValueError(
+                    f"Version conflict (expected {expected_version})",
+                )
+            updated_ids.append(str(element_id))
+            succeeded += 1
+        except ElementPackageInvariantError as exc:
+            failed += 1
+            errors.append(f"Update at index {idx}: {exc}")
+        except Exception as exc:
+            failed += 1
+            errors.append(f"Update at index {idx}: {exc}")
+
+    return {
+        "succeeded": succeeded, "failed": failed,
+        "errors": errors, "ids": updated_ids,
+    }
+
+
 async def batch_clone_elements(
     db: DatabasePort,
     ids: list[str],

--- a/backend/tests/test_batch/test_batch_create_update_elements.py
+++ b/backend/tests/test_batch/test_batch_create_update_elements.py
@@ -1,0 +1,235 @@
+"""Integration tests for batch element create + update (v6.10.0, ADR-200, #173 item 6).
+
+New tools:
+
+- POST /api/batch/elements/create — bulk create
+- POST /api/batch/elements/update — bulk update with per-item optimistic concurrency
+
+Per-item failure isolation: one bad item doesn't sink the whole batch.
+The response includes a `BatchResultWithIds` envelope: succeeded count,
+failed count, errors list, and the IDs of created/updated items.
+
+Same fixture pattern as test_operations.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _create_set(c: httpx.AsyncClient, h: dict, name: str = "S") -> str:
+    r = await c.post("/api/sets", json={"name": name}, headers=h)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+class TestBatchCreateElements:
+    async def test_create_three_elements_in_one_call(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+
+        resp = await client.post(
+            "/api/batch/elements/create",
+            json={"elements": [
+                {"element_type": "component", "name": "Apples", "data": {}, "set_id": set_id},
+                {"element_type": "component", "name": "Bananas", "data": {}, "set_id": set_id},
+                {"element_type": "component", "name": "Cherries", "data": {}, "set_id": set_id},
+            ]},
+            headers=h,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["succeeded"] == 3
+        assert body["failed"] == 0
+        assert body["errors"] == []
+        assert len(body["ids"]) == 3
+
+        list_resp = await client.get(f"/api/elements?set_id={set_id}", headers=h)
+        names = [e["name"] for e in list_resp.json()["items"]]
+        assert {"Apples", "Bananas", "Cherries"}.issubset(set(names))
+
+    async def test_partial_failure_isolated_per_item(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+
+        resp = await client.post(
+            "/api/batch/elements/create",
+            json={"elements": [
+                {"element_type": "component", "name": "Valid1", "data": {}, "set_id": set_id},
+                {"element_type": "",          "name": "InvalidType", "data": {}, "set_id": set_id},
+                {"element_type": "component", "name": "Valid2", "data": {}, "set_id": set_id},
+            ]},
+            headers=h,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["succeeded"] == 2
+        assert body["failed"] == 1
+        assert len(body["errors"]) == 1
+        assert "index 1" in body["errors"][0].lower() or "1" in body["errors"][0]
+        assert len(body["ids"]) == 2
+
+    async def test_empty_elements_returns_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        resp = await client.post(
+            "/api/batch/elements/create",
+            json={"elements": []},
+            headers=h,
+        )
+        assert resp.status_code == 422
+
+    async def test_requires_auth(self, client: httpx.AsyncClient) -> None:
+        resp = await client.post(
+            "/api/batch/elements/create",
+            json={"elements": [{"element_type": "component", "name": "X", "data": {}}]},
+        )
+        assert resp.status_code == 401
+
+
+class TestBatchUpdateElements:
+    async def test_update_two_elements_in_one_call(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+
+        e1 = (await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "Old1", "data": {}, "set_id": set_id},
+            headers=h,
+        )).json()
+        e2 = (await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "Old2", "data": {}, "set_id": set_id},
+            headers=h,
+        )).json()
+
+        resp = await client.post(
+            "/api/batch/elements/update",
+            json={"updates": [
+                {"element_id": e1["id"], "expected_version": e1["current_version"], "name": "New1", "data": {}},
+                {"element_id": e2["id"], "expected_version": e2["current_version"], "name": "New2", "data": {}},
+            ]},
+            headers=h,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["succeeded"] == 2
+        assert body["failed"] == 0
+        assert sorted(body["ids"]) == sorted([e1["id"], e2["id"]])
+
+        fresh1 = (await client.get(f"/api/elements/{e1['id']}", headers=h)).json()
+        fresh2 = (await client.get(f"/api/elements/{e2['id']}", headers=h)).json()
+        assert fresh1["name"] == "New1"
+        assert fresh2["name"] == "New2"
+
+    async def test_version_conflict_isolated_per_item(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _create_set(client, h)
+
+        e1 = (await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "E1", "data": {}, "set_id": set_id},
+            headers=h,
+        )).json()
+        e2 = (await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "E2", "data": {}, "set_id": set_id},
+            headers=h,
+        )).json()
+
+        # Bump e1's version out from under the batch with a singular PUT.
+        await client.put(
+            f"/api/elements/{e1['id']}",
+            json={"name": "E1-bumped", "data": {}},
+            headers={**h, "If-Match": str(e1["current_version"])},
+        )
+
+        resp = await client.post(
+            "/api/batch/elements/update",
+            json={"updates": [
+                # Stale expected_version on e1 — should fail.
+                {"element_id": e1["id"], "expected_version": e1["current_version"], "name": "E1-batch", "data": {}},
+                # Fresh expected_version on e2 — should succeed.
+                {"element_id": e2["id"], "expected_version": e2["current_version"], "name": "E2-batch", "data": {}},
+            ]},
+            headers=h,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["succeeded"] == 1
+        assert body["failed"] == 1
+        assert e2["id"] in body["ids"]
+        assert e1["id"] not in body["ids"]
+
+    async def test_empty_updates_returns_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        resp = await client.post(
+            "/api/batch/elements/update",
+            json={"updates": []},
+            headers=h,
+        )
+        assert resp.status_code == 422

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -680,6 +680,37 @@ def _resolve_null(value: str) -> str | None:
     return None if value.lower() == "null" else value
 
 
+def _load_batch_payload(source: str, *, key: str) -> dict[str, Any]:
+    """Load a {"<key>": [...]} JSON payload from a file path or '-' (stdin).
+
+    Used by ``iris create elements`` / ``iris update elements`` (ADR-200).
+    Validates that the payload is a dict containing ``key`` mapped to a
+    list — bails with a clear error otherwise so the user knows whether
+    the file shape is wrong vs the JSON is malformed.
+    """
+    import sys
+
+    if source == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            raw = Path(source).read_text(encoding="utf-8")
+        except OSError as exc:
+            output.print_error(f"--from-json: cannot read {source!r}: {exc}")
+            raise typer.Exit(code=1) from exc
+    try:
+        parsed = json_lib.loads(raw)
+    except json_lib.JSONDecodeError as exc:
+        output.print_error(f"--from-json: invalid JSON ({exc})")
+        raise typer.Exit(code=1) from exc
+    if not isinstance(parsed, dict) or not isinstance(parsed.get(key), list):
+        output.print_error(
+            f"--from-json: payload must be an object with a '{key}' array",
+        )
+        raise typer.Exit(code=1)
+    return parsed
+
+
 # Sentinel for "do not touch" on tri-state CLI flags (e.g. --package-id).
 _UNSET: Any = object()
 
@@ -823,6 +854,33 @@ def create_element_cmd(
     async def _do() -> Any:
         async with _client() as c:
             resp = await c._request("POST", "/api/elements", json=body)
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@create_app.command("elements")
+def create_elements_cmd(
+    from_json: str = typer.Option(
+        ...,
+        "--from-json",
+        help=(
+            "Path to a JSON file containing the bulk-create payload, or "
+            "'-' to read from stdin. Format: "
+            '{"elements": [ {...element fields...}, ... ]}. Each item '
+            "has the same fields as `iris create element` "
+            "(element_type, name, set_id, package_id, notation, "
+            "description, data, metadata). v6.10.0, ADR-200, #173."
+        ),
+    ),
+) -> None:
+    """Bulk-create elements (v6.10.0, ADR-200). Per-item failure isolation."""
+    body = _load_batch_payload(from_json, key="elements")
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/batch/elements/create", json=body,
+            )
             return resp.json()
     output.print_json(_run(_do()))
 
@@ -1015,6 +1073,33 @@ def update_element_cmd(
             headers = {"If-Match": str(current.get("current_version", 1))}
             resp = await c._request(
                 "PUT", f"/api/elements/{element_id}", json=body, headers=headers,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@update_app.command("elements")
+def update_elements_cmd(
+    from_json: str = typer.Option(
+        ...,
+        "--from-json",
+        help=(
+            "Path to a JSON file containing the bulk-update payload, or "
+            "'-' to read from stdin. Format: "
+            '{"updates": [{"element_id": "...", '
+            '"expected_version": N, "name": "...", ...}, ...]}. Each '
+            "item carries its own expected_version (per-item optimistic "
+            "concurrency). v6.10.0, ADR-200, #173."
+        ),
+    ),
+) -> None:
+    """Bulk-update elements (v6.10.0, ADR-200). Per-item failure isolation."""
+    body = _load_batch_payload(from_json, key="updates")
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/batch/elements/update", json=body,
             )
             return resp.json()
     output.print_json(_run(_do()))

--- a/docs/adrs/ADR-200-Batch-Element-Create-Update-Tools.md
+++ b/docs/adrs/ADR-200-Batch-Element-Create-Update-Tools.md
@@ -1,0 +1,168 @@
+# ADR-200: Batch element create + update tools across REST, MCP, CLI
+
+Status: Accepted (2026-05-18)
+Related: [ADR-182](ADR-182-Surface-Parity-Discipline.md) (surface parity)
+
+## Context
+
+Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 6
+— creating (or updating) a long list of elements via the
+`create_element` MCP tool requires one tool call per item. For a
+grocery-list-sized batch (10–50 items) this is slow,
+context-burny, and noisy in the assistant's transcript.
+
+The existing batch surface (`POST /api/batch/elements/*`) covers
+clone / delete / set-membership / tag operations but stops short
+of create and update. Adding them rounds out the bulk-ops
+toolkit.
+
+## Decision
+
+Add `create_elements` and `update_elements` (plural) across all
+three Iris surfaces, per Protocol §14 (surface parity, ADR-182).
+
+### REST
+
+- `POST /api/batch/elements/create` — body `{ elements: ElementCreateItem[] }`.
+- `POST /api/batch/elements/update` — body `{ updates: ElementUpdateItem[] }`.
+
+Both return a `BatchResultWithIds` envelope:
+
+```json
+{ "succeeded": N, "failed": M, "errors": ["Element at index 1: ..."], "ids": ["<uuid>", ...] }
+```
+
+Per-item failure isolation. One bad row gets reported as
+`Element at index <i>: <reason>` and the rest of the batch
+proceeds. The HTTP status stays 200 — the caller reads
+`failed`/`errors` to decide.
+
+Per-item update payload carries its own `element_id` +
+`expected_version` (per-item optimistic concurrency). A stale
+version surfaces as a per-item failure, not a whole-batch 409 —
+this is the only sensible behaviour for batches, since one stale
+row shouldn't reject the other 99.
+
+### MCP
+
+- `create_elements(elements: list[...])` — handler calls the REST
+  endpoint and returns the response verbatim.
+- `update_elements(updates: list[...])` — same.
+
+Both tools accept a free-form `additionalProperties: True` schema
+per-item so the MCP client can construct any subset of the
+`create_element` / `update_element` fields without us re-stating
+the full schema in the array item.
+
+### CLI
+
+- `iris create elements --from-json path.json` (or `--from-json -`
+  for stdin).
+- `iris update elements --from-json path.json`.
+
+Payload format mirrors the REST body. JSON-only — no per-field
+CLI flags. The shape can have dozens of fields per row; flags
+would be unusable. Files / stdin are the natural input.
+
+## Atomicity: per-item, not whole-batch
+
+Two choices considered:
+
+1. **Whole-batch transactional.** One DB transaction wraps every
+   row; any failure rolls the lot back. *Skipped.*
+2. **Per-item commit (chosen).** Each `create_element` /
+   `update_element` call commits its own row. Failures are
+   isolated.
+
+Per-item is right for the actual use case (ingesting a long list
+that the model assembled from a chat — most rows are
+independent). Whole-batch atomicity would make the "one bad row
+ruins everything" failure mode a lot worse, with no real
+trade-off benefit: there's no consistency invariant across the
+elements in a typical batch.
+
+This matches the existing `batch_clone_elements` semantics —
+loop, try, accumulate errors.
+
+## Surface parity script
+
+`scripts/check_surface_parity.py` tracks singular CRUD per entity
+(`create_element`, `update_element` etc., scoped to
+`/api/elements/`). The new endpoints live under `/api/batch/` and
+the script's parser correctly ignores them as batch operations.
+
+No script change required — the new tools are an additional
+capability layer, not duplicate write paths for the existing
+parity contract. Verified locally with `scripts/check_surface_parity.py`.
+
+## Why not extend `create_element` to accept arrays
+
+Considered. Polymorphic input (single object OR array). Rejected
+because:
+
+- Type signature gets uglier across all three surfaces.
+- Clients have to handle two response shapes (single
+  `ElementResponse` vs `BatchResultWithIds`).
+- Surface parity check treats `create_element` and
+  `create_elements` as distinct verbs anyway; adding a sibling
+  tool is structurally cleaner.
+
+Singular `create_element` stays as-is for callers that only need
+to create one.
+
+## Why no batch delete with this PR
+
+`batch_delete_elements` already exists (`/api/batch/elements/delete`).
+Scope of this issue was create + update; delete was already
+covered.
+
+## Consequences
+
+- `backend/app/batch/models.py` — new `BatchElementCreateItem`,
+  `BatchElementsCreate`, `BatchElementUpdateItem`,
+  `BatchElementsUpdate`, `BatchResultWithIds`. Re-exports the
+  `_UNSET` sentinel from `ElementUpdate`.
+- `backend/app/batch/service.py` — new `batch_create_elements`
+  and `batch_update_elements`, each looping over the input list
+  and accumulating failures.
+- `backend/app/batch/router.py` — two new endpoints wired to the
+  service functions.
+- `backend/tests/test_batch/test_batch_create_update_elements.py`
+  — new pytest module, 7 cases (happy path, partial failure,
+  empty payload validation, auth, batch update, version
+  conflict isolation, empty update validation).
+- `mcp/src/iris_mcp/tools.py` — two new `Tool` registrations
+  (`create_elements`, `update_elements`) + two new handlers
+  (`_create_elements`, `_update_elements`).
+- `cli/src/iris_cli/main.py` — two new commands (`iris create
+  elements`, `iris update elements`) plus `_load_batch_payload`
+  helper.
+- CHANGELOG `[6.10.0]`. Minor bump — new feature surface.
+- No backend migration, no schema change. Pure code addition on
+  top of the existing element schema.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_batch/
+.venv/bin/python scripts/check_surface_parity.py  # ✅ Parity clean
+```
+
+Manual smoke:
+```
+# Create 3 elements
+echo '{"elements":[{"element_type":"component","name":"A","data":{}},
+                  {"element_type":"component","name":"B","data":{}},
+                  {"element_type":"component","name":"C","data":{}}]}' \
+  | iris create elements --from-json -
+
+# Or from an MCP client, invoke create_elements with the same payload.
+```
+
+## See also
+
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 6.
+- [ADR-182](ADR-182-Surface-Parity-Discipline.md) — the surface
+  parity discipline this PR satisfies.
+- Existing batch operations: `backend/app/batch/router.py`,
+  `backend/app/batch/service.py`.

--- a/docs/adrs/specs/SPEC-200-A-Batch-Element-Create-Update.md
+++ b/docs/adrs/specs/SPEC-200-A-Batch-Element-Create-Update.md
@@ -1,0 +1,162 @@
+# SPEC-200-A: Batch element create + update
+
+Implements: [ADR-200](../ADR-200-Batch-Element-Create-Update-Tools.md)
+Resolves: Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 6
+Status: Living
+
+## Surfaces
+
+### REST
+
+```
+POST /api/batch/elements/create
+Body: { "elements": [ ElementCreateItem, ... ] }   // 1..100 items
+Response 200: { succeeded: int, failed: int, errors: string[], ids: string[] }
+Response 422: empty array / payload shape violation
+Response 401: not authenticated
+
+POST /api/batch/elements/update
+Body: { "updates": [ ElementUpdateItem, ... ] }    // 1..100 items
+Response 200: { succeeded: int, failed: int, errors: string[], ids: string[] }
+Response 422: empty array
+Response 401: not authenticated
+```
+
+`ElementCreateItem` mirrors `ElementCreate` with all fields
+optional at the model boundary (failure surfaces per-item, not
+whole-batch):
+
+```ts
+{
+  element_type?: string,
+  name?: string,
+  description?: string | null,
+  data?: object,
+  set_id?: string | null,
+  package_id?: string | null,
+  metadata?: object | null,
+  notation?: string
+}
+```
+
+`ElementUpdateItem`:
+
+```ts
+{
+  element_id: string,            // required
+  expected_version: int,         // required (per-item optimistic concurrency)
+  name: string,                  // required, 1..255 chars
+  description?: string | null,
+  data?: object,
+  change_summary?: string | null,
+  metadata?: object | null,
+  package_id?: string | null     // tri-state: omit / null / uuid (via _UNSET sentinel)
+}
+```
+
+### MCP
+
+```
+create_elements(elements: list[<object>])
+update_elements(updates: list[<object>])
+```
+
+Per-item schema is `additionalProperties: true` — the MCP client
+constructs items matching the REST shapes. Handlers POST the
+input verbatim to `/api/batch/elements/create` and
+`/api/batch/elements/update` respectively and return the response
+JSON.
+
+### CLI
+
+```
+iris create elements --from-json <path|->
+iris update elements --from-json <path|->
+```
+
+JSON-only input (per-field flags would be unusable across N rows
+with up to 8 fields each). Reads from a file path or stdin (`-`).
+Validates that the parsed payload is `{ "elements": [...] }` /
+`{ "updates": [...] }` before posting.
+
+## Behaviour
+
+- **Per-item failure isolation.** Each item is wrapped in
+  `try/except`. Failures accumulate into `errors` as
+  `"Element at index <i>: <reason>"` / `"Update at index <i>: <reason>"`.
+- **Version conflicts on update** surface as a per-item failure
+  (the singular `update_element` returns `None` on stale version;
+  the batch translates that into a `Version conflict (expected N)`
+  error string).
+- **Atomicity.** Per-item commit. No whole-batch transaction.
+  Matches `batch_clone_elements` semantics.
+- **Limits.** 1 ≤ items ≤ 100 per call (mirrors the
+  `BatchIds` cap). Larger batches paginate client-side.
+
+## DRY / surface parity
+
+The new endpoints live under `/api/batch/` rather than
+`/api/elements/`. The surface parity script
+(`scripts/check_surface_parity.py`) tracks singular CRUD per
+entity and correctly does not require `create_elements` /
+`update_elements` as new parity entries — they're an additional
+capability layer, not duplicate write paths. The MCP and CLI
+sides are nevertheless added for **surface symmetry within the
+batch capability** so the three-surface rule holds for the new
+tools too.
+
+## Tests
+
+Backend — `backend/tests/test_batch/test_batch_create_update_elements.py`:
+
+1. `test_create_three_elements_in_one_call` — happy path, 3
+   items, all succeed, IDs returned, items visible in subsequent
+   list.
+2. `test_partial_failure_isolated_per_item` — 3 items, middle
+   one invalid (`element_type=""`); 2 succeed, 1 fails with
+   index-tagged error.
+3. `test_empty_elements_returns_422` — empty array rejected at
+   the validation layer.
+4. `test_requires_auth` — unauthenticated POST returns 401.
+5. `test_update_two_elements_in_one_call` — happy path, both
+   reflect new names on subsequent GETs.
+6. `test_version_conflict_isolated_per_item` — bump one element's
+   version out from under the batch via a singular PUT; the
+   batch update sees that item fail (version conflict) but the
+   other succeeds.
+7. `test_empty_updates_returns_422` — empty array rejected.
+
+Plus parity check:
+
+```
+.venv/bin/python scripts/check_surface_parity.py
+```
+
+Must report `✅ Parity clean`.
+
+## Acceptance criteria
+
+1. A single REST POST creates N elements (1 ≤ N ≤ 100), returns
+   per-item success/failure breakdown and the IDs of the
+   created items.
+2. A single REST POST updates N elements with per-item
+   optimistic concurrency; one stale version doesn't fail the
+   other items.
+3. The MCP `create_elements` / `update_elements` tools accept the
+   same payload shape and return the same envelope.
+4. The CLI `iris create elements --from-json` / `iris update
+   elements --from-json` round-trips the same payload from a file
+   or stdin.
+5. `scripts/check_surface_parity.py` stays green.
+6. No regression to existing `create_element` / `update_element`
+   singulars across any surface.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_batch/
+.venv/bin/python scripts/check_surface_parity.py
+.venv/bin/python -c "from iris_cli import main; print('OK')"
+```
+
+All green / OK. Manual smoke per ADR-200 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.9.0",
+	"version": "6.10.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.9.0"
+version = "6.10.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -372,6 +372,39 @@ async def _create_package(c: IrisClient, args: dict[str, Any]) -> str:
     return with_web_url(result.model_dump_json(), "package")
 
 
+async def _create_elements(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.10.0 / ADR-200: bulk create elements in one MCP call.
+
+    Avoids N round-trips when ingesting many items (e.g. a grocery
+    list). Per-item failure isolation — a bad row reports an index +
+    reason without sinking the rest of the batch.
+    """
+    body = {"elements": args.get("elements") or []}
+    try:
+        resp = await c._request(
+            "POST", "/api/batch/elements/create", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create elements (batch)")
+    return json.dumps(resp.json())
+
+
+async def _update_elements(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.10.0 / ADR-200: bulk update elements in one MCP call.
+
+    Each update item carries its own ``element_id`` + ``expected_version``;
+    version conflicts surface as per-item failures (not whole-batch).
+    """
+    body = {"updates": args.get("updates") or []}
+    try:
+        resp = await c._request(
+            "POST", "/api/batch/elements/update", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Update elements (batch)")
+    return json.dumps(resp.json())
+
+
 async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
     """ADR-178 (v6.4.0): create a standalone Element.
 
@@ -1473,6 +1506,71 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_create_element,
+    ),
+    # ── Bulk element create / update (v6.10.0, ADR-200, #173 item 6) ─────
+    Tool(
+        name="create_elements",
+        description=(
+            "Bulk-create up to 100 elements in one call (v6.10.0, "
+            "ADR-200). Each item is the same shape as `create_element`'s "
+            "input. Per-item failure isolation — a bad row reports an "
+            "index + reason without sinking the rest of the batch. "
+            "Response is a BatchResultWithIds envelope: succeeded, "
+            "failed, errors[], ids[]."
+        ),
+        input_schema=_schema({
+            "elements": (
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                    "description": (
+                        "List of element create payloads. Each item "
+                        "matches create_element: element_type, name, "
+                        "description, data, set_id, package_id, "
+                        "metadata, notation."
+                    ),
+                },
+                True,
+            ),
+        }),
+        handler=_create_elements,
+    ),
+    Tool(
+        name="update_elements",
+        description=(
+            "Bulk-update up to 100 elements in one call (v6.10.0, "
+            "ADR-200). Each item carries its own element_id + "
+            "expected_version (per-item optimistic concurrency); "
+            "version conflicts surface as per-item failures, not a "
+            "whole-batch 409. Response is a BatchResultWithIds envelope."
+        ),
+        input_schema=_schema({
+            "updates": (
+                {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 100,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": True,
+                    },
+                    "description": (
+                        "List of element update payloads. Each item "
+                        "needs element_id and expected_version, plus "
+                        "the same fields as update_element: name "
+                        "(required), description, data, change_summary, "
+                        "metadata, package_id (tri-state: omit/null/uuid)."
+                    ),
+                },
+                True,
+            ),
+        }),
+        handler=_update_elements,
     ),
     # ── Element templates (v6.8.0, ADR-191, issue #153) ────────────────
     Tool(


### PR DESCRIPTION
## Summary

Closes the last item in #173 — bulk \`create_elements\` and \`update_elements\` so MCP / CLI clients can ship many rows in one call instead of one tool call per item.

### Three surfaces (per §14 / ADR-182)

- **REST**: \`POST /api/batch/elements/create\`, \`POST /api/batch/elements/update\`. Both return \`BatchResultWithIds { succeeded, failed, errors, ids }\`. 1–100 items per call.
- **MCP**: \`create_elements\`, \`update_elements\`. Per-item schema is open so callers compose any subset of the singular fields.
- **CLI**: \`iris create elements --from-json <path|->\`, \`iris update elements --from-json <path|->\`. JSON-only input via file or stdin.

### Failure semantics

- **Per-item isolation.** A bad row reports \`Element at index <i>: <reason>\` and the rest of the batch proceeds. HTTP stays 200 — the caller reads \`failed\` / \`errors\`.
- **Per-item optimistic concurrency on update.** Each update item carries its own \`expected_version\`. A stale version surfaces as that one item failing (not a whole-batch 409). One conflict shouldn't reject the other 99 rows.

### Atomicity decision

Per-item commit, not whole-batch transaction. Matches existing \`batch_clone_elements\` semantics and the actual use case (independently-composed rows from a chat-driven ingest).

## Test plan

- [x] \`.venv/bin/python -m pytest backend/tests/test_batch/ backend/tests/test_elements/\` — 89 + 20 passed, no regression.
- [x] \`.venv/bin/python scripts/check_surface_parity.py\` — ✅ Parity clean.
- [x] \`.venv/bin/python -c "from iris_cli import main"\` — CLI loads.
- [ ] Browser smoke: invoke \`create_elements\` from an MCP client (Claude Code, etc.) with a 20-item grocery list, confirm one round-trip and a clean envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)