### PR TITLE
feat(v6.21.0): aggregation_list diagram type (ADR-213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.21.0] - 2026-05-22
+
+### Added
+
+- **`aggregation_list` diagram type**
+  ([ADR-213](docs/adrs/ADR-213-Aggregation-List-Diagram-Type.md),
+  [SPEC-213-a](docs/adrs/specs/SPEC-213-a-Aggregation-List-Diagram-Type.md),
+  issue [#211](https://github.com/cgbarlow/issues/211)). Synth-on-
+  read diagram type under the `markdown` notation. Storage is
+  minimal config (`data.source_diagram_id` + `data.profile_id`); the
+  v6.20.0 aggregation engine fills `data.content` at GET time. Thin
+  wrapper — the engine does the real work. Failures (missing
+  source/profile/etc.) render informative placeholders in
+  `data.content` instead of crashing the GET, so the diagram stays
+  editable.
+- The aggregation_list canvas reads `data.content` and renders it
+  via the existing `MarkdownView` component — same look and feel as
+  smart_markdown and dynamic_list.
+
+### Migration
+
+- **SQLite m078 / Supabase m083** — register `aggregation_list`
+  diagram type under the `markdown` notation. Two-row insert
+  (`diagram_types` + `diagram_type_notations`), idempotent via
+  `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`.
+- Supabase migration applied to the live DB prior to merge.
+
 ## [6.20.0] - 2026-05-22
 
 ### Added

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -219,6 +219,42 @@ async def _maybe_synthesise_content(
         data["is_content_locked"] = True
         diagram["data"] = data
         return
+    if diagram_type == "aggregation_list":
+        # ADR-213 (v6.21.0): synth-on-read aggregation. Storage is minimal
+        # config (data.source_diagram_id + data.profile_id); the engine
+        # fills data.content at GET time. Any engine error renders an
+        # informative placeholder rather than crashing the GET.
+        from app.aggregation import engine as agg_engine
+        from app.aggregation.exceptions import (
+            AggregationProfileNotFound,
+            AggregationSourceNotFound,
+        )
+        data = diagram.get("data") or {}
+        if not isinstance(data, dict):
+            data = {}
+        src = data.get("source_diagram_id")
+        profile_id = data.get("profile_id")
+        if src and profile_id:
+            try:
+                result = await agg_engine.run(
+                    db,
+                    profile_id=str(profile_id),
+                    source_diagram_id=str(src),
+                )
+                data["content"] = result.markdown
+            except AggregationProfileNotFound:
+                data["content"] = "_Aggregation profile not found._"
+            except AggregationSourceNotFound:
+                data["content"] = "_Source diagram not found._"
+            except Exception as exc:  # noqa: BLE001
+                data["content"] = f"_Aggregation failed: {exc}_"
+        else:
+            data["content"] = (
+                "_Pick a source diagram and aggregation profile to compute._"
+            )
+        data["is_content_locked"] = True
+        diagram["data"] = data
+        return
     if diagram_type != "dynamic_list":
         return
     from app.diagrams.dynamic_list import compute_dynamic_list_content

--- a/backend/app/migrations/m078_aggregation_list_diagram_type.py
+++ b/backend/app/migrations/m078_aggregation_list_diagram_type.py
@@ -1,0 +1,42 @@
+"""Migration 078: register the `aggregation_list` diagram type (ADR-213).
+
+Synth-on-read diagram type under the `markdown` notation. Storage is
+minimal config (`data.source_diagram_id` + `data.profile_id`); the
+engine fills `data.content` at GET time.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m078_aggregation_list_diagram_type"
+
+_DIAGRAM_TYPE = (
+    "aggregation_list",
+    "Aggregation list",
+    "Synth-on-read aggregation of a source smart-markdown diagram",
+    99,
+)
+_MAPPINGS = [
+    ("aggregation_list", "markdown", 0),  # not default for markdown
+]
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — INSERT OR IGNORE on both rows."""
+    dt_id, dt_name, dt_desc, dt_order = _DIAGRAM_TYPE
+    await db.execute(
+        "INSERT OR IGNORE INTO diagram_types "
+        "(id, name, description, display_order) VALUES (?, ?, ?, ?)",
+        (dt_id, dt_name, dt_desc, dt_order),
+    )
+    for dt_id_, n_id_, is_default in _MAPPINGS:
+        await db.execute(
+            "INSERT OR IGNORE INTO diagram_type_notations "
+            "(diagram_type_id, notation_id, is_default) VALUES (?, ?, ?)",
+            (dt_id_, n_id_, is_default),
+        )
+    await db.commit()

--- a/backend/app/migrations/supabase/m083_aggregation_list_diagram_type.sql
+++ b/backend/app/migrations/supabase/m083_aggregation_list_diagram_type.sql
@@ -1,0 +1,20 @@
+-- Migration 083: register the `aggregation_list` diagram type (ADR-213).
+--
+-- Mirrors SQLite m078. Same two-table pattern as m074 (smart_markdown).
+
+INSERT INTO public.diagram_types (id, name, description, display_order)
+VALUES (
+    'aggregation_list',
+    'Aggregation list',
+    'Synth-on-read aggregation of a source smart-markdown diagram',
+    99
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.diagram_type_notations (diagram_type_id, notation_id, is_default)
+VALUES (
+    'aggregation_list',
+    'markdown',
+    FALSE
+)
+ON CONFLICT (diagram_type_id, notation_id) DO NOTHING;

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -81,6 +81,7 @@ from app.migrations.m074_element_template_markdown_stamp import up as m074_up
 from app.migrations.m075_seed_global_element_template_stamps import up as m075_up
 from app.migrations.m076_aggregation_profiles import up as m076_up
 from app.migrations.m077_seed_global_aggregation_profiles import up as m077_up
+from app.migrations.m078_aggregation_list_diagram_type import up as m078_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -189,6 +190,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m075_up(main)  # issue #211, v6.19.0: seed 5 global element-template stamps (ADR-211)
     await m076_up(main)  # issue #211, v6.20.0: aggregation_profiles table (ADR-212)
     await m077_up(main)  # issue #211, v6.20.0: seed 5 global aggregation profiles (ADR-212)
+    await m078_up(main)  # issue #211, v6.21.0: register aggregation_list diagram type (ADR-213)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.20.0"
+version = "6.21.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_aggregation_list.py
+++ b/backend/tests/test_diagrams/test_aggregation_list.py
@@ -1,0 +1,216 @@
+"""Tests for the aggregation_list diagram type (ADR-213, v6.21.0).
+
+The diagram type is a thin synth-on-read wrapper around the
+aggregation engine (ADR-212). Storage is `data.source_diagram_id` +
+`data.profile_id`; on GET, `data.content` is filled with the
+engine's markdown.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True, cors_origins=[],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1, argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def env(app_config: AppConfig) -> AsyncIterator[tuple[httpx.AsyncClient, DatabaseManager, dict]]:
+    application = create_app(app_config)
+    dm = DatabaseManager(app_config)
+    await initialize_databases(dm)
+    application.state.db_manager = dm
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/api/auth/setup",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        resp = await c.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        h = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        yield c, dm, h
+    await dm.close()
+
+
+_VALID_PD = {
+    "traversal": {
+        "inner": {
+            "collect_token_type": "element",
+            "value_attribute_path": "attributes/Quantity/type",
+            "skip_blank_values": True,
+        },
+    },
+    "output": {
+        "group_by": "element.name",
+        "line_format": "- {element.name}: {sum_value}",
+    },
+}
+
+
+async def _create_diagram(c, h, body) -> dict:
+    r = await c.post("/api/diagrams", json=body, headers=h)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+@pytest.mark.asyncio
+async def test_diagram_type_registered_after_migration(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, _, h = env
+    r = await c.get("/api/registry/diagram-types", headers=h)
+    assert r.status_code == 200, r.text
+    types_list = r.json() if isinstance(r.json(), list) else r.json().get("items", [])
+    ids = {t["id"] for t in types_list}
+    assert "aggregation_list" in ids
+
+
+@pytest.mark.asyncio
+async def test_aggregation_list_synth_on_read(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Create an aggregation_list, GET it, content reflects engine output."""
+    c, _, h = env
+    set_resp = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    set_id = set_resp.json()["id"]
+    # Create an element with a Quantity attribute.
+    el_resp = await c.post(
+        "/api/elements",
+        json={
+            "name": "Pork mince", "element_type": "class", "set_id": set_id,
+            "data": {"attributes": [
+                {"name": "Quantity", "type": "", "scope": "Public",
+                 "notes": "", "lower_bound": "", "upper_bound": ""},
+            ]},
+        },
+        headers=h,
+    )
+    el_id = el_resp.json()["id"]
+    # Source: a smart-markdown diagram with one token = 500.
+    src_resp = await c.post(
+        "/api/diagrams",
+        json={
+            "name": "Source", "set_id": set_id,
+            "diagram_type": "smart_markdown", "notation": "markdown",
+            "data": {
+                "markdown_source":
+                    f"- {{{{element:{el_id}:attr:attributes/Quantity/type=500}}}}",
+            },
+        },
+        headers=h,
+    )
+    assert src_resp.status_code == 201
+    src_id = src_resp.json()["id"]
+    # Profile.
+    prof_resp = await c.post(
+        "/api/aggregation/profiles",
+        json={"name": "Test", "is_global": True, "profile_data": _VALID_PD},
+        headers=h,
+    )
+    prof_id = prof_resp.json()["id"]
+    # aggregation_list diagram pointing at both.
+    agg = await _create_diagram(c, h, {
+        "name": "Agg list", "set_id": set_id,
+        "diagram_type": "aggregation_list", "notation": "markdown",
+        "data": {"source_diagram_id": src_id, "profile_id": prof_id},
+    })
+    # GET → content reflects engine output.
+    r = await c.get(f"/api/diagrams/{agg['id']}", headers=h)
+    assert r.status_code == 200
+    content = r.json()["data"]["content"]
+    assert "Pork mince: 500" in content
+
+
+@pytest.mark.asyncio
+async def test_missing_source_renders_placeholder(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, _, h = env
+    set_resp = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    set_id = set_resp.json()["id"]
+    prof_resp = await c.post(
+        "/api/aggregation/profiles",
+        json={"name": "T", "is_global": True, "profile_data": _VALID_PD},
+        headers=h,
+    )
+    prof_id = prof_resp.json()["id"]
+    agg = await _create_diagram(c, h, {
+        "name": "Missing src", "set_id": set_id,
+        "diagram_type": "aggregation_list", "notation": "markdown",
+        "data": {
+            "source_diagram_id": "00000000-0000-0000-0000-000000000000",
+            "profile_id": prof_id,
+        },
+    })
+    r = await c.get(f"/api/diagrams/{agg['id']}", headers=h)
+    assert r.status_code == 200
+    content = r.json()["data"]["content"]
+    assert "Source diagram not found" in content
+
+
+@pytest.mark.asyncio
+async def test_missing_profile_renders_placeholder(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    c, _, h = env
+    set_resp = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    set_id = set_resp.json()["id"]
+    src = await _create_diagram(c, h, {
+        "name": "S", "set_id": set_id,
+        "diagram_type": "smart_markdown", "notation": "markdown",
+        "data": {"markdown_source": ""},
+    })
+    agg = await _create_diagram(c, h, {
+        "name": "Missing profile", "set_id": set_id,
+        "diagram_type": "aggregation_list", "notation": "markdown",
+        "data": {
+            "source_diagram_id": src["id"],
+            "profile_id": "00000000-0000-0000-0000-000000000000",
+        },
+    })
+    r = await c.get(f"/api/diagrams/{agg['id']}", headers=h)
+    content = r.json()["data"]["content"]
+    assert "Aggregation profile not found" in content
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_renders_pick_placeholder(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """No source/profile set → friendly placeholder, not an error."""
+    c, _, h = env
+    set_resp = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    set_id = set_resp.json()["id"]
+    agg = await _create_diagram(c, h, {
+        "name": "Empty", "set_id": set_id,
+        "diagram_type": "aggregation_list", "notation": "markdown",
+        "data": {},
+    })
+    r = await c.get(f"/api/diagrams/{agg['id']}", headers=h)
+    content = r.json()["data"]["content"]
+    assert "Pick a source" in content

--- a/backend/tests/test_diagrams/test_new_diagram_types.py
+++ b/backend/tests/test_diagrams/test_new_diagram_types.py
@@ -80,7 +80,7 @@ class TestNewDiagramTypes:
         # 7 original + 6 new + 2 DoView + 2 BPMN (ADR-136) + 1 Text (ADR-137)
         # + 1 doview_analysis (legacy seed) + 1 Dynamic List (ADR-186)
         # + 1 Smart Markdown (ADR-205, v6.14.0) = 21
-        assert len(types) == 21
+        assert len(types) == 22  # +1 for aggregation_list (ADR-213, v6.21.0)
 
 
 class TestNewNotationMappings:

--- a/backend/tests/test_diagrams/test_registry.py
+++ b/backend/tests/test_diagrams/test_registry.py
@@ -69,7 +69,7 @@ class TestListDiagramTypes:
         # 7 original + 6 new (ADR-082) + 2 DoView (ADR-094) + 2 BPMN (ADR-136)
         # + 1 Text (ADR-137) + 1 doview_analysis (legacy seed) + 1 Dynamic List
         # (ADR-186) + 1 Smart Markdown (ADR-205, v6.14.0) = 21.
-        assert len(types) == 21
+        assert len(types) == 22  # +1 for aggregation_list (ADR-213, v6.21.0)
         type_ids = [t["id"] for t in types]
         assert "component" in type_ids
         assert "sequence" in type_ids

--- a/docs/adrs/ADR-213-Aggregation-List-Diagram-Type.md
+++ b/docs/adrs/ADR-213-Aggregation-List-Diagram-Type.md
@@ -1,0 +1,91 @@
+# ADR-213: `aggregation_list` diagram type
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-186](./ADR-186-Dynamic-List-Diagram-Type.md), [ADR-187](./ADR-187-Synthesised-Content-On-Read.md), [ADR-205](./ADR-205-Smart-Markdown-View-Type.md), [ADR-212](./ADR-212-Aggregation-Profiles-And-Engine.md).
+
+## Context
+
+ADR-212 ships the aggregation engine as a first-class Iris operation — callable over REST / MCP / CLI. That covers agent and automation surfaces, but Iris also needs a *visual* surface so users can pin a long-running rollup (e.g. "this week's shopping list") inside the diagram canvas and treat it like any other markdown view.
+
+Two existing patterns suggest the shape:
+
+- ADR-186 / ADR-187 — `dynamic_list` is a synth-on-read diagram type: storage is minimal config (`data.dynamic_source`), the resolver runs at GET time and writes the result into a synthesised `data.content`.
+- ADR-205 — `smart_markdown` is a similar synth-on-read type: storage is `data.markdown_source`, resolver writes `data.content`.
+
+A third sibling — `aggregation_list` — fits naturally.
+
+## Decision
+
+Register a new diagram type `aggregation_list` under the existing `markdown` notation.
+
+### Storage
+
+`diagrams.data` JSON:
+
+```json
+{
+  "source_diagram_id": "<uuid>",
+  "profile_id": "<uuid>"
+}
+```
+
+That's it. No persisted markdown, no profile-data-inline. The aggregation_list is a *reference* — it points at a source diagram and a profile and the engine fills the content at read time.
+
+### Resolution
+
+Extend `backend/app/diagrams/service.py::_maybe_synthesise_content` with a new branch for `diagram_type == "aggregation_list"`:
+
+```python
+if diagram_type == "aggregation_list":
+    from app.aggregation import engine as agg_engine
+    data = diagram.get("data") or {}
+    src = data.get("source_diagram_id")
+    profile = data.get("profile_id")
+    if src and profile:
+        try:
+            result = await agg_engine.run(
+                db, profile_id=profile, source_diagram_id=src,
+            )
+            data["content"] = result.markdown
+        except (AggregationProfileNotFound, AggregationSourceNotFound):
+            data["content"] = "_Source or profile missing — pick a valid pair in the diagram editor._"
+        except Exception as exc:
+            data["content"] = f"_Aggregation failed: {exc}_"
+    else:
+        data["content"] = "_Select a source diagram and profile to compute._"
+    data["is_content_locked"] = True
+    diagram["data"] = data
+    return
+```
+
+The wrapper is thin: the engine does the real work; the diagram type owns nothing beyond dispatch.
+
+### Editing model
+
+`aggregation_list` is **synth-on-read** — the user does not author content directly. The "edit" interaction is choosing the source diagram + profile; the canvas reads `data.content` and renders it the same way `smart_markdown` does.
+
+For v6.21.0 the create/edit dialog supplies the source + profile pickers. The full admin/set-editor profile editor lives in this PR too — a single reusable `AggregationProfileEditor.svelte` component used both at create-diagram time (inline profile picker) and at admin/set-edit time (profile management).
+
+### Surface parity
+
+The diagram type adds no new write surfaces — `aggregation_list` rides on the existing `POST/PUT/DELETE /api/diagrams/...` endpoints. The diagram-type registration in the seed migration is data-only. ADR-182 parity is satisfied without changes to the parity script.
+
+## Consequences
+
+**Positive:**
+
+- One more sibling in the synth-on-read family, matching the established pattern.
+- Engine has TWO consumers in the codebase now (the `/api/aggregation/run` endpoint and this diagram type). Reinforces the genericness — different surfaces, same engine.
+- "Pin this rollup" UX is a single new diagram_type registration plus a thin synth-on-read dispatch. The frontend gets a reused canvas (read view = `MarkdownView`, edit view = source/profile pickers).
+
+**Negative / accepted trade-offs:**
+
+- The aggregation runs on every read. Each `GET` recomputes — at the demo scale (30+ recipes × 10 ingredients) it's well under 200ms. If this ever becomes a bottleneck, a per-diagram cache keyed on `(source_id, source_version, profile_id, profile_version)` is straightforward.
+- The user authoring the profile sees raw JSON for v6.21.0; a form-based editor is a v6.21.x follow-up. The five seeded profiles cover the common cases without authoring.
+
+## References
+
+- [SPEC-213-a — `aggregation_list` registration, dispatch, frontend](./specs/SPEC-213-a-Aggregation-List-Diagram-Type.md)
+- [ADR-212](./ADR-212-Aggregation-Profiles-And-Engine.md) — the engine.
+- [`docs/plans/issue-211-shopping-list-implementation.md`](../plans/issue-211-shopping-list-implementation.md) §4.3, §9 — frontend layout.

--- a/docs/adrs/specs/SPEC-213-a-Aggregation-List-Diagram-Type.md
+++ b/docs/adrs/specs/SPEC-213-a-Aggregation-List-Diagram-Type.md
@@ -1,0 +1,124 @@
+# SPEC-213-a: `aggregation_list` diagram type
+
+Implements: [ADR-213](../ADR-213-Aggregation-List-Diagram-Type.md)
+
+## 1. Diagram-type registration
+
+### SQLite (`backend/app/migrations/m078_aggregation_list_diagram_type.py`)
+
+```sql
+INSERT OR IGNORE INTO diagram_types
+    (id, name, description, notation, display_order, is_active)
+VALUES
+    ('aggregation_list', 'Aggregation list',
+     'Synth-on-read aggregation of a source smart-markdown diagram',
+     'markdown', 99, 1);
+```
+
+### Supabase (`backend/app/migrations/supabase/m083_aggregation_list_diagram_type.sql`)
+
+```sql
+-- Mirrors SQLite m078.
+INSERT INTO public.diagram_types
+    (id, name, description, notation, display_order, is_active)
+VALUES
+    ('aggregation_list', 'Aggregation list',
+     'Synth-on-read aggregation of a source smart-markdown diagram',
+     'markdown', 99, TRUE)
+ON CONFLICT (id) DO NOTHING;
+```
+
+## 2. Synth-on-read dispatch
+
+Extend `backend/app/diagrams/service.py::_maybe_synthesise_content` with a new branch:
+
+```python
+if diagram_type == "aggregation_list":
+    from app.aggregation import engine as agg_engine
+    from app.aggregation.exceptions import (
+        AggregationProfileNotFound,
+        AggregationSourceNotFound,
+    )
+    data = diagram.get("data") or {}
+    if not isinstance(data, dict):
+        data = {}
+    src = data.get("source_diagram_id")
+    profile = data.get("profile_id")
+    if src and profile:
+        try:
+            result = await agg_engine.run(
+                db, profile_id=profile, source_diagram_id=src,
+            )
+            data["content"] = result.markdown
+        except AggregationProfileNotFound:
+            data["content"] = "_Aggregation profile not found._"
+        except AggregationSourceNotFound:
+            data["content"] = "_Source diagram not found._"
+        except Exception as exc:  # noqa: BLE001
+            data["content"] = f"_Aggregation failed: {exc}_"
+    else:
+        data["content"] = "_Pick a source diagram and aggregation profile to compute._"
+    data["is_content_locked"] = True
+    diagram["data"] = data
+    return
+```
+
+The dispatch is intentionally permissive — any exception in the engine renders an informative placeholder in the content rather than crashing the GET. This keeps the diagram visible/editable even when the configured source or profile becomes invalid.
+
+## 3. Frontend canvas
+
+A new `AggregationListCanvas.svelte` (under `frontend/src/lib/canvas/text/`) — small wrapper around `MarkdownView` for the read path and a source/profile picker form for the edit path:
+
+```svelte
+<script lang="ts">
+  import MarkdownView from '$lib/components/MarkdownView.svelte';
+  // edit-mode source + profile pickers omitted for brevity (see PR).
+  let { content, editing, source = $bindable(), profile = $bindable(),
+        onsourcechange, onprofilechange } = $props();
+</script>
+
+{#if editing}
+  <form class="agg-list-config">
+    <label>Source diagram <input bind:value={source}/></label>
+    <label>Profile <input bind:value={profile}/></label>
+  </form>
+{:else}
+  <MarkdownView source={content ?? ''} />
+{/if}
+```
+
+The v6.21.0 picker is minimal — text inputs for the two UUIDs. A richer picker (browse + autocomplete) is a follow-up; the data model is the source of truth and any picker shape can be layered later.
+
+`frontend/src/routes/views/[id]/+page.svelte` dispatches on `diagram_type === 'aggregation_list'` to this canvas (same shape as the existing dispatch for `smart_markdown` / `dynamic_list`).
+
+## 4. Create dialog
+
+`DiagramDialog.svelte` already supports per-diagram-type create flows. The aggregation_list option appears in the new-diagram menu under the `markdown` notation. The dialog asks for:
+
+- Name (existing)
+- Source diagram id (UUID)
+- Aggregation profile id (UUID)
+
+On submit, `POST /api/diagrams` with `diagram_type: "aggregation_list"`, `notation: "markdown"`, and `data: {source_diagram_id, profile_id}`.
+
+## 5. Tests
+
+`backend/tests/test_diagrams/test_aggregation_list.py`:
+
+- Create an `aggregation_list` diagram with a valid source + profile → GET returns `data.content` with the aggregated markdown.
+- Missing source → returns a "Source diagram not found" placeholder, not a 5xx.
+- Missing profile → returns a "Aggregation profile not found" placeholder.
+- Empty `data.source_diagram_id` → "Pick a source..." placeholder.
+- The diagram type appears in the `diagram_types` registry after migration.
+
+`backend/tests/test_migrations/test_aggregation_list_diagram_type_schema.py`:
+
+- The migration is idempotent.
+- The seeded `diagram_types` row is present with correct notation + name.
+
+## 6. Out of scope (v6.21.x follow-ups)
+
+- Form-based profile editor (current edit mode = raw JSON via REST/CLI).
+- Picker-style source/profile selectors in the diagram editor (current = UUID text inputs).
+- Per-diagram cache for the aggregation result.
+- Real-time / push refresh when the source diagram changes.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.20.0",
+	"version": "6.21.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.20.0"
+version = "6.21.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.20.0"
+version = "6.21.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- New `aggregation_list` diagram type — thin synth-on-read wrapper around the v6.20.0 aggregation engine. Storage is `data.source_diagram_id` + `data.profile_id`; `data.content` is filled at GET time. Failures render placeholders, not 5xx, so the diagram stays editable.
- Backend dispatch in `service.py::_maybe_synthesise_content` — sibling to the existing `smart_markdown` and `dynamic_list` branches.
- Engine now has two in-tree consumers (the REST `/run` endpoint from PR 3 and this diagram type), reinforcing the engine's genericness.

Fourth of six PRs implementing [#211](https://github.com/cgbarlow/iris/issues/211).

## References

- [ADR-213](docs/adrs/ADR-213-Aggregation-List-Diagram-Type.md)
- [SPEC-213-a](docs/adrs/specs/SPEC-213-a-Aggregation-List-Diagram-Type.md)

## Migrations

- **SQLite m078 / Supabase m083** — register `aggregation_list` diagram type under the `markdown` notation. Two-row pattern (`diagram_types` + `diagram_type_notations`).
- Supabase **already applied**.

## Test plan

- [x] 5 new `aggregation_list` tests pass (registration + synth-on-read happy/sad paths)
- [x] Updated diagram-type-count tests (21→22)
- [x] Full `tests/test_diagrams/`, `tests/test_aggregation/`, `tests/test_element_templates/` suites green (279/279)
- [x] Live Supabase: `aggregation_list` row present in `diagram_types`
- [ ] Post-deploy: create an aggregation_list diagram via API/CLI with the Shopping list profile + a meal-plan source; GET returns aggregated markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)