### PR TITLE
fix(v6.16.1): picker opens at view's collection; browse for non-elements; Tab/. in browse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.16.1] - 2026-05-20
+
+### Fixed
+
+- **Picker opens at the calling view's collection** (issue
+  [#185](https://github.com/cgbarlow/iris/issues/185) regression
+  follow-up). v6.16.0 always opened at the global root; users
+  expected the picker to start at their current scope so search
+  "at this level" matches the intent of the original 2026-05-19
+  comment. SmartMarkdownCanvas now passes the diagram's `set_id`
+  as `contextSetId`; the picker fetches the set, seeds its
+  initial breadcrumb to `Root > {collection}` (or `Root > {set}`
+  if the set has no parent collection), and the first browse
+  fetch uses that scope.
+- **Package drill replaced with browse navigation** — clicking a
+  package in the picker now navigates browse to
+  `scope=package` (showing the breadcrumb + "Pick this package"
+  + contained elements), matching the set-level pattern. The
+  v6.16.0 drill-with-children-list felt off because non-element
+  drill UX visually diverged from set/collection browse.
+- **IDE-style Tab and `.` in browse mode** — Tab or `.` on the
+  highlighted browse item now commits and navigates (or drills
+  for elements), matching the in-drill behaviour. Tab no longer
+  tabs focus out of the picker.
+
+### Changed
+
+- **Bucket order at scope=set is now Packages → Views → Elements**
+  (was Elements → Packages → Views). Matches user direction.
+- **`scope=package` returns the contained elements as items**
+  instead of a `counts` payload. Packages only contain elements,
+  so the bucket-card intermediary added unnecessary friction.
+
+### Migration
+
+- No DB changes. Code-only follow-up to v6.16.0.
+
 ## [6.16.0] - 2026-05-20
 
 ### Fixed

--- a/backend/app/search/router.py
+++ b/backend/app/search/router.py
@@ -334,8 +334,9 @@ async def picker_browse_endpoint(
             items=items,
         )
 
-    # ADR-207 (v6.16.0): scope=package returns counts; scope=package_bucket
-    # returns the elements directly inside the package.
+    # ADR-207 v6.16.1: scope=package returns its contained elements as
+    # items directly (packages only contain elements — no bucket-card
+    # intermediary needed). scope=package_bucket retained for symmetry.
     if scope == "package":
         if not package_id:
             raise HTTPException(
@@ -345,12 +346,18 @@ async def picker_browse_endpoint(
         if pkg_row is None:
             raise HTTPException(status_code=404, detail="Package not found")
         pkg_name, pkg_set_id = pkg_row
-        ec = await db.execute(
-            "SELECT COUNT(*) FROM elements "
-            "WHERE package_id = ? AND is_deleted = 0",
-            (package_id,),
+        cursor = await db.execute(
+            "SELECT e.id, ev.name FROM elements e "
+            "JOIN element_versions ev ON e.id = ev.element_id "
+            "  AND e.current_version = ev.version "
+            "WHERE e.package_id = ? AND e.is_deleted = 0 "
+            "ORDER BY LOWER(ev.name) LIMIT ?",
+            (package_id, limit),
         )
-        elements_count = (await ec.fetchone())[0]
+        items = [
+            EntitySearchResult(id=r[0], entity_type="element", name=r[1] or "")
+            for r in await cursor.fetchall()
+        ]
         # Build a Root → Collection → Set → Package breadcrumb.
         crumbs: list[BrowseBreadcrumb] = []
         if pkg_set_id:
@@ -364,12 +371,7 @@ async def picker_browse_endpoint(
         crumbs.append(BrowseBreadcrumb(
             label=pkg_name, scope="package", id=package_id,
         ))
-        return BrowseResponse(
-            breadcrumb=crumbs, items=[],
-            counts=BrowseCounts(
-                packages=0, diagrams=0, elements=elements_count,
-            ),
-        )
+        return BrowseResponse(breadcrumb=crumbs, items=items)
 
     if scope == "package_bucket":
         if not package_id:

--- a/backend/tests/test_search/test_picker_browse.py
+++ b/backend/tests/test_search/test_picker_browse.py
@@ -207,9 +207,12 @@ async def test_invalid_scope_returns_422(
 
 
 @pytest.mark.asyncio
-async def test_scope_package_returns_element_count(
+async def test_scope_package_returns_contained_elements(
     client: httpx.AsyncClient,
 ) -> None:
+    """ADR-207 v6.16.1: scope=package returns the elements as items
+    directly (no bucket-card intermediary — packages only contain
+    elements)."""
     h = await _auth(client)
     s = (await client.post("/api/sets", json={"name": "S"}, headers=h)).json()["id"]
     p = await client.post(
@@ -229,7 +232,10 @@ async def test_scope_package_returns_element_count(
     )
     assert r.status_code == 200, r.text
     body = r.json()
-    assert body["counts"]["elements"] == 3
+    names = sorted(i["name"] for i in body["items"])
+    assert names == ["A", "B", "C"]
+    # counts omitted (response_model_exclude_none=True)
+    assert "counts" not in body or body["counts"] is None
     # Breadcrumb should include Pkg as the last step
     assert body["breadcrumb"][-1]["label"] == "Pkg"
     assert body["breadcrumb"][-1]["scope"] == "package"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.16.0",
+	"version": "6.16.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/SmartMarkdownCanvas.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownCanvas.svelte
@@ -33,6 +33,11 @@
 		onsourcechange?: (source: string) => void;
 		/** Heading list updates — wire to MarkdownToc. */
 		onheadings?: (headings: TocHeading[]) => void;
+		/** ADR-207: the diagram's set_id. The picker uses it to seed
+		 *  its initial breadcrumb at the parent collection (or set if no
+		 *  collection) so the user opens at their current location, not
+		 *  at the global root. */
+		contextSetId?: string | null;
 	}
 
 	let {
@@ -42,6 +47,7 @@
 		textDiagramIds,
 		onsourcechange,
 		onheadings,
+		contextSetId = null,
 	}: Props = $props();
 
 	let textareaEl = $state<HTMLTextAreaElement | undefined>(undefined);
@@ -147,6 +153,7 @@
 				oninsert={onTokenInsert}
 				onclose={onPickerClose}
 				existingSource={source ?? ''}
+				contextSetId={contextSetId}
 			/>
 		{/if}
 	{:else}

--- a/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
@@ -36,7 +36,7 @@
 
 	interface BreadcrumbStep {
 		label: string;
-		scope?: 'collection' | 'set' | 'set_bucket';
+		scope?: 'collection' | 'set' | 'set_bucket' | 'package';
 		id?: string;
 		entity_type?: 'element' | 'package' | 'diagram';
 	}
@@ -63,9 +63,17 @@
 		oninsert: (token: string) => void;
 		onclose: () => void;
 		existingSource?: string;
+		/** ADR-207 follow-up: the set the calling view belongs to. The
+		 *  picker opens at the *collection* containing that set (or at
+		 *  the set itself when the set has no parent collection), so the
+		 *  user lands at their current scope instead of at the global
+		 *  root. Search "at this level" then matches the most likely
+		 *  intent (`/Pork` while editing a Groceries view shows Groceries
+		 *  results first). */
+		contextSetId?: string | null;
 	}
 
-	let { oninsert, onclose, existingSource = '' }: Props = $props();
+	let { oninsert, onclose, existingSource = '', contextSetId = null }: Props = $props();
 
 	// ── Browse mode state ────────────────────────────────────────
 	type Mode = 'browse' | 'drill';
@@ -86,10 +94,13 @@
 	let drillFilter = $state('');
 	let drillIdx = $state(0);
 	let drillSeq = 0;
-	// ADR-207: contained children surfaced when drilling into a
-	// non-element entity (collection → sets, set → all-buckets-flat,
-	// package → elements). Clicking a child enters drill for that
-	// child; Backspace pops back up the parent stack.
+	// ADR-207 v6.16.1: non-element entities are navigated via BROWSE
+	// (root → collection → set → package or set_bucket), not drill.
+	// Drill mode is reserved for element data-tree picking + the
+	// name/description shortcut for any entity type.
+	// containerChildren and drillParentStack are retained as no-op
+	// fields for compatibility with the existing derived; they are
+	// always empty.
 	let containerChildren = $state<EntitySearchResult[]>([]);
 	let drillParentStack = $state<EntitySearchResult[]>([]);
 	const NON_ELEMENT_FIELDS = ['name', 'description'];
@@ -112,7 +123,7 @@
 	const browseLeafEntity = $derived.by((): EntitySearchResult | null => {
 		const last = breadcrumb[breadcrumb.length - 1];
 		if (!last.scope || !last.id) return null;
-		if (last.scope === 'collection' || last.scope === 'set') {
+		if (last.scope === 'collection' || last.scope === 'set' || last.scope === 'package') {
 			return {
 				id: last.id,
 				entity_type: last.scope,
@@ -125,21 +136,16 @@
 	// ── Derived menu for drill mode ──────────────────────────────
 	type DrillItem =
 		| { kind: 'primitive'; label: string }
-		| { kind: 'container'; label: string }
-		| { kind: 'child_entity'; label: string; entity: EntitySearchResult };
+		| { kind: 'container'; label: string };
 	const drillMenuItems = $derived.by((): DrillItem[] => {
-		// ADR-207: non-element drill surfaces name/description PLUS
-		// contained children, so the user can pick the entity's own
-		// fields OR drill into one of its children.
+		// ADR-207 v6.16.1: non-element drill exposes name + description
+		// only. Their children are reachable via browse mode at the
+		// parent breadcrumb level (a package now appears as a browse
+		// scope, not a drill).
 		if (chosenEntity && chosenEntity.entity_type !== 'element') {
 			const items: DrillItem[] = [
 				{ kind: 'primitive' as const, label: 'name' },
 				{ kind: 'primitive' as const, label: 'description' },
-				...containerChildren.map((c) => ({
-					kind: 'child_entity' as const,
-					label: c.name,
-					entity: c,
-				})),
 			];
 			const filt = drillFilter.toLowerCase();
 			if (!filt) return items;
@@ -186,9 +192,43 @@
 	// ── Lifecycle ────────────────────────────────────────────────
 	onMount(async () => {
 		recentChips = await deriveRecent(existingSource);
+		await seedBreadcrumbFromContext();
 		await loadBrowse();
 		inputEl?.focus();
 	});
+
+	async function seedBreadcrumbFromContext() {
+		// ADR-207 follow-up: open the picker at the calling view's parent
+		// collection (or at the set when the set has no collection). The
+		// initial breadcrumb is set BEFORE loadBrowse() so the first fetch
+		// uses the right scope.
+		if (!contextSetId) return;
+		try {
+			const setData = await apiFetch<{
+				id: string;
+				name: string;
+				collection_id?: string | null;
+				collection_name?: string | null;
+			}>(`/api/sets/${encodeURIComponent(contextSetId)}`);
+			if (setData.collection_id && setData.collection_name) {
+				breadcrumb = [
+					{ label: 'Root' },
+					{
+						label: setData.collection_name,
+						scope: 'collection',
+						id: setData.collection_id,
+					},
+				];
+				return;
+			}
+			breadcrumb = [
+				{ label: 'Root' },
+				{ label: setData.name || 'Set', scope: 'set', id: setData.id },
+			];
+		} catch {
+			// On error, fall back to the root view. Best effort.
+		}
+	}
 
 	async function deriveRecent(source: string): Promise<RecentChip[]> {
 		const seen = new Set<string>();
@@ -241,6 +281,7 @@
 		if (!last.scope) return 'scope=root';
 		if (last.scope === 'collection') return `scope=collection&collection_id=${encodeURIComponent(last.id ?? '')}`;
 		if (last.scope === 'set') return `scope=set&set_id=${encodeURIComponent(last.id ?? '')}`;
+		if (last.scope === 'package') return `scope=package&package_id=${encodeURIComponent(last.id ?? '')}`;
 		// set_bucket
 		return `scope=set_bucket&set_id=${encodeURIComponent(last.id ?? '')}&entity_type=${last.entity_type}`;
 	}
@@ -310,6 +351,11 @@
 	}
 
 	async function clickItem(item: EntitySearchResult) {
+		// ADR-207 follow-up: containers (collection, set, package) navigate
+		// browse one level deeper so the breadcrumb-leaf entity is reachable
+		// via "Pick this {entity}" and its children render with the same
+		// browse-mode look at every level. Drill mode is reserved for
+		// elements (data-tree picking) and "Pick this" shortcuts.
 		if (item.entity_type === 'collection') {
 			breadcrumb = [
 				...breadcrumb,
@@ -325,7 +371,14 @@
 			await loadBrowse();
 			return;
 		}
-		// element / package / diagram → drill (or insert immediately for non-elements)
+		if (item.entity_type === 'package') {
+			breadcrumb = [...breadcrumb, { label: item.name, scope: 'package', id: item.id }];
+			query = '';
+			await loadBrowse();
+			return;
+		}
+		// element / diagram (view) → drill (data-tree picking for elements;
+		// name/description for views which have no data tree).
 		await enterDrill(item);
 	}
 
@@ -346,6 +399,12 @@
 	}
 
 	// ── Drill mode behaviour ─────────────────────────────────────
+	// ADR-207 follow-up (v6.16.1): drill mode is for ELEMENT field
+	// picking only (data-tree + name/description). Non-elements are
+	// navigated via browse mode (root → collection → set → package or
+	// set_bucket); their own name/description is picked via the
+	// "Pick this {entity}" shortcut, which lands here in drill mode
+	// with no children to show.
 	async function enterDrill(entity: EntitySearchResult, opts: { resetStack?: boolean } = {}) {
 		const { resetStack = true } = opts;
 		if (resetStack) drillParentStack = [];
@@ -359,48 +418,13 @@
 		if (entity.entity_type === 'element') {
 			await fetchDrillNode();
 		} else {
-			// ADR-207: non-element drill surfaces contained children
-			// alongside name/description. The drillMenuItems derived
-			// reads `containerChildren` for these entity types.
-			await fetchContainerChildren(entity);
+			// Non-elements expose name + description only; their
+			// children are reachable via browse mode at the parent
+			// level (no drill children, no clutter).
+			drillNode = { kind: 'empty' };
 		}
 		await tick();
 		drillInputEl?.focus();
-	}
-
-	async function fetchContainerChildren(entity: EntitySearchResult) {
-		const mySeq = ++drillSeq;
-		try {
-			let url = '';
-			if (entity.entity_type === 'collection') {
-				url = `/api/picker/browse?scope=collection&collection_id=${encodeURIComponent(entity.id)}`;
-			} else if (entity.entity_type === 'set') {
-				// Set has 3 buckets — concatenate in display order.
-				const all: EntitySearchResult[] = [];
-				for (const t of ['element', 'package', 'diagram'] as const) {
-					try {
-						const r = await apiFetch<BrowseResponse>(
-							`/api/picker/browse?scope=set_bucket&set_id=${encodeURIComponent(entity.id)}&entity_type=${t}`,
-						);
-						all.push(...(r.items ?? []));
-					} catch { /* skip unavailable bucket */ }
-				}
-				if (mySeq !== drillSeq) return;
-				containerChildren = all;
-				return;
-			} else if (entity.entity_type === 'package') {
-				url = `/api/picker/browse?scope=package_bucket&package_id=${encodeURIComponent(entity.id)}&entity_type=element`;
-			} else {
-				containerChildren = [];
-				return;
-			}
-			const r = await apiFetch<BrowseResponse>(url);
-			if (mySeq !== drillSeq) return;
-			containerChildren = r.items ?? [];
-		} catch {
-			if (mySeq !== drillSeq) return;
-			containerChildren = [];
-		}
 	}
 
 	async function fetchDrillNode() {
@@ -452,16 +476,6 @@
 			emitToken();
 			return;
 		}
-		// ADR-207: a child_entity item drills into that contained
-		// entity, pushing the current entity onto the parent stack so
-		// Backspace pops back.
-		if (item.kind === 'child_entity') {
-			if (chosenEntity) {
-				drillParentStack = [...drillParentStack, chosenEntity];
-			}
-			await enterDrill(item.entity, { resetStack: false });
-			return;
-		}
 		// Element data drill: container item → push the segment.
 		drillPath = [...drillPath, item.label];
 		drillFilter = '';
@@ -509,6 +523,16 @@
 		if (e.key === 'ArrowUp') {
 			e.preventDefault();
 			if (items.length > 0) listIdx = (listIdx - 1 + items.length) % items.length;
+			return;
+		}
+		// ADR-207 v6.16.1: IDE-style — Tab and `.` commit the highlighted
+		// item and navigate/drill, same as Enter or mouse-click. Tab
+		// always preventDefault so focus stays in the picker.
+		if (e.key === 'Tab' || e.key === '.') {
+			e.preventDefault();
+			if (items.length > 0) {
+				clickItem(items[listIdx]);
+			}
 			return;
 		}
 		if (e.key === 'Enter' && items.length > 0) {
@@ -638,20 +662,9 @@
 		{/if}
 
 		{#if counts}
+			<!-- ADR-207 v6.16.1: bucket order Packages → Views → Elements
+				 per user direction. -->
 			<ul class="slash-picker__list" role="listbox" aria-label="Buckets">
-				{#if counts.elements > 0}
-					<li
-						role="option"
-						aria-selected="false"
-						class="slash-picker__item"
-						onclick={() => clickBucket('element')}
-						onkeydown={(e) => { if (e.key === 'Enter') clickBucket('element'); }}
-						tabindex="-1"
-					>
-						<span class="slash-picker__badge slash-picker__badge--element">elements</span>
-						<span class="slash-picker__name">Elements ({counts.elements})</span>
-					</li>
-				{/if}
 				{#if counts.packages > 0}
 					<li
 						role="option"
@@ -676,6 +689,19 @@
 					>
 						<span class="slash-picker__badge slash-picker__badge--diagram">views</span>
 						<span class="slash-picker__name">Views ({counts.diagrams})</span>
+					</li>
+				{/if}
+				{#if counts.elements > 0}
+					<li
+						role="option"
+						aria-selected="false"
+						class="slash-picker__item"
+						onclick={() => clickBucket('element')}
+						onkeydown={(e) => { if (e.key === 'Enter') clickBucket('element'); }}
+						tabindex="-1"
+					>
+						<span class="slash-picker__badge slash-picker__badge--element">elements</span>
+						<span class="slash-picker__name">Elements ({counts.elements})</span>
 					</li>
 				{/if}
 				{#if counts.elements === 0 && counts.packages === 0 && counts.diagrams === 0}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -3042,6 +3042,7 @@
 									content={markdownContent}
 									source={(diagram.data?.markdown_source as string | undefined) ?? ''}
 									editing={editing}
+									contextSetId={diagram?.set_id ?? null}
 									onsourcechange={(s: string) => {
 										if (diagram) {
 											diagram.data = { ...(diagram.data ?? {}), markdown_source: s };
@@ -3149,6 +3150,7 @@
 										content={markdownContent}
 										source={(diagram.data?.markdown_source as string | undefined) ?? ''}
 										editing={false}
+										contextSetId={diagram?.set_id ?? null}
 										onheadings={(h) => (textHeadings = h)}
 									/>
 								{:else}


### PR DESCRIPTION
## Summary

v6.16.0 acceptance-testing surfaced four issues on the picker:

1. **Picker opened at the global root** regardless of where the user was. Now it opens at the calling view's parent collection (or set if no parent collection), via a new `contextSetId` prop wired through `SmartMarkdownCanvas` → `SmartMarkdownSlashPicker`. The first browse fetch uses the seeded scope.
2. **Clicking a package entered drill mode** with a flat list of contained elements — visually divergent from the set-level browse pattern. Now clicking a package navigates **browse** to `scope=package`, showing the breadcrumb + "Pick this package" shortcut + contained elements as items. Drill mode is reserved for element data-tree picking.
3. **IDE-keystrokes (`.`, Tab) in browse mode were no-ops** — Tab in particular tabbed focus out of the picker. Now both commit the highlighted item and navigate (or drill for elements). Matches the in-drill behaviour from v6.16.0.
4. **Bucket order** at `scope=set` changed from `Elements → Packages → Views` to **`Packages → Views → Elements`** per direction.

Also: `scope=package` backend now returns the contained elements as items directly (was returning counts). Test updated.

## Test plan

- Backend: 11/11 picker_browse cases green.
- Frontend: type-check clean on `SmartMarkdown*.svelte`.

## Migration

- No DB changes. Code-only follow-up to v6.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)