### PR TITLE
fix(v6.17.7): markdown thumbnail font-family broke text rendering on Render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.7] - 2026-05-21
+
+### Fixed
+
+- **Markdown view thumbnails now actually render text on Render**
+  (issue [#205](https://github.com/cgbarlow/iris/issues/205) item 3
+  regression). v6.17.6's text spans specified
+  `font-family="ui-monospace,monospace"` — on Render's container,
+  Pango couldn't resolve the family and produced text with no
+  visible glyphs (blank background tile). Dropped the font-family
+  attribute so cairosvg uses the same default the visual-diagram
+  thumbnails use successfully.
+- **`generate_and_store_thumbnail` now catches non-ImportError
+  exceptions from cairosvg** so a single rasterisation failure
+  can't break the whole `regenerate_all_thumbnails` startup sweep.
+  Falls back to storing raw SVG bytes — browsers render SVG via
+  `<img>` natively.
+
+### Migration
+
+- None.
+
 ## [6.17.6] - 2026-05-21
 
 ### Added

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -127,7 +127,7 @@ def _generate_markdown_preview_svg(
             y += font_size + 4
             continue
         svg_parts.append(
-            f'<text x="20" y="{y}" font-family="ui-monospace,monospace" '
+            f'<text x="20" y="{y}" '
             f'font-size="{font_size}" fill="{colors["text_fill"]}">'
             f'{html_escape(display)}</text>',
         )
@@ -242,14 +242,28 @@ async def generate_and_store_thumbnail(
     """
     svg_str = generate_svg_from_diagram_data(data, diagram_type, theme=theme)
 
+    png_bytes: bytes
     try:
-        import cairosvg
+        import cairosvg  # noqa: PLC0415
 
         png_bytes = cairosvg.svg2png(
-            bytestring=svg_str.encode(), output_width=400, output_height=250
+            bytestring=svg_str.encode(),
+            output_width=400,
+            output_height=250,
         )
     except ImportError:
         # cairosvg not installed -- store SVG bytes as fallback
+        png_bytes = svg_str.encode()
+    except Exception as exc:  # noqa: BLE001
+        # v6.17.7: defensive — never let a single bad SVG kill the
+        # whole regenerate_all_thumbnails sweep on startup. Log and
+        # store the raw SVG bytes so the gallery still has something
+        # to serve (browsers happily render SVG via <img>).
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).warning(
+            "cairosvg failed for diagram %s theme=%s: %s — storing raw SVG",
+            diagram_id, theme, exc,
+        )
         png_bytes = svg_str.encode()
 
     now = datetime.now(tz=UTC).isoformat()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.17.6"
+version = "6.17.7"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.6",
+	"version": "6.17.7",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.17.6"
+version = "6.17.7"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.17.6"
+version = "6.17.7"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
v6.17.6 specified `font-family=\"ui-monospace,monospace\"` on the text spans for markdown view thumbnails. On Render's container, Pango can't resolve `ui-monospace` and renders the spans with no visible glyphs — the PNG ends up as just a solid-coloured 400×250 tile. Confirmed via Pillow inspection of the live PNG bytes (every sampled pixel was the dark theme background colour).

Fix:
- Drop the `font-family` attribute (visual-diagram thumbnails work fine without it — cairosvg picks the system default).
- Catch generic exceptions from `cairosvg.svg2png` in `generate_and_store_thumbnail` so a single bad SVG doesn't crash the whole `regenerate_all_thumbnails` startup sweep; falls back to storing raw SVG bytes.

Four-version bump to 6.17.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)