### PR TITLE
feat(v6.19.0): element-template markdown stamps + 5 seeded globals (ADR-211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.19.0] - 2026-05-22
+
+### Added
+
+- **Markdown stamps on element templates**
+  ([ADR-211](docs/adrs/ADR-211-Element-Template-Stamps.md),
+  [SPEC-211-a](docs/adrs/specs/SPEC-211-a-Element-Template-Stamps.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211)).
+  `element_templates` gains a new `markdown_stamp TEXT` column that
+  holds a smart-markdown fragment using `{{self:<field-spec>}}`
+  placeholders. At smart-markdown insert time the picker substitutes
+  `self` with the selected element's ID, so a single pick yields a
+  multi-token line (e.g. quantity + unit + name) instead of three
+  separate picker round-trips. Stamps live on element_templates so
+  they reuse the existing scope (`is_global` / `set_id`) and
+  management UX.
+- **`POST` / `PUT /api/element-templates` accept `markdown_stamp`
+  and direct `template_data`**. `source_element_id` is now optional —
+  a template can carry direct content via `template_data`, a stamp
+  via `markdown_stamp`, or both. At least one of the three (source,
+  data, stamp) must yield non-empty content; empty templates are
+  rejected with 422.
+- **`GET /api/element-templates/stamps?element_id=<id>`** — new read
+  endpoint returning in-scope stamps for an element. Scope rules:
+  template is global OR set-matches the element's set; if the
+  template's captured `element_type` is set, it must match the
+  element's. Each returned `markdown_stamp` has `{{self:…}}` already
+  rewritten to `{{element:<element-id>:…}}` so the body is paste-ready.
+- **MCP tool `list_element_template_stamps`** — calls the new
+  endpoint. Discoverable by Claude Desktop / any agent during smart-
+  markdown authoring sessions.
+- **MCP `create_element_template` and `update_element_template`** accept
+  the new `markdown_stamp` and `template_data` arguments. CLI
+  `iris create / update element-template` gain `--markdown-stamp`
+  and `--template-data-file` flags.
+- **Five seeded global element-template stamps** ship in m075 / m080:
+  - **Quantified item** — `{{self:attr:attributes/Quantity/type=}} {{self:attr:attributes/Unit/type}} {{self:name}}`
+  - **Sized story** — `{{self:attr:attributes/Points/type=}} pts — {{self:name}}`
+  - **Logged work** — `{{self:attr:attributes/Hours/type=}}h — {{self:name}}`
+  - **Line item** — `{{self:attr:attributes/Currency/type}}{{self:attr:attributes/Amount/type=}} — {{self:name}}`
+  - **Read entry** — `{{self:attr:attributes/Pages/type=}} pages — "{{self:name}}" by {{self:attr:attributes/Author/type}}`
+
+  Each carries a pre-filled `data.attributes` blueprint so creating an
+  element from the template yields the slots its stamp expects. All
+  ship as `is_global = TRUE` with `created_by = NULL`.
+
+### Changed
+
+- `element_templates.created_by` is now nullable in the response
+  model — seeded global templates have no authoring user. Existing
+  user-created templates always carry the author's id (unchanged).
+
+### Migration
+
+- **SQLite m074** — `markdown_stamp` column added to
+  `element_templates`. Idempotent.
+- **Supabase m079** — mirror of m074. Apply via
+  `scripts/supabase-migrate.sh` before rolling forward.
+- **SQLite m075 / Supabase m080** — seed the five global stamps with
+  deterministic UUIDv5 ids so re-running is a no-op.
+- Order per memory `feedback_render_supabase_ordering`: apply Supabase
+  migrations first, then merge to `main` so Render serves code with
+  the column already present.
+
 ## [6.18.0] - 2026-05-22
 
 ### Added

--- a/backend/app/element_templates/models.py
+++ b/backend/app/element_templates/models.py
@@ -22,16 +22,23 @@ INCLUDED_FIELD_WHITELIST: frozenset[str] = frozenset({
 class ElementTemplateCreate(BaseModel):
     """Request body for creating an element template.
 
-    ``source_element_id`` is required: v1 templates are always captured
-    from an existing element. ``set_id`` and ``is_global`` are
-    mutually exclusive — exactly one must produce a non-null scope
-    (enforced by the DB CHECK constraint and the service layer).
+    ADR-211 (v6.19.0): a template's content can come from any of three
+    sources: snapshotting an existing element (``source_element_id`` +
+    ``included_fields``), supplying ``template_data`` directly, or just
+    carrying a ``markdown_stamp``. At least one must produce non-empty
+    content — pure no-op templates are rejected with 422.
+
+    ``set_id`` and ``is_global`` are mutually exclusive — exactly one
+    must produce a non-null scope (enforced by the DB CHECK constraint
+    and the service layer).
     """
 
-    source_element_id: str = Field(min_length=1)
+    source_element_id: str | None = Field(default=None, min_length=1)
     name: str = Field(min_length=1, max_length=255)
     description: str | None = None
-    included_fields: list[str] = Field(min_length=1)
+    included_fields: list[str] = Field(default_factory=list)
+    template_data: dict[str, object] | None = None
+    markdown_stamp: str | None = None
     set_id: str | None = None
     is_global: bool = False
 
@@ -42,12 +49,15 @@ class ElementTemplateUpdate(BaseModel):
     All fields optional; absent fields are not touched. ``set_id`` and
     ``is_global`` can be flipped to promote a template global or
     demote it back (the CHECK constraint validates the resulting
-    state).
+    state). ADR-211: ``template_data`` and ``markdown_stamp`` are
+    direct-write fields — setting them replaces the existing value.
     """
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
     description: str | None = None
     included_fields: list[str] | None = None
+    template_data: dict[str, object] | None = None
+    markdown_stamp: str | None = None
     set_id: str | None = None
     is_global: bool | None = None
 
@@ -65,10 +75,36 @@ class ElementTemplateResponse(BaseModel):
     source_element_name: str | None = None
     included_fields: list[str]
     template_data: dict[str, object]
-    created_by: str
+    markdown_stamp: str | None = None
+    # ADR-211 v6.19.0: seeded global templates have created_by NULL (no user
+    # exists at migration time). Allow nullable for those rows; CRUD-created
+    # templates always carry the authoring user.
+    created_by: str | None = None
     created_by_username: str = "Unknown"
     created_at: str
     updated_at: str
+
+
+class ElementTemplateStampResponse(BaseModel):
+    """ADR-211: in-scope stamp returned by GET /api/element-templates/stamps.
+
+    ``markdown_stamp`` is pre-resolved — ``{{self:…}}`` placeholders are
+    already substituted with ``{{element:<requested-id>:…}}`` so the
+    body is ready to paste into the source.
+    """
+
+    id: str
+    name: str
+    description: str | None = None
+    set_id: str | None = None
+    is_global: bool = False
+    markdown_stamp: str
+
+
+class ElementTemplateStampListResponse(BaseModel):
+    """List wrapper for the stamps endpoint."""
+
+    items: list[ElementTemplateStampResponse]
 
 
 class ElementTemplateListResponse(BaseModel):

--- a/backend/app/element_templates/router.py
+++ b/backend/app/element_templates/router.py
@@ -11,6 +11,8 @@ from app.element_templates.models import (
     ElementTemplateCreate,
     ElementTemplateListResponse,
     ElementTemplateResponse,
+    ElementTemplateStampListResponse,
+    ElementTemplateStampResponse,
     ElementTemplateUpdate,
 )
 from app.element_templates.service import (
@@ -20,6 +22,7 @@ from app.element_templates.service import (
     delete_element_template,
     get_element_template,
     list_element_templates,
+    list_stamps_for_element,
     update_element_template,
 )
 
@@ -32,7 +35,12 @@ async def create(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> ElementTemplateResponse:
-    """Create a template from an existing element."""
+    """Create a template (ADR-191 + ADR-211).
+
+    Content sources are alternatives: snapshot from ``source_element_id``,
+    direct ``template_data``, or a ``markdown_stamp``. At least one must
+    yield non-empty content.
+    """
     db = request.app.state.db_manager.main_db
     try:
         result = await create_element_template(
@@ -44,6 +52,8 @@ async def create(
             set_id=body.set_id,
             is_global=body.is_global,
             created_by=current_user["id"],
+            template_data_direct=body.template_data,
+            markdown_stamp=body.markdown_stamp,
         )
     except ElementTemplateScopeError as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
@@ -75,6 +85,28 @@ async def list_all(
         total=total,
         page=page,
         page_size=page_size,
+    )
+
+
+@router.get(
+    "/stamps",
+    response_model=ElementTemplateStampListResponse,
+)
+async def list_stamps(
+    request: Request,
+    element_id: str = Query(..., min_length=1),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> ElementTemplateStampListResponse:
+    """ADR-211: list in-scope stamps for an element.
+
+    Each ``markdown_stamp`` is pre-resolved — ``{{self:…}}`` is already
+    rewritten to ``{{element:<element_id>:…}}`` so the body can be
+    pasted into a smart-markdown source unchanged.
+    """
+    db = request.app.state.db_manager.main_db
+    items = await list_stamps_for_element(db, element_id)
+    return ElementTemplateStampListResponse(
+        items=[ElementTemplateStampResponse(**i) for i in items],
     )
 
 
@@ -118,6 +150,10 @@ async def update(
         kwargs["is_global"] = raw["is_global"]
     if "set_id" in raw:
         kwargs["set_id"] = raw["set_id"]  # may be None
+    if "template_data" in raw:
+        kwargs["template_data_direct"] = raw["template_data"]
+    if "markdown_stamp" in raw:
+        kwargs["markdown_stamp"] = raw["markdown_stamp"]
     try:
         result = await update_element_template(db, template_id, **kwargs)
     except ElementTemplateScopeError as exc:

--- a/backend/app/element_templates/service.py
+++ b/backend/app/element_templates/service.py
@@ -1,10 +1,10 @@
-"""Element template CRUD service (ADR-191, issue #153).
+"""Element template CRUD service (ADR-191, issue #153; ADR-211, v6.19.0).
 
-Templates capture a snapshot of selected fields from a source element
-so later element creation can be pre-filled. Set-scoped by default;
-``is_global`` promotes a template across sets. ``included_fields`` is
-filtered against ``INCLUDED_FIELD_WHITELIST`` to keep the surface
-narrow.
+Templates carry reusable element content: either a snapshot of an
+existing element (ADR-191) or direct content with an optional
+``markdown_stamp`` (ADR-211). Set-scoped by default; ``is_global``
+promotes a template across sets. ``included_fields`` is filtered
+against ``INCLUDED_FIELD_WHITELIST`` to keep the surface narrow.
 
 Row access is positional throughout (Protocol §15) so the same code
 runs on SQLite and Supabase.
@@ -13,6 +13,7 @@ runs on SQLite and Supabase.
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -21,6 +22,22 @@ from app.element_templates.models import INCLUDED_FIELD_WHITELIST
 
 if TYPE_CHECKING:
     from app.db.adapter import DatabasePort
+
+
+# ADR-211: `{{self:<field-spec>}}` placeholder used in markdown_stamp.
+_SELF_TOKEN_RE = re.compile(r"\{\{self:([^}]+)\}\}")
+
+
+def substitute_self(stamp_body: str, element_id: str) -> str:
+    """Rewrite ``{{self:<field-spec>}}`` → ``{{element:<element_id>:<field-spec>}}``.
+
+    Used at picker insert time so the resulting body is a normal smart-
+    markdown fragment with concrete element IDs. ADR-211.
+    """
+    return _SELF_TOKEN_RE.sub(
+        lambda m: f"{{{{element:{element_id}:{m.group(1)}}}}}",
+        stamp_body,
+    )
 
 
 class ElementTemplateScopeError(ValueError):
@@ -106,25 +123,47 @@ def _project_template_data(
 async def create_element_template(
     db: DatabasePort,
     *,
-    source_element_id: str,
+    source_element_id: str | None,
     name: str,
     description: str | None,
     included_fields: list[str],
     set_id: str | None,
     is_global: bool,
     created_by: str,
+    template_data_direct: dict[str, Any] | None = None,
+    markdown_stamp: str | None = None,
 ) -> dict[str, Any]:
-    """Create a new template by snapshotting an element."""
+    """Create a new template (ADR-191 + ADR-211).
+
+    Three content paths:
+      1. ``source_element_id`` + ``included_fields`` → snapshot from element.
+      2. ``template_data_direct`` (non-empty) → use as-is.
+      3. ``markdown_stamp`` only → stamp-only template.
+
+    At least one path must yield non-empty content.
+    """
     _validate_scope(set_id=set_id, is_global=is_global)
+
     filtered = _filter_included_fields(included_fields)
-    if not filtered:
+    template_data: dict[str, Any] = {}
+
+    if source_element_id is not None:
+        src = await _load_source_element(db, source_element_id)
+        if filtered:
+            template_data = _project_template_data(src, filtered)
+    elif template_data_direct is not None:
+        template_data = dict(template_data_direct)
+
+    has_data = bool(template_data)
+    has_stamp = bool(markdown_stamp and markdown_stamp.strip())
+
+    if not has_data and not has_stamp:
         msg = (
-            "included_fields must contain at least one whitelisted "
-            f"field. Whitelist: {sorted(INCLUDED_FIELD_WHITELIST)}"
+            "Template must have at least one of: a source_element_id "
+            "with included_fields, template_data, or markdown_stamp."
         )
         raise ElementTemplateScopeError(msg)
-    src = await _load_source_element(db, source_element_id)
-    template_data = _project_template_data(src, filtered)
+
     template_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
     # Literal ``, 0)`` for is_deleted caused HTTP 500 on Supabase —
@@ -136,13 +175,15 @@ async def create_element_template(
     await db.execute(
         "INSERT INTO element_templates "
         "(id, name, description, set_id, is_global, source_element_id, "
-        "included_fields, template_data, created_by, created_at, "
-        "updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "included_fields, template_data, markdown_stamp, created_by, "
+        "created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             template_id, name, description, set_id, 1 if is_global else 0,
             source_element_id, json.dumps(filtered),
-            json.dumps(template_data), created_by, now, now,
+            json.dumps(template_data),
+            markdown_stamp if has_stamp else None,
+            created_by, now, now,
         ),
     )
     await db.commit()
@@ -162,7 +203,7 @@ async def get_element_template(
         "  AND e.current_version = ev.version "
         "  AND e.is_deleted = 0) AS source_name, "
         "t.included_fields, t.template_data, t.created_by, "
-        "u.username, t.created_at, t.updated_at "
+        "u.username, t.created_at, t.updated_at, t.markdown_stamp "
         "FROM element_templates t "
         "LEFT JOIN sets s ON s.id = t.set_id "
         "LEFT JOIN users u ON u.id = t.created_by "
@@ -187,6 +228,7 @@ async def get_element_template(
         "created_by_username": row[11] or "Unknown",
         "created_at": row[12],
         "updated_at": row[13],
+        "markdown_stamp": row[14],
     }
 
 
@@ -238,7 +280,7 @@ async def list_element_templates(
         "  AND e.current_version = ev.version "
         "  AND e.is_deleted = 0) AS source_name, "
         "t.included_fields, t.template_data, t.created_by, "
-        "u.username, t.created_at, t.updated_at "
+        "u.username, t.created_at, t.updated_at, t.markdown_stamp "
         "FROM element_templates t "
         "LEFT JOIN sets s ON s.id = t.set_id "
         "LEFT JOIN users u ON u.id = t.created_by "
@@ -264,6 +306,7 @@ async def list_element_templates(
             "created_by_username": r[11] or "Unknown",
             "created_at": r[12],
             "updated_at": r[13],
+            "markdown_stamp": r[14],
         }
         for r in rows
     ]
@@ -279,6 +322,8 @@ async def update_element_template(
     included_fields: list[str] | None = None,
     set_id: str | None | type[Ellipsis] = ...,  # ... = "not touched"
     is_global: bool | None = None,
+    template_data_direct: dict[str, Any] | None | type[Ellipsis] = ...,
+    markdown_stamp: str | None | type[Ellipsis] = ...,
 ) -> dict[str, Any] | None:
     """Edit a template's mutable fields.
 
@@ -286,6 +331,10 @@ async def update_element_template(
     ``included_fields`` changes AND the source element is still alive.
     If the source has been deleted, the existing ``template_data`` is
     filtered down to the intersection with the new ``included_fields``.
+
+    ADR-211: ``markdown_stamp`` and ``template_data_direct`` are
+    sentinel-or-value parameters (``...`` means "not touched"). Setting
+    ``markdown_stamp`` to ``None`` clears it.
     """
     existing = await get_element_template(db, template_id)
     if existing is None:
@@ -305,20 +354,23 @@ async def update_element_template(
         new_set_id = set_id  # may be None or a string
     _validate_scope(set_id=new_set_id, is_global=new_is_global)
 
-    new_included = (
-        _filter_included_fields(included_fields)
-        if included_fields is not None
-        else list(existing["included_fields"])
-    )
-    if not new_included:
-        msg = "included_fields must contain at least one whitelisted field"
-        raise ElementTemplateScopeError(msg)
-
-    new_data = existing["template_data"]
+    # included_fields: optional. ADR-211 relaxes the prior "must be
+    # non-empty" rule — a stamp-only template can carry an empty list.
+    new_included: list[str]
     if included_fields is not None:
-        # Re-project: prefer fresh data from the source element if it
-        # still exists; otherwise keep the prior snapshot for fields
-        # that survived the included_fields filter.
+        new_included = _filter_included_fields(included_fields)
+    else:
+        new_included = list(existing["included_fields"])
+
+    # template_data:
+    #   - If the caller passed template_data_direct (sentinel not Ellipsis),
+    #     use that directly (write-through).
+    #   - Else if included_fields was reshaped, re-project from source.
+    #   - Else carry forward existing.
+    new_data: dict[str, Any]
+    if template_data_direct is not ...:
+        new_data = dict(template_data_direct) if template_data_direct else {}
+    elif included_fields is not None and new_included:
         try:
             src = await _load_source_element(
                 db, existing["source_element_id"],
@@ -328,18 +380,39 @@ async def update_element_template(
         if src is not None:
             new_data = _project_template_data(src, new_included)
         else:
-            new_data = {k: existing["template_data"].get(k) for k in new_included}
+            new_data = {
+                k: existing["template_data"].get(k) for k in new_included
+            }
+    else:
+        new_data = existing["template_data"]
+
+    # markdown_stamp: ... = no change; None = clear; str = set.
+    new_stamp: str | None
+    if markdown_stamp is ...:
+        new_stamp = existing.get("markdown_stamp")
+    else:
+        new_stamp = markdown_stamp
+
+    # Validation: template still must have at least one of data/stamp/included
+    if not new_data and not (new_stamp and new_stamp.strip()) and not new_included:
+        msg = (
+            "Template must keep at least one of: included_fields, "
+            "template_data, or markdown_stamp"
+        )
+        raise ElementTemplateScopeError(msg)
 
     now = datetime.now(tz=UTC).isoformat()
     await db.execute(
         "UPDATE element_templates SET "
         "name = ?, description = ?, set_id = ?, is_global = ?, "
-        "included_fields = ?, template_data = ?, updated_at = ? "
+        "included_fields = ?, template_data = ?, markdown_stamp = ?, "
+        "updated_at = ? "
         "WHERE id = ? AND is_deleted = 0",
         (
             new_name, new_description, new_set_id,
             1 if new_is_global else 0,
-            json.dumps(new_included), json.dumps(new_data), now,
+            json.dumps(new_included), json.dumps(new_data), new_stamp,
+            now,
             template_id,
         ),
     )
@@ -381,3 +454,62 @@ def apply_template_to_create_body(
         if key in data:
             merged[key] = data[key]
     return merged
+
+
+async def list_stamps_for_element(
+    db: DatabasePort, element_id: str,
+) -> list[dict[str, Any]]:
+    """Return in-scope stamps for an element (ADR-211 scope rules).
+
+    A stamp is in-scope when:
+      - The template has a non-empty ``markdown_stamp``.
+      - The template is global (``is_global = 1``) OR set-scoped to
+        the element's set.
+      - The template's captured ``element_type`` matches the element's
+        ``element_type`` (or the template doesn't capture an
+        element_type — then it's offered for any).
+
+    Each returned ``markdown_stamp`` has ``{{self:…}}`` already
+    substituted with the element's ID so the picker can paste it
+    directly.
+    """
+    # Resolve element's set_id + element_type.
+    cursor = await db.execute(
+        "SELECT e.set_id, e.element_type FROM elements e "
+        "WHERE e.id = ? AND e.is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return []
+    set_id, element_type = row[0], row[1]
+
+    cursor = await db.execute(
+        "SELECT id, name, description, set_id, is_global, "
+        "template_data, markdown_stamp "
+        "FROM element_templates "
+        "WHERE is_deleted = 0 "
+        "AND markdown_stamp IS NOT NULL AND markdown_stamp != '' "
+        "AND (is_global = 1 OR set_id = ?) "
+        "ORDER BY is_global DESC, name ASC",
+        (set_id,),
+    )
+    rows = await cursor.fetchall()
+
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        td = json.loads(r[5]) if r[5] else {}
+        td_etype = td.get("element_type") if isinstance(td, dict) else None
+        if td_etype and td_etype != element_type:
+            continue
+        stamp_body = r[6] or ""
+        resolved = substitute_self(stamp_body, element_id)
+        out.append({
+            "id": r[0],
+            "name": r[1],
+            "description": r[2],
+            "set_id": r[3],
+            "is_global": bool(r[4]),
+            "markdown_stamp": resolved,
+        })
+    return out

--- a/backend/app/migrations/m074_element_template_markdown_stamp.py
+++ b/backend/app/migrations/m074_element_template_markdown_stamp.py
@@ -1,0 +1,28 @@
+"""Migration 074: ``markdown_stamp`` column on ``element_templates`` (ADR-211).
+
+Adds a TEXT column that stores a smart-markdown fragment using
+``{{self:<field-spec>}}`` placeholders, substituted by the picker at
+insert time. The seeded global stamps (m075) populate this column.
+
+Idempotent — column-presence check.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m074_element_template_markdown_stamp"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    cursor = await db.execute("PRAGMA table_info(element_templates)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "markdown_stamp" not in cols:
+        await db.execute(
+            "ALTER TABLE element_templates ADD COLUMN markdown_stamp TEXT",
+        )
+    await db.commit()

--- a/backend/app/migrations/m075_seed_global_element_template_stamps.py
+++ b/backend/app/migrations/m075_seed_global_element_template_stamps.py
@@ -1,0 +1,154 @@
+"""Migration 075: seed five global element-template stamps (ADR-211).
+
+Ships the canonical "Quantified item / Sized story / Logged work / Line
+item / Read entry" stamps as ``is_global = 1`` element_templates with
+deterministic UUIDv5 IDs so re-running is a no-op.
+
+Each template carries a markdown_stamp using `{{self:…}}` placeholders
+plus a ``template_data`` blueprint that pre-fills attribute slots so
+elements created from the template are immediately compatible with the
+matching aggregation profile (added in m076 / ADR-212).
+
+Idempotent via INSERT OR IGNORE.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m075_seed_global_element_template_stamps"
+
+# Stable namespace for UUIDv5 — anything constant works; this is the
+# uuid.NAMESPACE_DNS variant with a fixed string so future re-runs and
+# Supabase mirror produce identical IDs.
+_STAMP_NAMESPACE = uuid.UUID("c1f5b6e0-1b4e-4f1c-9a2d-211211211211")
+
+_SYSTEM_USER_ID = None  # element_templates.created_by is nullable; users aren't seeded at migration time
+
+
+def _blueprint(element_type: str, attribute_names: list[str]) -> dict:
+    """Build a template_data blueprint that pre-fills attribute slots."""
+    return {
+        "element_type": element_type,
+        "notation": "simple",
+        "data": {
+            "attributes": [
+                {
+                    "name": attr_name,
+                    "type": "",
+                    "scope": "Public",
+                    "notes": "",
+                    "lower_bound": "",
+                    "upper_bound": "",
+                }
+                for attr_name in attribute_names
+            ],
+        },
+    }
+
+
+SEEDED_STAMPS = [
+    {
+        "name": "Quantified item",
+        "description": (
+            "Element with a numeric quantity + unit (groceries, parts, "
+            "stock items, line items in a list with totals). Pairs with "
+            "the 'Shopping list' / sum-by-unit aggregation profile."
+        ),
+        "element_type": "class",
+        "attributes": ["Quantity", "Unit"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Quantity/type=}} "
+            "{{self:attr:attributes/Unit/type}} "
+            "{{self:name}}"
+        ),
+    },
+    {
+        "name": "Sized story",
+        "description": (
+            "Work item with story points. Pairs with the 'Sprint points "
+            "rollup' aggregation profile."
+        ),
+        "element_type": "class",
+        "attributes": ["Points"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Points/type=}} pts — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Logged work",
+        "description": (
+            "Work-log entry with hours. Pairs with the 'Time tracker "
+            "rollup' aggregation profile."
+        ),
+        "element_type": "class",
+        "attributes": ["Hours"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Hours/type=}}h — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Line item",
+        "description": (
+            "Expense / billing line item. Pairs with the 'Expense report' "
+            "aggregation profile."
+        ),
+        "element_type": "class",
+        "attributes": ["Amount", "Currency"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Currency/type}}"
+            "{{self:attr:attributes/Amount/type=}} — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Read entry",
+        "description": (
+            "Reading-log entry. Pairs with the 'Reading log rollup' "
+            "aggregation profile."
+        ),
+        "element_type": "class",
+        "attributes": ["Pages", "Author"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Pages/type=}} pages — "
+            "\"{{self:name}}\" by {{self:attr:attributes/Author/type}}"
+        ),
+    },
+]
+
+
+def stamp_id_for(name: str) -> str:
+    """Deterministic UUIDv5 for a stamp name. Stable across re-runs and
+    across SQLite/Supabase so the two seeds produce identical rows."""
+    return str(uuid.uuid5(_STAMP_NAMESPACE, f"global-stamp:{name}"))
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — INSERT OR IGNORE."""
+    now = datetime.now(tz=UTC).isoformat()
+    for stamp in SEEDED_STAMPS:
+        template_data = _blueprint(stamp["element_type"], stamp["attributes"])
+        await db.execute(
+            "INSERT OR IGNORE INTO element_templates ("
+            "id, name, description, set_id, is_global, "
+            "source_element_id, included_fields, template_data, "
+            "markdown_stamp, created_by, created_at, updated_at"
+            ") VALUES (?, ?, ?, NULL, 1, NULL, ?, ?, ?, ?, ?, ?)",
+            (
+                stamp_id_for(stamp["name"]),
+                stamp["name"],
+                stamp["description"],
+                json.dumps(["element_type", "notation", "data"]),
+                json.dumps(template_data),
+                stamp["markdown_stamp"],
+                _SYSTEM_USER_ID,
+                now,
+                now,
+            ),
+        )
+    await db.commit()

--- a/backend/app/migrations/supabase/m079_element_template_markdown_stamp.sql
+++ b/backend/app/migrations/supabase/m079_element_template_markdown_stamp.sql
@@ -1,0 +1,10 @@
+-- Migration 079: markdown_stamp column on element_templates (ADR-211).
+--
+-- Mirrors SQLite m074. Adds a TEXT column that holds a smart-markdown
+-- fragment using `{{self:<field-spec>}}` placeholders, resolved by the
+-- picker at insert time. Seeded by m080 with five global stamps.
+--
+-- Idempotent.
+
+ALTER TABLE public.element_templates
+    ADD COLUMN IF NOT EXISTS markdown_stamp TEXT;

--- a/backend/app/migrations/supabase/m080_seed_global_element_template_stamps.sql
+++ b/backend/app/migrations/supabase/m080_seed_global_element_template_stamps.sql
@@ -1,0 +1,78 @@
+-- Migration 080: seed five global element-template stamps (ADR-211).
+--
+-- Mirrors SQLite m075. Inserts the canonical "Quantified item / Sized
+-- story / Logged work / Line item / Read entry" stamps as global
+-- element_templates with deterministic UUIDs (matching m075's UUIDv5
+-- computation: uuid5(ns="c1f5b6e0-1b4e-4f1c-9a2d-211211211211",
+-- "global-stamp:<name>")).
+--
+-- Idempotent via ON CONFLICT (id) DO NOTHING.
+
+INSERT INTO public.element_templates (
+    id, name, description,
+    set_id, is_global,
+    source_element_id, included_fields, template_data, markdown_stamp,
+    created_by, created_at, updated_at
+)
+VALUES
+    (
+        'ea8829e5-6e3f-5cf6-b1cc-a5ad92312dbf',
+        'Quantified item',
+        'Element with a numeric quantity + unit (groceries, parts, stock items, line items in a list with totals). Pairs with the ''Shopping list'' / sum-by-unit aggregation profile.',
+        NULL, TRUE,
+        NULL,
+        '["element_type", "notation", "data"]'::jsonb::text,
+        '{"element_type":"class","notation":"simple","data":{"attributes":[{"name":"Quantity","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""},{"name":"Unit","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""}]}}',
+        '{{self:attr:attributes/Quantity/type=}} {{self:attr:attributes/Unit/type}} {{self:name}}',
+        NULL,
+        NOW(), NOW()
+    ),
+    (
+        '08f53b8a-3876-5af5-bd9d-5b6959fea660',
+        'Sized story',
+        'Work item with story points. Pairs with the ''Sprint points rollup'' aggregation profile.',
+        NULL, TRUE,
+        NULL,
+        '["element_type", "notation", "data"]'::jsonb::text,
+        '{"element_type":"class","notation":"simple","data":{"attributes":[{"name":"Points","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""}]}}',
+        '{{self:attr:attributes/Points/type=}} pts — {{self:name}}',
+        NULL,
+        NOW(), NOW()
+    ),
+    (
+        '7fd2b6d1-4cd7-5322-ae72-c753bbea649f',
+        'Logged work',
+        'Work-log entry with hours. Pairs with the ''Time tracker rollup'' aggregation profile.',
+        NULL, TRUE,
+        NULL,
+        '["element_type", "notation", "data"]'::jsonb::text,
+        '{"element_type":"class","notation":"simple","data":{"attributes":[{"name":"Hours","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""}]}}',
+        '{{self:attr:attributes/Hours/type=}}h — {{self:name}}',
+        NULL,
+        NOW(), NOW()
+    ),
+    (
+        'afd69eab-832b-5ee5-a885-ec745b2e3b22',
+        'Line item',
+        'Expense / billing line item. Pairs with the ''Expense report'' aggregation profile.',
+        NULL, TRUE,
+        NULL,
+        '["element_type", "notation", "data"]'::jsonb::text,
+        '{"element_type":"class","notation":"simple","data":{"attributes":[{"name":"Amount","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""},{"name":"Currency","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""}]}}',
+        '{{self:attr:attributes/Currency/type}}{{self:attr:attributes/Amount/type=}} — {{self:name}}',
+        NULL,
+        NOW(), NOW()
+    ),
+    (
+        '7a17859b-838e-58ed-aff0-a3f5c94284be',
+        'Read entry',
+        'Reading-log entry. Pairs with the ''Reading log rollup'' aggregation profile.',
+        NULL, TRUE,
+        NULL,
+        '["element_type", "notation", "data"]'::jsonb::text,
+        '{"element_type":"class","notation":"simple","data":{"attributes":[{"name":"Pages","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""},{"name":"Author","type":"","scope":"Public","notes":"","lower_bound":"","upper_bound":""}]}}',
+        '{{self:attr:attributes/Pages/type=}} pages — "{{self:name}}" by {{self:attr:attributes/Author/type}}',
+        NULL,
+        NOW(), NOW()
+    )
+ON CONFLICT (id) DO NOTHING;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -77,6 +77,8 @@ from app.migrations.m070_smart_markdown_diagram_type import up as m070_up
 from app.migrations.m071_rename_text_to_standard_markdown import up as m071_up
 from app.migrations.m072_sets_element_tab_default import up as m072_up
 from app.migrations.m073_entity_images import up as m073_up
+from app.migrations.m074_element_template_markdown_stamp import up as m074_up
+from app.migrations.m075_seed_global_element_template_stamps import up as m075_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -181,6 +183,8 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m071_up(main)  # v6.14.1: rename 'text' diagram type display label to 'Standard Markdown'
     await m072_up(main)  # issue #192, v6.16.0: per-set element_tab_default (ADR-208)
     await m073_up(main)  # issue #194, v6.17.0: entity_images junction table (ADR-209)
+    await m074_up(main)  # issue #211, v6.19.0: element_templates.markdown_stamp (ADR-211)
+    await m075_up(main)  # issue #211, v6.19.0: seed 5 global element-template stamps (ADR-211)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.18.0"
+version = "6.19.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_element_templates/test_crud_and_apply.py
+++ b/backend/tests/test_element_templates/test_crud_and_apply.py
@@ -306,14 +306,20 @@ class TestListAndGet:
         )
         assert r.status_code == 201
 
-        # set_id=A + include_global → A's 2 + 1 global = 3
+        # set_id=A + include_global → A's 2 + 1 user-global + 5 seeded
+        # globals (Quantified item / Sized story / Logged work / Line item
+        # / Read entry per ADR-211). Filter to user-created entries to keep
+        # the assertion stable across future seeded additions.
         r = await client.get(
             f"/api/element-templates?set_id={set_a}&include_global=true",
             headers=h,
         )
         assert r.status_code == 200
-        names = sorted(t["name"] for t in r.json()["items"])
-        assert names == ["A1", "A2", "G1"]
+        user_names = sorted(
+            t["name"] for t in r.json()["items"]
+            if t["created_by"] is not None  # exclude seeded (created_by NULL)
+        )
+        assert user_names == ["A1", "A2", "G1"]
 
         # set_id=A + include_global=false → A's 2 only
         r = await client.get(
@@ -323,12 +329,16 @@ class TestListAndGet:
         names = sorted(t["name"] for t in r.json()["items"])
         assert names == ["A1", "A2"]
 
-        # set_id absent + include_global → globals only
+        # set_id absent + include_global → globals only (user G1 +
+        # the 5 seeded stamps per ADR-211; filter by created_by).
         r = await client.get(
             "/api/element-templates?include_global=true", headers=h,
         )
-        names = sorted(t["name"] for t in r.json()["items"])
-        assert names == ["G1"]
+        user_names = sorted(
+            t["name"] for t in r.json()["items"]
+            if t["created_by"] is not None
+        )
+        assert user_names == ["G1"]
 
     async def test_get_one_returns_full_template(
         self, client: httpx.AsyncClient,

--- a/backend/tests/test_element_templates/test_deleted_source.py
+++ b/backend/tests/test_element_templates/test_deleted_source.py
@@ -158,7 +158,12 @@ class TestGetTemplateAfterSourceSoftDelete:
             f"/api/element-templates?set_id={set_id}", headers=h,
         )
         assert list_resp.status_code == 200, list_resp.text
-        items = list_resp.json()["items"]
+        # ADR-211 v6.19.0: globals include the 5 seeded stamps. Filter
+        # to the user-created template (created_by non-null).
+        items = [
+            i for i in list_resp.json()["items"]
+            if i["created_by"] is not None
+        ]
         assert len(items) == 1
         assert items[0]["source_element_name"] is None
         assert items[0]["source_element_id"] == source["id"]

--- a/backend/tests/test_element_templates/test_stamps.py
+++ b/backend/tests/test_element_templates/test_stamps.py
@@ -1,0 +1,337 @@
+"""Element template markdown stamps (ADR-211, v6.19.0, issue #211).
+
+Covers:
+- markdown_stamp create + update on /api/element-templates.
+- substitute_self() unit behaviour.
+- GET /api/element-templates/stamps?element_id=X with scope and
+  element_type filtering.
+- The five seeded global stamps are present after migrations.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.element_templates.service import substitute_self
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _create_set(c: httpx.AsyncClient, h: dict, name: str = "S") -> str:
+    r = await c.post("/api/sets", json={"name": name}, headers=h)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _create_element(
+    c: httpx.AsyncClient, h: dict, *, set_id: str,
+    name: str = "E", element_type: str = "class",
+) -> str:
+    r = await c.post(
+        "/api/elements",
+        json={
+            "name": name, "element_type": element_type,
+            "set_id": set_id,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# substitute_self() — pure function
+# ─────────────────────────────────────────────────────────────────────
+
+
+def test_substitute_self_single_token() -> None:
+    out = substitute_self("Hello {{self:name}}.", "abc")
+    assert out == "Hello {{element:abc:name}}."
+
+
+def test_substitute_self_multiple_tokens() -> None:
+    out = substitute_self(
+        "{{self:attr:Q/type=}} {{self:attr:U/type}} {{self:name}}",
+        "xyz",
+    )
+    assert out == (
+        "{{element:xyz:attr:Q/type=}} "
+        "{{element:xyz:attr:U/type}} "
+        "{{element:xyz:name}}"
+    )
+
+
+def test_substitute_self_no_tokens() -> None:
+    assert substitute_self("plain markdown", "abc") == "plain markdown"
+
+
+def test_substitute_self_preserves_non_self_tokens() -> None:
+    """Only `self` tokens are rewritten; other entity types pass through."""
+    src = "{{self:name}} vs {{element:other-id:name}}"
+    out = substitute_self(src, "abc")
+    assert out == "{{element:abc:name}} vs {{element:other-id:name}}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# CRUD: create / update with markdown_stamp
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_template_with_markdown_stamp_no_source(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Stamp only",
+            "description": "no source element, just a stamp",
+            "markdown_stamp": "{{self:name}}",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["markdown_stamp"] == "{{self:name}}"
+    assert body["source_element_id"] is None
+    assert body["is_global"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_empty_template(
+    client: httpx.AsyncClient,
+) -> None:
+    """ADR-211: a template must have *some* content."""
+    h = await _auth(client)
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Empty",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 422
+    assert "at least one" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_create_with_direct_template_data(
+    client: httpx.AsyncClient,
+) -> None:
+    """ADR-211: template_data can be supplied directly without a source."""
+    h = await _auth(client)
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Blueprint",
+            "template_data": {
+                "element_type": "class",
+                "data": {"attributes": [{"name": "X", "type": ""}]},
+            },
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["template_data"]["element_type"] == "class"
+
+
+@pytest.mark.asyncio
+async def test_update_markdown_stamp(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    # create a stamp-only template
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Original",
+            "markdown_stamp": "{{self:name}}",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    tid = r.json()["id"]
+    # update the stamp
+    r = await client.put(
+        f"/api/element-templates/{tid}",
+        json={"markdown_stamp": "{{self:attr:Q/type=}} {{self:name}}"},
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert (
+        r.json()["markdown_stamp"]
+        == "{{self:attr:Q/type=}} {{self:name}}"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# GET /api/element-templates/stamps?element_id=…
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stamps_endpoint_returns_seeded_globals_for_class_element(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    assert r.status_code == 200, r.text
+    names = sorted(s["name"] for s in r.json()["items"])
+    # Five seeded global stamps all target element_type=class.
+    assert names == [
+        "Line item", "Logged work", "Quantified item",
+        "Read entry", "Sized story",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stamps_self_substituted_to_element_id(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, name="Pork mince", element_type="class",
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    assert r.status_code == 200
+    quantified = next(
+        s for s in r.json()["items"] if s["name"] == "Quantified item"
+    )
+    # `self` is rewritten to `element:<eid>` in the returned stamp body.
+    assert f"element:{eid}:attr:attributes/Quantity/type=" in (
+        quantified["markdown_stamp"]
+    )
+    assert f"element:{eid}:name" in quantified["markdown_stamp"]
+    assert "{{self:" not in quantified["markdown_stamp"]
+
+
+@pytest.mark.asyncio
+async def test_stamps_element_type_filter(
+    client: httpx.AsyncClient,
+) -> None:
+    """Stamp template_data.element_type narrows applicability."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    # An element of element_type="component" should NOT see stamps that
+    # the seed migration targeted at element_type="class".
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="component",
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_stamps_set_scope_filter(
+    client: httpx.AsyncClient,
+) -> None:
+    """A set-scoped stamp doesn't surface for elements in other sets."""
+    h = await _auth(client)
+    set_a = await _create_set(client, h, "A")
+    set_b = await _create_set(client, h, "B")
+    el_a = await _create_element(client, h, set_id=set_a)
+    el_b = await _create_element(client, h, set_id=set_b)
+    # Create a set-A-scoped stamp.
+    await client.post(
+        "/api/element-templates",
+        json={
+            "name": "A-only stamp",
+            "markdown_stamp": "{{self:name}}",
+            "set_id": set_a,
+            "is_global": False,
+        },
+        headers=h,
+    )
+    # In set A: appears.
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={el_a}", headers=h,
+    )
+    names_a = [s["name"] for s in r.json()["items"]]
+    assert "A-only stamp" in names_a
+    # In set B: not visible.
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={el_b}", headers=h,
+    )
+    names_b = [s["name"] for s in r.json()["items"]]
+    assert "A-only stamp" not in names_b
+
+
+@pytest.mark.asyncio
+async def test_stamps_missing_element_returns_empty_list(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    r = await client.get(
+        "/api/element-templates/stamps?"
+        "element_id=00000000-0000-0000-0000-000000000000",
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json()["items"] == []

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -1132,14 +1132,36 @@ def _parse_csv_opt(raw: str | None, flag: str) -> list[str] | None:
 
 @create_app.command("element-template")
 def create_element_template_cmd(
-    source_element: str = typer.Option(..., "--source-element"),
     name: str = typer.Option(..., "--name"),
-    include: str = typer.Option(
-        ..., "--include",
+    source_element: str | None = typer.Option(
+        None, "--source-element",
         help=(
-            "Comma-separated whitelist of element fields to carry "
-            "into the template (e.g. name,description,data,tags). "
+            "Optional: snapshot the template from this element. Combine "
+            "with --include. Mutually compatible with --template-data-file "
+            "and --markdown-stamp — at least one content source required."
+        ),
+    ),
+    include: str | None = typer.Option(
+        None, "--include",
+        help=(
+            "Comma-separated whitelist of element fields to snapshot "
+            "from --source-element (e.g. name,description,data,tags). "
             "Non-whitelisted fields are dropped silently."
+        ),
+    ),
+    template_data_file: str | None = typer.Option(
+        None, "--template-data-file",
+        help=(
+            "ADR-211: path to a JSON file containing template_data "
+            "directly. Alternative to --source-element."
+        ),
+    ),
+    markdown_stamp: str | None = typer.Option(
+        None, "--markdown-stamp",
+        help=(
+            "ADR-211: smart-markdown fragment using `{{self:<field-spec>}}` "
+            "placeholders. Picker substitutes `self` with the selected "
+            "element's id at insert time."
         ),
     ),
     set_id: str | None = typer.Option(
@@ -1155,13 +1177,29 @@ def create_element_template_cmd(
     ),
     description: str | None = typer.Option(None, "--description"),
 ) -> None:
-    """Capture an element template from an existing element."""
+    """Create an element template.
+
+    Three content paths (at least one required):
+      - --source-element + --include: snapshot from an element.
+      - --template-data-file: direct content from JSON file.
+      - --markdown-stamp: stamp-only template (ADR-211).
+    """
+    import json as _json
+    from pathlib import Path as _Path
+
     body: dict[str, Any] = {
-        "source_element_id": source_element,
         "name": name,
-        "included_fields": _parse_csv_opt(include, "--include"),
         "is_global": is_global,
     }
+    if source_element is not None:
+        body["source_element_id"] = source_element
+    inc = _parse_csv_opt(include, "--include")
+    if inc is not None:
+        body["included_fields"] = inc
+    if template_data_file is not None:
+        body["template_data"] = _json.loads(_Path(template_data_file).read_text())
+    if markdown_stamp is not None:
+        body["markdown_stamp"] = markdown_stamp
     if description is not None:
         body["description"] = description
     if set_id is not None:
@@ -1200,8 +1238,25 @@ def update_element_template_cmd(
         None, "--global/--no-global",
         help="Promote to global or demote back.",
     ),
+    template_data_file: str | None = typer.Option(
+        None, "--template-data-file",
+        help=(
+            "ADR-211: path to a JSON file replacing template_data "
+            "directly (skips re-projection from source element)."
+        ),
+    ),
+    markdown_stamp: str | None = typer.Option(
+        None, "--markdown-stamp",
+        help=(
+            "ADR-211: replace the markdown_stamp body. Pass an empty "
+            "string to clear."
+        ),
+    ),
 ) -> None:
     """Update an element template (no versioning — no If-Match)."""
+    import json as _json
+    from pathlib import Path as _Path
+
     body: dict[str, Any] = {}
     if name is not None:
         body["name"] = name
@@ -1214,6 +1269,10 @@ def update_element_template_cmd(
         body["set_id"] = _resolve_null(set_id)
     if is_global is not None:
         body["is_global"] = is_global
+    if template_data_file is not None:
+        body["template_data"] = _json.loads(_Path(template_data_file).read_text())
+    if markdown_stamp is not None:
+        body["markdown_stamp"] = markdown_stamp
 
     async def _do() -> Any:
         async with _client() as c:

--- a/docs/adrs/ADR-211-Element-Template-Stamps.md
+++ b/docs/adrs/ADR-211-Element-Template-Stamps.md
@@ -1,0 +1,89 @@
+# ADR-211: Markdown stamps on element templates
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-191](./ADR-191-Element-Templates.md), [ADR-205](./ADR-205-Smart-Markdown-View-Type.md), [ADR-206](./ADR-206-Smart-Markdown-Picker-Evolution.md), [ADR-210](./ADR-210-Smart-Markdown-Value-Overrides.md).
+
+## Context
+
+ADR-210 makes structured per-use values first-class in the smart-markdown grammar (`{{element:UUID:attr:path=500}}`). But composing the full "500 g Pork mince" recipe line still needs three tokens — quantity, unit, name — and three picker round-trips. For the user authoring 30+ recipes, that's tedious; for the `/goal`-driven shopping-list workflow ([issue #211](https://github.com/cgbarlow/iris/issues/211)) it's the friction point that pushes users back to free-text prose.
+
+The existing `element_templates` machinery (ADR-191) already manages reusable artefacts scoped to a set or globally. It captures element fields for re-use at element-creation time, but has no concept of a *markdown snippet* to insert at recipe-authoring time.
+
+## Decision
+
+Add an optional `markdown_stamp TEXT` column to `element_templates`. The value is a smart-markdown fragment that may use a new `{{self:<field-spec>}}` token form — at insert time the picker substitutes `self` with the chosen element's actual ID, and the resulting fragment is placed at the cursor.
+
+### `{{self:…}}` token
+
+```
+{{self:name}}                                       → {{element:UUID:name}}
+{{self:attr:attributes/Quantity/type=}}             → {{element:UUID:attr:attributes/Quantity/type=}}
+{{self:attr:attributes/Unit/type}}                  → {{element:UUID:attr:attributes/Unit/type}}
+```
+
+The grammar shape is identical to ADR-205's `<entity-type>:<id>:<field-spec>` but with the literal string `self` in place of `<id>` and a missing `<entity-type>`. `self` only appears inside a stamp's body; at insert time, the picker rewrites every `{{self:<field-spec>}}` to `{{element:<resolved-id>:<field-spec>}}`. The resolver never sees `self` tokens — they don't need to be valid against the existing `_TOKEN_RE` regex.
+
+### Picker integration
+
+When the smart-markdown picker has selected an entity, it queries `GET /api/element-templates/stamps?element_id=<id>` for in-scope stamps (a stamp is "in scope" when its template is global or matches the entity's set, and the template's captured `element_type` either matches the entity's `element_type` or was not captured at all). Stamps are displayed as a top section above the existing field-step menu. Picking a stamp emits its body with `self` substituted.
+
+### Stamp authoring UX (deferred to v6.19.1)
+
+A first-class stamp editor — smart-markdown editor in self-mode — is out of scope for v6.19.0. v6.19.0 ships the data model + picker integration + seeded global stamps; stamps can be authored via the existing element-template create/update endpoints (REST/MCP/CLI) by setting `markdown_stamp`. The richer UX comes in v6.19.1.
+
+### Source-element optionality
+
+ADR-191's `ElementTemplateCreate` required `source_element_id`. Stamps don't always have a source — a "Quantified item" stamp is a *type* of usage pattern, not a snapshot of a specific element. So `source_element_id` becomes optional. When absent, the caller supplies `template_data` directly (or leaves it empty); when present, the existing snapshot flow runs.
+
+A template must declare a non-trivial purpose: at least one of `template_data` (non-empty) or `markdown_stamp` (non-empty) must be set. Pure no-op templates are rejected with HTTP 422.
+
+### Scope semantics for stamps
+
+The picker filters stamps for in-scope:
+
+1. **Scope match**: `is_global = TRUE` OR `set_id` equals the selected entity's `set_id`.
+2. **Element-type match**: if the template's `template_data` includes an `element_type`, it must equal the selected entity's `element_type`. If the template doesn't carry an `element_type`, the stamp is offered for any element type.
+
+The second rule makes the stamp editor itself the place to constrain applicability — no separate `stamp_element_type_filter` column needed (this was the user's Q1 in the research-phase clarification).
+
+### Seeds
+
+Five global templates ship in the migration that adds the column ([§4.4](../plans/issue-211-shopping-list-implementation.md)). Each carries a `markdown_stamp` and a `template_data` blueprint (with blank attributes), so creating an element from the template yields the attribute slots the stamp expects:
+
+| Template | Stamp |
+|---|---|
+| Quantified item | `{{self:attr:attributes/Quantity/type=}} {{self:attr:attributes/Unit/type}} {{self:name}}` |
+| Sized story | `{{self:attr:attributes/Points/type=}} pts — {{self:name}}` |
+| Logged work | `{{self:attr:attributes/Hours/type=}}h — {{self:name}}` |
+| Line item | `{{self:attr:attributes/Currency/type}}{{self:attr:attributes/Amount/type=}} — {{self:name}}` |
+| Read entry | `{{self:attr:attributes/Pages/type=}} pages — "{{self:name}}" by {{self:attr:attributes/Author/type}}` |
+
+All five carry `is_global = TRUE`, `set_id = NULL`, `source_element_id = NULL`. The `template_data` for each is a pre-filled `{element_type: "class", notation: "simple", data: {attributes: [...]}}` blueprint.
+
+## Consequences
+
+**Positive:**
+
+- One-pick insertion of multi-token chunks against any element. Picker round-trips drop from 3 → 1 for a "quantity unit name" line.
+- Stamps are user-managed data, not Iris-core code — the genericness invariant (ADR-214) is preserved.
+- Composes with ADR-210: stamps that contain `=` (fillable slots) deliver a "fill in the value" UX immediately on insertion.
+- Five seeded global stamps cover the demo workflow and demonstrate the pattern for users to clone.
+
+**Negative / accepted trade-offs:**
+
+- ADR-191's `source_element_id` requirement is relaxed. Existing CHECK constraints still pass because the column was already nullable in the DB schema; the requirement was at the pydantic-model level. Backward-compatible.
+- Stamp authoring without a richer UI (deferred to v6.19.1) means users editing stamps via API need to know the `{{self:…}}` syntax. Seeded stamps cover the common cases; doc'd in the spec.
+
+## Rejected alternatives
+
+- **Per-element `markdown_stamp` column.** Each element could carry its own stamp. Rejected: stamps are *type-of-usage* patterns reused across many elements; living on the template (which is the type registry) matches the conceptual model.
+- **Separate `element_stamps` table.** Cleaner separation but duplicates the scope (`is_global`, `set_id`) and management UX that `element_templates` already provides. DRY violation (§13).
+- **New `{{stamp:<stamp-id>}}` token form.** Late-binding by storing stamp ID in the markdown. Rejected: each diagram would silently re-resolve the stamp on every read, making the stored markdown opaque and hard to edit. Stamps are a paste-once author-time convenience, not a runtime reference.
+
+## References
+
+- [ADR-191](./ADR-191-Element-Templates.md) — original template model.
+- [ADR-210](./ADR-210-Smart-Markdown-Value-Overrides.md) — `=value` overrides (used by the seeded stamps).
+- [SPEC-211-a-Element-Template-Stamps.md](./specs/SPEC-211-a-Element-Template-Stamps.md) — schema, substitution algorithm, endpoint shape, seed table.
+- [`docs/plans/issue-211-shopping-list-implementation.md`](../plans/issue-211-shopping-list-implementation.md) §4.4 — full seed table.

--- a/docs/adrs/specs/SPEC-211-a-Element-Template-Stamps.md
+++ b/docs/adrs/specs/SPEC-211-a-Element-Template-Stamps.md
@@ -1,0 +1,323 @@
+# SPEC-211-a: Element template markdown stamps
+
+Implements: [ADR-211](../ADR-211-Element-Template-Stamps.md)
+
+## 1. Schema change
+
+### SQLite (`backend/app/migrations/m074_element_template_markdown_stamp.py`)
+
+```sql
+ALTER TABLE element_templates ADD COLUMN markdown_stamp TEXT;
+```
+
+### Supabase (`backend/app/migrations/supabase/m079_element_template_markdown_stamp.sql`)
+
+```sql
+-- Mirrors SQLite m074.
+ALTER TABLE element_templates ADD COLUMN IF NOT EXISTS markdown_stamp TEXT;
+```
+
+Schema test: `backend/tests/test_migrations/test_element_template_markdown_stamp_schema.py` asserts the column exists, idempotency holds, and no boolean-literal regression slips in.
+
+## 2. Model changes
+
+```python
+class ElementTemplateCreate(BaseModel):
+    source_element_id: str | None = None        # was required, now optional
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    included_fields: list[str] = Field(default_factory=list)  # was min_length=1
+    template_data: dict[str, object] | None = None            # NEW
+    markdown_stamp: str | None = None                          # NEW
+    set_id: str | None = None
+    is_global: bool = False
+
+class ElementTemplateUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    included_fields: list[str] | None = None
+    template_data: dict[str, object] | None = None             # NEW (write-through)
+    markdown_stamp: str | None = None                          # NEW
+    set_id: str | None = None
+    is_global: bool | None = None
+
+class ElementTemplateResponse(BaseModel):
+    ...                                                        # existing fields
+    markdown_stamp: str | None = None                          # NEW
+```
+
+A template's purpose is non-trivial if any of:
+- `source_element_id` is provided (snapshot from element),
+- `template_data` is provided non-empty,
+- `markdown_stamp` is provided non-empty.
+
+If none of the three is set, `create_element_template` raises `ElementTemplateScopeError` ("template has no content").
+
+## 3. Service changes (`backend/app/element_templates/service.py`)
+
+### `create_element_template`
+
+```python
+async def create_element_template(
+    db, *, source_element_id, name, description, included_fields,
+    set_id, is_global, created_by,
+    template_data_direct=None, markdown_stamp=None,
+):
+    _validate_scope(...)
+    has_anything = False
+
+    # Path A: snapshot from source element
+    if source_element_id:
+        src = await _load_source_element(db, source_element_id)
+        filtered = _filter_included_fields(included_fields or [])
+        template_data = _project_template_data(src, filtered) if filtered else {}
+        has_anything = bool(template_data)
+    # Path B: direct template_data
+    elif template_data_direct is not None:
+        template_data = template_data_direct
+        filtered = []
+        has_anything = bool(template_data)
+    else:
+        template_data = {}
+        filtered = []
+
+    if markdown_stamp:
+        has_anything = True
+
+    if not has_anything:
+        raise ElementTemplateScopeError(
+            "Template must have at least one of: source_element_id, "
+            "template_data, or markdown_stamp"
+        )
+
+    # INSERT including the new markdown_stamp column.
+    ...
+```
+
+### `get_element_template` / `list_element_templates`
+
+Selects extended to include `markdown_stamp` (column index 14, after `updated_at`). Response dict carries `markdown_stamp` key.
+
+### `update_element_template`
+
+Accepts optional `markdown_stamp` and `template_data_direct` parameters. Update SQL extended to include both columns.
+
+### `substitute_self(stamp_body: str, element_id: str) -> str`
+
+```python
+_SELF_TOKEN_RE = re.compile(r"\{\{self:([^}]+)\}\}")
+
+def substitute_self(stamp_body: str, element_id: str) -> str:
+    """Rewrite `{{self:<field-spec>}}` to `{{element:<element-id>:<field-spec>}}`."""
+    return _SELF_TOKEN_RE.sub(
+        lambda m: f"{{{{element:{element_id}:{m.group(1)}}}}}",
+        stamp_body,
+    )
+```
+
+### `list_stamps_for_element(db, element_id) -> list[dict]`
+
+```python
+async def list_stamps_for_element(db, element_id):
+    """Return in-scope stamps for an element (ADR-211 scope rules)."""
+    # 1. Load element's set_id and element_type.
+    cursor = await db.execute(
+        "SELECT e.set_id, e.element_type FROM elements e "
+        "WHERE e.id = ? AND e.is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return []
+    set_id, element_type = row[0], row[1]
+
+    # 2. Select templates with non-empty markdown_stamp, in scope.
+    cursor = await db.execute(
+        "SELECT id, name, description, set_id, is_global, "
+        "template_data, markdown_stamp "
+        "FROM element_templates "
+        "WHERE is_deleted = 0 "
+        "AND markdown_stamp IS NOT NULL AND markdown_stamp != '' "
+        "AND (is_global = 1 OR set_id = ?) "
+        "ORDER BY is_global DESC, name ASC",
+        (set_id,),
+    )
+    rows = await cursor.fetchall()
+
+    # 3. Element-type filter: if template's template_data.element_type is
+    #    set, must match element's element_type. Else any element_type.
+    out = []
+    for r in rows:
+        td = json.loads(r[5]) if r[5] else {}
+        td_etype = td.get("element_type")
+        if td_etype and td_etype != element_type:
+            continue
+        # Substitute self with element_id at fetch time so the caller
+        # gets a ready-to-insert body.
+        stamp_resolved = substitute_self(r[6], element_id)
+        out.append({
+            "id": r[0],
+            "name": r[1],
+            "description": r[2],
+            "set_id": r[3],
+            "is_global": bool(r[4]),
+            "markdown_stamp": stamp_resolved,
+        })
+    return out
+```
+
+## 4. Router / endpoint changes
+
+### Existing endpoints (POST/PATCH on `/api/element-templates/{id}`)
+
+Accept and persist `markdown_stamp` and `template_data` (direct) per the model changes.
+
+### New read endpoint
+
+```
+GET /api/element-templates/stamps?element_id=<element-id>
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "id": "<template-id>",
+      "name": "Quantified item",
+      "description": "...",
+      "set_id": null,
+      "is_global": true,
+      "markdown_stamp": "{{element:<element-id>:attr:attributes/Quantity/type=}} {{element:<element-id>:attr:attributes/Unit/type}} {{element:<element-id>:name}}"
+    }
+  ]
+}
+```
+
+Auth: same as existing template list — authenticated read.
+
+## 5. Seed migration
+
+### SQLite (`backend/app/migrations/m075_seed_global_element_template_stamps.py`)
+
+Inserts five rows with deterministic IDs (UUIDv5 over the template name + a stable namespace). `is_global = 1`, `set_id = NULL`, `source_element_id = NULL`, `included_fields = "[]"`, `template_data = <blueprint>`, `markdown_stamp = <stamp>`. Idempotent via `INSERT OR IGNORE`.
+
+### Supabase (`backend/app/migrations/supabase/m080_seed_global_element_template_stamps.sql`)
+
+Same rows. `is_global = TRUE`, booleans literal. `ON CONFLICT (id) DO NOTHING`.
+
+### Seed contents
+
+```python
+SEEDED_TEMPLATES = [
+    {
+        "name": "Quantified item",
+        "description": "Element with a numeric quantity + unit (groceries, parts, stock items, …)",
+        "element_type": "class",
+        "attributes": ["Quantity", "Unit"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Quantity/type=}} "
+            "{{self:attr:attributes/Unit/type}} "
+            "{{self:name}}"
+        ),
+    },
+    {
+        "name": "Sized story",
+        "description": "Work item with story points",
+        "element_type": "class",
+        "attributes": ["Points"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Points/type=}} pts — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Logged work",
+        "description": "Work-log entry with hours",
+        "element_type": "class",
+        "attributes": ["Hours"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Hours/type=}}h — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Line item",
+        "description": "Expense / billing line item",
+        "element_type": "class",
+        "attributes": ["Amount", "Currency"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Currency/type}}"
+            "{{self:attr:attributes/Amount/type=}} — {{self:name}}"
+        ),
+    },
+    {
+        "name": "Read entry",
+        "description": "Reading-log entry",
+        "element_type": "class",
+        "attributes": ["Pages", "Author"],
+        "markdown_stamp": (
+            "{{self:attr:attributes/Pages/type=}} pages — "
+            "\"{{self:name}}\" by {{self:attr:attributes/Author/type}}"
+        ),
+    },
+]
+```
+
+The blueprint `template_data` per row is:
+
+```python
+{
+    "element_type": "class",
+    "notation": "simple",
+    "data": {
+        "attributes": [
+            {
+                "name": attr_name,
+                "type": "",
+                "scope": "Public",
+                "notes": "",
+                "lower_bound": "",
+                "upper_bound": "",
+            }
+            for attr_name in attributes
+        ]
+    },
+}
+```
+
+## 6. Surface parity
+
+Every write endpoint must carry through to MCP and CLI per protocol §14.
+
+- `POST /api/element-templates` and `PATCH /api/element-templates/{id}` already exist; both gain `markdown_stamp` and `template_data` optional params in pydantic models. Existing parity entries still apply — no new tools needed.
+- `GET /api/element-templates/stamps` is **read-only** — does not require parity per the §14 read/write split. MCP tool `list_element_template_stamps` is still provided as a convenience for agent discovery.
+- MCP tool `create_element_template` input schema extended to accept `markdown_stamp` (string, optional) and `template_data` (object, optional).
+- MCP tool `update_element_template` likewise.
+- CLI `iris create element-template` adds `--markdown-stamp <text>` and `--template-data-file <path>` flags.
+- CLI `iris update element-template` likewise.
+
+## 7. Tests
+
+`backend/tests/test_element_templates/test_stamps.py` covers:
+
+- Create template with `markdown_stamp` set, no source element → 201.
+- Create with all three optional fields empty → 422.
+- Update `markdown_stamp` field on existing template → returned in subsequent GET.
+- `substitute_self("foo {{self:name}} bar", "abc")` → `"foo {{element:abc:name}} bar"`.
+- `substitute_self` with multiple `{{self:…}}` tokens — all replaced.
+- `substitute_self` with no self tokens — returns input unchanged.
+- `GET /api/element-templates/stamps?element_id=X` returns in-scope stamps with `self` substituted to `X`.
+- Stamp filter by `element_type`: template with `template_data.element_type = "class"` does NOT appear for an element of `element_type = "interface"`.
+- Stamp filter by scope: set-scoped stamp does NOT appear for an element in a different set.
+- Global stamp appears for elements in any set.
+- Deleted element → `GET /stamps` returns `[]`.
+
+`backend/tests/test_migrations/test_element_template_markdown_stamp_schema.py` covers the schema migration.
+
+`backend/tests/test_migrations/test_seed_global_element_templates_schema.py` asserts all five seeded rows after migration.
+
+## 8. Out of scope (deferred to v6.19.1)
+
+- Frontend stamp editor in self-mode (smart-markdown editor with picker locked to `{{self:…}}`).
+- Picker UI showing the "Stamps" section above fields. The endpoint + helpers ship; the picker integration is a follow-up — for v6.19.0 stamps are usable via REST/MCP/CLI by agents (Claude Desktop etc.), which is the primary `/goal` consumer.
+- Per-element override of a template's stamp.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.18.0",
+	"version": "6.19.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.18.0"
+version = "6.19.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.18.0"
+version = "6.19.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -440,20 +440,33 @@ async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
 
 
 async def _create_element_template(c: IrisClient, args: dict[str, Any]) -> str:
-    """v6.8.0 (ADR-191): capture a template from an existing element.
+    """v6.8.0 (ADR-191) / v6.19.0 (ADR-211): create a template.
 
-    ``included_fields`` selects which element fields the template
-    carries (whitelist: name, description, element_type, notation,
-    data, metadata, package_id, tags). Templates are set-scoped by
-    default; pass ``is_global=true`` to make a template visible from
-    any set (in which case omit ``set_id``).
+    Content paths (at least one must yield non-empty content):
+      - Snapshot from an existing element: pass ``source_element_id``
+        plus ``included_fields`` (whitelist: name, description,
+        element_type, notation, data, metadata, package_id, tags).
+      - Direct template data: pass ``template_data`` as a dict.
+      - Stamp-only template (ADR-211): pass ``markdown_stamp`` — a
+        smart-markdown fragment using ``{{self:<field-spec>}}``
+        placeholders, substituted by the picker at insert time.
+
+    Templates are set-scoped by default; pass ``is_global=true`` to
+    make a template visible from any set (in which case omit
+    ``set_id``).
     """
     body: dict[str, Any] = {
-        "source_element_id": args["source_element_id"],
         "name": args["name"],
-        "included_fields": args["included_fields"],
         "is_global": bool(args.get("is_global", False)),
     }
+    if args.get("source_element_id") is not None:
+        body["source_element_id"] = args["source_element_id"]
+    if args.get("included_fields") is not None:
+        body["included_fields"] = args["included_fields"]
+    if args.get("template_data") is not None:
+        body["template_data"] = args["template_data"]
+    if args.get("markdown_stamp") is not None:
+        body["markdown_stamp"] = args["markdown_stamp"]
     if args.get("description") is not None:
         body["description"] = args["description"]
     if args.get("set_id") is not None:
@@ -499,11 +512,15 @@ async def _get_element_template(c: IrisClient, args: dict[str, Any]) -> str:
 
 
 async def _update_element_template(c: IrisClient, args: dict[str, Any]) -> str:
-    """v6.8.0 (ADR-191): edit a template (no If-Match — templates are
-    not versioned). Only the keys present in ``args`` are sent."""
+    """v6.8.0 (ADR-191) / v6.19.0 (ADR-211): edit a template (no If-Match
+    — templates are not versioned). Only the keys present in ``args``
+    are sent. ADR-211 adds ``template_data`` and ``markdown_stamp``."""
     template_id = args["template_id"]
     body: dict[str, Any] = {}
-    for key in ("name", "description", "included_fields", "is_global"):
+    for key in (
+        "name", "description", "included_fields", "is_global",
+        "template_data", "markdown_stamp",
+    ):
         if key in args and args[key] is not None:
             body[key] = args[key]
     # set_id is tri-state-friendly: caller may pass None to mean
@@ -517,6 +534,27 @@ async def _update_element_template(c: IrisClient, args: dict[str, Any]) -> str:
     except IrisAuthError:
         return _auth_required_payload("Update element template")
     return with_web_url(json.dumps(resp.json()), "element-template")
+
+
+async def _list_element_template_stamps(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.19.0 (ADR-211): list in-scope stamps for an element.
+
+    Returns templates whose ``markdown_stamp`` is non-empty and whose
+    scope (global or set-matching) and ``element_type`` (if captured)
+    match the element. Each stamp's body comes back with
+    ``{{self:…}}`` already rewritten to ``{{element:<id>:…}}`` so it
+    can be pasted into a smart-markdown source as-is.
+    """
+    try:
+        resp = await c._request(
+            "GET", "/api/element-templates/stamps",
+            params={"element_id": args["element_id"]},
+        )
+    except IrisAuthError:
+        return _auth_required_payload("List element template stamps")
+    return json.dumps(resp.json().get("items", []))
 
 
 async def _delete_element_template(c: IrisClient, args: dict[str, Any]) -> str:
@@ -1624,35 +1662,64 @@ TOOLS: list[Tool] = [
     Tool(
         name="create_element_template",
         description=(
-            "Capture a saved template from an existing element. The "
-            "template snapshots a user-chosen subset of the element's "
-            "fields (whitelist: name, description, element_type, "
-            "notation, data, metadata, package_id, tags) so future "
-            "`create_element` calls can pre-fill from it via "
-            "`template_id`. Set-scoped by default; pass "
-            "`is_global=true` to share across sets (and omit "
-            "`set_id`). v6.8.0, ADR-191, issue #153."
+            "Create a template. Content sources (alternatives — at least "
+            "one must yield non-empty content):\n"
+            "  - Snapshot from an existing element: pass "
+            "`source_element_id` + `included_fields` (whitelist: name, "
+            "description, element_type, notation, data, metadata, "
+            "package_id, tags) — the template snapshots that element.\n"
+            "  - Direct content: pass `template_data` (object) — used "
+            "as-is when creating elements from this template.\n"
+            "  - Stamp-only: pass `markdown_stamp` — a smart-markdown "
+            "fragment using `{{self:<field-spec>}}` placeholders that "
+            "the picker substitutes at insert time (ADR-211, v6.19.0).\n"
+            "Set-scoped by default; pass `is_global=true` to share "
+            "across sets (and omit `set_id`). v6.8.0 (ADR-191) / "
+            "v6.19.0 (ADR-211)."
         ),
         input_schema=_schema({
-            "source_element_id": _str_arg(
-                "source_element_id",
-                "ID of the element to snapshot the template from",
-            ),
             "name": _str_arg(
                 "name", "Display name for the template",
+            ),
+            "source_element_id": _str_arg(
+                "source_element_id",
+                "Optional: snapshot the template from this element.",
+                required=False,
             ),
             "included_fields": (
                 {
                     "type": "array",
                     "items": {"type": "string"},
                     "description": (
-                        "Element fields to carry into the template. "
+                        "Element fields to carry into the template "
+                        "when snapshotting from `source_element_id`. "
                         "Anything outside the whitelist is dropped "
-                        "silently. At least one whitelisted field is "
-                        "required."
+                        "silently."
                     ),
                 },
-                True,
+                False,
+            ),
+            "template_data": (
+                {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": (
+                        "Optional: direct template content. Used when "
+                        "creating elements from this template. "
+                        "Required if neither `source_element_id` nor "
+                        "`markdown_stamp` is set."
+                    ),
+                },
+                False,
+            ),
+            "markdown_stamp": _str_arg(
+                "markdown_stamp",
+                "ADR-211: smart-markdown fragment using `{{self:…}}` "
+                "placeholders that the picker substitutes with the "
+                "selected element's ID at insert time. Optional; if "
+                "set, makes this template available in the smart-"
+                "markdown picker's Stamps section.",
+                required=False,
             ),
             "description": _str_arg(
                 "description", "Optional template description",
@@ -1778,6 +1845,23 @@ TOOLS: list[Tool] = [
                 },
                 False,
             ),
+            "template_data": (
+                {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": (
+                        "ADR-211: replace `template_data` directly "
+                        "without snapshotting from a source element."
+                    ),
+                },
+                False,
+            ),
+            "markdown_stamp": _str_arg(
+                "markdown_stamp",
+                "ADR-211: update the markdown stamp (smart-markdown "
+                "fragment using `{{self:…}}` placeholders).",
+                required=False,
+            ),
         }),
         handler=_update_element_template,
     ),
@@ -1792,6 +1876,28 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_delete_element_template,
+    ),
+    Tool(
+        name="list_element_template_stamps",
+        description=(
+            "v6.19.0 (ADR-211): list in-scope markdown stamps for an "
+            "element. A stamp is a smart-markdown fragment using "
+            "`{{self:<field-spec>}}` placeholders. Returned stamps "
+            "have `self` already substituted with the element's id, "
+            "so the body can be inserted into a smart-markdown source "
+            "unchanged. Use this when authoring a smart-markdown "
+            "diagram and you want a one-pick insertion of multi-token "
+            "lines (e.g. quantity + unit + name)."
+        ),
+        input_schema=_schema({
+            "element_id": _str_arg(
+                "element_id",
+                "ID of the element to fetch stamps for. The element's "
+                "set_id and element_type drive the scope and "
+                "applicability filter.",
+            ),
+        }),
+        handler=_list_element_template_stamps,
     ),
     # ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────
     Tool(


### PR DESCRIPTION
## Summary

- Adds `markdown_stamp TEXT` to `element_templates`. Stamps hold smart-markdown fragments using `{{self:<field-spec>}}` — substituted with the selected element's id by the picker at insert time. Compresses multi-token authoring lines (quantity + unit + name) from three picker round-trips to one.
- `source_element_id` relaxed to optional. Templates can carry direct `template_data`, a `markdown_stamp`, or both. At least one of three (source, data, stamp) must yield non-empty content; empty templates 422.
- New `GET /api/element-templates/stamps?element_id=<id>` — returns in-scope stamps for an element with `self` already substituted. New MCP `list_element_template_stamps`. CLI `--markdown-stamp` and `--template-data-file` on `iris create / update element-template`.
- Five seeded global stamps: Quantified item, Sized story, Logged work, Line item, Read entry. All `is_global = TRUE`, deterministic UUIDv5 ids, paired SQLite m075 + Supabase m080.

Second of six PRs implementing [#211](https://github.com/cgbarlow/iris/issues/211).

## References

- [ADR-211](docs/adrs/ADR-211-Element-Template-Stamps.md)
- [SPEC-211-a](docs/adrs/specs/SPEC-211-a-Element-Template-Stamps.md)

## Migrations

- **SQLite m074** — `ALTER TABLE element_templates ADD COLUMN markdown_stamp TEXT`. Idempotent.
- **Supabase m079** — mirror.
- **SQLite m075 / Supabase m080** — seed 5 global stamps with deterministic UUIDv5 ids (re-running is no-op).
- **Already applied to the live Supabase DB** via `scripts/supabase-migrate.sh` per `feedback_render_supabase_ordering` (memory). Code merge below trips the Render redeploy with the column already present.

## Test plan

- [x] Backend: 33 element_template tests pass (20 existing + 13 new stamp tests)
- [x] Backend: `tests/test_diagrams/test_smart_markdown.py` still green (42/42)
- [x] `scripts/check_surface_parity.py` — clean
- [x] Live Supabase verification: `SELECT name, length(markdown_stamp) FROM element_templates WHERE is_global = TRUE` returns 5 rows
- [ ] In-browser smoke test post-deploy: call `GET /api/element-templates/stamps?element_id=<any-class-element>` and confirm the 5 stamps come back with `self` substituted

🤖 Generated with [Claude Code](https://claude.com/claude-code)