### PR TITLE
fix(v6.17.2): entity_images.created_at must be TIMESTAMPTZ (asyncpg adapter mismatch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.2] - 2026-05-20
+
+### Fixed
+
+- **Image upload now actually persists on Supabase**. v6.17.0's
+  paired Supabase migration m078 declared
+  `entity_images.created_at TEXT NOT NULL`, but Iris's asyncpg adapter
+  (`_convert_params` in `backend/app/db/adapter.py`) unconditionally
+  converts ISO-format string parameters into native `datetime`
+  objects. asyncpg then rejected the INSERT with
+  `DataError: invalid input for query argument $6 (expected str, got
+  datetime)`. Other Iris tables (m002, m006, m007, …) already use
+  `TIMESTAMPTZ`; m078 was the outlier. Updated m078 to
+  `TIMESTAMPTZ NOT NULL` for new installs and to `ALTER COLUMN ...
+  TYPE TIMESTAMPTZ` for existing installs. The v6.17.1 graceful 503
+  handler made this diagnosable from the response body.
+
+### Migration
+
+- **Supabase m078 needs to be re-run** by the operator
+  (`scripts/supabase-migrate.sh`). The script is idempotent: on
+  databases where `created_at` is already TEXT, it converts in
+  place; on fresh installs it skips the ALTER and creates the
+  column with the right type.
+
 ## [6.17.1] - 2026-05-20
 
 ### Fixed

--- a/backend/app/migrations/supabase/m078_entity_images.sql
+++ b/backend/app/migrations/supabase/m078_entity_images.sql
@@ -12,10 +12,32 @@ CREATE TABLE IF NOT EXISTS public.entity_images (
     entity_id     TEXT NOT NULL,
     image_id      TEXT NOT NULL,
     display_order INTEGER NOT NULL DEFAULT 0,
-    created_at    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
     created_by    TEXT NOT NULL,
     UNIQUE (entity_type, entity_id, image_id)
 );
+
+-- v6.17.2: prior m078 declared `created_at TEXT` which fights with
+-- Iris's asyncpg adapter (`_convert_params` in `backend/app/db/adapter.py`
+-- converts ISO-string parameters to native `datetime` unconditionally).
+-- asyncpg then rejected the INSERT with "expected str, got datetime".
+-- This ALTER converts existing TEXT columns to TIMESTAMPTZ in place;
+-- it's a no-op on fresh databases where the CREATE above already
+-- yielded the right type. Cast is safe because every stored value
+-- to date was an ISO timestamp.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'entity_images'
+          AND column_name = 'created_at'
+          AND data_type = 'text'
+    ) THEN
+        ALTER TABLE public.entity_images
+            ALTER COLUMN created_at TYPE TIMESTAMPTZ USING (created_at::TIMESTAMPTZ);
+    END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_entity_images_entity
     ON public.entity_images (entity_type, entity_id, display_order);

--- a/backend/tests/test_migrations/test_entity_images_schema.py
+++ b/backend/tests/test_migrations/test_entity_images_schema.py
@@ -53,6 +53,17 @@ def test_supabase_m078_creates_table() -> None:
     assert "UNIQUE (entity_type, entity_id, image_id)" in sql
 
 
+def test_supabase_m078_uses_timestamptz_for_created_at() -> None:
+    """v6.17.2 (Iris asyncpg adapter): ISO-string params are converted to
+    native `datetime`. The column must be TIMESTAMPTZ on Supabase or
+    asyncpg refuses the bind with `expected str, got datetime`."""
+    sql = _read("app/migrations/supabase/m078_entity_images.sql")
+    assert "created_at    TIMESTAMPTZ NOT NULL" in sql
+    # Migration also retypes any existing TEXT column to TIMESTAMPTZ
+    # in case a prior version of m078 (with `created_at TEXT`) ran first.
+    assert "ALTER COLUMN created_at TYPE TIMESTAMPTZ" in sql
+
+
 def test_supabase_m078_creates_index() -> None:
     sql = _read("app/migrations/supabase/m078_entity_images.sql")
     assert "CREATE INDEX IF NOT EXISTS idx_entity_images_entity" in sql

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.1",
+	"version": "6.17.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",


### PR DESCRIPTION
## Root cause

v6.17.1's graceful 503 surfaced the real error from the field:

```
DataError: invalid input for query argument $6:
datetime.datetime(2026, 5, 20, ...) (expected str, got datetime)
```

Iris's asyncpg adapter (`_convert_params` in `backend/app/db/adapter.py:272`) unconditionally converts ISO-string parameters into native `datetime` objects (asyncpg requires native types). m078 declared `created_at TEXT NOT NULL`, so asyncpg saw the column as TEXT and refused the datetime bind. Other Iris Supabase migrations (m002, m006, m007, …) use `TIMESTAMPTZ` precisely for this — m078 was the outlier.

## Fix

- **New installs**: `CREATE TABLE` now declares `created_at TIMESTAMPTZ NOT NULL`.
- **Existing installs**: idempotent `ALTER COLUMN ... TYPE TIMESTAMPTZ USING (created_at::TIMESTAMPTZ)` wrapped in a `DO` block that only runs if the column is currently TEXT. Safe — no successful inserts to date, so every stored value would already be an ISO timestamp anyway.

## Operator action

Re-run `scripts/supabase-migrate.sh`. Idempotent — converts in place on the broken database, skips the ALTER on fresh ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)