### PR TITLE
feat(v6.17.9): smart_markdown thumbnails render resolved text (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.17.9] - 2026-05-21
+
+### Changed
+
+- **Smart-markdown thumbnails now show the rendered text**, not the
+  raw `{{element:GUID:field}}` tokens stripped to `[…]`
+  (issue [#208](https://github.com/cgbarlow/iris/issues/208) follow-up).
+  `generate_and_store_thumbnail` now calls
+  `compute_smart_markdown_content` for `smart_markdown` diagrams so
+  the thumbnail reflects what the user sees in the rendered view. The
+  resolver's markdown link syntax (`[value](iris://… "name")`) is
+  stripped to plain text for the tile; inline `<img>` tags become
+  `[image]`; strikethrough'd unresolvable tokens unwrap to the raw
+  token (then `_markdown_preview_lines` applies the old `[…]`
+  placeholder).
+- Falls back to the previous v6.17.6 behaviour (raw source with tokens
+  → `[…]`) if the resolver raises — logged but non-fatal.
+
+### Migration
+
+- None.
+
 ## [6.17.8] - 2026-05-21
 
 ### Fixed

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -53,6 +53,23 @@ _SMART_MD_TOKEN_RE = re.compile(
     r"[^:}]+(?::[^}]+)?\}\}",
 )
 
+# Markdown link `[text](url "title")` produced by the smart_markdown
+# resolver — for the thumbnail we want just the rendered text.
+_MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+# `<img ...>` tags returned by `_resolve_image` — render as a tag
+# placeholder in the thumbnail; the gallery tile can't show inline imgs.
+_IMG_TAG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+# Strikethrough markers the resolver wraps around unresolvable tokens.
+_STRIKETHROUGH_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
+
+
+def _resolved_to_plain_text(resolved: str) -> str:
+    """Strip the smart_markdown resolver's markup so the thumbnail
+    shows the rendered text instead of raw markdown link syntax."""
+    resolved = _IMG_TAG_RE.sub("[image]", resolved)
+    resolved = _MARKDOWN_LINK_RE.sub(r"\1", resolved)
+    return _STRIKETHROUGH_RE.sub(r"\1", resolved)
+
 
 def _markdown_preview_lines(data: dict, diagram_type: str) -> list[str]:
     """Pick a few representative source lines for the thumbnail.
@@ -240,6 +257,25 @@ async def generate_and_store_thumbnail(
 
     Falls back to storing SVG as bytes if cairosvg is not available.
     """
+    # v6.17.9 (issue #208): for smart_markdown, resolve `{{...}}` tokens
+    # to their rendered values so the thumbnail shows the actual content
+    # the user sees in the view, not bracket placeholders. The resolver
+    # is async and needs db/diagram_id, so we do it here (not in the
+    # sync SVG generator) and pass the plain text via a synthetic dict.
+    if diagram_type == "smart_markdown":
+        try:
+            from app.diagrams.smart_markdown import (  # noqa: PLC0415
+                compute_smart_markdown_content,
+            )
+            resolved = await compute_smart_markdown_content(db, diagram_id)
+            data = {**data, "markdown_source": _resolved_to_plain_text(resolved)}
+        except Exception as exc:  # noqa: BLE001
+            import logging  # noqa: PLC0415
+            logging.getLogger(__name__).warning(
+                "smart_markdown resolve failed for %s: %s — falling back to raw source",
+                diagram_id, exc,
+            )
+
     svg_str = generate_svg_from_diagram_data(data, diagram_type, theme=theme)
 
     png_bytes: bytes

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.17.8"
+version = "6.17.9"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_markdown_thumbnail.py
+++ b/backend/tests/test_diagrams/test_markdown_thumbnail.py
@@ -8,7 +8,10 @@ plus heading rendering and token-stripping behaviour.
 
 from __future__ import annotations
 
-from app.diagrams.thumbnail import generate_svg_from_diagram_data
+from app.diagrams.thumbnail import (
+    _resolved_to_plain_text,
+    generate_svg_from_diagram_data,
+)
 
 
 def test_smart_markdown_preview_contains_heading() -> None:
@@ -80,6 +83,32 @@ def test_markdown_preview_caps_line_count() -> None:
     assert "line5" in svg
     assert "line6" not in svg
     assert "line19" not in svg
+
+
+def test_resolved_to_plain_text_strips_link_syntax() -> None:
+    """The smart_markdown resolver wraps each token as
+    `[value](iris://... "name")`. For the thumbnail we want just the
+    rendered text, no markdown link noise."""
+    resolved = 'Use 500g of [pork mince](iris://element/abc-123 "Pork Mince") from pantry.'
+    assert _resolved_to_plain_text(resolved) == "Use 500g of pork mince from pantry."
+
+
+def test_resolved_to_plain_text_unwraps_strikethrough_unresolvable() -> None:
+    """The resolver wraps unresolvable tokens in `~~...~~`. Drop the
+    markers so the thumbnail isn't visually noisy."""
+    resolved = "Missing: ~~{{element:gone:name}}~~ here."
+    out = _resolved_to_plain_text(resolved)
+    assert "~~" not in out
+    assert "{{element:gone:name}}" in out  # raw token surfaced as fallback
+
+
+def test_resolved_to_plain_text_replaces_img_with_placeholder() -> None:
+    """Inline `<img>` HTML returned by the image resolver can't render
+    in the cairosvg thumbnail; substitute a short placeholder."""
+    resolved = 'Photo: <img src="data:image/png;base64,abc" alt="x"> below.'
+    out = _resolved_to_plain_text(resolved)
+    assert "<img" not in out
+    assert "[image]" in out
 
 
 def test_visual_diagram_still_uses_nodes_path() -> None:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.8",
+	"version": "6.17.9",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.17.8"
+version = "6.17.9"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.17.8"
+version = "6.17.9"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- `generate_and_store_thumbnail` now resolves smart_markdown tokens via `compute_smart_markdown_content` before drawing the tile, so the thumbnail mirrors what the user sees in the rendered view (instead of `[…]` placeholders).
- The resolver's markdown link wrapper `[value](iris://… "name")` is stripped to plain text; inline `<img>` becomes `[image]`; strikethrough'd unresolvable tokens unwrap.
- Soft-fail with a log line if the resolver raises — falls back to the v6.17.6 raw-source-with-`[…]` path.

User context (issue #208): "i want to see the rendered text content in the thumbnail, not [...]"

## Test plan

- [x] `pytest backend/tests/test_diagrams/test_markdown_thumbnail.py` (11 passed, +3 for the resolver helper)
- [x] `pytest backend/tests/test_diagrams/ tests/test_images/` (238 passed)
- [ ] Post-deploy: hard-refresh `/views` → smart_markdown tile shows e.g. "Use 500g of pork mince…" instead of "Use 500g of […]"

🤖 Generated with [Claude Code](https://claude.com/claude-code)