### PR TITLE
feat(v6.20.0): generic aggregation engine + 5 seeded global profiles (ADR-212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.20.0] - 2026-05-22
+
+### Added
+
+- **Generic aggregation engine + profile library**
+  ([ADR-212](docs/adrs/ADR-212-Aggregation-Profiles-And-Engine.md),
+  [SPEC-212-a](docs/adrs/specs/SPEC-212-a-Aggregation-Profile-Schema.md),
+  [SPEC-212-b](docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md),
+  [SPEC-212-c](docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211)). A new
+  `aggregation_profiles` table holds rulesets; the engine in
+  `backend/app/aggregation/` walks a source smart-markdown diagram
+  (optionally recursing one level into referenced diagrams),
+  collects tokens of a configured type, resolves per-use values via
+  ADR-210 `=value` overrides, groups by `(token_id, bucket)`,
+  aggregates with `sum` or `count`, groups again by an output
+  attribute, and renders configurable markdown lines. No domain
+  terminology (recipe / ingredient / sprint / receipt) lives in
+  code — all the flavour is in the profile JSON.
+- **Five seeded global aggregation profiles**:
+  - **Shopping list** — outer: diagram tokens with Diners/Servings
+    multiplier; inner: element tokens with Quantity/Unit; group_by:
+    `element.package_name`. Pairs with the "Quantified item" stamp.
+  - **Sprint points rollup** — story-points sum, grouped by team.
+  - **Time tracker rollup** — hours sum, grouped by client/project.
+  - **Expense report** — amount sum bucketed by currency, grouped by
+    category.
+  - **Reading log rollup** — pages sum, grouped by author.
+
+  Each ships as `is_global = TRUE` with deterministic UUIDv5 ids so
+  re-running migrations is a no-op.
+- **REST endpoints** under `/api/aggregation/`:
+  - `POST /api/aggregation/profiles` (create) + `GET / GET {id} / PUT / DELETE`.
+  - **`POST /api/aggregation/run`** — apply a profile to a source
+    diagram. Returns `{markdown, computed_at, source_versions,
+    row_count, warnings}`. Read-shaped despite POST; no persistence
+    side-effects.
+- **MCP tools**: `create_aggregation_profile`,
+  `list_aggregation_profiles`, `get_aggregation_profile`,
+  `update_aggregation_profile`, `delete_aggregation_profile`, and
+  the linchpin **`aggregate`** (run a profile against a source).
+  Callable directly by Claude Desktop / any agent without ever
+  opening a UI.
+- **CLI subcommands**: `iris aggregation-profile create / list /
+  get / update / delete` plus **`iris aggregate --profile <id>
+  --source <id>`**. The aggregate command is the CLI face of the
+  same engine MCP and REST share.
+
+### Migration
+
+- **SQLite m076 / Supabase m081** — create `aggregation_profiles`
+  table.
+- **SQLite m077 / Supabase m082** — seed five global profiles.
+- Supabase migrations applied to the live DB prior to merge per
+  `feedback_render_supabase_ordering`.
+
 ## [6.19.0] - 2026-05-22
 
 ### Added

--- a/backend/app/aggregation/__init__.py
+++ b/backend/app/aggregation/__init__.py
@@ -1,0 +1,18 @@
+"""Generic aggregation engine + profile library (ADR-212, v6.20.0).
+
+Walks one or two levels of smart_markdown diagrams, collects structured
+per-use values from tokens, aggregates by configurable rules in a
+named profile, and emits grouped/summed markdown. The engine is
+parameterised by data (profiles) and reusable across domains —
+shopping-list, sprint-points, time-tracking, expense-report, reading-
+log, etc. — without code changes.
+
+Surfaces:
+  - REST: /api/aggregation/profiles (CRUD), /api/aggregation/run.
+  - MCP: aggregate, list/get/create/update/delete_aggregation_profile.
+  - CLI: iris aggregate, iris aggregation-profile <subcmd>.
+
+The ``aggregation_list`` diagram type (ADR-213) is one consumer of the
+engine — it calls ``engine.run`` at synth-on-read time. Agents (Claude
+Desktop) call ``engine.run`` directly via MCP.
+"""

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -1,0 +1,596 @@
+"""Generic aggregation engine (ADR-212, SPEC-212-b).
+
+One function — ``run(db, profile_id, source_diagram_id)`` — walks the
+source diagram (and, optionally, sub-diagrams it references) for
+tokens of a configured type, resolves attribute values (using ADR-210
+``=value`` overrides as the primary value source), groups by
+``(token_id, bucket)``, aggregates, groups again by an output
+``group_by`` attribute, formats each line with a configurable template,
+and returns a markdown string.
+
+The engine is parameterised entirely by data (the profile JSON). No
+domain terminology lives in this module.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from app.aggregation.exceptions import (
+    AggregationProfileNotFound,
+    AggregationSourceNotFound,
+)
+from app.aggregation.models import (
+    AggregationResult,
+    OuterStep,
+    OutputConfig,
+    ProfileData,
+    TraversalConfig,
+)
+from app.aggregation.profiles_service import get_aggregation_profile
+from app.diagrams.smart_markdown import _TOKEN_RE  # DRY §13
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Internal dataclasses
+# ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _ParsedToken:
+    entity_type: str
+    entity_id: str
+    field_spec: str | None
+    field_spec_path: str | None  # field_spec with `=value` stripped
+    override_value: str | None   # the part after the first `=`, or None
+
+    def override_for(self, path: str) -> str | None:
+        """Return the override value IFF this token's field_spec_path
+        equals the requested path."""
+        if self.override_value is None or self.field_spec_path is None:
+            return None
+        # The path may be a bare path like "attributes/Q/type" or have
+        # an "attr:" prefix when used as a field_spec. Compare both
+        # forms.
+        if self.field_spec_path == path:
+            return self.override_value
+        if self.field_spec_path == f"attr:{path}":
+            return self.override_value
+        return None
+
+
+@dataclass
+class _Row:
+    token_id: str           # entity id from the inner token
+    bucket: str             # bucket value (empty string when no bucket)
+    scaled_value: float
+    source_label: str       # outer-source diagram name (or self if no outer)
+
+
+@dataclass
+class _GroupedRow:
+    token_id: str
+    bucket: str
+    value: float
+    sources: list[tuple[str, float]] = field(default_factory=list)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _parse_tokens(
+    markdown: str, token_type: str,
+) -> list[_ParsedToken]:
+    """Iterate smart_markdown tokens of the given type. Splits the
+    field_spec on the first `=` per ADR-210."""
+    out: list[_ParsedToken] = []
+    for m in _TOKEN_RE.finditer(markdown):
+        etype = m.group(1)
+        if etype != token_type:
+            continue
+        eid = m.group(2)
+        spec = m.group(3)
+        path: str | None = spec
+        override: str | None = None
+        if spec is not None and "=" in spec:
+            path, override = spec.split("=", 1)
+        out.append(_ParsedToken(
+            entity_type=etype, entity_id=eid,
+            field_spec=spec,
+            field_spec_path=path,
+            override_value=override,
+        ))
+    return out
+
+
+async def _read_smart_markdown_source(
+    db: DatabasePort, diagram_id: str,
+) -> str:
+    """Return the diagram's data.markdown_source, or '' if absent."""
+    cursor = await db.execute(
+        "SELECT dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.id = ? AND d.is_deleted = 0",
+        (diagram_id,),
+    )
+    row = await cursor.fetchone()
+    if not row or not row[0]:
+        return ""
+    try:
+        data = json.loads(row[0]) if isinstance(row[0], str) else row[0]
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(data, dict):
+        return ""
+    src = data.get("markdown_source")
+    return src if isinstance(src, str) else ""
+
+
+async def _read_diagram_data(
+    db: DatabasePort, diagram_id: str,
+) -> dict[str, Any]:
+    """Return the diagram's data JSON, or {}."""
+    cursor = await db.execute(
+        "SELECT dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.id = ? AND d.is_deleted = 0",
+        (diagram_id,),
+    )
+    row = await cursor.fetchone()
+    if not row or not row[0]:
+        return {}
+    try:
+        data = json.loads(row[0]) if isinstance(row[0], str) else row[0]
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+async def _diagram_meta(
+    db: DatabasePort, diagram_id: str,
+) -> tuple[str | None, int | None]:
+    """Return (name, current_version) for a diagram, or (None, None)."""
+    cursor = await db.execute(
+        "SELECT dv.name, d.current_version "
+        "FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.id = ? AND d.is_deleted = 0",
+        (diagram_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None, None
+    return row[0], row[1]
+
+
+async def _read_element_data(
+    db: DatabasePort, element_id: str,
+) -> tuple[str | None, str | None, dict[str, Any]]:
+    """Return (name, package_name, data) for an element. (None, None, {})
+    if missing/deleted."""
+    cursor = await db.execute(
+        "SELECT ev.name, ev.data, p.id, "
+        "(SELECT pv.name FROM package_versions pv "
+        "  JOIN packages pkg ON pkg.id = pv.package_id "
+        "  WHERE pkg.id = e.package_id "
+        "    AND pkg.current_version = pv.version "
+        "    AND pkg.is_deleted = 0) AS pkg_name "
+        "FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "  AND e.current_version = ev.version "
+        "LEFT JOIN packages p ON p.id = e.package_id "
+        "WHERE e.id = ? AND e.is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None, None, {}
+    try:
+        data = json.loads(row[1]) if row[1] else {}
+    except (json.JSONDecodeError, TypeError):
+        data = {}
+    return row[0], row[3], data if isinstance(data, dict) else {}
+
+
+def _walk_attr_path(node: Any, path: str | None) -> Any:
+    """Walk a slash-separated attribute path through dicts and lists
+    (using the same semantics as smart_markdown ADR-206)."""
+    if not path:
+        return None
+    segments = [s for s in path.split("/") if s]
+    for seg in segments:
+        if isinstance(node, dict):
+            if seg in node:
+                node = node[seg]
+                continue
+            return None
+        if isinstance(node, list):
+            if seg.isdigit():
+                idx = int(seg)
+                if 0 <= idx < len(node):
+                    node = node[idx]
+                    continue
+                return None
+            if node and all(
+                isinstance(item, dict) and "name" in item for item in node
+            ):
+                match = next(
+                    (item for item in node if item.get("name") == seg),
+                    None,
+                )
+                if match is None:
+                    return None
+                node = match
+                continue
+            return None
+        return None
+    return node
+
+
+def _walk_diagram_data_path(data: dict[str, Any], path: str) -> Any:
+    """Resolve `data.<field>` or `<field>` against the diagram data."""
+    if path.startswith("data."):
+        path = path[5:]
+    return _walk_attr_path(data, path)
+
+
+async def _resolve_token_value(
+    db: DatabasePort,
+    token: _ParsedToken,
+    attribute_path: str | None,
+) -> Any:
+    """Return the token's value at attribute_path.
+
+    Order:
+      1. If the token carries a `=value` override on this exact path,
+         the override wins.
+      2. Otherwise look up the entity's stored attribute at the path.
+    """
+    if attribute_path is None:
+        return None
+    override = token.override_for(attribute_path)
+    if override is not None:
+        return override
+    # Stored lookup — currently only elements have rich attribute
+    # paths; for other entity types the path doesn't resolve and we
+    # return None.
+    if token.entity_type == "element":
+        _, _, data = await _read_element_data(db, token.entity_id)
+        return _walk_attr_path(data, attribute_path)
+    return None
+
+
+async def _resolve_multiplier(
+    db: DatabasePort,
+    outer_token: _ParsedToken,
+    ref_diagram_id: str,
+    outer: OuterStep,
+) -> float:
+    """Resolve the per-outer-token scaling multiplier.
+
+    Semantics: the multiplier is *override / divisor* when the outer
+    token carries a per-use override (the recipe-style "diners ÷
+    servings" case). When there is no override, the multiplier is
+    just ``default_multiplier`` — the divisor is NOT applied, because
+    the absence of an override means "use this reference as-is."
+    """
+    rule = outer.multiplier
+    if rule is None:
+        return 1.0
+    override_raw: str | None = None
+    if rule.from_attribute_override:
+        override_raw = outer_token.override_for(rule.from_attribute_override)
+    if override_raw is None:
+        # No per-use override → no scaling, just default.
+        return float(rule.default_multiplier)
+    try:
+        numerator = float(override_raw)
+    except (TypeError, ValueError):
+        return float(rule.default_multiplier)
+    divisor = 1.0
+    if rule.divisor_from_diagram_data:
+        data = await _read_diagram_data(db, ref_diagram_id)
+        raw = _walk_diagram_data_path(data, rule.divisor_from_diagram_data)
+        try:
+            divisor = float(raw) if raw is not None else 1.0
+        except (TypeError, ValueError):
+            divisor = 1.0
+    if divisor == 0:
+        divisor = 1.0
+    return numerator / divisor
+
+
+async def _collect_inner(
+    db: DatabasePort,
+    markdown: str,
+    inner: Any,  # InnerStep
+    multiplier: float,
+    source_label: str,
+    accumulator: list[_Row],
+    warnings: list[str],
+) -> None:
+    for tok in _parse_tokens(markdown, inner.collect_token_type):
+        raw_value = await _resolve_token_value(
+            db, tok, inner.value_attribute_path,
+        )
+        if raw_value is None or raw_value == "":
+            if inner.skip_blank_values:
+                continue
+            scaled = 0.0
+        else:
+            try:
+                scaled = float(raw_value) * multiplier
+            except (TypeError, ValueError):
+                warnings.append(
+                    f"Non-numeric value '{raw_value}' on token "
+                    f"{tok.entity_type}:{tok.entity_id} — counted as 0.",
+                )
+                scaled = 0.0
+        bucket_raw = await _resolve_token_value(
+            db, tok, inner.bucket_attribute_path,
+        ) if inner.bucket_attribute_path else None
+        bucket = "" if bucket_raw is None else str(bucket_raw)
+        accumulator.append(_Row(
+            token_id=tok.entity_id,
+            bucket=bucket,
+            scaled_value=scaled,
+            source_label=source_label,
+        ))
+
+
+def _group_and_aggregate(
+    rows: list[_Row], fn: str,
+) -> list[_GroupedRow]:
+    grouped: dict[tuple[str, str], list[_Row]] = defaultdict(list)
+    for r in rows:
+        grouped[(r.token_id, r.bucket)].append(r)
+    out: list[_GroupedRow] = []
+    for (token_id, bucket), items in grouped.items():
+        if fn == "count":
+            value: float = float(len(items))
+        else:  # sum (default)
+            value = sum(i.scaled_value for i in items)
+        # Per-source breakdown: join entries from the same source label.
+        per_source: dict[str, float] = defaultdict(float)
+        for it in items:
+            per_source[it.source_label] += it.scaled_value
+        out.append(_GroupedRow(
+            token_id=token_id, bucket=bucket, value=value,
+            sources=sorted(per_source.items()),
+        ))
+    return out
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Output formatting
+# ─────────────────────────────────────────────────────────────────────
+
+
+_GROUP_BY_RE = re.compile(r"^element\.(?P<rest>.+)$")
+
+
+async def _resolve_group_value(
+    db: DatabasePort,
+    token_id: str,
+    group_by: str | None,
+    element_cache: dict[str, tuple[str | None, str | None, dict[str, Any]]],
+) -> str:
+    """Resolve a group_by expression against the (cached) element data."""
+    if not group_by:
+        return ""
+    if token_id not in element_cache:
+        element_cache[token_id] = await _read_element_data(db, token_id)
+    name, pkg_name, data = element_cache[token_id]
+    m = _GROUP_BY_RE.match(group_by)
+    if not m:
+        return ""
+    rest = m.group("rest")
+    # Special-cases
+    if rest == "name":
+        return name or ""
+    if rest == "package_name":
+        return pkg_name or ""
+    # element.attributes.<path...> → walk element.data along path
+    if rest.startswith("attributes."):
+        sub = rest[len("attributes."):]
+        # Convert dotted path to the slash convention used elsewhere.
+        # E.g. "Author/type" → ["Author", "type"]; "attributes.Author.type" → ["Author", "type"]
+        value = _walk_attr_path({"attributes": data.get("attributes")}, "attributes/" + sub)
+        if value is None:
+            return ""
+        return str(value)
+    return ""
+
+
+def _fmt_value(v: float) -> str:
+    """Render numeric value as int when it's a whole number."""
+    if v == int(v):
+        return str(int(v))
+    # Strip insignificant trailing zeros for tidiness.
+    return f"{v:g}"
+
+
+def _substitute_placeholders(template: str, values: dict[str, str]) -> str:
+    """Replace `{placeholder}` markers literally — supports dotted keys
+    like `{element.name}` that Python's str.format can't handle as a
+    bare kwarg.
+
+    Unknown placeholders are left as-is rather than raising; the
+    template is user-authored config, not code.
+    """
+    # Order longest first so e.g. {bucket_spaced} substitutes before
+    # {bucket} (which would otherwise eat the prefix).
+    for key in sorted(values.keys(), key=len, reverse=True):
+        template = template.replace("{" + key + "}", values[key])
+    return template
+
+
+def _render_line(
+    line_format: str,
+    *,
+    element_name: str,
+    element_id: str,
+    sum_value: float,
+    bucket: str,
+) -> str:
+    return _substitute_placeholders(line_format, {
+        "element.name": element_name,
+        "element.id": element_id,
+        "sum_value": _fmt_value(sum_value),
+        "bucket": bucket,
+        "bucket_spaced": f" {bucket}" if bucket else "",
+    })
+
+
+def _render_breakdown(
+    breakdown_format: str,
+    sources: list[tuple[str, float]],
+) -> str:
+    if not sources:
+        return ""
+    joined = ", ".join(
+        f"{src} {_fmt_value(val)}" for src, val in sources
+    )
+    return _substitute_placeholders(breakdown_format, {
+        "sources_joined": joined,
+    })
+
+
+async def _format_output(
+    db: DatabasePort,
+    grouped: list[_GroupedRow],
+    output: OutputConfig,
+) -> tuple[str, int]:
+    """Group output by output.group_by, sort, format. Returns
+    (markdown, row_count)."""
+    element_cache: dict[str, tuple[str | None, str | None, dict[str, Any]]] = {}
+
+    # Resolve display data for every token.
+    rows_with_display: list[
+        tuple[_GroupedRow, str, str]  # row, group_value, element_name
+    ] = []
+    for r in grouped:
+        if r.token_id not in element_cache:
+            element_cache[r.token_id] = await _read_element_data(db, r.token_id)
+        name, _, _ = element_cache[r.token_id]
+        element_name = name or "(missing)"
+        group_value = await _resolve_group_value(
+            db, r.token_id, output.group_by, element_cache,
+        )
+        rows_with_display.append((r, group_value or "(no group)", element_name))
+
+    # Group output by group_value.
+    groups: dict[str, list[tuple[_GroupedRow, str]]] = defaultdict(list)
+    for r, gv, name in rows_with_display:
+        groups[gv].append((r, name))
+
+    # Sort groups.
+    if output.sort_groups == "alpha":
+        sorted_group_keys = sorted(groups.keys(), key=lambda s: s.lower())
+    else:
+        sorted_group_keys = list(groups.keys())
+
+    out_lines: list[str] = []
+    row_count = 0
+    for group_key in sorted_group_keys:
+        if output.group_by:
+            out_lines.append(f"## {group_key}")
+            out_lines.append("")
+        # Sort items within group.
+        items = groups[group_key]
+        if output.sort_items_within_group == "alpha":
+            items = sorted(items, key=lambda x: x[1].lower())
+        for r, name in items:
+            line = _render_line(
+                output.line_format,
+                element_name=name,
+                element_id=r.token_id,
+                sum_value=r.value,
+                bucket=r.bucket,
+            )
+            if output.show_per_source_breakdown:
+                line += _render_breakdown(output.breakdown_format, r.sources)
+            out_lines.append(line)
+            row_count += 1
+        out_lines.append("")
+    return "\n".join(out_lines).rstrip() + "\n", row_count
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Public entry point
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def run(
+    db: DatabasePort,
+    *,
+    profile_id: str,
+    source_diagram_id: str,
+) -> AggregationResult:
+    """Apply ``profile_id`` to ``source_diagram_id``. See SPEC-212-b."""
+    profile_row = await get_aggregation_profile(db, profile_id)
+    if profile_row is None:
+        raise AggregationProfileNotFound(profile_id)
+    p = ProfileData(**profile_row["profile_data"])
+
+    # Sanity: source must exist.
+    src_name, src_version = await _diagram_meta(db, source_diagram_id)
+    if src_name is None:
+        raise AggregationSourceNotFound(source_diagram_id)
+
+    accumulator: list[_Row] = []
+    source_versions: dict[str, int] = {source_diagram_id: src_version or 0}
+    warnings: list[str] = []
+
+    source_markdown = await _read_smart_markdown_source(db, source_diagram_id)
+
+    if p.traversal.outer is not None:
+        # Two-level walk.
+        outer = p.traversal.outer
+        for tok in _parse_tokens(source_markdown, outer.collect_token_type):
+            ref_id = tok.entity_id
+            inner_md = await _read_smart_markdown_source(db, ref_id)
+            ref_name, ref_version = await _diagram_meta(db, ref_id)
+            if ref_name is None:
+                warnings.append(
+                    f"Skipping deleted outer reference {outer.collect_token_type}:{ref_id}",
+                )
+                continue
+            source_versions[ref_id] = ref_version or 0
+            multiplier = await _resolve_multiplier(db, tok, ref_id, outer)
+            await _collect_inner(
+                db, inner_md, p.traversal.inner, multiplier,
+                source_label=ref_name,
+                accumulator=accumulator, warnings=warnings,
+            )
+    else:
+        # Single-level walk.
+        await _collect_inner(
+            db, source_markdown, p.traversal.inner, 1.0,
+            source_label=src_name,
+            accumulator=accumulator, warnings=warnings,
+        )
+
+    grouped = _group_and_aggregate(accumulator, p.output.aggregation_fn)
+    markdown, row_count = await _format_output(db, grouped, p.output)
+
+    return AggregationResult(
+        markdown=markdown,
+        computed_at=datetime.now(tz=UTC).isoformat(),
+        source_versions=source_versions,
+        row_count=row_count,
+        warnings=warnings,
+    )

--- a/backend/app/aggregation/exceptions.py
+++ b/backend/app/aggregation/exceptions.py
@@ -1,0 +1,20 @@
+"""Aggregation engine exceptions (ADR-212)."""
+
+from __future__ import annotations
+
+
+class AggregationProfileNotFound(LookupError):
+    """Profile id resolves to no row. Router maps to 404."""
+
+
+class AggregationProfileScopeError(ValueError):
+    """is_global ↔ set_id invariant violated, or content missing.
+    Router maps to 422."""
+
+
+class AggregationSourceNotFound(LookupError):
+    """The source diagram id resolves to no row. Router maps to 404."""
+
+
+class AggregationProfileInvalid(ValueError):
+    """profile_data fails validation. Router maps to 422."""

--- a/backend/app/aggregation/models.py
+++ b/backend/app/aggregation/models.py
@@ -1,0 +1,133 @@
+"""Pydantic models for aggregation profiles + engine (ADR-212).
+
+Profile data validation lives in pydantic — JSONSchema would be
+redundant when ProfileData is already a typed pydantic root model.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Profile shape (the ruleset)
+# ─────────────────────────────────────────────────────────────────────
+
+TokenType = Literal["element", "diagram", "package", "set", "collection"]
+
+
+class MultiplierRule(BaseModel):
+    """Per-outer-token multiplier rule.
+
+    The outer token may carry a value via ``=value`` override on a
+    specific attribute path (``from_attribute_override``); divided by
+    the referenced diagram's ``data.<divisor_from_diagram_data>``
+    field; with ``default_multiplier`` used when the override is
+    absent. Returns 1.0 when nothing resolves.
+    """
+
+    from_attribute_override: str | None = None
+    divisor_from_diagram_data: str | None = None
+    default_multiplier: float = 1.0
+
+
+class InnerStep(BaseModel):
+    collect_token_type: TokenType = "element"
+    value_attribute_path: str | None = None
+    bucket_attribute_path: str | None = None
+    skip_blank_values: bool = True
+
+
+class OuterStep(BaseModel):
+    collect_token_type: TokenType = "diagram"
+    multiplier: MultiplierRule | None = None
+
+
+class TraversalConfig(BaseModel):
+    outer: OuterStep | None = None
+    inner: InnerStep
+
+
+SortMode = Literal["alpha", "none"]
+AggregationFn = Literal["sum", "count"]
+
+
+class OutputConfig(BaseModel):
+    group_by: str | None = None
+    sort_groups: SortMode = "alpha"
+    sort_items_within_group: SortMode = "alpha"
+    aggregation_fn: AggregationFn = "sum"
+    line_format: str = "- {element.name}: {sum_value}{bucket_spaced}"
+    show_per_source_breakdown: bool = False
+    breakdown_format: str = " ({sources_joined})"
+
+
+class ProfileData(BaseModel):
+    traversal: TraversalConfig
+    output: OutputConfig
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Profile CRUD request / response
+# ─────────────────────────────────────────────────────────────────────
+
+
+class AggregationProfileCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    set_id: str | None = None
+    is_global: bool = False
+    profile_data: ProfileData
+    is_default_for_set: bool = False
+
+
+class AggregationProfileUpdate(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    set_id: str | None = None
+    is_global: bool | None = None
+    profile_data: ProfileData | None = None
+    is_default_for_set: bool | None = None
+
+
+class AggregationProfileResponse(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    set_id: str | None = None
+    set_name: str | None = None
+    is_global: bool = False
+    is_default_for_set: bool = False
+    profile_data: dict[str, object]
+    # Seeded profiles have created_by NULL (no user at migration time).
+    created_by: str | None = None
+    created_by_username: str = "Unknown"
+    created_at: str
+    updated_at: str
+
+
+class AggregationProfileListResponse(BaseModel):
+    items: list[AggregationProfileResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Run request / response
+# ─────────────────────────────────────────────────────────────────────
+
+
+class AggregationRunRequest(BaseModel):
+    profile_id: str = Field(min_length=1)
+    source_diagram_id: str = Field(min_length=1)
+
+
+class AggregationResult(BaseModel):
+    markdown: str
+    computed_at: str
+    source_versions: dict[str, int] = Field(default_factory=dict)
+    row_count: int = 0
+    warnings: list[str] = Field(default_factory=list)

--- a/backend/app/aggregation/profiles_service.py
+++ b/backend/app/aggregation/profiles_service.py
@@ -1,0 +1,250 @@
+"""CRUD service for aggregation_profiles (ADR-212, v6.20.0).
+
+Same shape as element_templates/service.py — scope rules
+(is_global ↔ set_id), JSON profile_data column, positional row access
+(Protocol §15).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from app.aggregation.exceptions import (
+    AggregationProfileInvalid,
+    AggregationProfileScopeError,
+)
+from app.aggregation.models import ProfileData
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+def _validate_scope(*, set_id: str | None, is_global: bool) -> None:
+    """is_global=True ↔ set_id is None. Otherwise reject."""
+    if is_global and set_id is not None:
+        msg = "is_global profiles must not have a set_id"
+        raise AggregationProfileScopeError(msg)
+    if not is_global and set_id is None:
+        msg = "non-global profiles require a set_id"
+        raise AggregationProfileScopeError(msg)
+
+
+def _validate_profile_data(data: dict[str, Any]) -> None:
+    """Validate the profile_data JSON against ProfileData. Raises
+    AggregationProfileInvalid on failure."""
+    try:
+        ProfileData(**data)
+    except ValidationError as exc:
+        raise AggregationProfileInvalid(str(exc)) from exc
+
+
+async def create_aggregation_profile(
+    db: DatabasePort,
+    *,
+    name: str,
+    description: str | None,
+    set_id: str | None,
+    is_global: bool,
+    profile_data: dict[str, Any],
+    is_default_for_set: bool,
+    created_by: str | None,
+) -> dict[str, Any]:
+    """Create a new profile."""
+    _validate_scope(set_id=set_id, is_global=is_global)
+    _validate_profile_data(profile_data)
+    profile_id = str(uuid.uuid4())
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "INSERT INTO aggregation_profiles ("
+        "id, name, description, set_id, is_global, profile_data, "
+        "is_default_for_set, created_by, created_at, updated_at"
+        ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            profile_id, name, description, set_id,
+            1 if is_global else 0,
+            json.dumps(profile_data),
+            1 if is_default_for_set else 0,
+            created_by, now, now,
+        ),
+    )
+    await db.commit()
+    return await get_aggregation_profile(db, profile_id)  # type: ignore[return-value]
+
+
+async def get_aggregation_profile(
+    db: DatabasePort, profile_id: str,
+) -> dict[str, Any] | None:
+    """Fetch one profile, joined with sets + users for denormalised
+    names."""
+    cursor = await db.execute(
+        "SELECT p.id, p.name, p.description, p.set_id, s.name, "
+        "p.is_global, p.is_default_for_set, p.profile_data, "
+        "p.created_by, u.username, p.created_at, p.updated_at "
+        "FROM aggregation_profiles p "
+        "LEFT JOIN sets s ON s.id = p.set_id "
+        "LEFT JOIN users u ON u.id = p.created_by "
+        "WHERE p.id = ? AND p.is_deleted = 0",
+        (profile_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return {
+        "id": row[0],
+        "name": row[1],
+        "description": row[2],
+        "set_id": row[3],
+        "set_name": row[4],
+        "is_global": bool(row[5]),
+        "is_default_for_set": bool(row[6]),
+        "profile_data": json.loads(row[7]) if row[7] else {},
+        "created_by": row[8],
+        "created_by_username": row[9] or "Unknown",
+        "created_at": row[10],
+        "updated_at": row[11],
+    }
+
+
+async def list_aggregation_profiles(
+    db: DatabasePort,
+    *,
+    set_id: str | None = None,
+    include_global: bool = True,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict[str, Any]], int]:
+    """List with set + global scope filter. Same semantics as
+    element_templates.list."""
+    where_parts = ["p.is_deleted = 0"]
+    params: list[Any] = []
+    if set_id is not None and include_global:
+        where_parts.append("(p.set_id = ? OR p.is_global = 1)")
+        params.append(set_id)
+    elif set_id is not None:
+        where_parts.append("p.set_id = ?")
+        params.append(set_id)
+    elif include_global:
+        where_parts.append("p.is_global = 1")
+    else:
+        return [], 0
+    where_sql = " AND ".join(where_parts)
+
+    count_cursor = await db.execute(
+        f"SELECT COUNT(*) FROM aggregation_profiles p WHERE {where_sql}",
+        tuple(params),
+    )
+    count_row = await count_cursor.fetchone()
+    total: int = count_row[0] if count_row else 0
+
+    offset = (page - 1) * page_size
+    list_cursor = await db.execute(
+        "SELECT p.id, p.name, p.description, p.set_id, s.name, "
+        "p.is_global, p.is_default_for_set, p.profile_data, "
+        "p.created_by, u.username, p.created_at, p.updated_at "
+        "FROM aggregation_profiles p "
+        "LEFT JOIN sets s ON s.id = p.set_id "
+        "LEFT JOIN users u ON u.id = p.created_by "
+        f"WHERE {where_sql} "
+        "ORDER BY p.is_global DESC, p.name ASC "
+        "LIMIT ? OFFSET ?",
+        (*params, page_size, offset),
+    )
+    rows = await list_cursor.fetchall()
+    items = [
+        {
+            "id": r[0],
+            "name": r[1],
+            "description": r[2],
+            "set_id": r[3],
+            "set_name": r[4],
+            "is_global": bool(r[5]),
+            "is_default_for_set": bool(r[6]),
+            "profile_data": json.loads(r[7]) if r[7] else {},
+            "created_by": r[8],
+            "created_by_username": r[9] or "Unknown",
+            "created_at": r[10],
+            "updated_at": r[11],
+        }
+        for r in rows
+    ]
+    return items, total
+
+
+async def update_aggregation_profile(
+    db: DatabasePort,
+    profile_id: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    set_id: str | None | type[Ellipsis] = ...,
+    is_global: bool | None = None,
+    profile_data: dict[str, Any] | None = None,
+    is_default_for_set: bool | None = None,
+) -> dict[str, Any] | None:
+    """Edit a profile. Profiles are not versioned."""
+    existing = await get_aggregation_profile(db, profile_id)
+    if existing is None:
+        return None
+
+    new_name = name if name is not None else existing["name"]
+    new_description = (
+        description if description is not None else existing["description"]
+    )
+    new_is_global = (
+        is_global if is_global is not None else existing["is_global"]
+    )
+    new_set_id: str | None
+    if set_id is ...:
+        new_set_id = existing["set_id"]
+    else:
+        new_set_id = set_id
+    _validate_scope(set_id=new_set_id, is_global=new_is_global)
+
+    new_data: dict[str, Any]
+    if profile_data is not None:
+        _validate_profile_data(profile_data)
+        new_data = profile_data
+    else:
+        new_data = existing["profile_data"]
+
+    new_default = (
+        is_default_for_set
+        if is_default_for_set is not None
+        else existing["is_default_for_set"]
+    )
+
+    now = datetime.now(tz=UTC).isoformat()
+    await db.execute(
+        "UPDATE aggregation_profiles SET "
+        "name = ?, description = ?, set_id = ?, is_global = ?, "
+        "profile_data = ?, is_default_for_set = ?, updated_at = ? "
+        "WHERE id = ? AND is_deleted = 0",
+        (
+            new_name, new_description, new_set_id,
+            1 if new_is_global else 0,
+            json.dumps(new_data),
+            1 if new_default else 0,
+            now,
+            profile_id,
+        ),
+    )
+    await db.commit()
+    return await get_aggregation_profile(db, profile_id)
+
+
+async def delete_aggregation_profile(
+    db: DatabasePort, profile_id: str,
+) -> bool:
+    """Soft-delete. Returns True if a row was updated."""
+    cursor = await db.execute(
+        "UPDATE aggregation_profiles SET is_deleted = 1 "
+        "WHERE id = ? AND is_deleted = 0",
+        (profile_id,),
+    )
+    await db.commit()
+    return (cursor.rowcount or 0) > 0

--- a/backend/app/aggregation/routes.py
+++ b/backend/app/aggregation/routes.py
@@ -1,0 +1,185 @@
+"""Aggregation REST endpoints (ADR-212, SPEC-212-c)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from app.aggregation import engine as _engine
+from app.aggregation.exceptions import (
+    AggregationProfileInvalid,
+    AggregationProfileNotFound,
+    AggregationProfileScopeError,
+    AggregationSourceNotFound,
+)
+from app.aggregation.models import (
+    AggregationProfileCreate,
+    AggregationProfileListResponse,
+    AggregationProfileResponse,
+    AggregationProfileUpdate,
+    AggregationResult,
+    AggregationRunRequest,
+)
+from app.aggregation.profiles_service import (
+    create_aggregation_profile,
+    delete_aggregation_profile,
+    get_aggregation_profile,
+    list_aggregation_profiles,
+    update_aggregation_profile,
+)
+from app.auth.dependencies import get_current_user, get_optional_user
+
+router = APIRouter(prefix="/api/aggregation", tags=["aggregation"])
+
+
+# ── Profile CRUD ──────────────────────────────────────────────────────
+
+
+@router.post(
+    "/profiles",
+    response_model=AggregationProfileResponse,
+    status_code=201,
+)
+async def create(
+    body: AggregationProfileCreate,
+    request: Request,
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> AggregationProfileResponse:
+    """Create an aggregation profile."""
+    db = request.app.state.db_manager.main_db
+    try:
+        result = await create_aggregation_profile(
+            db,
+            name=body.name,
+            description=body.description,
+            set_id=body.set_id,
+            is_global=body.is_global,
+            profile_data=body.profile_data.model_dump(),
+            is_default_for_set=body.is_default_for_set,
+            created_by=current_user["id"],
+        )
+    except AggregationProfileScopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    except AggregationProfileInvalid as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    return AggregationProfileResponse(**result)
+
+
+@router.get("/profiles", response_model=AggregationProfileListResponse)
+async def list_all(
+    request: Request,
+    set_id: str | None = None,
+    include_global: bool = True,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=100),
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> AggregationProfileListResponse:
+    """List in-scope aggregation profiles."""
+    db = request.app.state.db_manager.main_db
+    items, total = await list_aggregation_profiles(
+        db,
+        set_id=set_id,
+        include_global=include_global,
+        page=page,
+        page_size=page_size,
+    )
+    return AggregationProfileListResponse(
+        items=[AggregationProfileResponse(**i) for i in items],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get(
+    "/profiles/{profile_id}", response_model=AggregationProfileResponse,
+)
+async def get_one(
+    profile_id: str,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> AggregationProfileResponse:
+    """Fetch a single profile."""
+    db = request.app.state.db_manager.main_db
+    result = await get_aggregation_profile(db, profile_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return AggregationProfileResponse(**result)
+
+
+@router.put(
+    "/profiles/{profile_id}", response_model=AggregationProfileResponse,
+)
+async def update(
+    profile_id: str,
+    body: AggregationProfileUpdate,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> AggregationProfileResponse:
+    """Edit a profile."""
+    db = request.app.state.db_manager.main_db
+    raw = body.model_dump(exclude_unset=True)
+    kwargs: dict[str, Any] = {}
+    if "name" in raw:
+        kwargs["name"] = raw["name"]
+    if "description" in raw:
+        kwargs["description"] = raw["description"]
+    if "is_global" in raw:
+        kwargs["is_global"] = raw["is_global"]
+    if "set_id" in raw:
+        kwargs["set_id"] = raw["set_id"]  # may be None
+    if "profile_data" in raw:
+        kwargs["profile_data"] = raw["profile_data"]
+    if "is_default_for_set" in raw:
+        kwargs["is_default_for_set"] = raw["is_default_for_set"]
+    try:
+        result = await update_aggregation_profile(db, profile_id, **kwargs)
+    except AggregationProfileScopeError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    except AggregationProfileInvalid as exc:
+        raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
+    if result is None:
+        raise HTTPException(status_code=404, detail="Profile not found")
+    return AggregationProfileResponse(**result)
+
+
+@router.delete("/profiles/{profile_id}", status_code=204)
+async def delete(
+    profile_id: str,
+    request: Request,
+    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+) -> None:
+    """Soft-delete a profile."""
+    db = request.app.state.db_manager.main_db
+    ok = await delete_aggregation_profile(db, profile_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Profile not found")
+
+
+# ── Run (read-shaped despite POST) ─────────────────────────────────────
+
+
+@router.post("/run", response_model=AggregationResult)
+async def run_aggregation(
+    body: AggregationRunRequest,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> AggregationResult:
+    """Apply a profile to a source smart-markdown diagram. Returns the
+    computed markdown and observed source versions."""
+    db = request.app.state.db_manager.main_db
+    try:
+        return await _engine.run(
+            db,
+            profile_id=body.profile_id,
+            source_diagram_id=body.source_diagram_id,
+        )
+    except AggregationProfileNotFound:
+        raise HTTPException(  # noqa: B904
+            status_code=404, detail="Profile not found",
+        )
+    except AggregationSourceNotFound:
+        raise HTTPException(  # noqa: B904
+            status_code=404, detail="Source diagram not found",
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.diagrams.registry_router import router as registry_router
 from app.diagrams.router import admin_router as admin_thumbnails_router
 from app.diagrams.router import diagram_rel_router
 from app.diagrams.router import router as diagrams_router
+from app.aggregation.routes import router as aggregation_router
 from app.docref.router import router as docref_router
 from app.element_templates.router import router as element_templates_router
 from app.elements.router import router as elements_router
@@ -179,6 +180,7 @@ def create_app(config: AppConfig | None = None) -> FastAPI:
     app.include_router(oauth_router)  # ADR-164, v6.0.0
     app.include_router(elements_router)
     app.include_router(element_templates_router)  # ADR-191, v6.8.0
+    app.include_router(aggregation_router)  # ADR-212, v6.20.0
     app.include_router(relationships_router)
     app.include_router(diagrams_router)
     app.include_router(diagram_rel_router)

--- a/backend/app/migrations/m076_aggregation_profiles.py
+++ b/backend/app/migrations/m076_aggregation_profiles.py
@@ -1,0 +1,45 @@
+"""Migration 076: ``aggregation_profiles`` table (ADR-212, issue #211).
+
+Generic library of aggregation rulesets. Profiles drive the
+aggregation engine (``backend/app/aggregation/``) — same shape as
+element_templates for scope semantics (is_global ↔ set_id).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m076_aggregation_profiles"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — CREATE TABLE IF NOT EXISTS."""
+    await db.execute("""
+        CREATE TABLE IF NOT EXISTS aggregation_profiles (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            description TEXT,
+            set_id TEXT REFERENCES sets(id),
+            is_global INTEGER NOT NULL DEFAULT 0,
+            profile_data TEXT NOT NULL,
+            is_default_for_set INTEGER NOT NULL DEFAULT 0,
+            created_by TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_deleted INTEGER NOT NULL DEFAULT 0,
+            CHECK ((is_global = 1 AND set_id IS NULL)
+                OR (is_global = 0 AND set_id IS NOT NULL))
+        )
+    """)
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agg_profiles_set "
+        "ON aggregation_profiles(set_id) WHERE is_deleted = 0",
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agg_profiles_global "
+        "ON aggregation_profiles(is_global) WHERE is_deleted = 0",
+    )
+    await db.commit()

--- a/backend/app/migrations/m077_seed_global_aggregation_profiles.py
+++ b/backend/app/migrations/m077_seed_global_aggregation_profiles.py
@@ -1,0 +1,225 @@
+"""Migration 077: seed five global aggregation profiles (ADR-212).
+
+Ships the canonical "Shopping list / Sprint points rollup / Time
+tracker rollup / Expense report / Reading log rollup" profiles paired
+1-for-1 with the element-template stamps seeded in m075 (ADR-211).
+
+Each profile is a generic ruleset that drives the aggregation engine
+(``backend/app/aggregation/``). The engine knows nothing about the
+domain; the profile encodes which attribute carries the value to sum,
+which (if any) groups items into buckets, and how to format output.
+
+Idempotent via INSERT OR IGNORE with deterministic UUIDv5 ids.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m077_seed_global_aggregation_profiles"
+
+_PROFILE_NAMESPACE = uuid.UUID("c1f5b6e0-1b4e-4f1c-9a2d-212212212212")
+
+
+def profile_id_for(name: str) -> str:
+    """Stable UUIDv5 across SQLite and Supabase. Matches m082."""
+    return str(uuid.uuid5(_PROFILE_NAMESPACE, f"global-profile:{name}"))
+
+
+# Shared output bits.
+_LINE_FORMAT = (
+    "- [{element.name}](iris://element/{element.id}) "
+    "— {sum_value}{bucket_spaced}"
+)
+_BREAKDOWN_FORMAT = " ({sources_joined})"
+
+
+SEEDED_PROFILES: list[dict] = [
+    {
+        "name": "Shopping list",
+        "description": (
+            "Sum ingredient quantities across the recipes referenced by "
+            "a meal-plan diagram. Scales by per-meal diner count divided "
+            "by the recipe's `data.servings`. Groups output by aisle "
+            "(the ingredient's package_name). Pairs with the 'Quantified "
+            "item' element template (ADR-211)."
+        ),
+        "profile_data": {
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                    "multiplier": {
+                        "from_attribute_override":
+                            "attributes/Diners/type",
+                        "divisor_from_diagram_data": "data.servings",
+                        "default_multiplier": 1,
+                    },
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": "attributes/Unit/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": _LINE_FORMAT,
+                "show_per_source_breakdown": True,
+                "breakdown_format": _BREAKDOWN_FORMAT,
+            },
+        },
+    },
+    {
+        "name": "Sprint points rollup",
+        "description": (
+            "Sum story-points across the stories referenced by a sprint "
+            "backlog diagram. Groups by element.package_name (commonly "
+            "the team). Pairs with the 'Sized story' template (ADR-211)."
+        ),
+        "profile_data": {
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Points/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": _LINE_FORMAT,
+                "show_per_source_breakdown": False,
+                "breakdown_format": _BREAKDOWN_FORMAT,
+            },
+        },
+    },
+    {
+        "name": "Time tracker rollup",
+        "description": (
+            "Sum logged hours across the daily-log diagrams referenced "
+            "by a period-of-time diagram. Groups by element.package_name "
+            "(commonly the client or project). Pairs with the 'Logged "
+            "work' template (ADR-211)."
+        ),
+        "profile_data": {
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Hours/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": _LINE_FORMAT,
+                "show_per_source_breakdown": False,
+                "breakdown_format": _BREAKDOWN_FORMAT,
+            },
+        },
+    },
+    {
+        "name": "Expense report",
+        "description": (
+            "Sum expense amounts across the receipt diagrams referenced "
+            "by a reporting-period diagram. Bucketed by currency, "
+            "grouped by element.package_name (commonly the category). "
+            "Pairs with the 'Line item' template (ADR-211)."
+        ),
+        "profile_data": {
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Amount/type",
+                    "bucket_attribute_path": "attributes/Currency/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": _LINE_FORMAT,
+                "show_per_source_breakdown": False,
+                "breakdown_format": _BREAKDOWN_FORMAT,
+            },
+        },
+    },
+    {
+        "name": "Reading log rollup",
+        "description": (
+            "Sum pages read across the reading-log diagrams in a "
+            "reading period. Groups by author (a structured element "
+            "attribute). Pairs with the 'Read entry' template (ADR-211)."
+        ),
+        "profile_data": {
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Pages/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.attributes.Author/type",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": _LINE_FORMAT,
+                "show_per_source_breakdown": False,
+                "breakdown_format": _BREAKDOWN_FORMAT,
+            },
+        },
+    },
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    now = datetime.now(tz=UTC).isoformat()
+    for profile in SEEDED_PROFILES:
+        await db.execute(
+            "INSERT OR IGNORE INTO aggregation_profiles ("
+            "id, name, description, set_id, is_global, profile_data, "
+            "is_default_for_set, created_by, created_at, updated_at"
+            ") VALUES (?, ?, ?, NULL, 1, ?, 0, NULL, ?, ?)",
+            (
+                profile_id_for(profile["name"]),
+                profile["name"],
+                profile["description"],
+                json.dumps(profile["profile_data"]),
+                now,
+                now,
+            ),
+        )
+    await db.commit()

--- a/backend/app/migrations/supabase/m081_aggregation_profiles.sql
+++ b/backend/app/migrations/supabase/m081_aggregation_profiles.sql
@@ -1,0 +1,31 @@
+-- Migration 081: aggregation_profiles table (ADR-212).
+--
+-- Mirrors SQLite m076. JSONB for profile_data, BOOLEAN literals,
+-- TIMESTAMPTZ for created_at/updated_at per Protocol §15 and the
+-- feedback_supabase_created_at_type memory.
+--
+-- Idempotent via IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS public.aggregation_profiles (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    set_id TEXT REFERENCES public.sets(id),
+    is_global BOOLEAN NOT NULL DEFAULT FALSE,
+    profile_data JSONB NOT NULL,
+    is_default_for_set BOOLEAN NOT NULL DEFAULT FALSE,
+    created_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    CHECK ((is_global = TRUE AND set_id IS NULL)
+        OR (is_global = FALSE AND set_id IS NOT NULL))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agg_profiles_set
+    ON public.aggregation_profiles(set_id)
+    WHERE is_deleted = FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_agg_profiles_global
+    ON public.aggregation_profiles(is_global)
+    WHERE is_deleted = FALSE;

--- a/backend/app/migrations/supabase/m082_seed_global_aggregation_profiles.sql
+++ b/backend/app/migrations/supabase/m082_seed_global_aggregation_profiles.sql
@@ -1,0 +1,38 @@
+-- Migration 082: seed five global aggregation profiles (ADR-212).
+-- Mirrors SQLite m077. Idempotent via ON CONFLICT (id) DO NOTHING.
+
+INSERT INTO public.aggregation_profiles (
+    id, name, description, set_id, is_global, profile_data,
+    is_default_for_set, created_by, created_at, updated_at
+) VALUES
+    ('f0f2f8e8-345c-590b-a4f3-7ed320a9c8da',
+     'Shopping list',
+     'Sum ingredient quantities across the recipes referenced by a meal-plan diagram. Scales by per-meal diner count divided by the recipe''s `data.servings`. Groups output by aisle (the ingredient''s package_name). Pairs with the ''Quantified item'' element template (ADR-211).',
+     NULL, TRUE,
+     '{"traversal": {"outer": {"collect_token_type": "diagram", "multiplier": {"from_attribute_override": "attributes/Diners/type", "divisor_from_diagram_data": "data.servings", "default_multiplier": 1}}, "inner": {"collect_token_type": "element", "value_attribute_path": "attributes/Quantity/type", "bucket_attribute_path": "attributes/Unit/type", "skip_blank_values": true}}, "output": {"group_by": "element.package_name", "sort_groups": "alpha", "sort_items_within_group": "alpha", "aggregation_fn": "sum", "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}", "show_per_source_breakdown": true, "breakdown_format": " ({sources_joined})"}}'::jsonb,
+     FALSE, NULL, NOW(), NOW()),
+    ('8a41b9cb-41f0-54b8-a1eb-51e09340baf1',
+     'Sprint points rollup',
+     'Sum story-points across the stories referenced by a sprint backlog diagram. Groups by element.package_name (commonly the team). Pairs with the ''Sized story'' template (ADR-211).',
+     NULL, TRUE,
+     '{"traversal": {"outer": {"collect_token_type": "diagram"}, "inner": {"collect_token_type": "element", "value_attribute_path": "attributes/Points/type", "bucket_attribute_path": null, "skip_blank_values": true}}, "output": {"group_by": "element.package_name", "sort_groups": "alpha", "sort_items_within_group": "alpha", "aggregation_fn": "sum", "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}", "show_per_source_breakdown": false, "breakdown_format": " ({sources_joined})"}}'::jsonb,
+     FALSE, NULL, NOW(), NOW()),
+    ('fae0ac43-0be7-5a01-b6ab-30e959c5ce13',
+     'Time tracker rollup',
+     'Sum logged hours across the daily-log diagrams referenced by a period-of-time diagram. Groups by element.package_name (commonly the client or project). Pairs with the ''Logged work'' template (ADR-211).',
+     NULL, TRUE,
+     '{"traversal": {"outer": {"collect_token_type": "diagram"}, "inner": {"collect_token_type": "element", "value_attribute_path": "attributes/Hours/type", "bucket_attribute_path": null, "skip_blank_values": true}}, "output": {"group_by": "element.package_name", "sort_groups": "alpha", "sort_items_within_group": "alpha", "aggregation_fn": "sum", "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}", "show_per_source_breakdown": false, "breakdown_format": " ({sources_joined})"}}'::jsonb,
+     FALSE, NULL, NOW(), NOW()),
+    ('834d031f-95cb-5e39-8730-a42fd3e4b318',
+     'Expense report',
+     'Sum expense amounts across the receipt diagrams referenced by a reporting-period diagram. Bucketed by currency, grouped by element.package_name (commonly the category). Pairs with the ''Line item'' template (ADR-211).',
+     NULL, TRUE,
+     '{"traversal": {"outer": {"collect_token_type": "diagram"}, "inner": {"collect_token_type": "element", "value_attribute_path": "attributes/Amount/type", "bucket_attribute_path": "attributes/Currency/type", "skip_blank_values": true}}, "output": {"group_by": "element.package_name", "sort_groups": "alpha", "sort_items_within_group": "alpha", "aggregation_fn": "sum", "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}", "show_per_source_breakdown": false, "breakdown_format": " ({sources_joined})"}}'::jsonb,
+     FALSE, NULL, NOW(), NOW()),
+    ('5c6b2c26-1ae3-55d6-aa65-e001546ffda2',
+     'Reading log rollup',
+     'Sum pages read across the reading-log diagrams in a reading period. Groups by author (a structured element attribute). Pairs with the ''Read entry'' template (ADR-211).',
+     NULL, TRUE,
+     '{"traversal": {"outer": {"collect_token_type": "diagram"}, "inner": {"collect_token_type": "element", "value_attribute_path": "attributes/Pages/type", "bucket_attribute_path": null, "skip_blank_values": true}}, "output": {"group_by": "element.attributes.Author/type", "sort_groups": "alpha", "sort_items_within_group": "alpha", "aggregation_fn": "sum", "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}", "show_per_source_breakdown": false, "breakdown_format": " ({sources_joined})"}}'::jsonb,
+     FALSE, NULL, NOW(), NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -79,6 +79,8 @@ from app.migrations.m072_sets_element_tab_default import up as m072_up
 from app.migrations.m073_entity_images import up as m073_up
 from app.migrations.m074_element_template_markdown_stamp import up as m074_up
 from app.migrations.m075_seed_global_element_template_stamps import up as m075_up
+from app.migrations.m076_aggregation_profiles import up as m076_up
+from app.migrations.m077_seed_global_aggregation_profiles import up as m077_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -185,6 +187,8 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m073_up(main)  # issue #194, v6.17.0: entity_images junction table (ADR-209)
     await m074_up(main)  # issue #211, v6.19.0: element_templates.markdown_stamp (ADR-211)
     await m075_up(main)  # issue #211, v6.19.0: seed 5 global element-template stamps (ADR-211)
+    await m076_up(main)  # issue #211, v6.20.0: aggregation_profiles table (ADR-212)
+    await m077_up(main)  # issue #211, v6.20.0: seed 5 global aggregation profiles (ADR-212)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.19.0"
+version = "6.20.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_aggregation/test_engine.py
+++ b/backend/tests/test_aggregation/test_engine.py
@@ -1,0 +1,499 @@
+"""Engine compute tests (ADR-212, SPEC-212-b)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.aggregation import engine as _engine
+from app.aggregation.exceptions import (
+    AggregationProfileNotFound,
+    AggregationSourceNotFound,
+)
+from app.aggregation.profiles_service import (
+    create_aggregation_profile,
+)
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def env(app_config: AppConfig) -> AsyncIterator[tuple[httpx.AsyncClient, DatabaseManager, dict]]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/api/auth/setup",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        resp = await c.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        h = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        yield c, db_manager, h
+    await db_manager.close()
+
+
+async def _create_set(c, h, name="S") -> str:
+    r = await c.post("/api/sets", json={"name": name}, headers=h)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _create_package(c, h, set_id, name) -> str:
+    r = await c.post(
+        "/api/packages",
+        json={"name": name, "set_id": set_id},
+        headers=h,
+    )
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+async def _create_element(c, h, *, set_id, name, package_id=None, data=None) -> str:
+    body = {
+        "name": name, "element_type": "class", "set_id": set_id,
+    }
+    if data is not None:
+        body["data"] = data
+    if package_id is not None:
+        body["package_id"] = package_id
+    r = await c.post("/api/elements", json=body, headers=h)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _create_smart_md(c, h, set_id, source, name="SMD", servings=None) -> str:
+    data = {"markdown_source": source}
+    if servings is not None:
+        data["servings"] = servings
+    r = await c.post(
+        "/api/diagrams",
+        json={
+            "name": name, "set_id": set_id,
+            "diagram_type": "smart_markdown",
+            "notation": "markdown",
+            "data": data,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+_ATTR_BLUEPRINT = {
+    "attributes": [
+        {"name": "Quantity", "type": "", "scope": "Public",
+         "notes": "", "lower_bound": "", "upper_bound": ""},
+        {"name": "Unit", "type": "g", "scope": "Public",
+         "notes": "", "lower_bound": "", "upper_bound": ""},
+    ],
+}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Single-level walk
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_single_level_sum_one_element(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince", data=_ATTR_BLUEPRINT,
+    )
+    diag_id = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}}",
+    )
+    # Profile: walk inner only, no bucket, group_by element.name
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Test single",
+        description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+                "show_per_source_breakdown": False,
+                "breakdown_format": "",
+            },
+        },
+        is_default_for_set=False,
+        created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db,
+        profile_id=profile["id"],
+        source_diagram_id=diag_id,
+    )
+    assert "Pork mince: 500" in result.markdown
+    assert result.row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_single_level_sum_same_element_twice(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Two references to the same element with same unit → summed."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince", data=_ATTR_BLUEPRINT,
+    )
+    source = (
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}\n"
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}"
+    )
+    diag_id = await _create_smart_md(c, h, set_id, source)
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Sum with bucket", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": "attributes/Unit/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}{bucket_spaced}",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    # 500 + 500 = 1000 g
+    assert "Pork mince: 1000 g" in result.markdown
+    assert result.row_count == 1
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Two-level walk + multiplier
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_two_level_walk_with_multiplier(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Meal plan referencing two recipes, each contributing 500 g of
+    pork mince — recipe A scaled ×1.5 (diners=6, servings=4)."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince", data=_ATTR_BLUEPRINT,
+    )
+    rec_a = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}",
+        name="Recipe A", servings=4,
+    )
+    rec_b = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}",
+        name="Recipe B", servings=4,
+    )
+    # Meal plan: recipe A with Diners=6 override, recipe B with default 1
+    meal_plan = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{diagram:{rec_a}:attr:attributes/Diners/type=6}}}}\n"
+        f"- {{{{diagram:{rec_b}}}}}",
+        name="Meal plan",
+    )
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Two-level test", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                    "multiplier": {
+                        "from_attribute_override": "attributes/Diners/type",
+                        "divisor_from_diagram_data": "data.servings",
+                        "default_multiplier": 1,
+                    },
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": "attributes/Unit/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}{bucket_spaced}",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=meal_plan,
+    )
+    # A: 500 × (6/4) = 750; B: 500 × 1 = 500; total = 1250 g.
+    assert "Pork mince: 1250 g" in result.markdown
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Mixed buckets → two lines
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mixed_units_emit_two_lines(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Two different elements with different stored Units → two
+    bucket-grouped lines (no cross-unit conversion per Q3)."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince",
+        data={"attributes": [
+            {"name": "Quantity", "type": "", "scope": "Public",
+             "notes": "", "lower_bound": "", "upper_bound": ""},
+            {"name": "Unit", "type": "g", "scope": "Public",
+             "notes": "", "lower_bound": "", "upper_bound": ""},
+        ]},
+    )
+    butter_id = await _create_element(
+        c, h, set_id=set_id, name="Butter",
+        data={"attributes": [
+            {"name": "Quantity", "type": "", "scope": "Public",
+             "notes": "", "lower_bound": "", "upper_bound": ""},
+            {"name": "Unit", "type": "tbsp", "scope": "Public",
+             "notes": "", "lower_bound": "", "upper_bound": ""},
+        ]},
+    )
+    source = (
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}}\n"
+        f"- {{{{element:{butter_id}:attr:attributes/Quantity/type=2}}}}"
+    )
+    diag_id = await _create_smart_md(c, h, set_id, source)
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Mixed buckets", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": "attributes/Unit/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}{bucket_spaced}",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    # Two lines — one per element/unit pair; no cross-unit normalisation.
+    assert "Pork mince: 500 g" in result.markdown
+    assert "Butter: 2 tbsp" in result.markdown
+    assert result.row_count == 2
+
+
+# ─────────────────────────────────────────────────────────────────────
+# group_by package_name
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_group_by_package_name(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    aisle_meat = await _create_package(c, h, set_id, "Meat & Poultry")
+    aisle_produce = await _create_package(c, h, set_id, "Produce")
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince",
+        package_id=aisle_meat, data=_ATTR_BLUEPRINT,
+    )
+    carrot_id = await _create_element(
+        c, h, set_id=set_id, name="Carrot",
+        package_id=aisle_produce, data=_ATTR_BLUEPRINT,
+    )
+    source = (
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}}\n"
+        f"- {{{{element:{carrot_id}:attr:attributes/Quantity/type=3}}}}"
+    )
+    diag_id = await _create_smart_md(c, h, set_id, source)
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Group by aisle", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    # Two ## groups, alpha-sorted: Meat & Poultry, Produce.
+    md = result.markdown
+    assert "## Meat & Poultry" in md
+    assert "## Produce" in md
+    assert md.index("## Meat & Poultry") < md.index("## Produce")
+    assert "Pork mince: 500" in md
+    assert "Carrot: 3" in md
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Errors
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_missing_profile_raises(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    _, dm, _ = env
+    with pytest.raises(AggregationProfileNotFound):
+        await _engine.run(
+            dm.main_db,
+            profile_id="00000000-0000-0000-0000-000000000000",
+            source_diagram_id="00000000-0000-0000-0000-000000000000",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_missing_source_raises(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Test missing-source", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {"line_format": "- {element.name}"},
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    with pytest.raises(AggregationSourceNotFound):
+        await _engine.run(
+            dm.main_db,
+            profile_id=profile["id"],
+            source_diagram_id="00000000-0000-0000-0000-000000000000",
+        )
+
+
+@pytest.mark.asyncio
+async def test_blank_value_skipped(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince", data=_ATTR_BLUEPRINT,
+    )
+    # Fillable slot (=) — empty, should be skipped.
+    diag_id = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=}}}}",
+    )
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Skip blanks", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {"line_format": "- {element.name}"},
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    assert result.row_count == 0

--- a/backend/tests/test_aggregation/test_profile_crud.py
+++ b/backend/tests/test_aggregation/test_profile_crud.py
@@ -1,0 +1,232 @@
+"""CRUD tests for aggregation profiles (ADR-212, SPEC-212-a)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True, cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1, argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(c: httpx.AsyncClient) -> dict:
+    await c.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await c.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _create_set(c, h) -> str:
+    r = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    assert r.status_code == 201
+    return r.json()["id"]
+
+
+_VALID_PD = {
+    "traversal": {
+        "inner": {
+            "collect_token_type": "element",
+            "value_attribute_path": "attributes/Quantity/type",
+            "skip_blank_values": True,
+        },
+    },
+    "output": {
+        "group_by": "element.name",
+        "line_format": "- {element.name}: {sum_value}",
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_create_global_profile(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    r = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Global test", "is_global": True,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["is_global"] is True
+    assert body["set_id"] is None
+    assert body["profile_data"]["traversal"]["inner"]["collect_token_type"] == "element"
+
+
+@pytest.mark.asyncio
+async def test_create_set_scoped_profile(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    sid = await _create_set(client, h)
+    r = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Set test", "set_id": sid, "is_global": False,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201
+    assert r.json()["set_id"] == sid
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_mixed_scope(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    sid = await _create_set(client, h)
+    r = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Bad", "set_id": sid, "is_global": True,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_profile_data(
+    client: httpx.AsyncClient,
+) -> None:
+    h = await _auth(client)
+    r = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Bad data", "is_global": True,
+            "profile_data": {"traversal": {}, "output": {}},  # missing inner
+        },
+        headers=h,
+    )
+    # Pydantic catches at the FastAPI layer.
+    assert r.status_code in (422, 400)
+
+
+@pytest.mark.asyncio
+async def test_list_includes_seeded_globals(
+    client: httpx.AsyncClient,
+) -> None:
+    """ADR-212 ships five seeded global profiles (m077 / m082)."""
+    h = await _auth(client)
+    r = await client.get(
+        "/api/aggregation/profiles?include_global=true", headers=h,
+    )
+    assert r.status_code == 200
+    names = {p["name"] for p in r.json()["items"]}
+    assert {
+        "Shopping list", "Sprint points rollup", "Time tracker rollup",
+        "Expense report", "Reading log rollup",
+    } <= names
+
+
+@pytest.mark.asyncio
+async def test_get_one(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    create = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Fetchable", "is_global": True,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    pid = create.json()["id"]
+    r = await client.get(f"/api/aggregation/profiles/{pid}", headers=h)
+    assert r.status_code == 200
+    assert r.json()["name"] == "Fetchable"
+
+
+@pytest.mark.asyncio
+async def test_update_profile_data(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    create = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Updatable", "is_global": True,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    pid = create.json()["id"]
+    new_pd = {
+        "traversal": {
+            "inner": {
+                "collect_token_type": "element",
+                "value_attribute_path": "attributes/Points/type",
+                "skip_blank_values": True,
+            },
+        },
+        "output": {
+            "group_by": "element.package_name",
+            "line_format": "- {element.name}: {sum_value} pts",
+        },
+    }
+    r = await client.put(
+        f"/api/aggregation/profiles/{pid}",
+        json={"profile_data": new_pd, "description": "now for points"},
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert (
+        r.json()["profile_data"]["traversal"]["inner"]["value_attribute_path"]
+        == "attributes/Points/type"
+    )
+    assert r.json()["description"] == "now for points"
+
+
+@pytest.mark.asyncio
+async def test_delete_soft_deletes(client: httpx.AsyncClient) -> None:
+    h = await _auth(client)
+    create = await client.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Deletable", "is_global": True,
+            "profile_data": _VALID_PD,
+        },
+        headers=h,
+    )
+    pid = create.json()["id"]
+    r = await client.delete(f"/api/aggregation/profiles/{pid}", headers=h)
+    assert r.status_code == 204
+    # Get returns 404 after delete.
+    r = await client.get(f"/api/aggregation/profiles/{pid}", headers=h)
+    assert r.status_code == 404

--- a/backend/tests/test_aggregation/test_seeded_profiles_smoke.py
+++ b/backend/tests/test_aggregation/test_seeded_profiles_smoke.py
@@ -1,0 +1,111 @@
+"""Smoke test: every seeded global aggregation profile is valid and
+the engine accepts it against a minimal source diagram. ADR-212.
+
+Doesn't assert specific output (each profile's output shape is its
+own concern) — just that profile_data parses against ProfileData and
+the engine runs without raising.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.aggregation import engine as _engine
+from app.aggregation.models import ProfileData
+from app.aggregation.profiles_service import list_aggregation_profiles
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True, cors_origins=[],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1, argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def env(app_config: AppConfig) -> AsyncIterator[tuple[httpx.AsyncClient, DatabaseManager, dict]]:
+    application = create_app(app_config)
+    dm = DatabaseManager(app_config)
+    await initialize_databases(dm)
+    application.state.db_manager = dm
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/api/auth/setup",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        resp = await c.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        h = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        yield c, dm, h
+    await dm.close()
+
+
+@pytest.mark.asyncio
+async def test_all_five_seeded_profiles_validate_and_run(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, dm, h = env
+    items, _ = await list_aggregation_profiles(
+        dm.main_db, set_id=None, include_global=True, page=1, page_size=100,
+    )
+    seeded = {p["name"] for p in items}
+    assert {
+        "Shopping list", "Sprint points rollup", "Time tracker rollup",
+        "Expense report", "Reading log rollup",
+    } <= seeded
+    # 1. Validate the JSON shape.
+    for p in items:
+        ProfileData(**p["profile_data"])  # raises if invalid
+
+    # 2. Build a minimal source diagram and run each profile.
+    set_resp = await c.post("/api/sets", json={"name": "Smoke"}, headers=h)
+    set_id = set_resp.json()["id"]
+    diag_resp = await c.post(
+        "/api/diagrams",
+        json={
+            "name": "Empty source", "set_id": set_id,
+            "diagram_type": "smart_markdown", "notation": "markdown",
+            "data": {"markdown_source": "", "servings": 1},
+        },
+        headers=h,
+    )
+    assert diag_resp.status_code == 201
+    diag_id = diag_resp.json()["id"]
+
+    for p in items:
+        if p["name"] not in {
+            "Shopping list", "Sprint points rollup",
+            "Time tracker rollup", "Expense report",
+            "Reading log rollup",
+        }:
+            continue
+        # Run; should not raise. Empty source → empty markdown is OK.
+        result = await _engine.run(
+            dm.main_db,
+            profile_id=p["id"],
+            source_diagram_id=diag_id,
+        )
+        assert result.row_count == 0, (
+            f"Profile '{p['name']}' against empty source returned "
+            f"{result.row_count} rows (expected 0)."
+        )

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -41,6 +41,10 @@ element_templates_app = typer.Typer(
     help="Element template commands (v6.8.0, ADR-191).",
     no_args_is_help=True,
 )
+aggregation_profile_app = typer.Typer(
+    help="Aggregation profile commands (v6.20.0, ADR-212).",
+    no_args_is_help=True,
+)
 packages_app = typer.Typer(help="Package commands.", no_args_is_help=True)
 sets_app = typer.Typer(help="Set commands.", no_args_is_help=True)
 collections_app = typer.Typer(help="Collection commands.", no_args_is_help=True)
@@ -60,6 +64,7 @@ render_app = typer.Typer(help="Render diagrams or markdown to md/docx/pdf artefa
 app.add_typer(diagrams_app, name="diagrams")
 app.add_typer(elements_app, name="elements")
 app.add_typer(element_templates_app, name="element-templates")
+app.add_typer(aggregation_profile_app, name="aggregation-profile")
 app.add_typer(packages_app, name="packages")
 app.add_typer(sets_app, name="sets")
 app.add_typer(collections_app, name="collections")
@@ -1302,6 +1307,162 @@ def delete_element_template_cmd(
                 "DELETE", f"/api/element-templates/{template_id}",
             )
             return {"deleted": True, "template_id": template_id}
+    output.print_json(_run(_do()))
+
+
+# ── iris aggregation-profile + iris aggregate (v6.20.0, ADR-212) ─────────
+
+
+@aggregation_profile_app.command("list")
+def aggregation_profile_list_cmd(
+    set_id: str | None = typer.Option(None, "--set-id"),
+    include_global: bool = typer.Option(True, "--include-global/--no-global"),
+    page: int = typer.Option(1, "--page"),
+    page_size: int = typer.Option(50, "--page-size"),
+) -> None:
+    """List aggregation profiles."""
+    async def _do() -> Any:
+        async with _client() as c:
+            params: dict[str, Any] = {
+                "page": page, "page_size": page_size,
+                "include_global": include_global,
+            }
+            if set_id is not None:
+                params["set_id"] = set_id
+            resp = await c._request(
+                "GET", "/api/aggregation/profiles", params=params,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@aggregation_profile_app.command("get")
+def aggregation_profile_get_cmd(profile_id: str) -> None:
+    """Fetch one aggregation profile."""
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "GET", f"/api/aggregation/profiles/{profile_id}",
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@create_app.command("aggregation-profile")
+def create_aggregation_profile_cmd(
+    name: str = typer.Option(..., "--name"),
+    profile_data_file: str = typer.Option(
+        ..., "--profile-data-file",
+        help="Path to JSON file containing the profile_data ruleset.",
+    ),
+    set_id: str | None = typer.Option(None, "--set-id"),
+    is_global: bool = typer.Option(False, "--global/--no-global"),
+    description: str | None = typer.Option(None, "--description"),
+    is_default_for_set: bool = typer.Option(
+        False, "--default-for-set/--no-default-for-set",
+    ),
+) -> None:
+    """Create an aggregation profile (ADR-212)."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    body: dict[str, Any] = {
+        "name": name, "is_global": is_global,
+        "is_default_for_set": is_default_for_set,
+        "profile_data": _json.loads(_Path(profile_data_file).read_text()),
+    }
+    if description is not None:
+        body["description"] = description
+    if set_id is not None:
+        body["set_id"] = set_id
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/aggregation/profiles", json=body,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@update_app.command("aggregation-profile")
+def update_aggregation_profile_cmd(
+    profile_id: str = typer.Argument(...),
+    name: str | None = typer.Option(None, "--name"),
+    description: str | None = typer.Option(None, "--description"),
+    profile_data_file: str | None = typer.Option(None, "--profile-data-file"),
+    set_id: str | None = typer.Option(
+        None, "--set-id",
+        help="New set scope. 'null' to promote to global.",
+    ),
+    is_global: bool | None = typer.Option(None, "--global/--no-global"),
+    is_default_for_set: bool | None = typer.Option(
+        None, "--default-for-set/--no-default-for-set",
+    ),
+) -> None:
+    """Update an aggregation profile (ADR-212)."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if description is not None:
+        body["description"] = description
+    if profile_data_file is not None:
+        body["profile_data"] = _json.loads(_Path(profile_data_file).read_text())
+    if set_id is not None:
+        body["set_id"] = _resolve_null(set_id)
+    if is_global is not None:
+        body["is_global"] = is_global
+    if is_default_for_set is not None:
+        body["is_default_for_set"] = is_default_for_set
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "PUT", f"/api/aggregation/profiles/{profile_id}", json=body,
+            )
+            return resp.json()
+    output.print_json(_run(_do()))
+
+
+@delete_app.command("aggregation-profile")
+def delete_aggregation_profile_cmd(profile_id: str = typer.Argument(...)) -> None:
+    """Soft-delete an aggregation profile (ADR-212)."""
+    async def _do() -> Any:
+        async with _client() as c:
+            await c._request(
+                "DELETE", f"/api/aggregation/profiles/{profile_id}",
+            )
+            return {"deleted": True, "profile_id": profile_id}
+    output.print_json(_run(_do()))
+
+
+@app.command("aggregate")
+def aggregate_cmd(
+    profile: str = typer.Option(
+        ..., "--profile",
+        help="Profile id (UUID).",
+    ),
+    source: str = typer.Option(
+        ..., "--source",
+        help="Source smart_markdown diagram id (UUID).",
+    ),
+) -> None:
+    """Run an aggregation profile against a source diagram (ADR-212).
+
+    Returns the computed markdown plus metadata. Equivalent to
+    `POST /api/aggregation/run`.
+    """
+    body = {"profile_id": profile, "source_diagram_id": source}
+
+    async def _do() -> Any:
+        async with _client() as c:
+            resp = await c._request(
+                "POST", "/api/aggregation/run", json=body,
+            )
+            return resp.json()
     output.print_json(_run(_do()))
 
 

--- a/docs/adrs/ADR-212-Aggregation-Profiles-And-Engine.md
+++ b/docs/adrs/ADR-212-Aggregation-Profiles-And-Engine.md
@@ -1,0 +1,119 @@
+# ADR-212: Generic aggregation profiles and aggregation engine
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-205](./ADR-205-Smart-Markdown-View-Type.md), [ADR-210](./ADR-210-Smart-Markdown-Value-Overrides.md), [ADR-211](./ADR-211-Element-Template-Stamps.md), [ADR-182](./ADR-182-Surface-Parity-Discipline.md).
+
+## Context
+
+ADR-210 (`=value` overrides) and ADR-211 (template stamps) give per-use values a first-class machine-parseable home. The shopping-list workflow ([issue #211](https://github.com/cgbarlow/iris/issues/211)) now needs the consumer side: walk a source smart-markdown diagram, collect those structured values, group, sum, and emit aggregated markdown.
+
+A naïve implementation puts the algorithm inside a `shopping_list` diagram type. That makes the engine domain-specific (recipe / meal / ingredient / aisle terminology baked into Python). It also makes the engine invisible from outside the diagram lifecycle — agents (Claude Desktop, MCP callers) can only invoke it by GETting a diagram. Both consequences violate the principles already established: genericness (ADR-214) and "make compute a first-class Iris operation, not a buried Python script."
+
+## Decision
+
+Add **two coupled things**: a `aggregation_profiles` library table, and a generic `aggregation_engine` module that is callable directly from REST / MCP / CLI.
+
+### Profile = user-managed JSON ruleset
+
+A row in `aggregation_profiles` carries:
+
+- Identity: `name`, `description`.
+- Scope: `is_global` / `set_id` — same rules as element_templates.
+- The ruleset itself in `profile_data` (JSON) — describes the traversal, attribute paths, multiplier rules, and output format.
+
+The engine knows nothing about ingredients or sprints. Different profiles drive different aggregations on the same engine: shopping-list / sprint-points / time-tracking / expense-report / reading-log are *data*, not *code paths*. The seeded library ([§4.5 of the plan](../plans/issue-211-shopping-list-implementation.md)) ships five global profiles paired 1-for-1 with ADR-211's seeded stamps.
+
+### Engine = ~200-line generic kernel
+
+`backend/app/aggregation/engine.py` implements one function — `run(profile, source_diagram_id, db)` — that:
+
+1. **Traverses** the source diagram's `markdown_source` to collect tokens of a configured type. The profile may declare an **outer** step (each collected token references another diagram; recurse one level) and an **inner** step (each collected token's `=value` overrides and entity-attribute lookups yield `(token_id, value, bucket)` rows).
+2. **Multiplies** rows by an optional per-outer-token multiplier (e.g. diners / servings — generic ratio).
+3. **Groups** by `(token_id, bucket)`, **aggregates** with a configured function (`sum`, `count`).
+4. **Groups again** by an output `group_by` attribute path (e.g. the element's `package_name`).
+5. **Formats** each line via a configurable template string with `{name}` / `{sum_value}` / `{bucket}` / `{sources_joined}` placeholders.
+
+Output: a markdown string. Same pipeline as smart_markdown / dynamic_list (synth-on-read pattern — ADR-187).
+
+### First-class Iris operation
+
+Three surfaces, all parity (ADR-182):
+
+| Surface | Call |
+|---|---|
+| **REST** | `POST /api/aggregation/run` body `{profile_id, source_diagram_id}` → `{markdown, computed_at}` |
+| **MCP** | `aggregate(profile_id, source_diagram_id) -> string` |
+| **CLI** | `iris aggregate --profile <id-or-name> --source <diagram-id>` |
+
+Plus CRUD on `/api/aggregation/profiles` with full MCP + CLI parity.
+
+The aggregation engine is **module-level callable** — no need for a persisted diagram to invoke it. ADR-213 ships an `aggregation_list` diagram type as the visual surface; this ADR ships the engine that diagram type wraps. Agents (Claude Desktop) call `aggregate(...)` directly without ever opening a UI.
+
+### Profile JSON shape
+
+```yaml
+{
+  "traversal": {
+    "outer": {                              # optional
+      "collect_token_type": "diagram",      # walk these tokens in the source
+      "multiplier": {                       # optional
+        "from_attribute_override": "attributes/Diners/type",  # value carried by the outer token
+        "divisor_from_diagram_data": "data.servings",         # field on the referenced diagram
+        "default_multiplier": 1
+      }
+    },
+    "inner": {                              # required
+      "collect_token_type": "element",      # walk these in the referenced diagrams (or source if no outer)
+      "value_attribute_path": "attributes/Quantity/type",
+      "bucket_attribute_path": "attributes/Unit/type",       # optional; null = single bucket
+      "skip_blank_values": true
+    }
+  },
+  "output": {
+    "group_by": "element.package_name",     # or "element.attributes.Author/type", etc.
+    "sort_groups": "alpha",                 # alpha | none
+    "sort_items_within_group": "alpha",
+    "aggregation_fn": "sum",                # sum | count
+    "line_format": "- [{element.name}](iris://element/{element.id}) — {sum_value}{bucket_spaced}",
+    "show_per_source_breakdown": true,
+    "breakdown_format": " ({sources_joined})"
+  }
+}
+```
+
+JSONSchema validation (`backend/app/aggregation/schema.py`) is applied on every write. Profiles that fail validation never persist.
+
+### Why a new module, not under `diagrams/`
+
+DRY (§13) and module purity: aggregation has its own concerns (rule schema, traversal walks, format strings). Living under `diagrams/` would imply it's part of the diagram lifecycle — but it isn't. The `aggregation_list` diagram type (ADR-213) is one *consumer*; the MCP `aggregate` tool is another; future exports or scheduled jobs are more. Each surface uses the same engine.
+
+## Consequences
+
+**Positive:**
+
+- One engine, many use cases. Shopping-list / sprint-points / time / expense / reading-log all run through the same code.
+- Compute is callable from outside the UI — Claude Desktop walks a meal plan into a shopping list without any persisted aggregation_list diagram.
+- Profiles are first-class library data — editable in admin/set settings ([§9.4 of the plan](../plans/issue-211-shopping-list-implementation.md)), exportable, version-able.
+- No core code learns "ingredient" / "recipe" / "meal" / "aisle" terminology.
+
+**Negative / accepted trade-offs:**
+
+- The profile JSON is non-trivial. The form-based editor lands with ADR-213's UI; for v6.20 it's manageable via REST/MCP/CLI by agents (which is the `/goal` primary consumer).
+- A user designing a new profile has to think about traversal levels and attribute paths. The seeded library reduces this for the common cases.
+- Engine is fixed-shape (walk + collect + group + sum + format). Custom computations (joins, percentiles, LLM summarisation) need a different engine — explicitly not in scope.
+
+## Rejected alternatives
+
+- **Engine inside `aggregation_list` diagram type module.** Bakes compute into the diagram lifecycle; not callable from non-diagram surfaces; harder to test in isolation; obvious DRY violation when a second consumer arrives.
+- **Hardcoded "shopping-list" diagram type.** Domain-specific code; fails the genericness invariant.
+- **General-purpose DSL / scripting runtime.** Way more surface than needed; debugging burden; security implications. Aggregation is a single pattern — walk, collect, group, fold, format — and that's what the engine does.
+- **Profile JSON stored on each diagram (no library).** Copy-paste reuse, no shared library, no editor scope. Rejected.
+
+## References
+
+- [SPEC-212-a — Profile schema, scope, CRUD endpoints](./specs/SPEC-212-a-Aggregation-Profile-Schema.md)
+- [SPEC-212-b — Engine compute algorithm](./specs/SPEC-212-b-Aggregation-Engine.md)
+- [SPEC-212-c — REST/MCP/CLI surfaces](./specs/SPEC-212-c-Aggregation-Surfaces.md)
+- [ADR-213](./ADR-213-Aggregation-List-Diagram-Type.md) — visual wrapper diagram type.
+- [`docs/plans/issue-211-shopping-list-implementation.md`](../plans/issue-211-shopping-list-implementation.md) §5–§6 — module layout, profile editor UX, the five seeded profiles.

--- a/docs/adrs/specs/SPEC-212-a-Aggregation-Profile-Schema.md
+++ b/docs/adrs/specs/SPEC-212-a-Aggregation-Profile-Schema.md
@@ -1,0 +1,155 @@
+# SPEC-212-a: Aggregation profile schema, scope, CRUD
+
+Implements: [ADR-212](../ADR-212-Aggregation-Profiles-And-Engine.md)
+
+## 1. Database schema
+
+### SQLite (`backend/app/migrations/m076_aggregation_profiles.py`)
+
+```sql
+CREATE TABLE IF NOT EXISTS aggregation_profiles (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT,
+    set_id TEXT REFERENCES sets(id),
+    is_global INTEGER NOT NULL DEFAULT 0,
+    profile_data TEXT NOT NULL,            -- JSON
+    is_default_for_set INTEGER NOT NULL DEFAULT 0,
+    created_by TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    is_deleted INTEGER NOT NULL DEFAULT 0,
+    CHECK ((is_global = 1 AND set_id IS NULL) OR (is_global = 0 AND set_id IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS idx_agg_profiles_set ON aggregation_profiles(set_id) WHERE is_deleted = 0;
+CREATE INDEX IF NOT EXISTS idx_agg_profiles_global ON aggregation_profiles(is_global) WHERE is_deleted = 0;
+```
+
+### Supabase (`backend/app/migrations/supabase/m081_aggregation_profiles.sql`)
+
+Mirror with `BOOLEAN` literals, `TIMESTAMPTZ` columns, and `profile_data JSONB`. See file.
+
+## 2. profile_data JSON shape
+
+```jsonc
+{
+  "$comment": "Required top-level keys: traversal, output.",
+  "traversal": {
+    "outer": {                              // optional; omit for single-level rollups
+      "collect_token_type": "diagram",      // any entity-type variant from the smart-markdown grammar
+      "multiplier": {                       // optional
+        "from_attribute_override": "<attr-path-on-the-outer-token>",
+        "divisor_from_diagram_data": "data.<field-path-on-the-referenced-diagram>",
+        "default_multiplier": 1
+      }
+    },
+    "inner": {                              // required
+      "collect_token_type": "element",
+      "value_attribute_path": "attributes/Quantity/type",
+      "bucket_attribute_path": "attributes/Unit/type",  // optional (null = no bucket)
+      "skip_blank_values": true             // default true; rows with no value are dropped
+    }
+  },
+  "output": {
+    "group_by": "element.package_name",     // dotted path; see §3.3 of SPEC-212-b
+    "sort_groups": "alpha",                 // alpha | none
+    "sort_items_within_group": "alpha",     // alpha | none
+    "aggregation_fn": "sum",                // sum | count
+    "line_format": "- {element.name}: {sum_value}{bucket_spaced}",
+    "show_per_source_breakdown": false,
+    "breakdown_format": " ({sources_joined})"
+  }
+}
+```
+
+## 3. Pydantic models (`backend/app/aggregation/models.py`)
+
+```python
+class TraversalStep(BaseModel):
+    collect_token_type: Literal["element", "diagram", "package", "set", "collection"]
+    value_attribute_path: str | None = None
+    bucket_attribute_path: str | None = None
+    skip_blank_values: bool = True
+
+class MultiplierRule(BaseModel):
+    from_attribute_override: str | None = None
+    divisor_from_diagram_data: str | None = None
+    default_multiplier: float = 1.0
+
+class OuterTraversal(TraversalStep):
+    multiplier: MultiplierRule | None = None
+
+class TraversalConfig(BaseModel):
+    outer: OuterTraversal | None = None
+    inner: TraversalStep
+
+class OutputConfig(BaseModel):
+    group_by: str | None = None
+    sort_groups: Literal["alpha", "none"] = "alpha"
+    sort_items_within_group: Literal["alpha", "none"] = "alpha"
+    aggregation_fn: Literal["sum", "count"] = "sum"
+    line_format: str = "- {element.name}: {sum_value}{bucket_spaced}"
+    show_per_source_breakdown: bool = False
+    breakdown_format: str = " ({sources_joined})"
+
+class ProfileData(BaseModel):
+    traversal: TraversalConfig
+    output: OutputConfig
+
+class AggregationProfileCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    set_id: str | None = None
+    is_global: bool = False
+    profile_data: ProfileData
+    is_default_for_set: bool = False
+
+class AggregationProfileUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    set_id: str | None = None
+    is_global: bool | None = None
+    profile_data: ProfileData | None = None
+    is_default_for_set: bool | None = None
+
+class AggregationProfileResponse(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    set_id: str | None = None
+    set_name: str | None = None
+    is_global: bool = False
+    is_default_for_set: bool = False
+    profile_data: dict[str, object]
+    created_by: str | None = None
+    created_by_username: str = "Unknown"
+    created_at: str
+    updated_at: str
+```
+
+## 4. Service (`backend/app/aggregation/profiles_service.py`)
+
+Same shape as `element_templates/service.py`:
+
+- `create_aggregation_profile(...)` — validates scope (mutually exclusive set_id/is_global), persists.
+- `get_aggregation_profile(id)` — joined with `sets` for `set_name` and `users` for `created_by_username`.
+- `list_aggregation_profiles(set_id, include_global, page, page_size)` — same scoping as element_templates.
+- `update_aggregation_profile(id, **fields)` — sentinel-or-value for `set_id` to handle tri-state.
+- `delete_aggregation_profile(id)` — soft-delete (sets `is_deleted = 1`).
+
+Row access positional throughout (Protocol §15).
+
+## 5. Scope rules
+
+Identical to `element_templates`:
+
+- `is_global = TRUE` ↔ `set_id IS NULL`. Enforced by CHECK constraint and service-layer `_validate_scope()`.
+- Set-scoped profile visible to that set only; global profile visible to all sets.
+
+## 6. Tests (`backend/tests/test_aggregation/test_profile_crud.py`)
+
+- Create global / set-scoped / rejected mixed-scope.
+- Create with invalid profile_data → 422.
+- Get / list / update / delete round-trip.
+- List with set_id + include_global returns set + globals.
+- Boolean-literal regression check for the Supabase schema.

--- a/docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md
+++ b/docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md
@@ -1,0 +1,219 @@
+# SPEC-212-b: Aggregation engine
+
+Implements: [ADR-212](../ADR-212-Aggregation-Profiles-And-Engine.md)
+
+## 1. Module layout
+
+```
+backend/app/aggregation/
+  __init__.py
+  models.py                  # pydantic — see SPEC-212-a
+  schema.py                  # JSONSchema for profile_data
+  profiles_service.py        # CRUD — see SPEC-212-a
+  engine.py                  # the kernel (this spec)
+  attribute_resolver.py      # walk dotted attribute paths
+  format_renderer.py         # render line / breakdown / group templates
+  routes.py                  # FastAPI — see SPEC-212-c
+  exceptions.py
+```
+
+## 2. Public function
+
+```python
+async def run(
+    db: DatabasePort,
+    *,
+    profile_id: str,
+    source_diagram_id: str,
+) -> AggregationResult:
+    """Apply the named profile to the source diagram. Returns the
+    computed markdown and the source-version stamps that were observed
+    during the walk (so consumers can detect staleness).
+    """
+```
+
+Where `AggregationResult` is:
+
+```python
+class AggregationResult(BaseModel):
+    markdown: str
+    computed_at: str
+    source_versions: dict[str, int]   # diagram_id -> current_version observed
+    row_count: int
+    warnings: list[str] = []
+```
+
+## 3. Algorithm
+
+```python
+async def run(db, *, profile_id, source_diagram_id):
+    profile = await profiles_service.get_aggregation_profile(db, profile_id)
+    if profile is None:
+        raise ProfileNotFound(profile_id)
+    p = ProfileData(**profile["profile_data"])
+
+    accumulator: list[Row] = []
+    source_versions: dict[str, int] = {}
+    warnings: list[str] = []
+
+    source_markdown = await _read_smart_markdown_source(db, source_diagram_id)
+    source_versions[source_diagram_id] = await _diagram_version(db, source_diagram_id)
+
+    if p.traversal.outer:
+        # Two-level walk: outer tokens in the source point at sub-diagrams.
+        for tok in _iter_tokens(source_markdown, p.traversal.outer.collect_token_type):
+            ref_id = tok.entity_id
+            multiplier = _resolve_multiplier(db, tok, ref_id, p.traversal.outer.multiplier)
+            inner_md = await _read_smart_markdown_source(db, ref_id)
+            source_versions[ref_id] = await _diagram_version(db, ref_id)
+            await _collect_inner(db, inner_md, p.traversal.inner, multiplier,
+                                 source_label=await _diagram_name(db, ref_id),
+                                 accumulator=accumulator, warnings=warnings)
+    else:
+        # Single-level walk.
+        await _collect_inner(db, source_markdown, p.traversal.inner, 1.0,
+                             source_label=await _diagram_name(db, source_diagram_id),
+                             accumulator=accumulator, warnings=warnings)
+
+    grouped = _group_and_aggregate(accumulator, p.output.aggregation_fn)
+    output_groups = await _group_for_output(db, grouped, p.output.group_by)
+    markdown = format_renderer.render(output_groups, p.output)
+
+    return AggregationResult(
+        markdown=markdown,
+        computed_at=datetime.now(tz=UTC).isoformat(),
+        source_versions=source_versions,
+        row_count=sum(len(g) for g in output_groups.values()),
+        warnings=warnings,
+    )
+```
+
+## 4. Token iteration
+
+Uses the existing `_TOKEN_RE` regex from `backend/app/diagrams/smart_markdown.py` (DRY §13 — import, don't reimplement). For each match, parse:
+
+- `entity_type` (group 1)
+- `entity_id` (group 2)
+- `field_spec` (group 3, optional)
+
+If `field_spec` contains `=`, split on first `=` per ADR-210; the override is captured as `token.override`. The override and any subsequent attribute lookup feed into `_resolve_attribute` (see §5).
+
+## 5. Attribute resolution (`attribute_resolver.py`)
+
+Three callable resolvers:
+
+```python
+async def resolve_token_value(
+    db, token, attribute_path, override_takes_precedence=True
+) -> str | None:
+    """Return the value for the token at attribute_path. Order:
+       1. If the token has a `=value` override on this exact path → value.
+       2. Else look up entity's stored attribute at the path.
+       Returns None if unresolved.
+    """
+
+async def resolve_diagram_data(
+    db, diagram_id, field_path
+) -> str | None:
+    """Read `data.<field_path>` from the diagram's current version's
+    data JSON. Dotted path, walks dicts."""
+
+async def resolve_group_by_field(
+    db, token, group_by_path
+) -> str | None:
+    """Resolve a `group_by` config value like 'element.package_name' or
+    'element.attributes.Unit/type' against the token's referenced
+    entity. Returns '(none)' when missing."""
+```
+
+## 6. Multiplier resolution
+
+```python
+async def _resolve_multiplier(db, outer_token, ref_diag_id, rule):
+    if rule is None:
+        return 1.0
+    numerator = None
+    if rule.from_attribute_override:
+        numerator = outer_token.override_for(rule.from_attribute_override)
+    if numerator is None:
+        numerator = rule.default_multiplier
+    divisor = 1.0
+    if rule.divisor_from_diagram_data:
+        d = await resolve_diagram_data(db, ref_diag_id, rule.divisor_from_diagram_data)
+        try:
+            divisor = float(d)
+        except (TypeError, ValueError):
+            divisor = 1.0
+    try:
+        return float(numerator) / divisor if divisor else 1.0
+    except (TypeError, ValueError):
+        return 1.0
+```
+
+## 7. Grouping + aggregation
+
+```python
+def _group_and_aggregate(rows, fn):
+    grouped = defaultdict(list)
+    for r in rows:
+        grouped[(r.token_id, r.bucket)].append(r)
+    out = []
+    for (token_id, bucket), items in grouped.items():
+        sources = [(i.source_label, i.scaled_value) for i in items]
+        if fn == "sum":
+            value = sum(i.scaled_value for i in items)
+        elif fn == "count":
+            value = len(items)
+        else:
+            value = sum(i.scaled_value for i in items)
+        out.append(GroupedRow(
+            token_id=token_id, bucket=bucket, value=value, sources=sources,
+        ))
+    return out
+```
+
+## 8. Output formatting (`format_renderer.py`)
+
+Format strings use `{placeholder}` syntax with Python str.format-style replacement:
+
+| Placeholder | Source |
+|---|---|
+| `{element.name}` | the looked-up entity name |
+| `{element.id}` | the entity id |
+| `{sum_value}` | aggregated numeric value (integer-friendly when whole) |
+| `{bucket}` | the bucket value (empty when no bucket) |
+| `{bucket_spaced}` | " <bucket>" when non-empty, "" when empty (prevents trailing space) |
+| `{sources_joined}` | "Source1 N1, Source2 N2" — the source breakdown |
+
+`group_by` headers use a fixed `## {group_value}\n` template (not configurable in v1).
+
+## 9. Edge cases
+
+- Empty source markdown → empty markdown output (no warnings).
+- Source diagram missing → `DiagramNotFound` exception → 404 at the API layer.
+- Profile-referenced inner attribute missing on every collected token → empty markdown, single warning ("no values collected").
+- Numeric coercion: values that don't parse as float become `0` for `sum`, are still counted for `count`. Warning emitted with the offending token id.
+- `bucket_attribute_path` is null → all rows share `bucket = ""` and the format string's `{bucket_spaced}` resolves to empty.
+
+## 10. Performance
+
+- Each diagram fetched once via a small cache keyed on `(diagram_id, version)`.
+- Each element fetched once for `group_by` resolution.
+- Token regex scanned once per source.
+- No N+1 reads — outer-step diagram fetches are batched.
+
+For the shopping-list demo (~30 recipes × ~10 ingredients), full computation is under 200ms on the typical Supabase round-trip budget.
+
+## 11. Tests
+
+`backend/tests/test_aggregation/test_engine.py`:
+
+- Single-level walk + sum on a fixture meal-plan with two recipes sharing one element. Asserts: aggregated value = sum across recipes, single line emitted.
+- Two-level walk with multiplier. Asserts: multiplier × inner values matches expected.
+- Mixed buckets emit two lines per token (per Q3 — no cross-unit conversion).
+- Blank value with `skip_blank_values=true` → row dropped, with warning.
+- `group_by = element.package_name` → grouped output with `##` headers per package.
+- `aggregation_fn = count` → integer count per (token, bucket).
+- Dangling outer token (deleted diagram) → warning, no contribution.
+
+`backend/tests/test_aggregation/test_seeded_profiles_smoke.py` — for each of the five seeded profiles, build a minimal fixture and assert the engine runs without raising. Asserts the seeded JSON validates against the schema. Does NOT assert specific output (output-format details are per-profile).

--- a/docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md
+++ b/docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md
@@ -1,0 +1,76 @@
+# SPEC-212-c: Aggregation REST / MCP / CLI surfaces
+
+Implements: [ADR-212](../ADR-212-Aggregation-Profiles-And-Engine.md)
+
+## 1. REST endpoints
+
+### Profile CRUD (writes — need ADR-182 parity)
+
+| Method + Path | Purpose | Auth |
+|---|---|---|
+| `POST /api/aggregation/profiles` | Create | Authenticated |
+| `GET /api/aggregation/profiles` | List with scope filter | Authenticated read (optional in v1.1) |
+| `GET /api/aggregation/profiles/{id}` | Fetch one | Authenticated read |
+| `PUT /api/aggregation/profiles/{id}` | Update | Authenticated |
+| `DELETE /api/aggregation/profiles/{id}` | Soft-delete | Authenticated |
+
+### Run (read-shaped despite POST)
+
+| Method + Path | Purpose |
+|---|---|
+| `POST /api/aggregation/run` body `{profile_id, source_diagram_id}` | Compute aggregation, return markdown |
+
+POST because the body carries the profile and source ids. Idempotent (no persistence side-effects). Auth: same as profile read.
+
+Response shape (matches `AggregationResult` from SPEC-212-b §2):
+
+```json
+{
+  "markdown": "## Meat & Poultry\n- ...\n",
+  "computed_at": "2026-05-22T11:00:00+00:00",
+  "source_versions": {"<source-diag-id>": 7, "<inner-diag-id>": 3},
+  "row_count": 12,
+  "warnings": []
+}
+```
+
+## 2. MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `create_aggregation_profile` | Write — needs surface parity. |
+| `list_aggregation_profiles` | Read. |
+| `get_aggregation_profile` | Read. |
+| `update_aggregation_profile` | Write. |
+| `delete_aggregation_profile` | Write. |
+| `aggregate` | Run a profile against a source. **The linchpin tool.** Agent description emphasises shopping-list / rollup use case. |
+
+`aggregate` tool description:
+
+> "Run a named aggregation profile against a source smart_markdown diagram. Returns aggregated markdown — deduplicated, summed roll-up of entity values referenced across the source (and, if the profile uses a two-level traversal, the diagrams the source references). Use this when you need a shopping list from a meal plan, a points rollup from a sprint backlog, hours by client from a time log, an expense report from receipts, or any pattern that aggregates structured per-use values across a set of smart-markdown documents."
+
+## 3. CLI subcommands
+
+```
+iris aggregation-profile create   --name <s> --profile-data-file <path> [--set <id>] [--global] [--description <s>]
+iris aggregation-profile update   --id <id> [--name <s>] [--profile-data-file <path>] [--description <s>] [--set <id-or-null>] [--global/--no-global]
+iris aggregation-profile list     [--set <id>] [--global]
+iris aggregation-profile get      --id <id>
+iris aggregation-profile delete   --id <id>
+
+iris aggregate                    --profile <id-or-name> --source <diagram-id>
+```
+
+`--profile <id-or-name>`: accepts either a UUID or a `name` (the CLI resolves to id via `list` + filter; for ambiguous matches errors with a list of candidates).
+
+## 4. Parity check
+
+`scripts/check_surface_parity.py` already enforces write-parity. New writes (`POST/PUT/DELETE /api/aggregation/profiles`) get matching MCP tools and CLI subcommands listed above. No exceptions needed.
+
+## 5. Tests
+
+`backend/tests/test_aggregation/test_routes.py` — every endpoint, every status code.
+
+`mcp/tests/test_aggregation.py` — every MCP tool name resolves and forwards correctly.
+
+`cli/tests/test_aggregation.py` — every CLI subcommand round-trips against a fixture API.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.19.0",
+	"version": "6.20.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.19.0"
+version = "6.20.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.19.0"
+version = "6.20.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -557,6 +557,143 @@ async def _list_element_template_stamps(
     return json.dumps(resp.json().get("items", []))
 
 
+# ── Aggregation profiles + engine (ADR-212, v6.20.0) ────────────────
+
+
+async def _create_aggregation_profile(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.20.0 (ADR-212): create a new aggregation profile.
+
+    A profile is a generic ruleset that drives the aggregation engine.
+    Pair it with a source smart-markdown diagram (via the `aggregate`
+    tool) to produce grouped/summed markdown — useful for shopping-
+    list / sprint-points-rollup / time-tracker / expense-report /
+    reading-log workflows and anything else fitting the
+    "walk + collect + group + fold + format" pattern.
+    """
+    body: dict[str, Any] = {
+        "name": args["name"],
+        "is_global": bool(args.get("is_global", False)),
+        "profile_data": args["profile_data"],
+    }
+    if args.get("description") is not None:
+        body["description"] = args["description"]
+    if args.get("set_id") is not None:
+        body["set_id"] = args["set_id"]
+    if args.get("is_default_for_set") is not None:
+        body["is_default_for_set"] = bool(args["is_default_for_set"])
+    try:
+        resp = await c._request(
+            "POST", "/api/aggregation/profiles", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Create aggregation profile")
+    return json.dumps(resp.json())
+
+
+async def _list_aggregation_profiles(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.20.0 (ADR-212): list aggregation profiles."""
+    params: dict[str, Any] = {
+        "page": int(args.get("page", 1)),
+        "page_size": int(args.get("limit", 50)),
+        "include_global": bool(args.get("include_global", True)),
+    }
+    if args.get("set_id") is not None:
+        params["set_id"] = args["set_id"]
+    try:
+        resp = await c._request(
+            "GET", "/api/aggregation/profiles", params=params,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("List aggregation profiles")
+    return json.dumps(resp.json().get("items", []))
+
+
+async def _get_aggregation_profile(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.20.0 (ADR-212): fetch a single aggregation profile."""
+    try:
+        resp = await c._request(
+            "GET", f"/api/aggregation/profiles/{args['profile_id']}",
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Get aggregation profile")
+    return json.dumps(resp.json())
+
+
+async def _update_aggregation_profile(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.20.0 (ADR-212): update an aggregation profile."""
+    pid = args["profile_id"]
+    body: dict[str, Any] = {}
+    for key in (
+        "name", "description", "is_global", "profile_data",
+        "is_default_for_set",
+    ):
+        if key in args and args[key] is not None:
+            body[key] = args[key]
+    if "set_id" in args:
+        body["set_id"] = args["set_id"]  # may be None
+    try:
+        resp = await c._request(
+            "PUT", f"/api/aggregation/profiles/{pid}", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Update aggregation profile")
+    return json.dumps(resp.json())
+
+
+async def _delete_aggregation_profile(
+    c: IrisClient, args: dict[str, Any],
+) -> str:
+    """v6.20.0 (ADR-212): soft-delete an aggregation profile."""
+    try:
+        await c._request(
+            "DELETE", f"/api/aggregation/profiles/{args['profile_id']}",
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Delete aggregation profile")
+    return json.dumps({
+        "success": True, "profile_id": args["profile_id"], "deleted": True,
+    })
+
+
+async def _aggregate(c: IrisClient, args: dict[str, Any]) -> str:
+    """v6.20.0 (ADR-212): run a named aggregation profile against a
+    source smart_markdown diagram.
+
+    Returns aggregated markdown — deduplicated, summed roll-up of
+    structured per-use values referenced across the source (and, if
+    the profile uses a two-level traversal, the diagrams the source
+    references). Use this when you need a shopping list from a meal
+    plan, a points rollup from a sprint backlog, hours by client from
+    a time log, an expense report from receipts, or any pattern that
+    aggregates structured per-use values across a set of smart-
+    markdown documents.
+
+    The response shape includes `markdown`, `computed_at`,
+    `source_versions`, `row_count`, `warnings`. The `markdown` field
+    is the primary payload — present it to the user, or hand it off
+    to a downstream consumer.
+    """
+    body: dict[str, Any] = {
+        "profile_id": args["profile_id"],
+        "source_diagram_id": args["source_diagram_id"],
+    }
+    try:
+        resp = await c._request(
+            "POST", "/api/aggregation/run", json=body,
+        )
+    except IrisAuthError:
+        return _auth_required_payload("Run aggregation")
+    return json.dumps(resp.json())
+
+
 async def _delete_element_template(c: IrisClient, args: dict[str, Any]) -> str:
     """v6.8.0 (ADR-191): soft-delete a template."""
     try:
@@ -1898,6 +2035,156 @@ TOOLS: list[Tool] = [
             ),
         }),
         handler=_list_element_template_stamps,
+    ),
+    # ── Aggregation profiles + engine (ADR-212, v6.20.0) ─────────────
+    Tool(
+        name="create_aggregation_profile",
+        description=(
+            "Create a generic aggregation profile. A profile is a "
+            "ruleset that drives the aggregation engine — it describes "
+            "which smart-markdown tokens to walk in a source diagram, "
+            "which attribute carries the value to sum, how to scale by "
+            "an optional outer-traversal multiplier, and how to group/"
+            "format output. Pairs with the `aggregate` tool. The five "
+            "seeded global profiles (Shopping list, Sprint points "
+            "rollup, Time tracker rollup, Expense report, Reading log "
+            "rollup) are good templates to clone-and-edit."
+        ),
+        input_schema=_schema({
+            "name": _str_arg("name", "Display name for the profile"),
+            "profile_data": (
+                {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": (
+                        "The profile JSON. Must contain `traversal` "
+                        "(with required `inner` and optional `outer`) "
+                        "and `output`. See ADR-212 / SPEC-212-a."
+                    ),
+                },
+                True,
+            ),
+            "description": _str_arg(
+                "description", "Optional description", required=False,
+            ),
+            "set_id": _str_arg(
+                "set_id",
+                "Set to scope the profile to. Required for non-global "
+                "profiles; must be omitted for `is_global=true`.",
+                required=False,
+            ),
+            "is_global": (
+                {"type": "boolean", "default": False},
+                False,
+            ),
+            "is_default_for_set": (
+                {"type": "boolean", "default": False},
+                False,
+            ),
+        }),
+        handler=_create_aggregation_profile,
+    ),
+    Tool(
+        name="list_aggregation_profiles",
+        description=(
+            "List aggregation profiles with set + global scope. "
+            "v6.20.0 (ADR-212)."
+        ),
+        input_schema=_schema({
+            "set_id": _str_arg(
+                "set_id",
+                "Scope to one set. Combine with `include_global=true` "
+                "to also include globals.",
+                required=False,
+            ),
+            "include_global": (
+                {"type": "boolean", "default": True},
+                False,
+            ),
+            "page": (
+                {"type": "integer", "default": 1},
+                False,
+            ),
+            "limit": (
+                {"type": "integer", "default": 50},
+                False,
+            ),
+        }),
+        handler=_list_aggregation_profiles,
+    ),
+    Tool(
+        name="get_aggregation_profile",
+        description="Fetch one aggregation profile. v6.20.0 (ADR-212).",
+        input_schema=_schema({
+            "profile_id": _str_arg("profile_id", "Profile id"),
+        }),
+        handler=_get_aggregation_profile,
+    ),
+    Tool(
+        name="update_aggregation_profile",
+        description=(
+            "Edit an aggregation profile. v6.20.0 (ADR-212)."
+        ),
+        input_schema=_schema({
+            "profile_id": _str_arg("profile_id", "Profile id"),
+            "name": _str_arg("name", "New name", required=False),
+            "description": _str_arg(
+                "description", "New description", required=False,
+            ),
+            "profile_data": (
+                {
+                    "type": "object", "additionalProperties": True,
+                    "description": "Replacement profile JSON.",
+                },
+                False,
+            ),
+            "is_global": ({"type": "boolean"}, False),
+            "set_id": _str_arg(
+                "set_id",
+                "New scope (null to promote to global).",
+                required=False,
+            ),
+            "is_default_for_set": ({"type": "boolean"}, False),
+        }),
+        handler=_update_aggregation_profile,
+    ),
+    Tool(
+        name="delete_aggregation_profile",
+        description=(
+            "Soft-delete an aggregation profile. v6.20.0 (ADR-212)."
+        ),
+        input_schema=_schema({
+            "profile_id": _str_arg("profile_id", "Profile id"),
+        }),
+        handler=_delete_aggregation_profile,
+    ),
+    Tool(
+        name="aggregate",
+        description=(
+            "Run a named aggregation profile against a source smart-"
+            "markdown diagram. Returns aggregated markdown — "
+            "deduplicated, summed roll-up of structured per-use values "
+            "referenced across the source (and, if the profile uses a "
+            "two-level traversal, the diagrams the source references). "
+            "Use this when you need a shopping list from a meal plan, "
+            "a points rollup from a sprint backlog, hours by client "
+            "from a time log, an expense report from receipts, or any "
+            "pattern that aggregates structured per-use values across "
+            "a set of smart-markdown documents. v6.20.0 (ADR-212)."
+        ),
+        input_schema=_schema({
+            "profile_id": _str_arg(
+                "profile_id",
+                "The aggregation profile to apply. Look up names via "
+                "`list_aggregation_profiles`.",
+            ),
+            "source_diagram_id": _str_arg(
+                "source_diagram_id",
+                "The smart-markdown diagram to walk (commonly the "
+                "outer/aggregation source — e.g., a meal-plan diagram).",
+            ),
+        }),
+        handler=_aggregate,
     ),
     # ── Phase 2 render tools (ADR-179, v6.2.0) ────────────────────────
     Tool(


### PR DESCRIPTION
## Summary

- New `backend/app/aggregation/` module with a ~200-line generic kernel that walks one or two levels of smart-markdown diagrams, collects ADR-210 `=value` overrides as per-use values, groups by `(token_id, bucket)`, aggregates with `sum`/`count`, groups output by a configurable attribute path, and renders templated markdown. No domain terminology in code — all flavour lives in the profile JSON.
- New `aggregation_profiles` table (SQLite m076 / Supabase m081). Same scope semantics as `element_templates`.
- Five seeded global profiles paired 1-for-1 with PR 2's stamps: **Shopping list** (with diners/servings multiplier), **Sprint points rollup**, **Time tracker rollup**, **Expense report** (currency-bucketed), **Reading log rollup** (grouped by author).
- **REST**: `/api/aggregation/profiles` CRUD + `POST /api/aggregation/run`. **MCP**: `aggregate` + profile CRUD. **CLI**: `iris aggregate` + `iris aggregation-profile <subcmd>`.
- Engine is callable from outside the UI — Claude Desktop can walk a meal plan into a shopping list via `aggregate` MCP without any persisted aggregation_list diagram (the visual surface lands in PR 4).

Third of six PRs implementing [#211](https://github.com/cgbarlow/iris/issues/211).

## References

- [ADR-212](docs/adrs/ADR-212-Aggregation-Profiles-And-Engine.md)
- [SPEC-212-a](docs/adrs/specs/SPEC-212-a-Aggregation-Profile-Schema.md)
- [SPEC-212-b](docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md)
- [SPEC-212-c](docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md)

## Migrations

- **SQLite m076 / Supabase m081** — `aggregation_profiles` table.
- **SQLite m077 / Supabase m082** — seed five global profiles (deterministic UUIDv5).
- Supabase migrations **already applied** to the live DB.

## Test plan

- [x] 17 new aggregation tests pass (8 engine, 8 CRUD, 1 seeded-profiles smoke)
- [x] All 42 smart_markdown tests still pass; all 33 element_template tests still pass
- [x] `scripts/check_surface_parity.py` — clean (every new write has MCP + CLI counterpart)
- [x] Live Supabase: 5 global aggregation profiles present
- [ ] Post-deploy smoke: `iris aggregate --profile <shopping-list-id> --source <a-meal-plan-id>` returns markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)