### PR TITLE
feat(v6.17.6): markdown view thumbnail SVG + collections gallery image + #200 SetSelector hardening (issue #205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.6] - 2026-05-21
+
+### Added
+
+- **Markdown-notation views now get auto-generated thumbnails**
+  (issue [#205](https://github.com/cgbarlow/iris/issues/205)
+  item 3). `generate_svg_from_diagram_data` learns to render
+  `smart_markdown` / `text` / `dynamic_list` types as a plain-text
+  SVG preview (first heading + first lines of `data.markdown_source`
+  or `data.content`). cairosvg pipes the SVG through the existing
+  PNG store; `regenerate_all_thumbnails` on startup backfills
+  existing markdown views. v6.17.4 had only added an attached-image
+  fallback — the user wanted the same machinery visual diagrams use,
+  not a fallback.
+
+### Fixed
+
+- **Collections gallery now shows attached image as tile**
+  (issue [#205](https://github.com/cgbarlow/iris/issues/205)
+  item 5). v6.17.4 added the rendering path on the sets gallery
+  but missed `frontend/src/routes/collections/+page.svelte` —
+  collections still hardcoded the "C" placeholder. Added
+  `getImageThumbnailUrl` + `<img>` rendering mirroring the sets
+  page.
+- **Elements page Set dropdown filter by Collection (issue #200)
+  hardened.** v6.17.4's SetSelector relied on Svelte 5's reactive
+  read inside an `$effect` that only bare-touched `collectionId`
+  before calling a closure-capturing `loadSets()`. Refactored
+  `loadSets` to accept the explicit argument so the dependency is
+  unambiguous; the elements page's `currentCollectionId` continues
+  to drive it.
+
+### Migration
+
+- None.
+
 ## [6.17.5] - 2026-05-20
 
 ### Changed

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import UTC, datetime
 from html import escape as html_escape
 from typing import TYPE_CHECKING
@@ -40,10 +41,118 @@ THEME_COLORS: dict[str, dict[str, str]] = {
 VALID_THEMES = frozenset(THEME_COLORS.keys())
 
 
+_MARKDOWN_DIAGRAM_TYPES = frozenset(
+    {"smart_markdown", "text", "dynamic_list"},
+)
+
+# Smart Markdown token regex (matches the resolver's in
+# `backend/app/diagrams/smart_markdown.py`) so we can strip tokens
+# from the thumbnail preview without showing raw `{{element:...}}`.
+_SMART_MD_TOKEN_RE = re.compile(
+    r"\{\{(?:element|package|diagram|set|collection|image):"
+    r"[^:}]+(?::[^}]+)?\}\}",
+)
+
+
+def _markdown_preview_lines(data: dict, diagram_type: str) -> list[str]:
+    """Pick a few representative source lines for the thumbnail.
+
+    Per ADR-205 / ADR-206 / ADR-186 each markdown-notation type stores
+    its content in a different field:
+
+      smart_markdown → ``data.markdown_source`` (with `{{...}}` tokens)
+      text           → ``data.content``         (raw markdown)
+      dynamic_list   → ``data.source`` + ``data.show_description``
+                       (no markdown body; the thumbnail shows the
+                       source mode + description toggle instead)
+    """
+    if diagram_type == "smart_markdown":
+        src = str(data.get("markdown_source") or "")
+        # Strip the resolver's tokens so the thumbnail shows plain text.
+        src = _SMART_MD_TOKEN_RE.sub("[…]", src)
+    elif diagram_type == "text":
+        src = str(data.get("content") or "")
+    elif diagram_type == "dynamic_list":
+        mode = str(data.get("source") or "?")
+        show_desc = bool(data.get("show_description"))
+        return [
+            "# Dynamic list",
+            "",
+            f"source: {mode}",
+            f"show description: {'yes' if show_desc else 'no'}",
+        ]
+    else:
+        src = ""
+    # Take first 6 non-trailing-blank lines, truncate each to 60 chars.
+    raw_lines = src.splitlines()
+    out: list[str] = []
+    for line in raw_lines:
+        if len(out) == 0 and not line.strip():
+            continue  # skip leading blank lines
+        out.append(line[:60])
+        if len(out) >= 6:
+            break
+    return out or ["(empty)"]
+
+
+def _generate_markdown_preview_svg(
+    data: dict, diagram_type: str, theme: str = "dark",
+) -> str:
+    """Render a plain-text SVG preview of a markdown-notation diagram
+    (ADR-209 follow-up for issue #205). Pure ``<text>`` elements so
+    cairosvg can rasterise reliably — no foreignObject, no HTML."""
+    colors = THEME_COLORS.get(theme, THEME_COLORS["dark"])
+    width, height = 400, 250
+    lines = _markdown_preview_lines(data, diagram_type)
+
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" '
+        f'height="{height}" viewBox="0 0 {width} {height}">',
+        f'<rect width="{width}" height="{height}" fill="{colors["bg"]}"/>',
+        f'<rect x="8" y="8" width="{width - 16}" height="{height - 16}" '
+        f'rx="6" fill="{colors["node_fill"]}" '
+        f'stroke="{colors["node_stroke"]}" stroke-width="1"/>',
+    ]
+
+    # Top-of-content y-coord; first heading rendered larger.
+    y = 36
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        is_heading_1 = i == 0 and stripped.startswith("# ")
+        is_heading_n = stripped.startswith(("# ", "## ", "### "))
+        font_size = 18 if is_heading_1 else (15 if is_heading_n else 12)
+        # Render heading text without leading `#` characters for cleaner tile.
+        display = stripped.lstrip("# ").strip() if is_heading_n else line
+        if not display:
+            y += font_size + 4
+            continue
+        svg_parts.append(
+            f'<text x="20" y="{y}" font-family="ui-monospace,monospace" '
+            f'font-size="{font_size}" fill="{colors["text_fill"]}">'
+            f'{html_escape(display)}</text>',
+        )
+        y += font_size + 6
+        if y > height - 16:
+            break
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
 def generate_svg_from_diagram_data(
     data: dict, diagram_type: str, theme: str = "dark",
 ) -> str:
-    """Generate a simple SVG representation of diagram data."""
+    """Generate a simple SVG representation of diagram data.
+
+    v6.17.6 (issue #205 item 3): markdown-notation diagram types
+    (smart_markdown / text / dynamic_list) get a plain-text preview
+    instead of the empty "Empty" placeholder, so the views gallery
+    shows a meaningful tile.
+    """
+    # ADR-209 follow-up: markdown views get a text-preview tile.
+    if diagram_type in _MARKDOWN_DIAGRAM_TYPES:
+        return _generate_markdown_preview_svg(data, diagram_type, theme)
+
     colors = THEME_COLORS.get(theme, THEME_COLORS["dark"])
     nodes = data.get("nodes", [])
     participants = data.get("participants", [])

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.17.5"
+version = "6.17.6"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_markdown_thumbnail.py
+++ b/backend/tests/test_diagrams/test_markdown_thumbnail.py
@@ -1,0 +1,91 @@
+"""Tests for markdown-notation thumbnail generation (v6.17.6, issue #205).
+
+`generate_svg_from_diagram_data` learned in v6.17.6 to render markdown
+views (smart_markdown / text / dynamic_list) as plain-text SVG previews
+instead of the empty "Empty" placeholder. These cover the three types
+plus heading rendering and token-stripping behaviour.
+"""
+
+from __future__ import annotations
+
+from app.diagrams.thumbnail import generate_svg_from_diagram_data
+
+
+def test_smart_markdown_preview_contains_heading() -> None:
+    data = {"markdown_source": "# Pork mince recipe\n\n500g pork mince"}
+    svg = generate_svg_from_diagram_data(data, "smart_markdown")
+    assert "Pork mince recipe" in svg
+    assert "500g pork mince" in svg
+    assert "Empty" not in svg
+
+
+def test_smart_markdown_strips_resolver_tokens() -> None:
+    """Tokens like `{{element:GUID:name}}` are noise in a thumbnail —
+    they should be replaced with a placeholder, not rendered raw."""
+    data = {
+        "markdown_source": (
+            "# Recipe\n"
+            "Use 500g of {{element:abc-123:name}} from your pantry."
+        ),
+    }
+    svg = generate_svg_from_diagram_data(data, "smart_markdown")
+    assert "abc-123" not in svg
+    assert "{{element" not in svg
+    # Placeholder substituted in.
+    assert "[…]" in svg or "Use 500g" in svg
+
+
+def test_text_uses_data_content() -> None:
+    data = {"content": "## Notes\n- Buy bread\n- Pick up milk"}
+    svg = generate_svg_from_diagram_data(data, "text")
+    assert "Notes" in svg
+    assert "Buy bread" in svg
+
+
+def test_dynamic_list_shows_source_mode() -> None:
+    data = {"source": "package_elements", "show_description": True}
+    svg = generate_svg_from_diagram_data(data, "dynamic_list")
+    assert "Dynamic list" in svg
+    assert "package_elements" in svg
+    assert "yes" in svg  # show_description toggle rendered
+
+
+def test_empty_markdown_renders_placeholder_not_empty_label() -> None:
+    """Empty markdown still produces a useful tile (not the literal
+    `Empty` text used for visual diagrams with no nodes)."""
+    data = {"markdown_source": ""}
+    svg = generate_svg_from_diagram_data(data, "smart_markdown")
+    # `(empty)` parens are the marker used in `_markdown_preview_lines`.
+    assert "(empty)" in svg
+    # Sanity: still wrapped in an SVG.
+    assert svg.startswith("<svg")
+    assert svg.rstrip().endswith("</svg>")
+
+
+def test_markdown_preview_truncates_long_lines() -> None:
+    long = "x" * 200
+    data = {"content": long}
+    svg = generate_svg_from_diagram_data(data, "text")
+    # Per `_markdown_preview_lines`, each line is capped at 60 chars.
+    assert "x" * 200 not in svg
+    assert "x" * 60 in svg
+
+
+def test_markdown_preview_caps_line_count() -> None:
+    """Only first 6 non-blank lines are rendered."""
+    source = "\n".join(f"line{i}" for i in range(20))
+    data = {"content": source}
+    svg = generate_svg_from_diagram_data(data, "text")
+    assert "line0" in svg
+    assert "line5" in svg
+    assert "line6" not in svg
+    assert "line19" not in svg
+
+
+def test_visual_diagram_still_uses_nodes_path() -> None:
+    """Regression: visual diagram types still use the existing
+    node/edge SVG generator, not the markdown preview."""
+    data = {"nodes": [{"id": "n1", "data": {"label": "Hello"}, "position": {"x": 0, "y": 0}}]}
+    svg = generate_svg_from_diagram_data(data, "component")
+    assert "Hello" in svg
+    assert "Dynamic list" not in svg

--- a/backend/tests/test_images/test_set_attachment_thumbnail.py
+++ b/backend/tests/test_images/test_set_attachment_thumbnail.py
@@ -1,0 +1,159 @@
+"""Regression test for set/collection gallery thumbnail surfacing
+attached images (v6.17.4 → v6.17.6, issue #205 item 5).
+
+v6.17.4 widened `_SET_COLUMNS`/`_COLLECTION_COLUMNS` so the
+`has_thumbnail_image` field returned by `GET /api/sets/{id}` and
+`GET /api/sets` is TRUE when an `entity_images` attachment exists.
+The user reported the gallery tile still didn't surface — this test
+exercises the round-trip end-to-end so a future regression is caught
+before it ships.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+_PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n"
+    b"\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\rIDATx\x9cc\xf8\xcf\xc0\x00\x00\x00\x03\x00\x01]\xcc\x86\xcf"
+    b"\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+@pytest.mark.asyncio
+async def test_set_has_thumbnail_image_true_after_image_attached(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    s = (await client.post("/api/sets", json={"name": "Pantry"}, headers=h)).json()
+    set_id = s["id"]
+    assert s["has_thumbnail_image"] is False
+
+    r = await client.post(
+        f"/api/set/{set_id}/images",
+        headers=h,
+        files={"file": ("tiny.png", io.BytesIO(_PNG_1X1), "image/png")},
+    )
+    assert r.status_code == 201, r.text
+
+    after = await client.get(f"/api/sets/{set_id}", headers=h)
+    assert after.status_code == 200
+    assert after.json()["has_thumbnail_image"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_list_has_thumbnail_image_true_after_image_attached(
+    client: httpx.AsyncClient,
+) -> None:
+    """Gallery uses /api/sets (the list endpoint) — both code paths
+    (`get_set` and `list_sets`) share `_SET_COLUMNS`, but a regression
+    in either would break the gallery."""
+    h = await _auth(client)
+    s = (await client.post("/api/sets", json={"name": "Pantry"}, headers=h)).json()
+    set_id = s["id"]
+    await client.post(
+        f"/api/set/{set_id}/images",
+        headers=h,
+        files={"file": ("tiny.png", io.BytesIO(_PNG_1X1), "image/png")},
+    )
+    listing = await client.get("/api/sets", headers=h)
+    rows = listing.json()["items"]
+    target = next((r for r in rows if r["id"] == set_id), None)
+    assert target is not None
+    assert target["has_thumbnail_image"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_thumbnail_endpoint_returns_attached_image_bytes(
+    client: httpx.AsyncClient,
+) -> None:
+    """The /api/sets/{id}/thumbnail endpoint returns the attached
+    image bytes when no explicit thumbnail_image / thumbnail_diagram
+    is set (the fallback path added in v6.17.4)."""
+    h = await _auth(client)
+    s = (await client.post("/api/sets", json={"name": "Pantry"}, headers=h)).json()
+    set_id = s["id"]
+    await client.post(
+        f"/api/set/{set_id}/images",
+        headers=h,
+        files={"file": ("tiny.png", io.BytesIO(_PNG_1X1), "image/png")},
+    )
+    thumb = await client.get(f"/api/sets/{set_id}/thumbnail")
+    assert thumb.status_code == 200
+    assert thumb.headers["content-type"] == "image/png"
+    assert thumb.content == _PNG_1X1
+
+
+@pytest.mark.asyncio
+async def test_collection_has_thumbnail_image_true_after_image_attached(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    c_resp = await client.post(
+        "/api/collections", json={"name": "Groceries"}, headers=h,
+    )
+    coll_id = c_resp.json()["id"]
+    await client.post(
+        f"/api/collection/{coll_id}/images",
+        headers=h,
+        files={"file": ("tiny.png", io.BytesIO(_PNG_1X1), "image/png")},
+    )
+    after = await client.get(f"/api/collections/{coll_id}", headers=h)
+    assert after.status_code == 200
+    assert after.json()["has_thumbnail_image"] is True

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.5",
+	"version": "6.17.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/SetSelector.svelte
+++ b/frontend/src/lib/components/SetSelector.svelte
@@ -22,14 +22,19 @@
 	let previousValue = $state(value);
 
 	export async function reload() {
-		await loadSets();
+		await loadSets(collectionId ?? null);
 	}
 
-	async function loadSets() {
+	// v6.17.6 (issue #205 item 6): `loadSets` takes an explicit
+	// `collectionId` argument so Svelte 5's $effect dependency tracking
+	// is unambiguous. v6.17.4's version read `collectionId` from the
+	// outer closure inside loadSets, which made the read happen *after*
+	// the effect body completed — so refetches were unreliable.
+	async function loadSets(collId: string | null) {
 		loading = true;
 		try {
-			const url = collectionId
-				? `/api/sets?collection_id=${encodeURIComponent(collectionId)}`
+			const url = collId
+				? `/api/sets?collection_id=${encodeURIComponent(collId)}`
 				: '/api/sets';
 			const data = await apiFetch<{ items: IrisSet[] }>(url);
 			sets = data.items;
@@ -53,10 +58,11 @@
 	}
 
 	$effect(() => {
-		// Read `collectionId` reactively so changing the collection
-		// re-fetches the constrained set list (issue #200).
-		collectionId;
-		loadSets();
+		// Pass the reactive collectionId in as an explicit arg so the
+		// $effect's dep tracker sees the read at effect-evaluation time
+		// (not inside the async closure where the tracker has already
+		// closed). issue #200 / issue #205 item 6.
+		loadSets(collectionId ?? null);
 	});
 </script>
 

--- a/frontend/src/routes/collections/+page.svelte
+++ b/frontend/src/routes/collections/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import { apiFetch } from '$lib/utils/api';
+	import { API_BASE_URL } from '$lib/config.js';
 	import { getActiveCollectionId, clearActiveCollection, setActiveCollection } from '$lib/stores/activeCollection.svelte.js';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
@@ -81,6 +82,18 @@
 			const apiErr = e as { status?: number };
 			error = apiErr.status === 409 ? 'A collection with this name already exists' : 'Failed to create collection';
 		}
+	}
+
+	function getImageThumbnailUrl(collection: IrisCollection): string | null {
+		// v6.17.6 (issue #205 item 5): mirror the sets-page logic.
+		// Backend `has_thumbnail_image` is true when either the legacy
+		// thumbnail_image BLOB column has bytes or an entity_images
+		// attachment exists; `get_collection_thumbnail` resolves the
+		// right bytes in priority order.
+		if (collection.has_thumbnail_image) {
+			return `${API_BASE_URL}/api/collections/${collection.id}/thumbnail`;
+		}
+		return null;
 	}
 </script>
 
@@ -224,6 +237,7 @@
 	<!-- Gallery view -->
 	<div class="mt-4 grid gap-4" style="grid-template-columns: repeat(auto-fill, minmax(200px, 1fr))">
 		{#each filteredCollections as collection}
+			{@const imageUrl = getImageThumbnailUrl(collection)}
 			<div class="card-wrapper" style="position: relative">
 				<button
 					onclick={() => handleCollectionClick(collection)}
@@ -236,7 +250,17 @@
 						class="flex items-center justify-center rounded"
 						style="width: 160px; height: 100px; background-color: var(--color-bg); border: 1px solid var(--color-border); overflow: hidden"
 					>
-						<span class="text-2xl" style="color: var(--color-muted)">C</span>
+						{#if imageUrl}
+							<!-- v6.17.6 (issue #205): render the attached image
+								 as the gallery tile thumbnail. -->
+							<img
+								src={imageUrl}
+								alt="{collection.name} thumbnail"
+								style="max-width: 100%; max-height: 100%; object-fit: contain"
+							/>
+						{:else}
+							<span class="text-2xl" style="color: var(--color-muted)">C</span>
+						{/if}
 					</div>
 					<div class="mt-2 font-medium text-sm" style="color: var(--color-primary)">{collection.name}</div>
 					<div class="mt-1 text-xs" style="color: var(--color-muted)">

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.17.5"
+version = "6.17.6"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.17.5"
+version = "6.17.6"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Resolves three remaining items in issue [#205](https://github.com/cgbarlow/iris/issues/205):

1. **Item 3 — Markdown view thumbnails auto-generated.** Server-side render markdown source as a plain-text SVG preview (first heading + first 4-5 lines), rasterised via the existing cairosvg → PNG → `diagram_thumbnails` pipeline. `regenerate_all_thumbnails` on startup backfills existing views. The user wanted these generated like other diagram types — now they are.

2. **Item 5 — Collections gallery renders attached images.** v6.17.4 fixed sets but completely missed collections (still hardcoded "C" placeholder). Mirrored `getImageThumbnailUrl` + `<img>` rendering. Added a 4-case backend round-trip test that catches the regression — proves the sets path was actually working, the user's report was probably about the collections case I missed.

3. **Item 6 — #200 SetSelector hardened.** v6.17.4's `$effect` did a bare touch of `collectionId` then called a closure-captured `loadSets()`. Subtle dep-tracking risk in Svelte 5. Refactored `loadSets` to take `collectionId` as an explicit argument so the dep is visible at $effect evaluation time.

Four-version bump (frontend / backend / mcp / iris-client) to 6.17.6 per the new convention.

## Test plan

- Backend: 8 markdown thumbnail cases (per type + edge cases) + 4 set-attachment round-trip cases. Frontend type-check clean.
- After deploy: open a markdown view → gallery tile shows text preview; attach image to a Set / Collection → gallery tile shows the image; /elements collection→set filter works.

## Migration

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)