### PR TITLE
feat(v6.11.0): per-set hierarchy sort preference (ADR-202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.11.0] - 2026-05-18
+
+### Added
+
+- **Per-set hierarchy sort preference** (ADR-202). Each set can
+  now choose how its packages and diagrams are ordered in the
+  hierarchy views (dashboard tree, packages page sidebar, views
+  page tree). Four options on the set edit page (Edit Set →
+  Hierarchy sort):
+  - **Manual** (drag-and-drop sequence_order — current behaviour,
+    default for new and existing sets).
+  - **Alphabetical** (A → Z, case-insensitive, interleaves
+    packages and diagrams).
+  - **Newest first** (`created_at DESC`).
+  - **Oldest first** (`created_at ASC`).
+  - Also surfaced on the MCP `update_set` tool. New `hierarchy_sort`
+    field round-trips through `SetResponse` / `SetUpdate`.
+
+### Migration
+
+- **SQLite m068 + Supabase m072 (paired, §15)** — adds
+  `hierarchy_sort TEXT NOT NULL DEFAULT 'manual'` to `sets`. Enum
+  enforced at the Pydantic layer (no SQL CHECK, so SQLite and
+  Supabase syntax stay identical). Existing sets inherit the
+  `'manual'` default — no back-fill needed.
+- **Release ordering for Supabase**: run
+  `scripts/supabase-migrate.sh` against the Supabase DB **before**
+  the code deploys. The service layer has a defensive fallback so
+  a brief window without the migration degrades to manual sort
+  rather than 500-ing.
+
 ## [6.10.1] - 2026-05-18
 
 ### Fixed

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -792,6 +792,18 @@ async def get_diagram_children(
     ]
 
 
+_HIERARCHY_ORDER_BY: dict[str, str] = {
+    # ADR-202: per-set hierarchy sort. Each entry maps a sort key from
+    # ``sets.hierarchy_sort`` to the ORDER BY clause appended to the
+    # UNION query in ``get_diagram_hierarchy``.
+    "manual": "t.node_type, t.sequence_order, t.name",
+    # No node_type tie-break — packages and diagrams interleave by name.
+    "alpha": "LOWER(t.name)",
+    "newest": "t.created_at DESC",
+    "oldest": "t.created_at ASC",
+}
+
+
 async def get_diagram_hierarchy(
     db: DatabasePort,
     root_id: str | None = None,
@@ -805,10 +817,11 @@ async def get_diagram_hierarchy(
     package, and packages can nest via their own parent_package_id.
 
     If root_id is given, returns subtree rooted at that node.
-    If set_id is given, only includes items from that set.
+    If set_id is given, only includes items from that set; the set's
+    ``hierarchy_sort`` preference (ADR-202) selects the ORDER BY clause.
     Otherwise returns all root nodes with their children.
     """
-    params: list[str] = []
+    params: list[object] = []
     pkg_set_filter = ""
     diag_set_filter = ""
     if set_id is not None:
@@ -816,28 +829,47 @@ async def get_diagram_hierarchy(
         diag_set_filter = "AND d.set_id = ? "
         params = [set_id, set_id]
 
+    # ADR-202: resolve sort preference for this scope. Sets without a
+    # set_id (root_id-only or full-repo queries) fall back to 'manual'.
+    sort_key = "manual"
+    if set_id is not None:
+        try:
+            sort_cursor = await db.execute(
+                "SELECT hierarchy_sort FROM sets WHERE id = ?", (set_id,),
+            )
+            sort_row = await sort_cursor.fetchone()
+            if sort_row and sort_row[0] in _HIERARCHY_ORDER_BY:
+                sort_key = sort_row[0]
+        except Exception:
+            # If the column is missing (migration hasn't run on
+            # Supabase yet), gracefully fall back to manual.
+            sort_key = "manual"
+    order_by = _HIERARCHY_ORDER_BY[sort_key]
+
     # Fetch packages and diagrams in a single UNION query so we can
-    # build the full hierarchy in one pass.
+    # build the full hierarchy in one pass. ``created_at`` is selected
+    # so the date-based sorts (newest/oldest) work.
     query = (
         "SELECT t.id, t.name, t.node_type, t.parent_package_id, t.diagram_type, "
-        "t.data, t.notation, t.sequence_order "
+        "t.data, t.notation, t.sequence_order, t.created_at "
         "FROM ("
         "  SELECT p.id, pv.name, 'package' AS node_type, p.parent_package_id, "
         "         NULL AS diagram_type, NULL AS data, NULL AS notation, "
-        "         p.sequence_order "
+        "         p.sequence_order, p.created_at "
         "  FROM packages p "
         "  JOIN package_versions pv ON p.id = pv.package_id "
         "       AND p.current_version = pv.version "
         f"  WHERE p.is_deleted = 0 {pkg_set_filter}"
         "  UNION ALL "
         "  SELECT d.id, dv.name, 'diagram' AS node_type, d.parent_package_id, "
-        "         d.diagram_type, dv.data, d.notation, d.sequence_order "
+        "         d.diagram_type, dv.data, d.notation, d.sequence_order, "
+        "         d.created_at "
         "  FROM diagrams d "
         "  JOIN diagram_versions dv ON d.id = dv.diagram_id "
         "       AND d.current_version = dv.version "
         f"  WHERE d.is_deleted = 0 {diag_set_filter}"
         ") t "
-        "ORDER BY t.node_type, t.sequence_order, t.name"
+        f"ORDER BY {order_by}"  # noqa: S608 - order_by is from _HIERARCHY_ORDER_BY whitelist
     )
     cursor = await db.execute(query, params)
     rows = await cursor.fetchall()

--- a/backend/app/migrations/m068_sets_hierarchy_sort.py
+++ b/backend/app/migrations/m068_sets_hierarchy_sort.py
@@ -1,0 +1,43 @@
+"""Migration 068: per-set hierarchy sort preference (ADR-202).
+
+Adds a ``hierarchy_sort`` column to ``sets`` so each set can choose
+how its diagram/package tree is ordered when surfaced in the
+hierarchy views (dashboard, packages page, views page).
+
+Values:
+
+- ``manual``     — current behaviour (sequence_order with diagrams first).
+- ``alpha``      — alphabetical by name (interleaves packages and diagrams).
+- ``newest``     — created_at DESC.
+- ``oldest``     — created_at ASC.
+
+Enum is enforced at the application layer (Pydantic ``Literal``) rather
+than via a SQL CHECK constraint, to keep the SQLite ↔ Supabase syntax
+identical (Protocol §15).
+
+Default is ``'manual'`` so every existing set keeps its current
+ordering until the user opts in to something else.
+
+No back-fill required — the column DEFAULT handles existing rows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m068_sets_hierarchy_sort"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — checks for column presence."""
+    cursor = await db.execute("PRAGMA table_info(sets)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "hierarchy_sort" not in cols:
+        await db.execute(
+            "ALTER TABLE sets ADD COLUMN hierarchy_sort "
+            "TEXT NOT NULL DEFAULT 'manual'"
+        )
+    await db.commit()

--- a/backend/app/migrations/supabase/m072_sets_hierarchy_sort.sql
+++ b/backend/app/migrations/supabase/m072_sets_hierarchy_sort.sql
@@ -1,0 +1,17 @@
+-- Migration 072: per-set hierarchy sort preference (ADR-202).
+--
+-- Mirrors SQLite m068. Adds a ``hierarchy_sort`` column to ``sets``
+-- so each set chooses how its diagram/package tree is ordered when
+-- surfaced in the hierarchy views.
+--
+-- Values: 'manual' | 'alpha' | 'newest' | 'oldest'. Enum is enforced
+-- at the application layer (Pydantic ``Literal``) rather than a SQL
+-- CHECK constraint — keeps SQLite and Supabase syntax identical
+-- (Protocol §15).
+--
+-- Default is 'manual' so existing sets keep their current ordering.
+--
+-- Idempotent.
+
+ALTER TABLE public.sets
+    ADD COLUMN IF NOT EXISTS hierarchy_sort TEXT NOT NULL DEFAULT 'manual';

--- a/backend/app/sets/models.py
+++ b/backend/app/sets/models.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
+
+# ADR-202 (v6.11.0): per-set hierarchy sort preference. Pydantic
+# ``Literal`` enforces the enum at the API boundary so the DB column
+# stays a plain TEXT (keeps SQLite ↔ Supabase migration syntax
+# identical, Protocol §15).
+HierarchySort = Literal["manual", "alpha", "newest", "oldest"]
 
 
 class SetCreate(BaseModel):
@@ -23,6 +31,11 @@ class SetUpdate(BaseModel):
     collection_id: str | None = None
     system_prompt: str | None = None
     mcp_system_context: str | None = None
+    # None means "don't change" — preserves the existing value. Matches
+    # the MCP _put_merge_partial contract and keeps existing PUT
+    # clients (frontend / MCP) from accidentally resetting the field
+    # when they omit it.
+    hierarchy_sort: HierarchySort | None = None
 
 
 class SetResponse(BaseModel):
@@ -49,6 +62,9 @@ class SetResponse(BaseModel):
     thumbnail_diagram_type: str | None = None
     system_prompt: str | None = None
     mcp_system_context: str | None = None
+    # ADR-202 (v6.11.0): always returned, defaults to 'manual' for
+    # both newly-created and pre-migration sets.
+    hierarchy_sort: HierarchySort = "manual"
 
 
 class SetListResponse(BaseModel):

--- a/backend/app/sets/router.py
+++ b/backend/app/sets/router.py
@@ -103,6 +103,7 @@ async def update(
             collection_id=body.collection_id,
             system_prompt=body.system_prompt,
             mcp_system_context=body.mcp_system_context,
+            hierarchy_sort=body.hierarchy_sort,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -34,13 +34,17 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
         "collection_name": row[11] if len(row) > 11 else None,
         "system_prompt": row[12] if len(row) > 12 else None,
         "mcp_system_context": row[13] if len(row) > 13 else None,
+        # ADR-202: NULL fallback for pre-migration rows (shouldn't
+        # happen because the column has a DEFAULT, but belt-and-braces).
+        "hierarchy_sort": (row[14] if len(row) > 14 and row[14] else "manual"),
     }
 
 
 _SET_COLUMNS = (
     "s.id, s.name, s.description, s.created_at, s.created_by, "
     "s.updated_at, s.is_deleted, s.thumbnail_source, s.thumbnail_diagram_id, "
-    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt, s.mcp_system_context"
+    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt, "
+    "s.mcp_system_context, s.hierarchy_sort"
 )
 
 
@@ -84,6 +88,7 @@ async def create_set(
         "has_thumbnail_image": False,
         "system_prompt": None,
         "mcp_system_context": None,
+        "hierarchy_sort": "manual",  # ADR-202 default for new sets
     }
 
 
@@ -224,8 +229,13 @@ async def update_set(
     collection_id: str | None = None,
     system_prompt: str | None = None,
     mcp_system_context: str | None = None,
+    hierarchy_sort: str | None = None,
 ) -> dict[str, object] | None:
-    """Update a set's name, description, thumbnail, collection, system_prompt, and mcp_system_context.
+    """Update a set's metadata (ADR-202 adds hierarchy_sort).
+
+    ``hierarchy_sort`` is tri-stateish: None means "leave alone". The
+    Pydantic Literal on SetUpdate constrains the value space upstream
+    so we accept whatever the caller gave us as-is.
 
     Returns None if not found.
     """
@@ -267,6 +277,15 @@ async def update_set(
             (name, description, now, thumbnail_source, thumbnail_diagram_id,
              collection_id, system_prompt, mcp_system_context, set_id),
         )
+
+    # ADR-202: hierarchy_sort updated separately so the main UPDATE
+    # stays unchanged for callers that don't touch it.
+    if hierarchy_sort is not None:
+        await db.execute(
+            "UPDATE sets SET hierarchy_sort = ?, updated_at = ? WHERE id = ?",
+            (hierarchy_sort, now, set_id),
+        )
+
     await db.commit()
 
     await _index_set(db, set_id=set_id, name=name, description=description)

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -71,6 +71,7 @@ from app.migrations.m064_element_package_membership import up as m064_up
 from app.migrations.m065_dynamic_list_diagram_type import up as m065_up
 from app.migrations.m066_class_for_simple_notation import up as m066_up
 from app.migrations.m067_element_templates import up as m067_up
+from app.migrations.m068_sets_hierarchy_sort import up as m068_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -169,6 +170,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m065_up(main)  # issue #147, v6.7.0: dynamic_list diagram_type (ADR-186)
     await m066_up(main)  # issue #160, v6.7.4: register (class, simple) diagram_type_notations pair (ADR-188)
     await m067_up(main)  # issue #153, v6.8.0: element_templates table (ADR-191)
+    await m068_up(main)  # v6.11.0: per-set hierarchy sort preference (ADR-202)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/tests/test_diagrams/test_hierarchy_sort.py
+++ b/backend/tests/test_diagrams/test_hierarchy_sort.py
@@ -1,0 +1,233 @@
+"""Tests for per-set hierarchy sort preference (v6.11.0, ADR-202).
+
+Verifies that ``GET /api/diagrams/hierarchy?set_id=X`` honours the
+set's ``hierarchy_sort`` column for ordering returned siblings.
+
+Sort options:
+- ``manual``  — current behaviour: node_type, sequence_order, name.
+                Diagrams sort above packages within the same parent.
+- ``alpha``   — alphabetical by name, no node_type tie-break.
+- ``newest``  — created_at DESC.
+- ``oldest``  — created_at ASC.
+
+Default for new sets is ``manual``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _setup_mixed_set(c: httpx.AsyncClient, h: dict) -> str:
+    """Create a set with two packages and two diagrams at root level,
+    spread out in creation time so order-by-date is meaningful."""
+    set_resp = await c.post("/api/sets", json={"name": "SortSet"}, headers=h)
+    assert set_resp.status_code == 201
+    set_id = set_resp.json()["id"]
+
+    # Create in this order, with sleeps so created_at differs:
+    #   1. Pkg "Zulu"
+    #   2. Diag "Alpha"
+    #   3. Pkg "Mike"
+    #   4. Diag "Tango"
+    await c.post(
+        "/api/packages",
+        json={"name": "Zulu", "set_id": set_id},
+        headers=h,
+    )
+    await asyncio.sleep(0.01)
+    await c.post(
+        "/api/diagrams",
+        json={"diagram_type": "simple-view", "name": "Alpha", "data": {}, "set_id": set_id},
+        headers=h,
+    )
+    await asyncio.sleep(0.01)
+    await c.post(
+        "/api/packages",
+        json={"name": "Mike", "set_id": set_id},
+        headers=h,
+    )
+    await asyncio.sleep(0.01)
+    await c.post(
+        "/api/diagrams",
+        json={"diagram_type": "simple-view", "name": "Tango", "data": {}, "set_id": set_id},
+        headers=h,
+    )
+
+    return set_id
+
+
+async def _names(c: httpx.AsyncClient, h: dict, set_id: str) -> list[str]:
+    resp = await c.get(f"/api/diagrams/hierarchy?set_id={set_id}", headers=h)
+    assert resp.status_code == 200, resp.text
+    return [n["name"] for n in resp.json()]
+
+
+class TestDefaultSort:
+    async def test_new_set_defaults_to_manual(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "DefaultSortTest"}, headers=h,
+        )
+        assert set_resp.status_code == 201
+        body = set_resp.json()
+        assert body["hierarchy_sort"] == "manual", (
+            "default hierarchy_sort on new sets must be 'manual' so existing "
+            "behaviour is preserved (ADR-202)"
+        )
+
+    async def test_existing_sets_keep_manual_order(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """Without explicitly setting hierarchy_sort, the order is unchanged
+        from the historical default: diagrams above packages within the
+        same parent, then sequence_order (auto-assigned in creation order
+        per parent), then name as a final tiebreak."""
+        h = await _auth(client)
+        set_id = await _setup_mixed_set(client, h)
+        names = await _names(client, h, set_id)
+        # Manual sort: node_type ('diagram' < 'package' alphabetically).
+        # Diagrams in creation order: Alpha (created at t1), Tango (at t3).
+        # Packages in creation order: Zulu (at t0), Mike (at t2).
+        # sequence_order is auto-incremented per parent group on creation
+        # (packages/service.py:38-47), so it reflects creation order.
+        assert names == ["Alpha", "Tango", "Zulu", "Mike"]
+
+
+class TestAlphaSort:
+    async def test_alpha_sort_interleaves_packages_and_diagrams(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_id = await _setup_mixed_set(client, h)
+
+        # Switch the set to alphabetical sort.
+        put_resp = await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "SortSet", "hierarchy_sort": "alpha"},
+            headers=h,
+        )
+        assert put_resp.status_code == 200, put_resp.text
+        assert put_resp.json()["hierarchy_sort"] == "alpha"
+
+        names = await _names(client, h, set_id)
+        # Pure alphabetical, no node-type tie-break.
+        assert names == ["Alpha", "Mike", "Tango", "Zulu"]
+
+
+class TestDateSort:
+    async def test_newest_first(self, client: httpx.AsyncClient) -> None:
+        h = await _auth(client)
+        set_id = await _setup_mixed_set(client, h)
+        await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "SortSet", "hierarchy_sort": "newest"},
+            headers=h,
+        )
+        names = await _names(client, h, set_id)
+        # Created in order: Zulu, Alpha, Mike, Tango → newest first
+        # reverses that.
+        assert names == ["Tango", "Mike", "Alpha", "Zulu"]
+
+    async def test_oldest_first(self, client: httpx.AsyncClient) -> None:
+        h = await _auth(client)
+        set_id = await _setup_mixed_set(client, h)
+        await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "SortSet", "hierarchy_sort": "oldest"},
+            headers=h,
+        )
+        names = await _names(client, h, set_id)
+        assert names == ["Zulu", "Alpha", "Mike", "Tango"]
+
+
+class TestInvalidSort:
+    async def test_rejects_unknown_sort_value(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "X"}, headers=h,
+        )
+        set_id = set_resp.json()["id"]
+        put_resp = await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "X", "hierarchy_sort": "bogus"},
+            headers=h,
+        )
+        # Pydantic Literal rejects → 422.
+        assert put_resp.status_code == 422
+
+
+class TestSetResponse:
+    async def test_get_set_returns_hierarchy_sort(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "Y"}, headers=h,
+        )
+        set_id = set_resp.json()["id"]
+        await client.put(
+            f"/api/sets/{set_id}",
+            json={"name": "Y", "hierarchy_sort": "alpha"},
+            headers=h,
+        )
+        get_resp = await client.get(f"/api/sets/{set_id}", headers=h)
+        assert get_resp.json()["hierarchy_sort"] == "alpha"

--- a/backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py
+++ b/backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py
@@ -1,0 +1,89 @@
+"""Schema test for per-set hierarchy sort migration (v6.11.0, ADR-202).
+
+Pairs:
+- SQLite  m068_sets_hierarchy_sort.py
+- Supabase m072_sets_hierarchy_sort.sql
+
+Both add ``hierarchy_sort TEXT NOT NULL DEFAULT 'manual'`` to ``sets``.
+Enum (manual | alpha | newest | oldest) is enforced at the application
+layer via Pydantic ``Literal`` rather than a SQL CHECK constraint, so
+the SQLite ↔ Supabase syntax stays identical (Protocol §15).
+
+Static-parser style — same shape as
+``test_response_format_prompts_schema.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# ── SQLite m068 ────────────────────────────────────────────────────────
+
+
+def test_sqlite_m068_adds_hierarchy_sort_column() -> None:
+    py = _read("app/migrations/m068_sets_hierarchy_sort.py")
+    assert "ALTER TABLE sets ADD COLUMN hierarchy_sort" in py
+    assert "TEXT NOT NULL DEFAULT 'manual'" in py
+
+
+def test_sqlite_m068_is_idempotent_via_pragma_check() -> None:
+    py = _read("app/migrations/m068_sets_hierarchy_sort.py")
+    # PRAGMA table_info inspection is the canonical idempotency
+    # pattern for SQLite ALTER TABLE (SQLite lacks ADD COLUMN IF NOT EXISTS).
+    assert "PRAGMA table_info(sets)" in py
+    assert "hierarchy_sort" in py
+    assert 'if "hierarchy_sort" not in cols' in py
+
+
+# ── Supabase m072 ──────────────────────────────────────────────────────
+
+
+def test_supabase_m072_adds_hierarchy_sort_column() -> None:
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    assert "ALTER TABLE public.sets" in sql
+    assert "ADD COLUMN IF NOT EXISTS hierarchy_sort" in sql
+    assert "TEXT NOT NULL DEFAULT 'manual'" in sql
+
+
+def test_supabase_m072_is_idempotent() -> None:
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    assert "IF NOT EXISTS" in sql
+
+
+def test_supabase_m072_references_sqlite_mirror() -> None:
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    # Protocol §15: pair the Supabase file with its SQLite mirror in
+    # the header so reviewers can find them together.
+    assert "m068" in sql
+
+
+def test_supabase_m072_no_boolean_integer_literals() -> None:
+    """Protocol §15 regression guard: bare 0/1 in BOOLEAN context."""
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    # TEXT column — should not contain `= 0` or `= 1` patterns.
+    assert "= 0" not in sql
+    assert "= 1" not in sql
+
+
+# ── Cross-mode consistency ─────────────────────────────────────────────
+
+
+def test_default_value_matches_across_modes() -> None:
+    py = _read("app/migrations/m068_sets_hierarchy_sort.py")
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    assert "'manual'" in py
+    assert "'manual'" in sql
+
+
+def test_column_type_matches_across_modes() -> None:
+    py = _read("app/migrations/m068_sets_hierarchy_sort.py")
+    sql = _read("app/migrations/supabase/m072_sets_hierarchy_sort.sql")
+    assert "TEXT NOT NULL" in py
+    assert "TEXT NOT NULL" in sql

--- a/docs/adrs/ADR-202-Per-Set-Hierarchy-Sort-Preference.md
+++ b/docs/adrs/ADR-202-Per-Set-Hierarchy-Sort-Preference.md
@@ -1,0 +1,177 @@
+# ADR-202: Per-set hierarchy sort preference
+
+Status: Accepted (2026-05-18)
+
+## Context
+
+User feedback (post v6.10.x UAT): the diagram/package hierarchy that
+shows under each set was sorted by an opaque rule. Reading
+`backend/app/diagrams/service.py:get_diagram_hierarchy`, the order
+was:
+
+```sql
+ORDER BY t.node_type, t.sequence_order, t.name
+```
+
+So diagrams always rendered above packages within a parent, then
+items sorted by `sequence_order` (auto-incremented per parent on
+create — effectively creation order within a node-type group), then
+name as a final tiebreak.
+
+That's the right default for users who rely on the drag-and-drop
+reorder UI, but wrong for people who want **alphabetical** browsing
+(particularly catalogue-style sets with dozens of packages) or
+**newest-first** for fast-moving sets. There was no way to opt
+into a different ordering.
+
+## Decision
+
+Add a `hierarchy_sort` TEXT column to the `sets` table. Each set
+owns its own preference; the column value selects the ORDER BY
+clause applied in `get_diagram_hierarchy`.
+
+### Enum values
+
+| Value | ORDER BY | Use case |
+|---|---|---|
+| `manual` | `t.node_type, t.sequence_order, t.name` | Current behaviour. Diagrams above packages, then drag-and-drop order. **Default.** |
+| `alpha` | `LOWER(t.name)` | Alphabetical, case-insensitive. Packages and diagrams interleave. |
+| `newest` | `t.created_at DESC` | Latest items at the top. Catalogue / changelog browsing. |
+| `oldest` | `t.created_at ASC` | Oldest items at the top. Archive browsing. |
+
+### Enum enforcement
+
+At the Pydantic layer (`HierarchySort = Literal[...]`), not via a
+SQL `CHECK` constraint. Rationale: keeps the SQLite ↔ Supabase
+migration syntax **identical** — Protocol §15. CHECK constraints
+have slightly different syntax across the two engines (SQLite's
+`ALTER TABLE ADD COLUMN` accepts column-level CHECK, but the
+Postgres mirror would need a named constraint). Application-layer
+validation is the single source of truth and keeps the schema
+minimal.
+
+### Migration (paired §15)
+
+- SQLite: `m068_sets_hierarchy_sort.py` — PRAGMA-based idempotency,
+  `ALTER TABLE sets ADD COLUMN hierarchy_sort TEXT NOT NULL DEFAULT 'manual'`.
+- Supabase: `m072_sets_hierarchy_sort.sql` — `ADD COLUMN IF NOT EXISTS …`.
+
+Default `'manual'` on the column means existing sets and pre-
+migration rows automatically inherit current behaviour. No back-
+fill required.
+
+### API surface
+
+- `SetUpdate.hierarchy_sort: HierarchySort | None = None` — None
+  means "leave alone", preserving compatibility with `_put_merge_partial`
+  (MCP) and any future partial-update client.
+- `SetResponse.hierarchy_sort: HierarchySort = "manual"` — always
+  returned; clients can read the current value.
+- No new endpoint; the existing `PUT /api/sets/{id}` carries it.
+
+### MCP
+
+`_SET_UPDATE_FIELDS` adds `hierarchy_sort`. The `update_set` tool's
+input schema documents the four values. Existing MCP clients
+calling `update_set` without the field continue to work — the GET-
+then-merge helper preserves whatever's currently stored.
+
+### Frontend
+
+Set edit page (`frontend/src/routes/sets/[id]/+page.svelte`) gets a
+4-option `<select>` between Collection and System prompt sections,
+wired to `hierarchySort` state which round-trips through `IrisSet`.
+
+## Why per-set rather than global or per-user
+
+Per-set:
+- Different sets have different purposes — a curated reference set
+  benefits from alphabetical; a working draft benefits from manual
+  ordering.
+- The user can decide once per set; no friction at view time.
+
+Global was rejected: too coarse — locks every set to one rule.
+Per-user was rejected: would require a separate user-preferences
+table and reconciliation when multiple users browse the same set.
+Per-set is the right grain.
+
+## Why apply everywhere the hierarchy surfaces
+
+The endpoint is `GET /api/diagrams/hierarchy?set_id=X`. Every
+consumer (dashboard, packages page sidebar, views page tree) calls
+that endpoint with the set_id. Centralising the sort in the
+endpoint means consistency is free — every surface shows the same
+order, set by the set owner once.
+
+## Why no per-tab / per-component override
+
+Out of scope. The user asked for a per-set setting; per-component
+overrides add a control to every component that renders the tree
+and proliferate state. Can be a follow-up if a real use case
+emerges.
+
+## Release ordering (Supabase)
+
+This PR ships **migration + code together** per the autonomous goal.
+The standing memory ("Render+Supabase release ordering") applies:
+the Supabase migration (`m072`) must be applied before the code
+deploys, otherwise `SELECT hierarchy_sort FROM sets WHERE id = ?`
+would error. The service layer has a defensive `try/except` that
+falls back to `'manual'` if the column lookup fails, so a brief
+window without the migration is degraded but not broken.
+
+The release-notes call out the recommended sequence:
+1. Merge PR (migration + code).
+2. Run `scripts/supabase-migrate.sh` against the Supabase DB.
+3. Render auto-deploys on the merge; the new code path will find
+   the column ready.
+
+## Consequences
+
+- `backend/app/migrations/m068_sets_hierarchy_sort.py` — new SQLite migration.
+- `backend/app/migrations/supabase/m072_sets_hierarchy_sort.sql` — Supabase mirror.
+- `backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py` — 8 schema tests.
+- `backend/app/startup.py` — m068 registered in the run-all-migrations sequence.
+- `backend/app/sets/models.py` — `HierarchySort` Literal, fields on
+  `SetUpdate` (optional) and `SetResponse` (required, default 'manual').
+- `backend/app/sets/service.py` — `_SET_COLUMNS`, `_row_to_dict`,
+  `create_set` and `update_set` carry `hierarchy_sort`. Update SQL
+  is a separate UPDATE statement triggered only when non-None.
+- `backend/app/sets/router.py` — pass `body.hierarchy_sort` through.
+- `backend/app/diagrams/service.py` — `_HIERARCHY_ORDER_BY` whitelist
+  + sort-key resolution at the top of `get_diagram_hierarchy`; new
+  `created_at` selected in the UNION query; defensive fallback to
+  `'manual'` if the column lookup fails.
+- `backend/tests/test_diagrams/test_hierarchy_sort.py` — 7 behavioural
+  tests across the 4 sort modes, default, response shape, invalid
+  value rejection.
+- `mcp/src/iris_mcp/tools.py` — `_SET_UPDATE_FIELDS` extended;
+  `update_set` schema gets the field with documentation.
+- `frontend/src/lib/types/api.ts` — `HierarchySort` exported,
+  `IrisSet.hierarchy_sort` field.
+- `frontend/src/routes/sets/[id]/+page.svelte` — state, load, save,
+  and a `<select>` between Collection and System prompt.
+- CHANGELOG `[6.11.0]`. Minor bump.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_diagrams/test_hierarchy_sort.py \
+                            backend/tests/test_sets/ \
+                            backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py
+.venv/bin/python scripts/check_surface_parity.py
+```
+
+71 passed; parity clean.
+
+Manual smoke: open `/sets/{id}`, change Hierarchy sort to
+"Alphabetical (A → Z)", Save, then visit a page that renders this
+set's hierarchy (dashboard / packages page sidebar) and confirm
+items are now interleaved alphabetically.
+
+## See also
+
+- Issue [#173](https://github.com/cgbarlow/iris/issues/173) — the
+  original UAT batch where the hierarchy sort question came up.
+- Hierarchy endpoint: `backend/app/diagrams/service.py:get_diagram_hierarchy`.
+- §15 Migration parity: `docs/protocols.md`.

--- a/docs/adrs/specs/SPEC-202-A-Per-Set-Hierarchy-Sort.md
+++ b/docs/adrs/specs/SPEC-202-A-Per-Set-Hierarchy-Sort.md
@@ -1,0 +1,154 @@
+# SPEC-202-A: Per-set hierarchy sort
+
+Implements: [ADR-202](../ADR-202-Per-Set-Hierarchy-Sort-Preference.md)
+Status: Living
+
+## Data model
+
+Column added to `sets`:
+
+```
+hierarchy_sort TEXT NOT NULL DEFAULT 'manual'
+```
+
+Enum values enforced at the Pydantic layer (`HierarchySort =
+Literal['manual','alpha','newest','oldest']`). DB stores TEXT.
+
+## Sort behaviour
+
+The ORDER BY clause appended to the UNION in `get_diagram_hierarchy`:
+
+| Value | ORDER BY | Note |
+|---|---|---|
+| `manual` | `t.node_type, t.sequence_order, t.name` | Diagrams first (alphabetical 'diagram' < 'package'), then creation-order, then name. |
+| `alpha` | `LOWER(t.name)` | Packages and diagrams interleave alphabetically (case-insensitive). |
+| `newest` | `t.created_at DESC` | Latest first. |
+| `oldest` | `t.created_at ASC` | Earliest first. |
+
+The whitelist (`_HIERARCHY_ORDER_BY` dict in
+`backend/app/diagrams/service.py`) means the value is never
+string-formatted from user input — it's looked up by key. Invalid
+values fall back to `'manual'` defensively.
+
+`created_at` is added to both arms of the UNION SELECT so the
+date-based modes have the column they need.
+
+## Request / response
+
+`PUT /api/sets/{id}` accepts an optional `hierarchy_sort` field:
+
+```ts
+{
+  name: string,
+  description: string | null,
+  thumbnail_source: ...,
+  thumbnail_diagram_id: ...,
+  collection_id: ...,
+  system_prompt: ...,
+  mcp_system_context: ...,
+  hierarchy_sort?: 'manual' | 'alpha' | 'newest' | 'oldest' | null  // null = leave alone
+}
+```
+
+`GET /api/sets/{id}` and `GET /api/sets` always include
+`hierarchy_sort` in the response, defaulting to `'manual'` for any
+row that somehow lacks the value (belt-and-braces against
+pre-migration data).
+
+## Frontend
+
+`/sets/{id}` edit page adds a `<select>` between Collection and
+System prompt:
+
+```svelte
+<label for="set-edit-hierarchy-sort">Hierarchy sort</label>
+<select id="set-edit-hierarchy-sort" bind:value={hierarchySort}>
+  <option value="manual">Manual (drag-and-drop)</option>
+  <option value="alpha">Alphabetical (A → Z)</option>
+  <option value="newest">Newest first</option>
+  <option value="oldest">Oldest first</option>
+</select>
+```
+
+State seeded from `setData.hierarchy_sort` on load; included in
+the PUT body on save. Round-trips through `IrisSet.hierarchy_sort`
+(typed `HierarchySort`).
+
+## MCP
+
+`update_set` tool's schema documents `hierarchy_sort`. The
+`_put_merge_partial` helper preserves whatever value is currently
+stored when the caller omits the field. Callers can update
+just the sort:
+
+```
+update_set(set_id="...", hierarchy_sort="alpha")
+```
+
+## Acceptance criteria
+
+1. New sets are created with `hierarchy_sort = 'manual'`.
+2. Existing sets (pre-migration) report `hierarchy_sort = 'manual'`
+   via the API.
+3. Setting `hierarchy_sort = 'alpha'` causes
+   `/api/diagrams/hierarchy?set_id=...` to return items ordered
+   case-insensitively by name, interleaved across packages and
+   diagrams.
+4. `'newest'` returns items in `created_at DESC` order.
+5. `'oldest'` returns items in `created_at ASC` order.
+6. An invalid value in the PUT body returns 422 (Pydantic
+   `Literal` validation).
+7. The MCP `update_set` tool accepts `hierarchy_sort` and the GET-
+   then-merge path preserves it across other updates.
+8. `scripts/check_surface_parity.py` stays clean.
+
+## Tests
+
+Backend behaviour — `backend/tests/test_diagrams/test_hierarchy_sort.py`:
+
+1. New set defaults to `'manual'`.
+2. Existing sets keep manual order (diagrams first, then packages
+   in creation order — locks in the current behaviour as a
+   regression guard).
+3. `'alpha'` interleaves packages and diagrams alphabetically.
+4. `'newest'` returns newest-first.
+5. `'oldest'` returns oldest-first.
+6. Invalid value returns 422.
+7. `GET /api/sets/{id}` returns the current `hierarchy_sort`.
+
+Migration schema — `backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py`:
+
+1. SQLite `m068` adds the column with the right type + default.
+2. SQLite `m068` is idempotent via PRAGMA check.
+3. Supabase `m072` adds the column with the right type + default.
+4. Supabase `m072` uses `IF NOT EXISTS`.
+5. Supabase `m072` references the SQLite mirror in its header.
+6. Supabase `m072` has no bare boolean integer literals (Protocol §15 regression guard).
+7-8. Defaults and column types match across modes.
+
+## Release ordering (Supabase)
+
+Per the standing "Render+Supabase release ordering" memory:
+
+1. Merge this PR (migration + code).
+2. Run `scripts/supabase-migrate.sh` against the Supabase DB.
+3. Render auto-deploys on push — the new code path finds the
+   column ready.
+
+The service layer's `try/except` around the `SELECT hierarchy_sort`
+makes the deploy window non-fatal if the migration lags briefly —
+the hierarchy falls back to `'manual'` ordering until the column
+exists. Once the migration runs, ordering picks up the per-set
+preference.
+
+## Verification
+
+```
+.venv/bin/python -m pytest \
+  backend/tests/test_diagrams/test_hierarchy_sort.py \
+  backend/tests/test_sets/ \
+  backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py
+.venv/bin/python scripts/check_surface_parity.py
+```
+
+All green. Manual smoke per ADR-202.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.10.1",
+	"version": "6.11.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -268,6 +268,8 @@ export interface ElementStats {
 	diagram_usage_count: number;
 }
 
+export type HierarchySort = 'manual' | 'alpha' | 'newest' | 'oldest';
+
 export interface IrisSet {
 	id: string;
 	name: string;
@@ -286,6 +288,8 @@ export interface IrisSet {
 	collection_id: string | null;
 	collection_name: string | null;
 	system_prompt?: string | null;
+	// ADR-202 (v6.11.0): per-set hierarchy sort preference.
+	hierarchy_sort: HierarchySort;
 }
 
 export interface IrisCollection {

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -4,7 +4,7 @@
 	import { apiFetch } from '$lib/utils/api';
 	import { getAccessToken } from '$lib/stores/auth.svelte.js';
 	import { API_BASE_URL } from '$lib/config.js';
-	import type { IrisSet, IrisCollection, Diagram, PaginatedResponse } from '$lib/types/api';
+	import type { IrisSet, IrisCollection, Diagram, PaginatedResponse, HierarchySort } from '$lib/types/api';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import CollectionSelector from '$lib/components/CollectionSelector.svelte';
 	import NamedPromptsSection from '$lib/components/NamedPromptsSection.svelte';
@@ -25,6 +25,8 @@
 	let collectionId = $state<string | null>(null);
 	let systemPrompt = $state('');
 	let mcpSystemContext = $state('');
+	// ADR-202 (v6.11.0): per-set hierarchy sort preference.
+	let hierarchySort = $state<HierarchySort>('manual');
 
 	let showDeleteDialog = $state(false);
 	let deleting = $state(false);
@@ -54,6 +56,7 @@
 			collectionId = setData.collection_id ?? null;
 			systemPrompt = setData.system_prompt ?? '';
 			mcpSystemContext = (setData as IrisSet & { mcp_system_context?: string | null }).mcp_system_context ?? '';
+			hierarchySort = setData.hierarchy_sort ?? 'manual';
 		} catch {
 			error = 'Failed to load set';
 		}
@@ -86,6 +89,7 @@
 					collection_id: collectionId,
 					system_prompt: sanitizedPrompt,
 					mcp_system_context: sanitizedMcpSystemContext,
+					hierarchy_sort: hierarchySort,
 				}),
 			});
 
@@ -213,6 +217,27 @@
 				showAll={true}
 				label="Collection"
 			/>
+		</div>
+
+		<!-- Hierarchy sort (ADR-202, v6.11.0) -->
+		<div class="mt-4">
+			<label for="set-edit-hierarchy-sort" class="text-sm font-medium" style="color: var(--color-fg)">
+				Hierarchy sort
+			</label>
+			<select
+				id="set-edit-hierarchy-sort"
+				bind:value={hierarchySort}
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			>
+				<option value="manual">Manual (drag-and-drop)</option>
+				<option value="alpha">Alphabetical (A → Z)</option>
+				<option value="newest">Newest first</option>
+				<option value="oldest">Oldest first</option>
+			</select>
+			<p class="mt-1 text-xs" style="color: var(--color-muted)">
+				Controls how packages and diagrams are ordered in the dashboard tree, the packages-page sidebar, and the views-page tree for this set.
+			</p>
 		</div>
 
 		<!-- System prompt (ADR-150) -->

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.10.1"
+version = "6.11.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -676,6 +676,10 @@ _COLLECTION_UPDATE_FIELDS = (
 _SET_UPDATE_FIELDS = (
     "name", "description", "thumbnail_source", "thumbnail_diagram_id",
     "collection_id", "system_prompt", "mcp_system_context",
+    # ADR-202 (v6.11.0): per-set hierarchy sort preference. Forwarded
+    # through _put_merge_partial so MCP clients can read the current
+    # value and override it, or leave it alone by omitting.
+    "hierarchy_sort",
 )
 _SET_METADATA_FIELDS = tuple(f for f in _SET_UPDATE_FIELDS if f != "collection_id")
 _PACKAGE_UPDATE_FIELDS = ("name", "description", "metadata")
@@ -1855,6 +1859,15 @@ TOOLS: list[Tool] = [
             ),
             "thumbnail_diagram_id": _str_arg(
                 "thumbnail_diagram_id", "Thumbnail diagram id", required=False,
+            ),
+            "hierarchy_sort": _str_arg(
+                "hierarchy_sort",
+                "Hierarchy sort order for this set (v6.11.0, ADR-202). "
+                "One of: 'manual' (drag-and-drop sequence_order, default), "
+                "'alpha' (alphabetical by name), 'newest' (created_at DESC), "
+                "'oldest' (created_at ASC). Affects every surface that renders "
+                "this set's hierarchy (dashboard, packages page, views page).",
+                required=False,
             ),
         }),
         handler=_update_set,


### PR DESCRIPTION
## Summary

Adds a per-set sort preference for the diagram/package hierarchy. Lives on the **Edit Set** page as a new Hierarchy sort dropdown, and on the MCP \`update_set\` tool.

### Four options

| Value | Behaviour |
|---|---|
| **Manual** (default) | Current: drag-and-drop \`sequence_order\` with diagrams above packages. |
| **Alphabetical** | Case-insensitive by name, interleaves packages and diagrams. |
| **Newest first** | \`created_at DESC\`. |
| **Oldest first** | \`created_at ASC\`. |

Default for **every existing set** is \`manual\` — the column's SQL DEFAULT means no behavioural change on rollout. Users opt in.

## Migration (paired §15)

- SQLite \`m068_sets_hierarchy_sort.py\` — PRAGMA-checked ALTER TABLE.
- Supabase \`m072_sets_hierarchy_sort.sql\` — \`ADD COLUMN IF NOT EXISTS\`.

Enum enforced at the Pydantic \`Literal\` layer rather than a SQL CHECK constraint — keeps SQLite ↔ Supabase syntax identical. The service-layer fallback to \`'manual'\` on column-lookup failure means a brief window without the migration on Supabase degrades gracefully (no 500s).

### Release ordering for Supabase (per standing memory)

1. Merge this PR.
2. Run \`scripts/supabase-migrate.sh\` against the Supabase DB.
3. Render auto-deploys on push — the new code path finds the column ready.

## Surfaces touched

- REST: \`SetUpdate.hierarchy_sort\` (optional, None = leave alone) / \`SetResponse.hierarchy_sort\` (always returned).
- MCP: \`update_set\` adds \`hierarchy_sort\` (forwarded through \`_put_merge_partial\`).
- Frontend: \`/sets/{id}\` edit form gets a 4-option \`<select>\` between Collection and System prompt.
- Backend: \`get_diagram_hierarchy\` resolves the per-set sort via \`_HIERARCHY_ORDER_BY\` whitelist before assembling its UNION query.

## Test plan

- [x] \`.venv/bin/python -m pytest backend/tests/test_diagrams/test_hierarchy_sort.py backend/tests/test_sets/ backend/tests/test_migrations/test_sets_hierarchy_sort_schema.py\` — 71 passed.
- [x] \`.venv/bin/python scripts/check_surface_parity.py\` — ✅ Parity clean.
- [ ] Browser smoke (post-Supabase-migrate + deploy on iris-uat): edit a set, change Hierarchy sort, save, visit dashboard / packages-page sidebar, confirm new order applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)