### PR TITLE
fix(v6.17.1): views Images section + element/package headings + graceful 503 on missing table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.1] - 2026-05-20
+
+### Fixed
+
+- **Images section now appears on views (`/views/[id]`)** — was
+  using the canvas-edit flag rather than always-allow-upload, so the
+  section never surfaced unless the user entered canvas edit mode.
+  Now uses `editing={true}` and renders an `Images` heading (issue
+  #194 follow-up).
+- **Element details page now shows the `Images` heading** for
+  consistency with the other entity types.
+- **Packages page Images section now has a heading** to match the
+  other entity types.
+- **Backend image-attachment endpoints return a graceful 503**
+  (instead of an unhandled 500) when the underlying table doesn't
+  exist (Supabase migration m078 not yet applied). The 503 carries
+  CORS headers so the browser shows the real cause instead of a
+  misleading CORS error; the detail message tells the operator to
+  run `scripts/supabase-migrate.sh`.
+
 ## [6.17.0] - 2026-05-20
 
 ### Added

--- a/backend/app/images/entity_attachment_router.py
+++ b/backend/app/images/entity_attachment_router.py
@@ -110,6 +110,24 @@ async def upload_and_attach(
     except ImageNotFoundError as exc:
         # Shouldn't happen — we just created it.
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:
+        # v6.17.1: most common cause is the Supabase mirror not yet applied —
+        # `entity_images` table doesn't exist. Surface the real error so the
+        # CORS middleware decorates the response (raising an unhandled
+        # exception inside the service can produce a 500 without CORS
+        # headers, which the browser then reports as a confusing CORS error).
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).exception("attach_image failed: %s", exc)
+        msg = str(exc) or type(exc).__name__
+        raise HTTPException(  # noqa: B904
+            status_code=503,
+            detail=(
+                f"Image attachment service unavailable "
+                f"({type(exc).__name__}: {msg}). If this just deployed, "
+                "the operator may need to run scripts/supabase-migrate.sh "
+                "to apply migration m078."
+            ),
+        )
     return EntityImageResponse(**attachment)
 
 
@@ -138,6 +156,20 @@ async def attach_existing(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ImageNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        # v6.17.1: graceful 503 when the entity_images table is missing
+        # (Supabase migration m078 not yet applied) so CORS headers
+        # decorate the response and the real error surfaces to DevTools.
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).exception("attach_image failed: %s", exc)
+        msg = str(exc) or type(exc).__name__
+        raise HTTPException(  # noqa: B904
+            status_code=503,
+            detail=(
+                f"Image attachment service unavailable "
+                f"({type(exc).__name__}: {msg})."
+            ),
+        )
     return EntityImageResponse(**attachment)
 
 
@@ -155,7 +187,20 @@ async def list_attachments(
     `<img>` tags resolve in MarkdownView without auth."""
     et = _check_entity_type(entity_type)
     db = request.app.state.db_manager.main_db
-    rows = await list_entity_images(db, entity_type=et, entity_id=entity_id)
+    try:
+        rows = await list_entity_images(db, entity_type=et, entity_id=entity_id)
+    except Exception as exc:
+        # v6.17.1: graceful 503 on missing table (see attach_existing).
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).exception("list_entity_images failed: %s", exc)
+        msg = str(exc) or type(exc).__name__
+        raise HTTPException(  # noqa: B904
+            status_code=503,
+            detail=(
+                f"Image attachment service unavailable "
+                f"({type(exc).__name__}: {msg})."
+            ),
+        )
     return [EntityImageResponse(**r) for r in rows]
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.0",
+	"version": "6.17.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -881,11 +881,14 @@
 				</Accordion.Item>
 			</Accordion.Root>
 			<!-- ADR-209 (v6.17.0): attached images for this element. -->
-			<EntityImagesEditor
-				entityType="element"
-				entityId={entity.id}
-				editing={editingDetails}
-			/>
+			<div class="mt-4">
+				<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
+				<EntityImagesEditor
+					entityType="element"
+					entityId={entity.id}
+					editing={editingDetails}
+				/>
+			</div>
 		{:else if activeTab === 'relationships'}
 			<!-- ADR-208 (v6.16.0): the Relationships tab now hosts three
 				 sections — Package membership, Used in Views, and the

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -900,11 +900,14 @@
 			</Accordion.Root>
 			<!-- ADR-209 (v6.17.0): attached images for this package. -->
 			{#if pkg}
-				<EntityImagesEditor
-					entityType="package"
-					entityId={pkg.id}
-					editing={editingDetails}
-				/>
+				<div class="mt-4">
+					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
+					<EntityImagesEditor
+						entityType="package"
+						entityId={pkg.id}
+						editing={editingDetails}
+					/>
+				</div>
 			{/if}
 		{:else if activeTab === 'relationships'}
 			<section aria-labelledby="package-elements-heading">

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -3308,11 +3308,18 @@
 			{/if}
 			<!-- ADR-209 (v6.17.0): attached images for this view. -->
 			{#if diagram}
-				<EntityImagesEditor
-					entityType="diagram"
-					entityId={diagram.id}
-					editing={editing}
-				/>
+				<div class="mt-4">
+					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
+					<!-- v6.17.1 fix: `editing` here is the canvas-edit flag, not
+						 a details-edit flag. Always allow image upload so the
+						 user doesn't have to enter canvas edit mode just to
+						 attach an image to the view. -->
+					<EntityImagesEditor
+						entityType="diagram"
+						entityId={diagram.id}
+						editing={true}
+					/>
+				</div>
 			{/if}
 		{:else if activeTab === 'relationships'}
 			<!-- Add relationship buttons -->


### PR DESCRIPTION
## Summary

Three v6.17.0 regressions reported by user testing:

1. **`/views/[id]` Images section never appeared** — was gated on the canvas `editing` flag, not a details-edit flag, so the section was hidden unless the user entered canvas-edit mode. Now uses `editing={true}` (matching the collections / sets approach for routes without a discrete details-edit toggle) and renders an `Images` heading.
2. **`Images` heading missing on `/elements/[id]` and `/packages/[id]`** — added for consistency with the other entity types.
3. **Image-attachment endpoints returned an unhandled 500** when the `entity_images` table didn't exist (operator hadn't run `scripts/supabase-migrate.sh` yet). Unhandled exceptions bypass CORS middleware, so the browser surfaced the failure as a misleading CORS error. Now: graceful 503 with detail message + CORS headers preserved, instructing the operator to apply m078.

## Test plan

- 17/17 entity-attachment tests still green.
- Verify in DevTools: a failed upload now shows the 503 response body explaining the cause, not a generic CORS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)