### PR TITLE
fix(v6.17.3): rewrite image src to absolute backend URL; always-editable image gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.3] - 2026-05-20
+
+### Fixed
+
+- **Attached images now render in production.** v6.17.0/.1/.2's
+  `<img src="/api/images/<id>">` was a relative URL — the SvelteKit
+  SPA doesn't proxy `/api/*` to the backend in production, so the
+  browser loaded the SPA's `index.html` as image bytes and showed
+  a broken icon. New `frontend/src/lib/utils/imageUrl.ts` helper
+  prepends `API_BASE_URL`; used by `EntityImagesEditor` (grid +
+  lightbox) and `SmartMarkdownSlashPicker` (drill thumbs + sizer
+  preview).
+- **Smart Markdown `<img>` tags in browse mode also resolve.**
+  The resolver emits relative `/api/images/<id>` server-side;
+  `markdownHelpers.ts` now post-processes the sanitised HTML to
+  rewrite those `<img src>` attributes to absolute backend URLs.
+  Same rewriter, single source of truth.
+- **Element + package save button no longer gated by image
+  attachments.** Image attachments commit atomically server-side
+  on upload, so they shouldn't block the form's save/discard. The
+  Images section on `/elements/[id]` and `/packages/[id]` now
+  always shows the upload affordance regardless of edit mode —
+  matching the collections / sets pattern.
+
+### Migration
+
+- None.
+
 ## [6.17.2] - 2026-05-20
 
 ### Fixed

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.2",
+	"version": "6.17.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
@@ -24,6 +24,7 @@
 	 *   - Mouse click → equivalent to highlight + Tab.
 	 */
 	import { apiFetch } from '$lib/utils/api';
+	import { imageUrl } from '$lib/utils/imageUrl';
 	import { onMount, tick } from 'svelte';
 
 	type EntityType = 'element' | 'package' | 'diagram' | 'set' | 'collection';
@@ -828,7 +829,7 @@
 			<div class="slash-picker__sizer">
 				<div class="slash-picker__sizer-preview">
 					<img
-						src="/api/images/{imageSizer.chosen.image_id}"
+						src={imageUrl(imageSizer.chosen.image_id)}
 						alt=""
 						style="max-width: 100%; max-height: 120px; object-fit: contain;"
 					/>
@@ -893,7 +894,7 @@
 					>
 						{#if menuItem.kind === 'image'}
 							<img
-								src="/api/images/{menuItem.image.image_id}"
+								src={imageUrl(menuItem.image.image_id)}
 								alt=""
 								class="slash-picker__image-thumb"
 							/>

--- a/frontend/src/lib/components/EntityImagesEditor.svelte
+++ b/frontend/src/lib/components/EntityImagesEditor.svelte
@@ -13,6 +13,7 @@
 	 */
 	import { onMount } from 'svelte';
 	import { apiFetch } from '$lib/utils/api';
+	import { imageUrl } from '$lib/utils/imageUrl';
 
 	interface EntityImage {
 		id: string;
@@ -129,7 +130,7 @@
 							aria-label="View image"
 						>
 							<img
-								src="/api/images/{att.image_id}"
+								src={imageUrl(att.image_id)}
 								alt=""
 								loading="lazy"
 							/>
@@ -173,7 +174,7 @@
 		onkeydown={(e) => { if (e.key === 'Escape') lightboxImage = null; }}
 		role="presentation"
 	>
-		<img src="/api/images/{lightboxImage.image_id}" alt="" />
+		<img src={imageUrl(lightboxImage.image_id)} alt="" />
 	</div>
 {/if}
 

--- a/frontend/src/lib/components/markdownHelpers.ts
+++ b/frontend/src/lib/components/markdownHelpers.ts
@@ -14,6 +14,7 @@
 
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { rewriteImageSrcs } from '$lib/utils/imageUrl';
 import { markdownMermaidExtension } from './markdownMermaidExtension';
 
 // ADR-149: ```mermaid fenced blocks become <pre class="mermaid-block">
@@ -129,6 +130,14 @@ export function renderMarkdown(source: string, textDiagramIds?: Set<string>): Re
 			img.removeAttribute('src');
 		}
 	}
+
+	// v6.17.3 (ADR-209 follow-up): rewrite any surviving relative
+	// `/api/images/<id>` src to the absolute backend URL. The frontend
+	// SPA doesn't proxy /api/* in production, so a relative img src
+	// loads the SPA's index.html as image bytes (broken). Smart
+	// Markdown's resolver emits relative URLs server-side; this rewrite
+	// is the one place to fix them all.
+	tpl.innerHTML = rewriteImageSrcs(tpl.innerHTML);
 
 	const links: ExtractedLink[] = [];
 	for (const a of tpl.content.querySelectorAll('a')) {

--- a/frontend/src/lib/utils/imageUrl.ts
+++ b/frontend/src/lib/utils/imageUrl.ts
@@ -1,0 +1,45 @@
+/**
+ * v6.17.3 (issue #194 follow-up): build absolute URLs for image
+ * resources served by the Iris API.
+ *
+ * The frontend (SvelteKit SPA) does not proxy `/api/*` to the backend
+ * in production — a relative `<img src="/api/images/<id>">` resolves
+ * against the frontend origin, gets the SPA's index.html, and the
+ * img tag fails to decode HTML as an image. Prepending API_BASE_URL
+ * routes the request to the backend directly.
+ *
+ * Returns the input unchanged if it isn't an `/api/images/` path
+ * (so callers can pass URLs through without inspection).
+ */
+import { API_BASE_URL } from '$lib/config.js';
+
+const IMAGE_PATH_RE = /^\/api\/images\//;
+
+export function imageUrl(idOrPath: string): string {
+	if (!idOrPath) return idOrPath;
+	// Already absolute? Pass through.
+	if (idOrPath.startsWith('http://') || idOrPath.startsWith('https://')) {
+		return idOrPath;
+	}
+	// Strip leading slash variants and reconstruct.
+	const path = idOrPath.startsWith('/api/images/')
+		? idOrPath
+		: `/api/images/${idOrPath}`;
+	return `${API_BASE_URL}${path}`;
+}
+
+/**
+ * Rewrite any relative `<img src="/api/images/...">` URLs inside an
+ * HTML string to absolute backend URLs. Used as a post-DOMPurify
+ * pass on Smart Markdown content so resolver-emitted `<img>` tags
+ * actually load on production.
+ */
+export function rewriteImageSrcs(html: string): string {
+	if (!html || !API_BASE_URL) return html;
+	return html.replace(
+		/(<img\b[^>]*\bsrc=)(["'])(\/api\/images\/[^"']+)\2/g,
+		(_match, prefix: string, quote: string, path: string) => {
+			return `${prefix}${quote}${API_BASE_URL}${path}${quote}`;
+		},
+	);
+}

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -880,13 +880,16 @@
 					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>
-			<!-- ADR-209 (v6.17.0): attached images for this element. -->
+			<!-- ADR-209 (v6.17.0 / v6.17.3): attached images for this
+				 element. Always-editable (matches collections/sets) — image
+				 attachments are committed atomically by the backend, so they
+				 shouldn't gate the form's save/discard flow. -->
 			<div class="mt-4">
 				<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
 				<EntityImagesEditor
 					entityType="element"
 					entityId={entity.id}
-					editing={editingDetails}
+					editing={true}
 				/>
 			</div>
 		{:else if activeTab === 'relationships'}

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -898,14 +898,16 @@
 					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>
-			<!-- ADR-209 (v6.17.0): attached images for this package. -->
+			<!-- ADR-209 (v6.17.0 / v6.17.3): attached images for this
+				 package. Always-editable — atomic backend commit, no need to
+				 gate on form edit mode. -->
 			{#if pkg}
 				<div class="mt-4">
 					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
 					<EntityImagesEditor
 						entityType="package"
 						entityId={pkg.id}
-						editing={editingDetails}
+						editing={true}
 					/>
 				</div>
 			{/if}


### PR DESCRIPTION
## Summary

Three regressions after v6.17.2 unblocked uploads:

1. **Blank thumbnails on the entity Details pages.** Root cause: `<img src=\"/api/images/<id>\">` was relative. The SvelteKit SPA on `iris-uat.chrisbarlow.nz` does not proxy `/api/*` to the backend in production (verified — returns the SPA's index.html with `content-type: text/html`). The browser then loaded HTML as image bytes → broken icon. New `imageUrl()` helper prepends `API_BASE_URL`.
2. **Smart Markdown `<img>` tags in browse mode** had the same bug since the server-side resolver emits relative URLs. `markdownHelpers.ts` now post-processes the sanitised HTML to rewrite `/api/images/...` to absolute. Same rewriter, single source of truth.
3. **Save button on `/elements/[id]` was ghosted** despite the image appearing, because `EntityImagesEditor` was wired to the form's `editingDetails` flag and the image upload didn't flip a dirty bit. Image attachments commit atomically server-side — there's nothing to save in the form. Switched to `editing={true}` (matching collections/sets) so upload is always available regardless of form edit mode. Same change on `/packages/[id]`.

## Test plan

- Hard-refresh, retry image upload on `/elements/<id>` → thumbnail renders the image (not blank).
- Smart Markdown view referencing the image renders the actual image too.
- Save button no longer required for image attachments — they're saved on upload.

## Migration

None — code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)