### PR TITLE
feat(v6.17.4): /version page, views Details Images fix, markdown thumbnails, sets/collections 1-image cap, #200 set filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.4] - 2026-05-20
+
+### Fixed
+
+- **Views Details → Images section now actually renders.** v6.17.0
+  mounted the section just before `{:else if activeTab ==
+  'relationships'}` — but by that anchor we were inside the Canvas
+  branch (`{:else if activeTab == 'canvas'}` opens earlier). Moved
+  the mount inside the Details branch so clicking the Details tab
+  shows it.
+- **Elements page Set dropdown now filters by selected Collection**
+  (issue [#200](https://github.com/cgbarlow/iris/issues/200)). The
+  `SetSelector` gains an optional `collectionId` prop; when set,
+  it loads `/api/sets?collection_id=X`. The elements page wires
+  this from its active collection state.
+- **Markdown-notation views now show a thumbnail** in the views
+  gallery. `DiagramThumbnail` can't render markdown content into
+  a tile, so SVG mode left those views with an empty thumbnail.
+  The gallery now also tries the backend `/api/diagrams/{id}/
+  thumbnail` URL for markdown-notation views; the backend
+  `get_thumbnail` falls back to the first `entity_images`
+  attachment so users can pick a thumbnail by attaching an image
+  to the view's Details → Images section.
+- **Sets / collections gallery tiles use attached images.** When
+  a user uploads an image via the new Details → Images section,
+  `has_thumbnail_image` is now true (via SQL subquery that checks
+  `entity_images`) and the gallery renders the thumbnail URL.
+  Backend `get_set_thumbnail` and `get_collection_thumbnail` fall
+  back to the first attachment when no explicit thumbnail is set,
+  preserving the existing priority (model → image → attachment).
+
+### Added
+
+- **Collections and sets are now limited to 1 attached image.** The
+  `EntityImagesEditor` gains a `maxImages` prop; when the cap is
+  reached the upload affordance hides. Sets and collections pass
+  `maxImages={1}` because the attachment doubles as the gallery
+  tile thumbnail. Packages, views, and elements remain unlimited.
+- **`/version` page** lists the deployed version of each Iris
+  component (Frontend, Backend, MCP server, CLI). Backed by a new
+  `GET /api/version` endpoint that reads each component's
+  `pyproject.toml` at startup.
+
+### Migration
+
+- None.
+
 ## [6.17.3] - 2026-05-20
 
 ### Fixed

--- a/backend/app/collections/service.py
+++ b/backend/app/collections/service.py
@@ -36,7 +36,12 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
 _COLLECTION_COLUMNS = (
     "c.id, c.name, c.description, c.created_at, c.created_by, "
     "c.updated_at, c.is_deleted, c.thumbnail_source, c.thumbnail_diagram_id, "
-    "c.thumbnail_image IS NOT NULL, c.system_prompt, c.mcp_system_context"
+    # ADR-209 (v6.17.4): has_thumbnail_image is true when EITHER the
+    # legacy BLOB column has bytes OR an entity_images attachment exists.
+    "(c.thumbnail_image IS NOT NULL "
+    " OR EXISTS (SELECT 1 FROM entity_images ei "
+    "            WHERE ei.entity_type = 'collection' AND ei.entity_id = c.id)), "
+    "c.system_prompt, c.mcp_system_context"
 )
 
 
@@ -373,5 +378,20 @@ async def get_collection_thumbnail(
 
     if source == "image" and image_blob:
         return image_blob
+
+    # ADR-209 (v6.17.4): fall back to entity_images attachment (the new
+    # collection-level image upload UI) so it doubles as the gallery
+    # tile thumbnail.
+    cursor = await db.execute(
+        "SELECT i.bytes FROM entity_images ei "
+        "JOIN images i ON ei.image_id = i.id "
+        "WHERE ei.entity_type = 'collection' AND ei.entity_id = ? "
+        "ORDER BY ei.display_order, ei.created_at LIMIT 1",
+        (collection_id,),
+    )
+    arow = await cursor.fetchone()
+    if arow is not None and arow[0]:
+        raw = arow[0]
+        return bytes(raw) if not isinstance(raw, bytes) else raw
 
     return None

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -155,14 +155,37 @@ async def generate_and_store_thumbnail(
 async def get_thumbnail(
     db: DatabasePort, diagram_id: str, theme: str = "dark",
 ) -> bytes | None:
-    """Get stored thumbnail for a diagram."""
+    """Get stored thumbnail for a diagram.
+
+    ADR-209 (v6.17.4): markdown-notation diagrams have no graphical
+    representation to thumbnail, so they previously returned None and
+    the gallery showed an empty tile. Now: if no canonical thumbnail
+    exists, fall back to the first ``entity_images`` attachment so
+    users can pick their own thumbnail by attaching an image to the
+    view's Details → Images section.
+    """
     cursor = await db.execute(
         "SELECT thumbnail FROM diagram_thumbnails "
         "WHERE diagram_id = ? AND theme = ?",
         (diagram_id, theme),
     )
     row = await cursor.fetchone()
-    return row[0] if row else None
+    if row is not None and row[0]:
+        return row[0]
+
+    # Fall back to attached image.
+    cursor = await db.execute(
+        "SELECT i.bytes FROM entity_images ei "
+        "JOIN images i ON ei.image_id = i.id "
+        "WHERE ei.entity_type = 'diagram' AND ei.entity_id = ? "
+        "ORDER BY ei.display_order, ei.created_at LIMIT 1",
+        (diagram_id,),
+    )
+    arow = await cursor.fetchone()
+    if arow is not None and arow[0]:
+        raw = arow[0]
+        return bytes(raw) if not isinstance(raw, bytes) else raw
+    return None
 
 
 async def regenerate_all_thumbnails(db: DatabasePort) -> int:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.artefacts.router import router as artefacts_router
 from app.export.router import router as export_router
 from app.images.router import router as images_router
 from app.images.entity_attachment_router import router as entity_images_router
+from app.version_router import router as version_router
 from app.extensions.router import router as extensions_router
 from app.graph.router import router as graph_router
 from app.import_archimate.router import router as import_archimate_router
@@ -193,6 +194,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(import_router)
     app.include_router(images_router)
     app.include_router(entity_images_router)
+    app.include_router(version_router)
     app.include_router(import_pptx_router)
     app.include_router(import_archimate_router)
     app.include_router(package_relationships_router)

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -54,7 +54,14 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
 _SET_COLUMNS = (
     "s.id, s.name, s.description, s.created_at, s.created_by, "
     "s.updated_at, s.is_deleted, s.thumbnail_source, s.thumbnail_diagram_id, "
-    "s.thumbnail_image IS NOT NULL, s.collection_id, col.name, s.system_prompt, "
+    # ADR-209 (v6.17.4): has_thumbnail_image is true when EITHER the
+    # legacy thumbnail_image BLOB column has bytes OR there's at least
+    # one entity_images attachment. The thumbnail GET endpoint resolves
+    # in the right priority (model → image → attachment).
+    "(s.thumbnail_image IS NOT NULL "
+    " OR EXISTS (SELECT 1 FROM entity_images ei "
+    "            WHERE ei.entity_type = 'set' AND ei.entity_id = s.id)), "
+    "s.collection_id, col.name, s.system_prompt, "
     "s.mcp_system_context, s.hierarchy_sort, s.package_tab_default, "
     "s.view_tab_default, s.element_tab_default"
 )
@@ -574,6 +581,21 @@ async def get_set_thumbnail(
 
     if source == "image" and image_blob:
         return image_blob
+
+    # ADR-209 (v6.17.4): if no thumbnail is configured, fall back to the
+    # first attachment from entity_images. Lets the new attach-an-image
+    # UI on the set details page double as the gallery tile thumbnail.
+    cursor = await db.execute(
+        "SELECT i.bytes FROM entity_images ei "
+        "JOIN images i ON ei.image_id = i.id "
+        "WHERE ei.entity_type = 'set' AND ei.entity_id = ? "
+        "ORDER BY ei.display_order, ei.created_at LIMIT 1",
+        (set_id,),
+    )
+    arow = await cursor.fetchone()
+    if arow is not None and arow[0]:
+        raw = arow[0]
+        return bytes(raw) if not isinstance(raw, bytes) else raw
 
     return None
 

--- a/backend/app/version_router.py
+++ b/backend/app/version_router.py
@@ -1,0 +1,62 @@
+"""Version API endpoint (v6.17.4).
+
+Reads each Iris component's `pyproject.toml` version field once at
+import time and serves the result via `/api/version`. The frontend
+`/version` page displays them alongside its own
+`frontend/package.json` version.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter(tags=["version"])
+
+# `backend/app/version_router.py` → `<repo>/backend/app` → up two = repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_pyproject_version(rel: str) -> str | None:
+    path = _REPO_ROOT / rel
+    if not path.exists():
+        return None
+    try:
+        with path.open("rb") as f:
+            data = tomllib.load(f)
+        project = data.get("project") or {}
+        ver = project.get("version")
+        return str(ver) if ver else None
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+
+_BACKEND_VERSION = _read_pyproject_version("backend/pyproject.toml")
+_MCP_VERSION = _read_pyproject_version("mcp/pyproject.toml")
+_CLI_VERSION = _read_pyproject_version("iris-client/pyproject.toml")
+
+
+class VersionResponse(BaseModel):
+    """Per-component versions of the deployed Iris stack."""
+
+    backend: str | None
+    mcp: str | None
+    cli: str | None
+
+
+@router.get("/api/version", response_model=VersionResponse)
+async def get_version() -> VersionResponse:
+    """Return the deployed version of each Iris Python component.
+
+    Frontend version is known to the SPA itself (from
+    `frontend/package.json`) and rendered alongside the backend
+    response on the `/version` page.
+    """
+    return VersionResponse(
+        backend=_BACKEND_VERSION,
+        mcp=_MCP_VERSION,
+        cli=_CLI_VERSION,
+    )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.3",
+	"version": "6.17.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/EntityImagesEditor.svelte
+++ b/frontend/src/lib/components/EntityImagesEditor.svelte
@@ -31,9 +31,14 @@
 		entityType: 'collection' | 'set' | 'package' | 'diagram' | 'element';
 		entityId: string;
 		editing?: boolean;
+		/** v6.17.4: cap the number of attachments. When the cap is
+		 *  reached, the upload affordance is hidden. Sets and collections
+		 *  pass `maxImages={1}` because the attached image doubles as the
+		 *  gallery thumbnail. Undefined / 0 means unlimited. */
+		maxImages?: number;
 	}
 
-	let { entityType, entityId, editing = false }: Props = $props();
+	let { entityType, entityId, editing = false, maxImages }: Props = $props();
 
 	let attachments = $state<EntityImage[]>([]);
 	let loading = $state(false);
@@ -146,7 +151,7 @@
 						{/if}
 					</div>
 				{/each}
-				{#if editing}
+				{#if editing && (!maxImages || attachments.length < maxImages)}
 					<label class="ent-images__upload">
 						<input
 							type="file"

--- a/frontend/src/lib/components/SetSelector.svelte
+++ b/frontend/src/lib/components/SetSelector.svelte
@@ -9,9 +9,13 @@
 		label?: string;
 		showNewSet?: boolean;
 		onNewSet?: () => void;
+		/** v6.17.4 (issue #200): constrain the set list to a single
+		 *  collection. When set, the dropdown only shows sets whose
+		 *  collection_id matches; empty/undefined = all sets. */
+		collectionId?: string | null;
 	}
 
-	let { value, onchange, showAll = true, label = 'Set', showNewSet = false, onNewSet }: Props = $props();
+	let { value, onchange, showAll = true, label = 'Set', showNewSet = false, onNewSet, collectionId = null }: Props = $props();
 
 	let sets = $state<IrisSet[]>([]);
 	let loading = $state(true);
@@ -24,7 +28,10 @@
 	async function loadSets() {
 		loading = true;
 		try {
-			const data = await apiFetch<{ items: IrisSet[] }>('/api/sets');
+			const url = collectionId
+				? `/api/sets?collection_id=${encodeURIComponent(collectionId)}`
+				: '/api/sets';
+			const data = await apiFetch<{ items: IrisSet[] }>(url);
 			sets = data.items;
 		} catch {
 			sets = [];
@@ -46,6 +53,9 @@
 	}
 
 	$effect(() => {
+		// Read `collectionId` reactively so changing the collection
+		// re-fetches the constrained set list (issue #200).
+		collectionId;
 		loadSets();
 	});
 </script>

--- a/frontend/src/routes/collections/[id]/+page.svelte
+++ b/frontend/src/routes/collections/[id]/+page.svelte
@@ -219,6 +219,7 @@
 			entityType="collection"
 			entityId={collection?.id ?? ''}
 			editing={true}
+			maxImages={1}
 		/>
 	</div>
 

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -357,7 +357,9 @@
 <!-- Filters -->
 <div class="mt-4 flex flex-wrap gap-3">
 	<CollectionSelector value={currentCollectionId} onchange={handleCollectionChange} />
-	<SetSelector value={currentSetId} onchange={handleSetChange} />
+	<!-- v6.17.4 (issue #200): pass the active collection so the Set
+		 dropdown only lists sets within it. Empty/null = all sets. -->
+	<SetSelector value={currentSetId} onchange={handleSetChange} collectionId={currentCollectionId || null} />
 	<div>
 		<label for="element-search" class="sr-only">Search elements</label>
 		<input

--- a/frontend/src/routes/sets/+page.svelte
+++ b/frontend/src/routes/sets/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { apiFetch } from '$lib/utils/api';
+	import { API_BASE_URL } from '$lib/config.js';
 	import { getActiveSetId, clearActiveSet, setActiveSet } from '$lib/stores/activeSet.svelte.js';
 	import { setActiveCollection, clearActiveCollection, getActiveCollectionId } from '$lib/stores/activeCollection.svelte.js';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
@@ -94,8 +95,12 @@
 	}
 
 	function getImageThumbnailUrl(set: IrisSet): string | null {
-		if (set.thumbnail_source === 'image' && set.has_thumbnail_image) {
-			return `/api/sets/${set.id}/thumbnail`;
+		// v6.17.4 (ADR-209): also true when an entity_images attachment
+		// exists, so an image uploaded via the set Details Images section
+		// surfaces as the gallery tile. Backend get_set_thumbnail resolves
+		// in the right priority: model → image → attachment.
+		if (set.has_thumbnail_image) {
+			return `${API_BASE_URL}/api/sets/${set.id}/thumbnail`;
 		}
 		return null;
 	}

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -446,6 +446,7 @@
 			entityType="set"
 			entityId={set?.id ?? ''}
 			editing={true}
+			maxImages={1}
 		/>
 	</div>
 

--- a/frontend/src/routes/version/+page.svelte
+++ b/frontend/src/routes/version/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+	/**
+	 * /version (v6.17.4): shows the deployed version of every Iris
+	 * component. Frontend version is baked in at build time from
+	 * `frontend/package.json` (Vite injects via `__APP_VERSION__`).
+	 * Backend, MCP and CLI versions are fetched from
+	 * `GET /api/version`, which reads each component's pyproject.toml
+	 * at backend startup.
+	 */
+	import { onMount } from 'svelte';
+	import { apiFetch } from '$lib/utils/api';
+	import pkg from '../../../package.json';
+
+	const FRONTEND_VERSION: string = (pkg as { version: string }).version;
+
+	interface VersionResponse {
+		backend: string | null;
+		mcp: string | null;
+		cli: string | null;
+	}
+
+	let loading = $state(true);
+	let error = $state<string | null>(null);
+	let versions = $state<VersionResponse | null>(null);
+
+	onMount(async () => {
+		try {
+			versions = await apiFetch<VersionResponse>('/api/version');
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load versions.';
+		} finally {
+			loading = false;
+		}
+	});
+
+	function row(name: string, version: string | null | undefined): { name: string; version: string } {
+		return { name, version: version ?? '—' };
+	}
+</script>
+
+<svelte:head>
+	<title>Version — Iris</title>
+</svelte:head>
+
+<div style="max-width: 600px">
+	<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Iris versions</h1>
+	<p class="mt-1 text-sm" style="color: var(--color-muted)">
+		Deployed versions of each Iris component. Refresh after a release
+		to confirm the new build is live.
+	</p>
+
+	{#if loading}
+		<p class="mt-4 text-sm" style="color: var(--color-muted)">Loading…</p>
+	{:else}
+		<table class="mt-4 w-full text-sm">
+			<thead>
+				<tr style="border-bottom: 1px solid var(--color-border)">
+					<th class="py-2 text-left" style="color: var(--color-muted)">Component</th>
+					<th class="py-2 text-left" style="color: var(--color-muted)">Version</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each [
+					row('Frontend (SPA)', FRONTEND_VERSION),
+					row('Backend (FastAPI)', versions?.backend ?? null),
+					row('MCP server', versions?.mcp ?? null),
+					row('CLI / iris-client', versions?.cli ?? null),
+				] as r (r.name)}
+					<tr style="border-bottom: 1px solid var(--color-border)">
+						<td class="py-2" style="color: var(--color-fg)">{r.name}</td>
+						<td class="py-2 font-mono" style="color: var(--color-fg)">{r.version}</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+		{#if error}
+			<p class="mt-3 text-sm" style="color: var(--color-danger, #b91c1c)" role="alert">
+				Backend version fetch failed: {error}. Frontend version is rendered above.
+			</p>
+		{/if}
+	{/if}
+</div>

--- a/frontend/src/routes/views/+page.svelte
+++ b/frontend/src/routes/views/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { API_BASE_URL } from '$lib/config.js';
 	import { getActiveSetId, setActiveSet, clearActiveSet } from '$lib/stores/activeSet.svelte.js';
 	import { getActiveCollectionId } from '$lib/stores/activeCollection.svelte.js';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
@@ -715,9 +716,15 @@
 						{/if}
 						<a href="/views/{model.id}" class="flex flex-col">
 							<div class="flex h-28 items-center justify-center overflow-hidden" style="border-bottom: 1px solid var(--color-border)">
-								{#if thumbnailMode === 'png' && !thumbnailErrors.has(model.id)}
+								{#if (thumbnailMode === 'png' || model.notation === 'markdown') && !thumbnailErrors.has(model.id)}
+									<!-- v6.17.4: markdown-notation views also try the
+										 backend thumbnail URL so an attached image
+										 (entity_images) surfaces as the tile. SVG-mode
+										 DiagramThumbnail can't render markdown text into
+										 a thumbnail, so this is the only path to a
+										 meaningful tile for those views. -->
 									<img
-										src="/api/diagrams/{model.id}/thumbnail?theme={currentTheme}"
+										src="{API_BASE_URL}/api/diagrams/{model.id}/thumbnail?theme={currentTheme}"
 										alt="Thumbnail for {model.name}"
 										class="h-full w-full object-contain"
 										loading="lazy"

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2469,6 +2469,21 @@
 					</Accordion.Content>
 				</Accordion.Item>
 			</Accordion.Root>
+			<!-- ADR-209 (v6.17.4 fix): attached images for this view —
+				 now correctly inside the Details branch. v6.17.0–.3 mounted
+				 it at the end of the Canvas branch by mistake (anchored before
+				 the wrong {:else if}), so it never appeared on the Details
+				 tab. -->
+			{#if diagram}
+				<div class="mt-4">
+					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
+					<EntityImagesEditor
+						entityType="diagram"
+						entityId={diagram.id}
+						editing={true}
+					/>
+				</div>
+			{/if}
 		{:else if activeTab === 'canvas'}
 			{#if lockConflictUser}
 				<div class="mb-3 flex items-center gap-2 rounded border px-4 py-2 text-sm" style="border-color: var(--color-warning, #f59e0b); background: rgba(245, 158, 11, 0.1); color: var(--color-fg)">
@@ -3305,21 +3320,6 @@
 					</div>
 					{/if}
 				{/if}
-			{/if}
-			<!-- ADR-209 (v6.17.0): attached images for this view. -->
-			{#if diagram}
-				<div class="mt-4">
-					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Images</h3>
-					<!-- v6.17.1 fix: `editing` here is the canvas-edit flag, not
-						 a details-edit flag. Always allow image upload so the
-						 user doesn't have to enter canvas edit mode just to
-						 attach an image to the view. -->
-					<EntityImagesEditor
-						entityType="diagram"
-						entityId={diagram.id}
-						editing={true}
-					/>
-				</div>
 			{/if}
 		{:else if activeTab === 'relationships'}
 			<!-- Add relationship buttons -->


### PR DESCRIPTION
## Summary

Six fixes/additions in one release:

1. **`/version` page** — new SPA route showing the deployed version of every Iris component (Frontend, Backend, MCP, CLI). Backed by new `GET /api/version` that reads each component's `pyproject.toml` at startup.

2. **Views Details → Images section now renders.** v6.17.0 anchored the mount before `{:else if activeTab === 'relationships'}` — but that's already inside the Canvas branch (`{:else if activeTab === 'canvas'}` opens earlier). Moved into the Details branch.

3. **Markdown-notation views get a gallery thumbnail.** `DiagramThumbnail` can't render markdown into a tile; the gallery now also tries the backend `/thumbnail` URL for markdown views, and `get_thumbnail` falls back to the first `entity_images` attachment.

4. **Sets/collections gallery tiles use attached images.** `has_thumbnail_image` widened via SQL subquery to include `entity_images` attachments. Thumbnail GET endpoints fall back to the first attachment when no explicit thumbnail is set (priority preserved: model → image → attachment).

5. **Collections and sets capped at 1 attached image.** New `maxImages` prop on `EntityImagesEditor` hides the upload affordance when the cap is reached. The single attachment doubles as the gallery thumbnail. Packages/views/elements remain unlimited.

6. **Issue [#200](https://github.com/cgbarlow/iris/issues/200): Set dropdown on elements page filters by selected Collection.** `SetSelector` gains an optional `collectionId` prop; when set, fetches `/api/sets?collection_id=X`.

## Test plan

- Backend: 47/47 existing tests still green (smart_markdown + entity_attachments).
- Frontend: type-check clean on all modified files.

## Migration

None — code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)