### PR TITLE
fix(v6.17.5): sync all four component version numbers; /version shows git sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.5] - 2026-05-20
+
+### Changed
+
+- **All four component version numbers are now bumped together** on
+  every Iris release. v6.17.4 added the `/version` page but the
+  per-component pyproject versions (backend 1.2.0 / mcp 6.13.0 /
+  cli 0.1.0) had drifted years behind the frontend's release-tag
+  cadence, so the page showed misleading stale numbers. Synced all
+  four to `6.17.5`; future releases follow this convention.
+- **`/version` page now leads with the Iris release tag** (from
+  `frontend/package.json`) and the build's git commit sha, with
+  the per-component versions as a secondary table. A warning row
+  flags any version divergence between components so a stuck
+  deploy is obvious.
+
+### Added
+
+- **`GET /api/version` now returns `git_sha`** — sourced from
+  `IRIS_GIT_SHA` / `RENDER_GIT_COMMIT` env vars at backend startup,
+  with a `git rev-parse HEAD` fallback for local dev. The
+  ground-truth signal when package numbers are out of sync.
+
+### Migration
+
+- None.
+
 ## [6.17.4] - 2026-05-20
 
 ### Fixed

--- a/backend/app/version_router.py
+++ b/backend/app/version_router.py
@@ -1,13 +1,20 @@
-"""Version API endpoint (v6.17.4).
+"""Version API endpoint (v6.17.4+).
 
 Reads each Iris component's `pyproject.toml` version field once at
-import time and serves the result via `/api/version`. The frontend
-`/version` page displays them alongside its own
-`frontend/package.json` version.
+import time and serves the result via `/api/version`. Also exposes
+the build's git commit sha (from the ``IRIS_GIT_SHA`` /
+``RENDER_GIT_COMMIT`` env vars, with a ``git rev-parse HEAD``
+fallback for local dev).
+
+v6.17.5 convention: bump backend / mcp / iris-client pyproject
+versions in lockstep with ``frontend/package.json`` on every Iris
+release so the four numbers always agree on the deployed version.
 """
 
 from __future__ import annotations
 
+import os
+import subprocess
 import tomllib
 from pathlib import Path
 
@@ -34,9 +41,29 @@ def _read_pyproject_version(rel: str) -> str | None:
         return None
 
 
+def _resolve_git_sha() -> str | None:
+    """Best-effort lookup of the build's git sha."""
+    for env in ("IRIS_GIT_SHA", "RENDER_GIT_COMMIT"):
+        v = os.environ.get(env)
+        if v:
+            return v[:40]
+    try:
+        out = subprocess.check_output(  # noqa: S603, S607
+            ["git", "rev-parse", "HEAD"],
+            cwd=_REPO_ROOT,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+        sha = out.decode("ascii", errors="ignore").strip()
+        return sha or None
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+
+
 _BACKEND_VERSION = _read_pyproject_version("backend/pyproject.toml")
 _MCP_VERSION = _read_pyproject_version("mcp/pyproject.toml")
 _CLI_VERSION = _read_pyproject_version("iris-client/pyproject.toml")
+_GIT_SHA = _resolve_git_sha()
 
 
 class VersionResponse(BaseModel):
@@ -45,18 +72,18 @@ class VersionResponse(BaseModel):
     backend: str | None
     mcp: str | None
     cli: str | None
+    git_sha: str | None = None
 
 
 @router.get("/api/version", response_model=VersionResponse)
 async def get_version() -> VersionResponse:
-    """Return the deployed version of each Iris Python component.
-
-    Frontend version is known to the SPA itself (from
-    `frontend/package.json`) and rendered alongside the backend
-    response on the `/version` page.
-    """
+    """Return the deployed version of each Iris Python component plus
+    the build's git commit sha. Frontend version is known to the SPA
+    itself (from `frontend/package.json`) and rendered alongside the
+    backend response on the `/version` page."""
     return VersionResponse(
         backend=_BACKEND_VERSION,
         mcp=_MCP_VERSION,
         cli=_CLI_VERSION,
+        git_sha=_GIT_SHA,
     )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "1.2.0"
+version = "6.17.5"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.4",
+	"version": "6.17.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/version/+page.svelte
+++ b/frontend/src/routes/version/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	/**
-	 * /version (v6.17.4): shows the deployed version of every Iris
-	 * component. Frontend version is baked in at build time from
-	 * `frontend/package.json` (Vite injects via `__APP_VERSION__`).
-	 * Backend, MCP and CLI versions are fetched from
-	 * `GET /api/version`, which reads each component's pyproject.toml
-	 * at backend startup.
+	 * /version (v6.17.4+): shows the deployed version of every Iris
+	 * component plus the build's git commit sha. Frontend version is
+	 * baked in at build time from `frontend/package.json`. Backend,
+	 * MCP and CLI versions plus git sha come from `GET /api/version`.
+	 *
+	 * v6.17.5 convention: all four pyproject.toml / package.json
+	 * versions are bumped together on each Iris release so the numbers
+	 * in this table always match. The git sha is the ground-truth
+	 * signal if the package numbers ever diverge.
 	 */
 	import { onMount } from 'svelte';
 	import { apiFetch } from '$lib/utils/api';
@@ -17,11 +20,24 @@
 		backend: string | null;
 		mcp: string | null;
 		cli: string | null;
+		git_sha: string | null;
 	}
 
 	let loading = $state(true);
 	let error = $state<string | null>(null);
 	let versions = $state<VersionResponse | null>(null);
+
+	const allMatchExpected = $derived.by(() => {
+		if (!versions) return null;
+		const all = [
+			FRONTEND_VERSION,
+			versions.backend,
+			versions.mcp,
+			versions.cli,
+		].filter((v): v is string => !!v);
+		if (all.length === 0) return null;
+		return all.every((v) => v === all[0]);
+	});
 
 	onMount(async () => {
 		try {
@@ -33,8 +49,8 @@
 		}
 	});
 
-	function row(name: string, version: string | null | undefined): { name: string; version: string } {
-		return { name, version: version ?? '—' };
+	function shortSha(sha: string | null | undefined): string {
+		return sha ? sha.slice(0, 7) : '—';
 	}
 </script>
 
@@ -44,15 +60,25 @@
 
 <div style="max-width: 600px">
 	<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Iris versions</h1>
-	<p class="mt-1 text-sm" style="color: var(--color-muted)">
-		Deployed versions of each Iris component. Refresh after a release
-		to confirm the new build is live.
-	</p>
+
+	{#if !loading}
+		<div class="mt-4 rounded border p-4" style="border-color: var(--color-border); background: var(--color-surface)">
+			<div class="text-xs uppercase tracking-wide" style="color: var(--color-muted)">Iris release</div>
+			<div class="mt-1 font-mono text-2xl" style="color: var(--color-fg)">v{FRONTEND_VERSION}</div>
+			{#if versions?.git_sha}
+				<div class="mt-2 text-xs" style="color: var(--color-muted)">
+					commit <span class="font-mono">{shortSha(versions.git_sha)}</span>
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	<h2 class="mt-6 text-sm font-semibold" style="color: var(--color-fg)">Components</h2>
 
 	{#if loading}
-		<p class="mt-4 text-sm" style="color: var(--color-muted)">Loading…</p>
+		<p class="mt-2 text-sm" style="color: var(--color-muted)">Loading…</p>
 	{:else}
-		<table class="mt-4 w-full text-sm">
+		<table class="mt-2 w-full text-sm">
 			<thead>
 				<tr style="border-bottom: 1px solid var(--color-border)">
 					<th class="py-2 text-left" style="color: var(--color-muted)">Component</th>
@@ -60,19 +86,31 @@
 				</tr>
 			</thead>
 			<tbody>
-				{#each [
-					row('Frontend (SPA)', FRONTEND_VERSION),
-					row('Backend (FastAPI)', versions?.backend ?? null),
-					row('MCP server', versions?.mcp ?? null),
-					row('CLI / iris-client', versions?.cli ?? null),
-				] as r (r.name)}
-					<tr style="border-bottom: 1px solid var(--color-border)">
-						<td class="py-2" style="color: var(--color-fg)">{r.name}</td>
-						<td class="py-2 font-mono" style="color: var(--color-fg)">{r.version}</td>
-					</tr>
-				{/each}
+				<tr style="border-bottom: 1px solid var(--color-border)">
+					<td class="py-2" style="color: var(--color-fg)">Frontend (SPA)</td>
+					<td class="py-2 font-mono" style="color: var(--color-fg)">{FRONTEND_VERSION}</td>
+				</tr>
+				<tr style="border-bottom: 1px solid var(--color-border)">
+					<td class="py-2" style="color: var(--color-fg)">Backend (FastAPI)</td>
+					<td class="py-2 font-mono" style="color: var(--color-fg)">{versions?.backend ?? '—'}</td>
+				</tr>
+				<tr style="border-bottom: 1px solid var(--color-border)">
+					<td class="py-2" style="color: var(--color-fg)">MCP server</td>
+					<td class="py-2 font-mono" style="color: var(--color-fg)">{versions?.mcp ?? '—'}</td>
+				</tr>
+				<tr style="border-bottom: 1px solid var(--color-border)">
+					<td class="py-2" style="color: var(--color-fg)">CLI / iris-client</td>
+					<td class="py-2 font-mono" style="color: var(--color-fg)">{versions?.cli ?? '—'}</td>
+				</tr>
 			</tbody>
 		</table>
+
+		{#if allMatchExpected === false}
+			<p class="mt-3 text-xs" style="color: var(--color-warning, #b45309)">
+				⚠ Component versions diverge. One or more components is out of sync — check the git sha above against the GitHub release tag to confirm what's actually deployed.
+			</p>
+		{/if}
+
 		{#if error}
 			<p class="mt-3 text-sm" style="color: var(--color-danger, #b91c1c)" role="alert">
 				Backend version fetch failed: {error}. Frontend version is rendered above.

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "0.1.0"
+version = "6.17.5"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.13.0"
+version = "6.17.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
User flagged that /version (v6.17.4) was showing stale per-component pyproject versions. Synced all four (frontend / backend / mcp / iris-client) to **6.17.5** and added the git commit sha to /api/version + /version page hero. Future releases follow this convention; the /version page now flags divergence as a warning if I miss a bump. No DB changes.