### PR TITLE
fix(v6.10.1): relationships tab auto-reloads on package navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.10.1] - 2026-05-18
+
+### Fixed
+
+- **Relationships tab stayed empty on cross-package navigation**
+  (ADR-201, follows ADR-195). After ADR-195 correctly cleared the
+  previous package's data on navigation, the Relationships tab
+  did not auto-rehydrate when the user navigated from one
+  package to another via the hierarchy sidebar — the list went
+  empty until the user clicked the "Relationships" tab heading.
+  `loadPackage` now triggers `loadPackageElements` automatically
+  if the user is already sitting on the Relationships tab when
+  the new package loads.
+
 ## [6.10.0] - 2026-05-18
 
 ### Added

--- a/docs/adrs/ADR-201-Package-Relationships-Auto-Reload-On-Navigation.md
+++ b/docs/adrs/ADR-201-Package-Relationships-Auto-Reload-On-Navigation.md
@@ -1,0 +1,99 @@
+# ADR-201: Package detail Relationships tab auto-reloads on cross-package navigation
+
+Status: Accepted (2026-05-18)
+Extends: [ADR-195](ADR-195-Package-Detail-State-Reset-On-Navigation.md)
+
+## Context
+
+Follow-up to ADR-195 (v6.8.4). That ADR fixed the stale-data bug by
+resetting the relationships state at the top of `loadPackage`, so
+navigating from package A to package B no longer left A's elements
+rendered against B's heading.
+
+A residual half-bug remained: if the user was already on the
+**Relationships** tab and navigated to a different package via the
+hierarchy sidebar, the elements list went *empty* and stayed empty
+until the user clicked the "Relationships" tab heading. The reset
+worked; the auto-hydration was missing.
+
+Mechanism: `loadPackage` clears `packageElementsLoaded` etc., but
+the only call site that issues `loadPackageElements` is
+`activateRelationshipsTab` (the tab-button click handler). A
+navigation event that doesn't fire a tab click never triggers the
+re-fetch.
+
+## Decision
+
+At the end of `loadPackage`, after `loading = false`, check whether
+the user is sitting on the Relationships tab and kick off
+`loadPackageElements(pkg.id)` if so:
+
+```ts
+if (pkg && activeTab === 'relationships' && !packageElementsLoading) {
+    loadPackageElements(pkg.id);
+}
+```
+
+The `!packageElementsLoading` guard prevents stomping a concurrent
+fetch in the edge case where another code path raced ahead.
+
+## Why not run from a `$effect` watching `activeTab`/`pkg`
+
+Reactivity-driven solution considered:
+
+```ts
+$effect(() => {
+    if (pkg && activeTab === 'relationships' && !packageElementsLoaded && !packageElementsLoading) {
+        loadPackageElements(pkg.id);
+    }
+});
+```
+
+Equally correct and arguably more idiomatic, but it spreads the
+"when does the tab hydrate" rule across two places (the original
+`activateRelationshipsTab` handler and a new `$effect`). The
+in-line follow-up keeps the rule in one place: `loadPackage` is
+the single chokepoint for navigation, and the rehydration sits
+right next to the reset that necessitated it.
+
+## Why not unify with `activateRelationshipsTab`
+
+Both call sites need the same body, but unifying them means the
+tab-click path always re-fetches even when `packageElementsLoaded`
+is already true (today's guard short-circuits that). Keeping the
+two paths separate preserves the "no redundant fetch on tab
+re-open" behaviour.
+
+## Consequences
+
+- `frontend/src/routes/packages/[id]/+page.svelte:loadPackage` —
+  5-line trailing block that calls `loadPackageElements` when on
+  the relationships tab.
+- `frontend/tests/unit/packageRelationshipsAutoReload.test.ts` —
+  new static-parser test (3 assertions) verifies the reset is
+  preserved, the auto-hydrate fires only on the relationships
+  tab, and the in-flight guard is present.
+- No backend changes; no migration; no MCP / CLI changes.
+- CHANGELOG `[6.10.1]`.
+
+## Verification
+
+```
+npx vitest run \
+  tests/unit/packageRelationshipsAutoReload.test.ts \
+  tests/unit/packageDetailStateReset.test.ts \
+  tests/unit/packageRelationshipsTab.test.ts
+```
+
+24 green.
+
+Manual smoke: open package A → Relationships tab → click package
+B in hierarchy sidebar → B's elements render without a tab-click
+or hard refresh.
+
+## See also
+
+- [ADR-195](ADR-195-Package-Detail-State-Reset-On-Navigation.md)
+  — the reset that this ADR completes.
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) item 3
+  — original feedback.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.10.0",
+	"version": "6.10.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -158,6 +158,15 @@
 				: 'Failed to load package';
 		}
 		loading = false;
+
+		// v6.10.1 / ADR-201: if the user navigated here while sitting on
+		// the Relationships tab, rehydrate the elements list automatically.
+		// ADR-195 cleared the previous package's data; without this
+		// follow-up the tab would stay empty until the user clicked the
+		// heading (which fires activateRelationshipsTab).
+		if (pkg && activeTab === 'relationships' && !packageElementsLoading) {
+			loadPackageElements(pkg.id);
+		}
 	}
 
 	async function loadVersions(id: string) {

--- a/frontend/tests/unit/packageRelationshipsAutoReload.test.ts
+++ b/frontend/tests/unit/packageRelationshipsAutoReload.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Packages detail — Relationships auto-reload on navigation
+ * (v6.10.1, ADR-201, follows ADR-195).
+ *
+ * ADR-195 fixed the stale-data bug by resetting the relationships
+ * state at the top of `loadPackage`. That removed the wrong-package's
+ * elements from view, but left a follow-up bug: if the user was
+ * already on the Relationships tab and navigated to a different
+ * package from the hierarchy sidebar, the elements list went empty
+ * and stayed empty until the user clicked the Relationships tab
+ * heading (which calls `activateRelationshipsTab` → loadPackageElements).
+ *
+ * Fix: at the end of `loadPackage`, if `activeTab === 'relationships'`
+ * and we have a `pkg`, kick off `loadPackageElements(pkg.id)` so the
+ * tab content rehydrates without requiring a tab-click.
+ *
+ * Static-parser style.
+ */
+
+const pkgPageSrc = readFileSync(
+	resolve(__dirname, '../../src/routes/packages/[id]/+page.svelte'),
+	'utf-8',
+);
+
+function loadPackageBody(): string {
+	const start = pkgPageSrc.indexOf('async function loadPackage(');
+	expect(start, 'loadPackage function not found').toBeGreaterThan(-1);
+	const braceStart = pkgPageSrc.indexOf('{', start);
+	let depth = 0;
+	let i = braceStart;
+	for (; i < pkgPageSrc.length; i++) {
+		const ch = pkgPageSrc[i];
+		if (ch === '{') depth++;
+		else if (ch === '}') {
+			depth--;
+			if (depth === 0) break;
+		}
+	}
+	return pkgPageSrc.slice(braceStart, i + 1);
+}
+
+describe('Package detail — loadPackage auto-reloads relationships on navigation (#173-followup)', () => {
+	const body = loadPackageBody();
+
+	it('still resets relationships state at the top (ADR-195 behaviour preserved)', () => {
+		expect(body).toMatch(/packageElementsLoaded\s*=\s*false/);
+	});
+
+	it("kicks off loadPackageElements when navigating into the Relationships tab", () => {
+		// The re-hydration check looks for activeTab === 'relationships'
+		// and an existing pkg, then calls loadPackageElements with
+		// pkg.id (not the function's `id` argument, since the try/catch
+		// may have set pkg to something different if a redirect path
+		// existed — keep symmetric with the activate handler).
+		expect(body).toMatch(/activeTab\s*===\s*'relationships'/);
+		expect(body).toMatch(/loadPackageElements\(pkg\.id\)/);
+	});
+
+	it("does not call loadPackageElements if a load is already in flight", () => {
+		// Guard prevents stomping a concurrent fetch.
+		expect(body).toMatch(/!packageElementsLoading/);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.10.0"
+version = "6.10.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Direct follow-up to ADR-195 (v6.8.4 / PR #174). Closes the residual half-bug the user spotted: when sitting on the Relationships tab and navigating to another package via the hierarchy sidebar, the elements list went empty and stayed empty until they clicked the tab heading.

\`loadPackage\` correctly cleared the previous package's data per ADR-195 — what was missing was the auto-rehydrate. Now: after a navigation completes, if \`activeTab === 'relationships'\`, kick off \`loadPackageElements(pkg.id)\` automatically (with the \`!packageElementsLoading\` guard to avoid stomping any in-flight fetch).

## Test plan

- [x] \`npx vitest run tests/unit/packageRelationshipsAutoReload.test.ts tests/unit/packageDetailStateReset.test.ts tests/unit/packageRelationshipsTab.test.ts\` — 24 green.
- [ ] Browser smoke (post-deploy on iris-uat): open a package → Relationships tab → click another package in the hierarchy sidebar → confirm its elements render without a tab-click or hard refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)