### PR TITLE
fix(v6.17.8): regenerate thumbnails on Supabase startup + set filter on views/bookmarks (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.8] - 2026-05-21
+
+### Fixed
+
+- **Markdown view thumbnails now actually regenerate on Supabase
+  deployments** (issue [#208](https://github.com/cgbarlow/iris/issues/208)).
+  `_initialize_supabase` was deliberately skipping
+  `regenerate_all_thumbnails` based on a stale comment about
+  "Netlify Function runtime" — Iris runs on Render's Docker image
+  which bundles cairo + pango. As a result, the v6.17.6/v6.17.7
+  markdown-preview SVG generator was dormant for pre-existing
+  diagrams. Now runs on every Supabase startup (soft-fail with a log
+  line if cairosvg is somehow unavailable).
+- **Set filter by collection now applies on the Views and Bookmarks
+  pages** (issue [#208](https://github.com/cgbarlow/iris/issues/208) /
+  issue [#200](https://github.com/cgbarlow/iris/issues/200) follow-up).
+  Both pages rendered `<SetSelector>` without the `collectionId` prop,
+  so the dropdown always loaded the full set list regardless of which
+  collection was picked. Elements page (the original #200 target) was
+  already wired correctly in v6.17.6; the same fix now lands here.
+
+### Migration
+
+- None.
+
 ## [6.17.7] - 2026-05-21
 
 ### Fixed

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -221,9 +221,12 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
 async def _initialize_supabase(db_manager: DatabaseManager) -> None:
     """Run Supabase/PostgreSQL initialization: run idempotent migrations, seed core data.
 
-    FTS rebuild and thumbnail generation are skipped:
-    - FTS uses PostgreSQL tsvector triggers (auto-updated on INSERT/UPDATE)
-    - cairosvg thumbnail generation may not be available in Netlify Function runtime
+    FTS is skipped — PostgreSQL tsvector triggers keep the index live on
+    INSERT/UPDATE. Thumbnail regeneration *was* skipped historically on the
+    assumption cairosvg wouldn't be present on the runtime; the Render
+    Docker image bundles cairo + pango (see backend/Dockerfile), so we
+    now run it on every boot so changes to ``generate_svg_from_diagram_data``
+    propagate to pre-existing diagrams (issue #208).
     """
     # Migrations are run externally via psql (scripts/supabase-migrate.sh or SQL Editor).
     # asyncpg cannot execute dollar-quoted SQL ($$) used in trigger/function definitions.
@@ -325,3 +328,13 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
         "WHERE id::text NOT IN (SELECT id FROM users)"
     )
     await port.commit()
+
+    # v6.17.8 (issue #208): regenerate PNG thumbnails so changes to
+    # ``generate_svg_from_diagram_data`` propagate to pre-existing
+    # diagrams (the markdown-notation preview branch added in v6.17.6
+    # was otherwise dormant on Supabase deployments).
+    try:
+        count = await regenerate_all_thumbnails(port)
+        print(f"[STARTUP] regenerated {count} diagram thumbnails", flush=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[STARTUP] thumbnail regeneration skipped: {exc}", flush=True)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.17.7"
+version = "6.17.8"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.7",
+	"version": "6.17.8",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/bookmarks/+page.svelte
+++ b/frontend/src/routes/bookmarks/+page.svelte
@@ -142,7 +142,7 @@
 	</div>
 	<div class="flex items-center gap-2">
 		<CollectionSelector value={currentCollectionId} onchange={handleCollectionChange} />
-		<SetSelector value={currentSetId} onchange={handleSetChange} />
+		<SetSelector value={currentSetId} onchange={handleSetChange} collectionId={currentCollectionId || null} />
 	</div>
 </div>
 

--- a/frontend/src/routes/views/+page.svelte
+++ b/frontend/src/routes/views/+page.svelte
@@ -429,7 +429,7 @@
 <!-- Filters -->
 <div class="mt-4 flex flex-wrap gap-3">
 	<CollectionSelector value={currentCollectionId} onchange={handleCollectionChange} />
-	<SetSelector value={currentSetId} onchange={handleSetChange} />
+	<SetSelector value={currentSetId} onchange={handleSetChange} collectionId={currentCollectionId || null} />
 	<div>
 		<label for="diagram-search" class="sr-only">Search views</label>
 		<input

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.17.7"
+version = "6.17.8"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.17.7"
+version = "6.17.8"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `_initialize_supabase` deliberately skipped `regenerate_all_thumbnails` based on a stale "Netlify Function runtime" comment. Iris runs on Render's Docker image (cairo + pango bundled), so my v6.17.6/v6.17.7 markdown-preview SVG code was dormant for pre-existing diagrams. Now runs on every Supabase startup, soft-fail with log line if cairosvg is unavailable.
- `SetSelector` on `views/+page.svelte:432` and `bookmarks/+page.svelte:145` was rendered without `collectionId`, so the set dropdown ignored the active collection. Elements page (the original #200 target) was already wired in v6.17.6; the same one-line fix lands here.

Closes #208 — both issues observed by the user on v6.17.7.

## Test plan

- [x] `pytest backend/tests/test_diagrams/test_markdown_thumbnail.py` (8 passed)
- [ ] Post-deploy: hard-refresh `/views` → markdown view tiles show first source lines instead of "Empty"
- [ ] Post-deploy: `/views` + pick a Collection → Set dropdown reloads to only the collection's sets
- [ ] Post-deploy: `/bookmarks` + pick a Collection → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)