### PR TITLE
feat(v6.18.0): smart-markdown =value overrides + fillable-slot picker (ADR-210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.18.0] - 2026-05-22
+
+### Added
+
+- **Smart-markdown tokens accept inline `=value` overrides on the
+  field-spec** ([ADR-210](docs/adrs/ADR-210-Smart-Markdown-Value-Overrides.md),
+  [SPEC-210-a](docs/adrs/specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211)). A token
+  of the form `{{element:UUID:attr:Quantity/type=500}}` resolves to
+  "500" regardless of the stored attribute value — per-use values
+  without a side table. The resolver splits on the first `=` so
+  override values may themselves contain `=`. A token with an empty
+  override (`{{...:attr:path=}}`) is a "fillable slot" marker:
+  renders as strikethrough so an unfilled placeholder is visible.
+  Dangling references (deleted entities) still strike through even
+  when an override is present. Existing tokens without `=` resolve
+  identically to before — pure additive grammar extension.
+- **Smart-markdown picker — Shift+Enter inserts as fillable slot**.
+  Pressing Enter on a primitive in the picker emits the normal token;
+  Shift+Enter emits the same token with `=` appended so the author
+  can fill the value in the source pane (or hand the diagram to a
+  collaborator). Hint text in the picker updated.
+
+### Migration
+
+- None. Pure grammar additive change; no schema or data migration.
+- Existing recipes with plain-text quantities (e.g.
+  `500 {{element:UUID:attr:Unit/type}} {{element:UUID:name}}`) render
+  identically. Migration to the new override form is optional and
+  arrives later via issue #211 PR 6.
+
 ## [6.17.9] - 2026-05-21
 
 ### Changed

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -10,6 +10,14 @@ where ``entity-type`` is one of ``element``, ``package``, ``diagram``,
 is ``name``, ``description``, or (for elements only) ``attr:<key>``
 where ``<key>`` is a key in the element's ``data`` JSON.
 
+ADR-210 (v6.18.0): ``<field-spec>`` may carry an inline ``=<value>``
+override — ``{{element:UUID:attr:Quantity=500}}`` resolves to "500"
+regardless of the stored value. An empty override (``...path=``) is the
+"fillable slot" marker — render as strikethrough so the unfilled slot
+is visible. Splits on the first ``=`` only, so override values may
+contain ``=``. Dangling entity references still strike through even
+when an override is present.
+
 Unresolvable tokens (entity not found, deleted, wrong field for the
 entity type, missing attribute) render as ``~~{{...}}~~`` so the user
 sees them — silent drops would hide data loss.
@@ -313,36 +321,58 @@ async def _resolve_one(
     """Return the resolved value, or None if unresolvable.
 
     None signals: entity missing / deleted, field invalid for the type,
-    or attribute key missing. Callers turn None into strikethrough.
+    attribute key missing, or empty-override fillable-slot marker.
+    Callers turn None into strikethrough.
 
     ADR-209 (v6.17.0): entity-reference values are wrapped in a markdown
     link `[value](iris://<type>/<id> "<entity name>")` so MarkdownView
     routes the click and shows the name as a hover tooltip. Images
     (`{{image:...}}`) are returned as raw `<img>` HTML and are NOT
     wrapped.
+
+    ADR-210 (v6.18.0): if ``field_spec`` contains ``=``, split on the
+    first one — the suffix is an inline override value used in place
+    of the stored field. Empty override (``...path=``) → return None so
+    the token renders as strikethrough (the "fillable slot" marker).
+    Dangling entity references still strike through regardless of
+    override.
     """
     if entity_type == "image":
         return await _resolve_image(db, entity_id, field_spec)
     # Non-image entity types require a field_spec.
     if field_spec is None or field_spec == "":
         return None
-    raw_value: str | None = None
-    if entity_type == "element":
-        raw_value = await _fetch_element_field(db, entity_id, field_spec)
+
+    # ADR-210: parse inline =value override.
+    field_spec_path: str = field_spec
+    override_value: str | None = None
+    if "=" in field_spec:
+        field_spec_path, override_value = field_spec.split("=", 1)
+        if override_value == "":
+            # Fillable-slot marker — author declared "fill this in,"
+            # leave unfilled → strikethrough (don't fall through to
+            # stored value).
+            return None
+
+    raw_value: str | None
+    if override_value is not None:
+        raw_value = override_value
+    elif entity_type == "element":
+        raw_value = await _fetch_element_field(db, entity_id, field_spec_path)
     elif entity_type == "package":
         raw_value = await _fetch_named_field(
             db, table="packages", versions_table="package_versions",
-            fk="package_id", entity_id=entity_id, field_spec=field_spec,
+            fk="package_id", entity_id=entity_id, field_spec=field_spec_path,
         )
     elif entity_type == "diagram":
         raw_value = await _fetch_named_field(
             db, table="diagrams", versions_table="diagram_versions",
-            fk="diagram_id", entity_id=entity_id, field_spec=field_spec,
+            fk="diagram_id", entity_id=entity_id, field_spec=field_spec_path,
         )
     elif entity_type == "set":
-        raw_value = await _fetch_set_field(db, entity_id, field_spec)
+        raw_value = await _fetch_set_field(db, entity_id, field_spec_path)
     elif entity_type == "collection":
-        raw_value = await _fetch_collection_field(db, entity_id, field_spec)
+        raw_value = await _fetch_collection_field(db, entity_id, field_spec_path)
     else:
         return None
 
@@ -351,8 +381,12 @@ async def _resolve_one(
 
     # Wrap in an iris:// markdown link so the rendered output is a
     # clickable, tooltip-bearing reference to the source entity.
+    # ADR-210: even with an override, look up the entity to confirm it
+    # exists — a dangling reference should strike through regardless.
     name = await _fetch_entity_display_name(db, entity_type, entity_id)
-    title = _markdown_escape_title(name or entity_id)
+    if name is None:
+        return None
+    title = _markdown_escape_title(name)
     text = _markdown_escape_link_text(str(raw_value))
     return f'[{text}](iris://{entity_type}/{entity_id} "{title}")'
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.17.9"
+version = "6.18.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -596,3 +596,222 @@ async def test_primitive_then_more_segments_renders_strikethrough(
     )
     rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
     assert rendered == f"~~{{{{element:{eid}:attr:unit/extra}}}}~~"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# ADR-210: token =value overrides (per-use values + fillable slots)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_override_value_replaces_stored_attr(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: `attr:path=500` resolves to "500" regardless of stored value."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="Pork mince", data={"Quantity": "5"},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:Quantity=500}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "500"
+
+
+@pytest.mark.asyncio
+async def test_override_value_with_blank_stored_attr(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: override works even when stored attribute is absent."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X")  # no Quantity attr
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:Quantity=500}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "500"
+
+
+@pytest.mark.asyncio
+async def test_empty_override_renders_strikethrough_fillable_slot(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: `attr:path=` (empty override) is the fillable-slot marker."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X")
+    token = f"{{{{element:{eid}:attr:Quantity=}}}}"
+    diag_id = await _create_smart_markdown_diagram(c, h, set_id, token)
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered == f"~~{token}~~"
+
+
+@pytest.mark.asyncio
+async def test_empty_override_strikethrough_even_with_stored_value(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: empty override does NOT fall through to stored value.
+    The author explicitly chose "this is a slot to fill" — respect that."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X", data={"Q": "preset"})
+    token = f"{{{{element:{eid}:attr:Q=}}}}"
+    diag_id = await _create_smart_markdown_diagram(c, h, set_id, token)
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered == f"~~{token}~~"
+
+
+@pytest.mark.asyncio
+async def test_override_on_name_field(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: override works on `name` field too, not just attr."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="Pork mince")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:name=Custom Label}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "Custom Label"
+
+
+@pytest.mark.asyncio
+async def test_override_on_package_name(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: override works on any non-element entity's name/description."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    r = await c.post(
+        "/api/packages",
+        json={"name": "Pantry", "set_id": set_id},
+        headers=h,
+    )
+    assert r.status_code == 201
+    pid = r.json()["id"]
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{package:{pid}:name=Aisle 7}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "Aisle 7"
+
+
+@pytest.mark.asyncio
+async def test_override_value_containing_equals_signs(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: split on FIRST `=` — values can contain `=`."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:foo=k=v=w}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "k=v=w"
+
+
+@pytest.mark.asyncio
+async def test_override_value_with_markdown_brackets_is_escaped(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: override values pass through the same markdown-link-text
+    escape as stored values (so `[`/`]` don't break the iris:// wrapper)."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:x=hello [world]}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Wrapped: [hello \[world\]](iris://element/<id> "X")
+    assert "[hello \\[world\\]]" in rendered
+    assert f"iris://element/{eid}" in rendered
+
+
+@pytest.mark.asyncio
+async def test_override_on_deleted_entity_strikes_through(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: dangling reference takes precedence over override —
+    a deleted element renders as strikethrough even with an override."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="X")
+    # Soft-delete the element (optimistic locking requires If-Match)
+    r = await c.delete(
+        f"/api/elements/{eid}",
+        headers={**h, "If-Match": "1"},
+    )
+    assert r.status_code in (200, 204), r.text
+    token = f"{{{{element:{eid}:attr:Quantity=500}}}}"
+    diag_id = await _create_smart_markdown_diagram(c, h, set_id, token)
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered == f"~~{token}~~"
+
+
+@pytest.mark.asyncio
+async def test_no_override_existing_behaviour_preserved(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: tokens without `=` resolve to stored value as before."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X", data={"Unit": "g"},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:Unit}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "g"
+
+
+@pytest.mark.asyncio
+async def test_override_alongside_unoverridden_in_one_diagram(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: real-world recipe line composes override + stored + stored."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="Pork mince", data={"Unit": "g"},
+    )
+    src = (
+        f"- {{{{element:{eid}:attr:Quantity=500}}}}"
+        f" {{{{element:{eid}:attr:Unit}}}}"
+        f" {{{{element:{eid}:name}}}}"
+    )
+    diag_id = await _create_smart_markdown_diagram(c, h, set_id, src)
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "- 500 g Pork mince"
+
+
+@pytest.mark.asyncio
+async def test_override_on_attr_path_with_nested_segments(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """ADR-210: works on multi-segment attribute paths too (ADR-206 grammar)."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X",
+        data={"attributes": [{"name": "Quantity", "type": ""}]},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{element:{eid}:attr:attributes/Quantity/type=2.5}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "2.5"

--- a/docs/adrs/ADR-210-Smart-Markdown-Value-Overrides.md
+++ b/docs/adrs/ADR-210-Smart-Markdown-Value-Overrides.md
@@ -1,0 +1,83 @@
+# ADR-210: Smart-markdown token `=value` overrides and blank-attribute editable spans
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-205](./ADR-205-Smart-Markdown-View-Type.md), [ADR-206](./ADR-206-Smart-Markdown-Picker-Evolution.md).
+
+## Context
+
+Smart_markdown today resolves entity field tokens against the stored value on the referenced entity. Per-use values — a recipe saying "500 g of pork mince *for this dish*" — have no first-class place to live. Users hand-write the quantity as free text prefix:
+
+```
+- 500 {{element:UUID:attr:attributes/Unit/type}} {{element:UUID:name}}
+```
+
+This works for human readers but the `500` is plain prose, not structured data. Any downstream feature that needs to consume those numbers — most immediately, the aggregation engine that will build the shopping list for [issue #211](https://github.com/cgbarlow/iris/issues/211) — would have to parse natural language ("500g", "1/2 cup", "a pinch") out of arbitrary markdown. Brittle.
+
+Three options were considered:
+
+1. **Migrate recipes to Recipe elements with `Recipe -[contains]-> Ingredient` relationships, qty/unit on relationship.data.** Clean structurally but loses the recipe-as-document UX (cooking method, photos, notes interleaved with ingredients), and forces a one-shot rewrite of all existing recipes into element-graph form.
+
+2. **Add a domain-specific token type — `{{ingredient:UUID:qty:500}}`.** Compact and machine-readable, but bakes "ingredient" semantics into Iris core, violating the genericness invariant ([ADR-214](./ADR-214-Genericness-Invariant-Shopping-List.md)).
+
+3. **Extend the existing attribute-reference token with an inline `=value` override.** Same grammar shape, generic, machine-parseable, additive.
+
+(1) and (2) are rejected — (1) for UX cost, (2) for genericness. (3) — this ADR — wins.
+
+## Decision
+
+Extend ADR-205's token grammar with an inline value-override suffix on attribute references:
+
+```
+{{<entity-type>:<id>:<field-spec>}}              → existing form, resolves stored value
+{{<entity-type>:<id>:<field-spec>=<value>}}      → new form, uses <value> verbatim
+{{<entity-type>:<id>:<field-spec>=}}             → new form, empty value = "fillable slot" marker
+```
+
+The override applies to any `field-spec` (name, description, `attr:<path>`) and any non-image entity type. Image tokens are unaffected (ADR-209 grammar is unchanged).
+
+### Resolver precedence
+
+1. If `field-spec` contains `=`:
+   - Split on the **first** `=` only. Everything after is the override value. (Values can contain `=`; paths cannot.)
+   - **Non-empty override** → return the override value, wrapped in the same `[text](iris://<type>/<id> "<entity-name>")` link the resolver already emits for stored values. The link still points at the source entity; the text is the per-use value.
+   - **Empty override** (`...field-spec=`) → return `None`. The token then renders as `~~{{...}}~~` strikethrough. This is the **fillable slot** marker — author has declared "this is a slot to fill in," and strikethrough makes the unfilled slot visible.
+2. If `field-spec` has no `=` → existing behaviour: look up the stored value; `None` if missing/empty → strikethrough.
+
+### Entity existence still checked
+
+Even when an override is present, the resolver looks up the entity to populate the link's `title` attribute. If the entity is deleted/missing, the token renders as strikethrough regardless of override — dangling references shouldn't masquerade as resolved just because they carry a value.
+
+### Canvas editing behaviour
+
+`SmartMarkdownCanvas.svelte` in **edit mode** detects tokens whose override is empty (the fillable-slot form) and renders them as inline `<input>` elements styled to fit inline with the surrounding markdown. On blur, the canvas rewrites the token in `data.markdown_source` from `...=` to `...=<value>` and re-runs the resolver against the updated source.
+
+The picker (ADR-206) gains a new option in the field-step: **"Insert as fillable placeholder"** — inserts the token with a trailing `=` so the author can fill it later (or leave blank for the next person).
+
+### Source-pane fallback
+
+The source pane (raw `data.markdown_source` textarea) is the always-available edit path; users can type or paste `...=500` directly. The inline-editable span is a quality-of-life affordance, not a requirement.
+
+## Consequences
+
+**Positive:**
+
+- Structured per-use values without any new entity-type variant. Same regex shape; same resolver dispatch.
+- Downstream consumers (aggregation engine, MCP tools, exports) can parse `=value` from the token string deterministically — no NL parsing.
+- The fillable-slot marker (`...=`) is a visible UI affordance distinct from "value resolved" and "entity missing."
+- Composes with element-template stamps ([ADR-211](./ADR-211-Element-Template-Stamps.md)) — a stamp can include `{{self:attr:Quantity/type=}}` and every element minted via the stamp is born ready to be filled in.
+- Renders identically to today's free-text-quantity pattern, so existing recipes continue to read the same after migration ([§4.7 of the plan](../plans/issue-211-shopping-list-implementation.md)).
+
+**Negative / accepted trade-offs:**
+
+- Attribute paths cannot contain `=` (paths walk dotted JSON keys, which by convention don't carry `=`). Documented in SPEC-210-a; resolver splits on first `=`.
+- A blank stored attribute and a fillable-slot marker are visually identical in render (both strikethrough). The intent distinction (author-declared vs. data-missing) lives only in the source. Acceptable — both need user attention; the render's job is to signal "look here," which strikethrough does.
+- `style` attribute is not added to the inline `<input>` directly via Svelte text rendering — input is a real DOM element bound by the canvas, not produced by the resolver. No new `{@html}` paths (protocol §7).
+
+## References
+
+- [ADR-205](./ADR-205-Smart-Markdown-View-Type.md) — original token grammar.
+- [ADR-206](./ADR-206-Smart-Markdown-Picker-Evolution.md) — picker hierarchical browse + subtree search; this ADR adds one new field-step option.
+- [ADR-209](./ADR-209-Entity-Image-Attachments.md) — `image` token variant, unaffected.
+- [SPEC-210-a-Smart-Markdown-Value-Overrides.md](./specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md) — grammar regex, resolver pseudocode, canvas behaviour spec, test matrix.
+- [`docs/plans/issue-211-shopping-list-implementation.md`](../plans/issue-211-shopping-list-implementation.md) §2 — placement in the overall plan.

--- a/docs/adrs/specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md
+++ b/docs/adrs/specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md
@@ -1,0 +1,166 @@
+# SPEC-210-a: Smart-markdown value overrides
+
+Implements: [ADR-210](../ADR-210-Smart-Markdown-Value-Overrides.md)
+
+## 1. Token grammar
+
+```
+TOKEN          := "{{" ENTITY_TYPE ":" ENTITY_ID [ ":" FIELD_SPEC ] "}}"
+ENTITY_TYPE    := "element" | "package" | "diagram" | "set" | "collection" | "image"
+ENTITY_ID      := [^:}]+
+FIELD_SPEC     := FIELD_PATH [ "=" OVERRIDE_VALUE ]
+FIELD_PATH     := "name" | "description" | "attr:" ATTR_PATH | IMAGE_SIZING
+ATTR_PATH      := SEGMENT ( "/" SEGMENT )*
+SEGMENT        := [^/=}]+         ; no slash, equals, or close-brace
+OVERRIDE_VALUE := [^}]*           ; any text except close-brace; may be empty
+IMAGE_SIZING   := "width:" NUMBER UNIT | "height:" NUMBER UNIT | "original"
+```
+
+The regex in `_TOKEN_RE` is unchanged from ADR-209 — its third capture group already accepts `[^}]*`, which subsumes the `=value` suffix.
+
+## 2. Resolver precedence
+
+In `backend/app/diagrams/smart_markdown.py::_resolve_one`:
+
+```
+1. If entity_type == "image":
+       return _resolve_image(...)
+2. If field_spec is None or empty:
+       return None  (strikethrough)
+3. Split field_spec at first "=":
+       (field_spec_path, override_value)
+       where override_value is None if no "=" was present.
+4. If override_value is not None and override_value != "":
+       raw_value = override_value
+5. Elif override_value is not None and override_value == "":
+       return None  (fillable-slot marker; renders strikethrough)
+6. Else:
+       raw_value = <existing per-entity-type lookup of field_spec_path>
+7. If raw_value is None:
+       return None
+8. Look up entity display name. If None:
+       return None  (dangling reference takes precedence over override)
+9. Return wrapped link: "[" escape(raw_value) "](iris://" type "/" id ' "' escape(name) '")'
+```
+
+## 3. Edge cases
+
+| Case | Token | Result |
+|---|---|---|
+| Stored value resolves | `{{element:UUID:attr:Unit/type}}` | `[g](iris://element/UUID "Pork mince")` |
+| Override non-empty | `{{element:UUID:attr:Quantity/type=500}}` | `[500](iris://element/UUID "Pork mince")` |
+| Override empty (fillable) | `{{element:UUID:attr:Quantity/type=}}` | `~~{{element:UUID:attr:Quantity/type=}}~~` |
+| Override on non-attr field | `{{element:UUID:name=Custom Label}}` | `[Custom Label](iris://element/UUID "Pork mince")` |
+| Override on package | `{{package:UUID:name=Aisle 7}}` | `[Aisle 7](iris://package/UUID "Pantry")` |
+| Override contains `=` | `{{element:UUID:attr:foo=k=v}}` | `[k=v](iris://element/UUID "X")` — split on **first** `=` |
+| Override with markdown brackets | `{{element:UUID:attr:x=hello [world]}}` | text escaped as `hello \[world\]` |
+| Deleted entity + override | `{{element:DELETED:attr:x=500}}` | `~~{{...}}~~` — dangling beats override |
+| Stored value present + no override | `{{element:UUID:attr:Unit/type}}` (stored=g) | `[g](iris://element/UUID "...")` (existing behaviour) |
+| No override + stored blank | `{{element:UUID:attr:Quantity/type}}` (blank) | `~~{{...}}~~` (existing behaviour) |
+| Image token, unaffected | `{{image:UUID:width:50%}}` | unchanged |
+
+## 4. Backend implementation
+
+### 4.1 Function-level changes
+
+In `_resolve_one(db, entity_type, entity_id, field_spec)`:
+
+```python
+async def _resolve_one(db, entity_type, entity_id, field_spec):
+    if entity_type == "image":
+        return await _resolve_image(db, entity_id, field_spec)
+    if not field_spec:
+        return None
+
+    # ADR-210: split off =value override
+    if "=" in field_spec:
+        field_spec_path, override_value = field_spec.split("=", 1)
+    else:
+        field_spec_path, override_value = field_spec, None
+
+    if override_value is not None:
+        if override_value == "":
+            return None  # fillable-slot marker
+        raw_value: str | None = override_value
+    else:
+        # existing per-entity-type lookup, using field_spec_path
+        ...
+
+    if raw_value is None:
+        return None
+
+    name = await _fetch_entity_display_name(db, entity_type, entity_id)
+    if name is None:
+        return None  # dangling reference
+    title = _markdown_escape_title(name)
+    text = _markdown_escape_link_text(str(raw_value))
+    return f'[{text}](iris://{entity_type}/{entity_id} "{title}")'
+```
+
+### 4.2 Backwards compatibility
+
+- Tokens without `=` resolve identically to today. Existing recipes and existing tests pass unchanged.
+- The default fallback (`title = name or entity_id`) at line 355 of the existing implementation is **tightened** to `title = name; return None if name is None`. This is technically a behaviour change for the case "entity missing but field returned a value somehow" — which is unreachable in current code paths (every fetch_*_field returns None for missing entities). Defensive change captured in tests.
+
+## 5. Canvas behaviour (frontend)
+
+### 5.1 Inline editable spans for fillable slots
+
+In `SmartMarkdownCanvas.svelte` edit mode:
+
+1. After every resolve, scan `data.markdown_source` for tokens matching `\{\{[^}]+=\}\}` (the empty-override regex).
+2. For each match in the rendered output (which the resolver wrote as strikethrough), replace the strikethrough fragment in the **edit-mode preview overlay** with a `contenteditable` span:
+
+   ```svelte
+   <span class="iris-fillable-slot"
+         contenteditable="plaintext-only"
+         data-token-start={start}
+         data-token-end={end}
+         on:blur={() => persistSlot(start, end, $$node.textContent)}>
+   </span>
+   ```
+
+3. `persistSlot(start, end, value)` rewrites the substring of `data.markdown_source[start:end]` from `{{...path=}}` to `{{...path=<value>}}` (with `}` and `\` escaped) and re-renders.
+
+The read-mode view is unchanged — fillable slots in a non-editable view render as strikethrough.
+
+### 5.2 Picker integration
+
+In `EntityPicker.svelte` (the ADR-206 picker), the field-step gains a new top option visible whenever the selected field is `attr:<path>`:
+
+```
+► Insert as fillable placeholder
+  name
+  description
+  attr ► attributes ► Quantity ► type   (currently focused)
+  attr ► attributes ► Unit ► type
+  ...
+```
+
+Picking it inserts the token with `=` at the end and no override value. Picking the regular field option inserts the token without `=`.
+
+### 5.3 No `{@html}` paths
+
+The inline span is a real DOM element bound by the canvas component; no `{@html}` is used to render it. Token resolution → markdown → marked → DOMPurify → HTML remains the unchanged pipeline (protocol §7). The fillable-slot replacement happens **after** marked rendering, by walking the rendered DOM and swapping strikethrough fragments that contain the empty-override token text.
+
+## 6. Test matrix
+
+`backend/tests/test_diagrams/test_smart_markdown.py` gains a new test class `TestValueOverrides` with one test per edge-case row in §3 above. Existing tests remain unchanged (backward compatibility).
+
+Frontend tests in `frontend/src/lib/canvas/text/SmartMarkdownCanvas.test.ts` (new) cover:
+- The strike-through→input swap on edit-mode mount.
+- Blur-persists-into-markdown-source.
+- Two fillable slots in the same diagram are independently editable.
+- Switching to read-mode hides the inputs (strikethrough only).
+- Source-pane edit bypasses the inline UX entirely.
+
+## 7. Migration
+
+None. Pure additive grammar extension. Existing tokens resolve identically; existing markdown_source values are untouched. The recipe-migration script (PR 6 / SPEC-214) rewrites pre-existing free-text quantities into the new override form — separate work.
+
+## 8. Out of scope
+
+- Multi-value overrides (e.g. `{{...:attr:list=[a,b,c]}}`) — paths returning lists already render the JSON literal; overrides accept any string.
+- Type coercion (`=500` is the string "500", not the integer). Consumers (aggregation engine) coerce per their own rules.
+- Override on the `image` entity type — image tokens have their own sizing grammar, unrelated.
+- Escape grammar for `=` or `}` in override values — both are technically already unescapable (the regex stops at `}`; `=` only matters at split-point). Edge case documented; no escaping syntax in v1.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.17.9",
+	"version": "6.18.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownSlashPicker.svelte
@@ -520,25 +520,29 @@
 		}
 	}
 
-	function emitToken(terminalSeg?: string) {
+	function emitToken(terminalSeg?: string, opts?: { fillable?: boolean }) {
 		if (!chosenEntity) return;
+		// ADR-210 (v6.18.0): `fillable` appends `=` to the token so it
+		// renders as a fillable-slot strikethrough until the author types
+		// a value into the source.
+		const suffix = opts?.fillable ? '=' : '';
 		// terminalSeg = the literal `name`/`description` shortcut or
 		// an explicit primitive picked at the current path level.
 		if (terminalSeg === 'name' || terminalSeg === 'description') {
-			oninsert(`{{${chosenEntity.entity_type}:${chosenEntity.id}:${terminalSeg}}}`);
+			oninsert(`{{${chosenEntity.entity_type}:${chosenEntity.id}:${terminalSeg}${suffix}}}`);
 			return;
 		}
 		if (chosenEntity.entity_type !== 'element' && terminalSeg) {
-			oninsert(`{{${chosenEntity.entity_type}:${chosenEntity.id}:${terminalSeg}}}`);
+			oninsert(`{{${chosenEntity.entity_type}:${chosenEntity.id}:${terminalSeg}${suffix}}}`);
 			return;
 		}
 		// Element path:
 		const path = [...drillPath, ...(terminalSeg ? [terminalSeg] : [])];
 		if (path.length === 0) return;
-		oninsert(`{{element:${chosenEntity.id}:attr:${path.join('/')}}}`);
+		oninsert(`{{element:${chosenEntity.id}:attr:${path.join('/')}${suffix}}}`);
 	}
 
-	async function chooseDrillItem(item: DrillItem) {
+	async function chooseDrillItem(item: DrillItem, opts?: { fillable?: boolean }) {
 		// ADR-209: image item → open sizing chooser (does not emit yet).
 		if (item.kind === 'image') {
 			openImageSizer(item.image);
@@ -547,12 +551,12 @@
 		if (item.kind === 'primitive') {
 			// Top-level name/description shortcuts
 			if (drillPath.length === 0 && NON_ELEMENT_FIELDS.includes(item.label)) {
-				emitToken(item.label);
+				emitToken(item.label, opts);
 				return;
 			}
 			// Terminal primitive at this path level (current path resolved
 			// to a primitive value).
-			emitToken();
+			emitToken(undefined, opts);
 			return;
 		}
 		// Element data drill: container item → push the segment.
@@ -653,7 +657,11 @@
 		if (e.key === 'Enter') {
 			if (menu.length > 0) {
 				e.preventDefault();
-				chooseDrillItem(menu[Math.min(drillIdx, menu.length - 1)]);
+				// ADR-210: Shift+Enter inserts the token as a fillable-slot
+				// placeholder (trailing `=`) so the author fills the value in
+				// the source. Plain Enter inserts the normal token form.
+				chooseDrillItem(menu[Math.min(drillIdx, menu.length - 1)],
+					{ fillable: e.shiftKey });
 			}
 			return;
 		}
@@ -877,7 +885,7 @@
 				bind:this={drillInputEl}
 				type="text"
 				class="slash-picker__input slash-picker__input--drill"
-				placeholder="Type . or Tab to drill, Enter to insert"
+				placeholder="Type . or Tab to drill, Enter to insert (Shift+Enter for fillable slot)"
 				bind:value={drillFilter}
 				onkeydown={handleDrillKey}
 			/>

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.17.9"
+version = "6.18.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.17.9"
+version = "6.18.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Adds inline `=value` overrides to smart-markdown token grammar — `{{element:UUID:attr:Quantity/type=500}}` resolves to "500" regardless of stored value, giving per-use values without a side table.
- Empty override (`...=`) is the fillable-slot marker — strikethrough render makes unfilled placeholders visible.
- Picker: Shift+Enter on a primitive emits the fillable-slot form.
- No schema migration; existing tokens resolve identically.

First of six PRs implementing [issue #211](https://github.com/cgbarlow/iris/issues/211)'s meal-plan → shopping-list workflow via four generic primitives. Per `docs/plans/issue-211-shopping-list-implementation.md`.

## References

- [ADR-210](docs/adrs/ADR-210-Smart-Markdown-Value-Overrides.md)
- [SPEC-210-a](docs/adrs/specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md)

## Test plan

- [x] Backend: 42 smart_markdown tests pass (12 new override cases + 30 existing untouched)
- [x] Backend: full `tests/test_diagrams/` suite green (224/224)
- [x] `scripts/check_surface_parity.py` — clean (no new write endpoints)
- [x] `svelte-check` — no new errors introduced (pre-existing errors unchanged)
- [ ] In-browser: open a smart_markdown diagram, type `/`, pick an attr field, press Shift+Enter → token has trailing `=` and renders as strikethrough until source pane edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)