### PR TITLE
fix(v6.11.1): KG settings popover fits the Relationships tab label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.11.1] - 2026-05-18
+
+### Fixed
+
+- **KG settings dropdown "Relationships" tab overflowed**. After
+  v6.9.0 (ADR-199) added the third tab, the 220px min-width
+  popover couldn't fit "Relationships" on one line; it wrapped or
+  clipped. Bumped to 300px and added `whitespace-nowrap` to each
+  tab button so labels stay on a single line regardless of any
+  future container resizing.
+
 ## [6.10.1] - 2026-05-18
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.10.1",
+	"version": "6.11.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/KnowledgeGraphSettings.svelte
+++ b/frontend/src/lib/components/KnowledgeGraphSettings.svelte
@@ -80,23 +80,27 @@
 </script>
 
 <div
-	style="position: absolute; top: 100%; right: 0; z-index: 20; margin-top: 4px; min-width: 220px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 4px 16px rgba(0,0,0,0.18); padding: 0"
+	style="position: absolute; top: 100%; right: 0; z-index: 20; margin-top: 4px; min-width: 300px; border-radius: 8px; border: 1px solid var(--color-border); background: var(--color-surface); box-shadow: 0 4px 16px rgba(0,0,0,0.18); padding: 0"
 >
-	<!-- Tabs (issue #173 item 4: Nodes / Relationships / Display) -->
+	<!--
+		v6.11.1: bumped min-width from 220 → 300 and added whitespace-nowrap
+		to each tab button so the "Relationships" label introduced in
+		v6.9.0 (ADR-199) renders on one line without wrapping or clipping.
+	-->
 	<div class="flex" style="border-bottom: 1px solid var(--color-border)">
 		<button
 			onclick={() => (activeTab = 'nodes')}
-			class="flex-1 px-3 py-2 text-xs font-medium"
+			class="flex-1 whitespace-nowrap px-3 py-2 text-xs font-medium"
 			style="color: {activeTab === 'nodes' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'nodes' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
 		>Nodes</button>
 		<button
 			onclick={() => (activeTab = 'relationships')}
-			class="flex-1 px-3 py-2 text-xs font-medium"
+			class="flex-1 whitespace-nowrap px-3 py-2 text-xs font-medium"
 			style="color: {activeTab === 'relationships' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'relationships' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
 		>Relationships</button>
 		<button
 			onclick={() => (activeTab = 'display')}
-			class="flex-1 px-3 py-2 text-xs font-medium"
+			class="flex-1 whitespace-nowrap px-3 py-2 text-xs font-medium"
 			style="color: {activeTab === 'display' ? 'var(--color-primary)' : 'var(--color-muted)'}; border-bottom: 2px solid {activeTab === 'display' ? 'var(--color-primary)' : 'transparent'}; background: none; border-top: none; border-left: none; border-right: none; cursor: pointer; margin-bottom: -1px"
 		>Display</button>
 	</div>

--- a/frontend/tests/unit/kgSettingsWidth.test.ts
+++ b/frontend/tests/unit/kgSettingsWidth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * KG settings dropdown width (v6.11.1).
+ *
+ * Bug: after v6.9.0 (ADR-199) split the Visibility tab into Nodes,
+ * Relationships, and Display, the "Relationships" label didn't fit
+ * within the 220px min-width popover — it wrapped or clipped.
+ *
+ * Fix: bump min-width to 300px and add `whitespace-nowrap` to each
+ * tab button so labels stay on one line regardless of container size.
+ */
+
+const src = readFileSync(
+	resolve(__dirname, '../../src/lib/components/KnowledgeGraphSettings.svelte'),
+	'utf-8',
+);
+
+describe('KG settings popover width (v6.11.1)', () => {
+	it('uses min-width: 300px on the popover container', () => {
+		expect(src).toMatch(/min-width:\s*300px/);
+	});
+
+	it('no longer uses the old 220px min-width', () => {
+		expect(src).not.toMatch(/min-width:\s*220px/);
+	});
+
+	it('applies whitespace-nowrap to each tab button', () => {
+		// Each of the three tab buttons gets the class so labels never
+		// wrap regardless of any future container changes.
+		const tabButtonCount = (src.match(/flex-1\s+whitespace-nowrap\s+px-3\s+py-2\s+text-xs\s+font-medium/g) || []).length;
+		expect(tabButtonCount).toBe(3);
+	});
+});

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.10.1"
+version = "6.11.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Tiny visual fix. After v6.9.0 split the Visibility tab into three (Nodes / Relationships / Display, ADR-199), the popover's existing 220px min-width couldn't fit the "Relationships" label on one line — it wrapped or clipped depending on the exact rendering.

- Bumped \`min-width\` from 220px → 300px.
- Added \`whitespace-nowrap\` to each tab button so labels stay on a single line regardless of any future container changes.

## Test plan

- [x] \`npx vitest run tests/unit/kgSettingsWidth.test.ts\` — 3 passed.
- [ ] Browser smoke (post-deploy on iris-uat): open KG, click settings cog, confirm all three tab labels render cleanly on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)