### PR TITLE
feat(v6.12.0): KG skips redundant set->element edges for packaged elements (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.12.0] - 2026-05-18
+
+### Changed
+
+- **Knowledge graph: packaged elements reached via the package
+  chain only** (issue
+  [#181](https://github.com/cgbarlow/iris/issues/181), ADR-203).
+  Previously, an element belonging to a package rendered both
+  `set → element` (set_membership) and `set → package → element`
+  (chain) — visual redundancy. The direct `set → element` edge
+  is now skipped when the element's package is visible in the
+  current scope. Free-floating elements (no `package_id`) keep
+  their direct edge. If the package is out of scope (soft-
+  deleted, different set), the direct edge falls through so the
+  element isn't visually orphaned. No toggle — the chain conveys
+  containment more usefully and the redundant edge is just
+  clutter.
+
 ## [6.11.1] - 2026-05-18
 
 ### Fixed

--- a/backend/app/graph/service.py
+++ b/backend/app/graph/service.py
@@ -365,8 +365,17 @@ async def get_graph_data(
             })
 
     # 8. Set → Element/Diagram/Package membership
+    # ADR-203 (issue #181): when an element has a package_id that's
+    # visible in the current scope, skip the direct set → element
+    # edge. The set → package → element chain conveys containment
+    # more usefully; the direct edge would be redundant clutter.
+    # If the package is out-of-scope (e.g. soft-deleted, or in a
+    # different set), fall through and emit the direct edge so the
+    # element isn't visually orphaned.
     for row in element_rows:
-        eid, sid = row[0], row[4]
+        eid, sid, pkg_id = row[0], row[4], row[5]
+        if pkg_id and pkg_id in package_ids:
+            continue  # ADR-203: chain via package, skip direct edge.
         if sid and sid in set_ids:
             edges.append({
                 "id": str(uuid.uuid4()),

--- a/backend/tests/test_graph/test_element_package_edges.py
+++ b/backend/tests/test_graph/test_element_package_edges.py
@@ -158,6 +158,71 @@ class TestGraphEmitsElementPackageEdges:
         ep_edges = [e for e in body["edges"] if e["edge_type"] == "element_package"]
         assert ep_edges == []
 
+    async def test_no_redundant_set_membership_when_element_packaged(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        """ADR-203 / issue #181: the set → package → element chain
+        replaces the direct set → element edge for packaged elements.
+        Only the un-packaged element's set_membership edge remains."""
+        h = await _auth(client)
+        set_resp = await client.post(
+            "/api/sets", json={"name": "GraphSet"}, headers=h,
+        )
+        set_id = set_resp.json()["id"]
+
+        pkg_resp = await client.post(
+            "/api/packages",
+            json={"name": "Pantry", "set_id": set_id},
+            headers=h,
+        )
+        pkg_id = pkg_resp.json()["id"]
+
+        packaged = (await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "Tinned Tomatoes",
+                "data": {},
+                "set_id": set_id,
+                "package_id": pkg_id,
+            },
+            headers=h,
+        )).json()
+        free_floating = (await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component",
+                "name": "FreeFloating",
+                "data": {},
+                "set_id": set_id,
+            },
+            headers=h,
+        )).json()
+
+        graph_resp = await client.get(f"/api/graph?set_id={set_id}", headers=h)
+        body = graph_resp.json()
+
+        set_member_targets = {
+            e["target"] for e in body["edges"]
+            if e["edge_type"] == "set_membership" and e["source"] == set_id
+        }
+        # Free-floating element keeps its direct set→element edge.
+        assert free_floating["id"] in set_member_targets
+        # Packaged element does NOT — reachable via set → package → element.
+        assert packaged["id"] not in set_member_targets, (
+            "ADR-203: packaged elements must not duplicate their "
+            "containment as a direct set → element edge"
+        )
+        # set → package edge still present (separate rule).
+        assert pkg_id in set_member_targets
+
+        # The element_package chain works.
+        ep_edges = [e for e in body["edges"] if e["edge_type"] == "element_package"]
+        assert any(
+            e["source"] == pkg_id and e["target"] == packaged["id"]
+            for e in ep_edges
+        )
+
     async def test_node_type_remains_element_not_package(
         self, client: httpx.AsyncClient,
     ) -> None:

--- a/docs/adrs/ADR-203-Skip-Redundant-Set-Element-Edges-For-Packaged.md
+++ b/docs/adrs/ADR-203-Skip-Redundant-Set-Element-Edges-For-Packaged.md
@@ -1,0 +1,114 @@
+# ADR-203: KG skips redundant set → element edges for packaged elements
+
+Status: Accepted (2026-05-18)
+Extends: [ADR-199](ADR-199-KG-Settings-Tab-Split-And-Element-Package-Edge.md)
+
+## Context
+
+Issue [#181](https://github.com/cgbarlow/iris/issues/181) — on the
+knowledge graph view, the user wants the chain `set → package →
+element`, not the direct `set → element` edge for elements that
+already belong to a package.
+
+Background. ADR-199 (v6.9.0) added the `element_package` edge type
+so packages render as containers of their elements. But the graph
+service kept emitting the existing `set_membership` edge from
+`set → element` *unconditionally*, so a packaged element ended up
+with two paths from its set:
+
+```
+set ──────────────────────► element   (set_membership, ADR-184)
+ │                            ▲
+ └─► package ─────────────────┘       (set_membership + element_package, ADR-199)
+```
+
+That's redundant clutter. The set → package → element chain
+conveys the containment more usefully and the direct edge adds
+no information for a packaged element.
+
+The user explicitly asked whether a new toggle was needed.
+
+## Decision
+
+Skip the direct `set → element` edge whenever the element has a
+`package_id` that is **visible in the current scope** (i.e. the
+package is in `package_ids`). No new toggle.
+
+Implementation: one `if pkg_id and pkg_id in package_ids: continue`
+guard at the top of the existing `set_membership` element loop in
+`get_graph_data`.
+
+### Why no toggle
+
+- The redundant edge is visual noise — every user benefits from
+  the cleaner default.
+- The information is preserved: the chain `set → package → element`
+  is still there.
+- Toggle proliferation is its own cost. A toggle implies "some
+  users will want this on, some off"; here the answer is "almost
+  everyone wants the cleaner view".
+- If a future user genuinely needs the direct edge, they can hide
+  the `element_package` and `package` toggles and the set →
+  element edges will still be there for un-packaged elements;
+  packaged elements would then surface their containment via the
+  `set → package` chain (with packages hidden, they'd look
+  orphaned — but that's the user's explicit choice).
+
+Trivially reversible: the rule is one `continue` statement. If
+the call comes for a toggle, add it; until then, simpler.
+
+### Why "visible in the current scope" rather than unconditional
+
+If an element has a `package_id` pointing to a package that's
+*not* in the current scope (e.g. soft-deleted, or in a different
+set when the graph is scoped to a single set), removing the
+direct set → element edge would visually orphan the element —
+neither the chain nor the direct edge would render. The guard
+`pkg_id in package_ids` ensures we only skip the direct edge
+when the chain actually exists.
+
+## Why no migration / schema change
+
+Pure read-path filtering. No data is added or removed; the
+`element.package_id` column the rule reads has been there since
+ADR-184. The element_package edge type registered in ADR-199 is
+unchanged.
+
+## Consequences
+
+- `backend/app/graph/service.py:368-377` — three-line guard
+  before the existing element `set_membership` loop.
+- `backend/tests/test_graph/test_element_package_edges.py` — one
+  new test (`test_no_redundant_set_membership_when_element_packaged`)
+  asserts the rule and the surviving `set → package` and
+  `package → element` edges. The 4 prior tests still pass
+  (they didn't exercise this combination).
+- No frontend change — the front end just renders what the
+  backend emits.
+- No migration, no MCP / CLI change.
+- CHANGELOG `[6.12.0]`. Minor bump because it changes user-
+  visible graph rendering for any set that has packaged elements.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_graph/
+```
+
+31 green.
+
+Manual smoke: open KG for a set containing both free-floating
+elements and elements assigned to packages. Confirm:
+- Free-floating elements still show a direct `set → element` edge.
+- Packaged elements are reached only via `set → package → element`.
+- Toggling `element_package` off (in the new Relationships tab)
+  hides the chain; packaged elements then look set-less in the
+  graph. That's the documented trade-off.
+
+## See also
+
+- Issue [#181](https://github.com/cgbarlow/iris/issues/181).
+- [ADR-199](ADR-199-KG-Settings-Tab-Split-And-Element-Package-Edge.md)
+  — the `element_package` edge type this ADR builds on.
+- [ADR-184](ADR-184-Element-Package-Membership.md) — the
+  `element.package_id` column underpinning both edges.

--- a/docs/adrs/specs/SPEC-203-A-Skip-Redundant-Set-Element-Edges.md
+++ b/docs/adrs/specs/SPEC-203-A-Skip-Redundant-Set-Element-Edges.md
@@ -1,0 +1,68 @@
+# SPEC-203-A: Skip redundant set → element edges for packaged elements
+
+Implements: [ADR-203](../ADR-203-Skip-Redundant-Set-Element-Edges-For-Packaged.md)
+Resolves: Issue [#181](https://github.com/cgbarlow/iris/issues/181)
+Status: Living
+
+## Emission rule
+
+In `backend/app/graph/service.py:get_graph_data`, the element
+`set_membership` loop now skips elements whose `package_id` resolves
+to a visible package in the current scope:
+
+```python
+for row in element_rows:
+    eid, sid, pkg_id = row[0], row[4], row[5]
+    if pkg_id and pkg_id in package_ids:
+        continue   # ADR-203: chain via package, skip direct edge.
+    if sid and sid in set_ids:
+        edges.append({...edge_type: "set_membership"...})
+```
+
+The `element_package` emission (ADR-199) is unchanged — it always
+fires when the element has a visible package.
+
+## Resulting graph shapes
+
+| Element state | set → element | set → package | package → element |
+|---|:-:|:-:|:-:|
+| Free-floating (`package_id IS NULL`) | ✅ | n/a | n/a |
+| Packaged, package in scope | ❌ (this PR) | ✅ | ✅ |
+| Packaged, package out of scope | ✅ (fallback) | n/a | n/a |
+
+## Acceptance criteria
+
+1. A graph fetched for a set containing both free-floating and
+   packaged elements renders direct `set_membership` edges only
+   for the free-floating ones.
+2. Packaged elements appear via `set → package` + `package →
+   element` chain (two edges).
+3. An element whose `package_id` references a package outside the
+   current scope (e.g. the package is soft-deleted) still gets
+   its direct `set → element` edge so it isn't visually orphaned.
+4. No other edge types are affected. The `set_membership` edges
+   from set → diagram and set → package are unchanged.
+
+## Tests
+
+`backend/tests/test_graph/test_element_package_edges.py`:
+
+- `test_no_redundant_set_membership_when_element_packaged` — new.
+  Asserts the free-floating element keeps its set→element edge,
+  the packaged element does not, the set→package edge for the
+  packaging package is still present, and the package→element
+  chain exists.
+
+- All 4 prior tests in the module continue to pass — they
+  cover defaults, edge emission for packaged elements, no-edge
+  when un-packaged, and node typing.
+
+## Verification
+
+```
+.venv/bin/python -m pytest backend/tests/test_graph/
+```
+
+All 31 green.
+
+Manual smoke per ADR-203 verification section.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.11.1",
+	"version": "6.12.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.11.1"
+version = "6.12.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes #181. The user wanted the KG to render \`set → package → element\` for packaged elements without the redundant direct \`set → element\` edge.

The direct \`set_membership\` edge is now skipped when the element's \`package_id\` is visible in the current scope. Free-floating elements (no \`package_id\`) keep their direct edge as before. Packages whose \`package_id\` is out of scope (soft-deleted, in a different set) still get the direct edge as a fallback so the element isn't visually orphaned.

## Why no toggle

The user explicitly asked whether a new toggle was needed. My take: no. The chain \`set → package → element\` conveys the same containment more usefully than the direct edge, and the redundant edge is just clutter. Every user benefits from the cleaner default. Trivially reversible if demand emerges — it's one \`continue\` statement.

ADR-203 documents the rationale and the fallback behaviour.

## Test plan

- [x] \`.venv/bin/python -m pytest backend/tests/test_graph/\` — 31 passed (1 new test + all existing).
- [ ] Browser smoke (post-deploy on iris-uat):
  - Open KG for a set with packaged + free-floating elements.
  - Confirm free-floating elements still show direct \`set → element\` edges.
  - Confirm packaged elements are reached only via \`set → package → element\` chain.
  - Confirm toggling \`element_package\` off (Relationships tab → Package group) hides the chain; packaged elements then look set-less — the documented trade-off.

## Surfaces touched

- \`backend/app/graph/service.py:368-377\` — 3-line guard at the top of the existing element \`set_membership\` loop.
- No frontend change (graph just renders what the backend emits).
- No migration, no MCP / CLI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)