### PR TITLE
feat(v6.22.0): operator scripts + live data migration for issue #211 demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.22.0] - 2026-05-22
+
+### Added
+
+- **Three operator-run migration scripts** for the meal-plan →
+  shopping-list demo workflow (issue #211):
+  - `scripts/backfill_quantity_attribute.py` — adds a blank
+    `Quantity` attribute to every element in a target set so authors
+    can write `=<value>` overrides without first editing each
+    element's data.
+  - `scripts/migrate_recipes_to_quantity_tokens.py` — rewrites the
+    legacy free-text quantity pattern
+    `NNN {{element:UUID:attr:.../Unit/type}} {{element:UUID:name}}`
+    into the ADR-210 structured form
+    `{{element:UUID:attr:attributes/Quantity/type=NNN}} {{element:UUID:attr:attributes/Unit/type}} {{element:UUID:name}}`.
+    Renders identically; now machine-parseable by the v6.20.0
+    aggregation engine.
+  - `scripts/backfill_servings_on_recipes.py` — sets
+    `data.servings` on smart_markdown diagrams so the Shopping list
+    profile's diner-count multiplier has a denominator.
+- All three scripts: argparse CLI; dry-run mode; idempotent;
+  `--created-by <uuid>` for Supabase NOT-NULL attribution (auto-
+  detected from existing rows in the set when omitted).
+- Pure-function regex tests in
+  `backend/tests/test_scripts/test_migrate_recipes_regex.py`.
+- **Live demo data migrated**: 178 grocery elements gained a
+  Quantity attribute; 124 quantity prefixes rewritten across 29
+  recipes; 34 recipes gained `data.servings = 4`. Issue #211
+  end-to-end workflow is now exercisable.
+
+### Migration
+
+- Operator-run, not in the SQLite startup runner (target sets are
+  environment-specific). The three scripts are pure data
+  transforms — no schema changes. Already applied to the live UAT/
+  prod data.
+
 ## [6.21.1] - 2026-05-22
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.21.1"
+version = "6.22.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_scripts/test_migrate_recipes_regex.py
+++ b/backend/tests/test_scripts/test_migrate_recipes_regex.py
@@ -1,0 +1,83 @@
+"""Unit tests for the recipe-rewrite regex (issue #211 PR 6).
+
+The DB-touching scripts in `scripts/` are exercised in dry-run against
+the live UAT as part of the v6.22.0 deploy verification; here we just
+validate the pure-function rewrite logic.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "rewriter",
+        REPO_ROOT / "scripts" / "migrate_recipes_to_quantity_tokens.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_UUID = "a8db6014-584b-46bd-bc33-cfddc040cca4"
+
+
+def test_rewrites_legacy_pattern() -> None:
+    mod = _load_module()
+    src = (
+        f"- 500 {{{{element:{_UUID}:attr:attributes/Unit/type}}}} "
+        f"{{{{element:{_UUID}:name}}}}"
+    )
+    new, count = mod._rewrite(src)
+    assert count == 1
+    assert f"{{{{element:{_UUID}:attr:attributes/Quantity/type=500}}}}" in new
+
+
+def test_idempotent() -> None:
+    mod = _load_module()
+    src = (
+        f"- 500 {{{{element:{_UUID}:attr:attributes/Unit/type}}}} "
+        f"{{{{element:{_UUID}:name}}}}"
+    )
+    once, count1 = mod._rewrite(src)
+    twice, count2 = mod._rewrite(once)
+    assert count1 == 1
+    assert count2 == 0
+    assert twice == once
+
+
+def test_decimal_quantities() -> None:
+    mod = _load_module()
+    src = (
+        f"- 1.5 {{{{element:{_UUID}:attr:attributes/Unit/type}}}} "
+        f"{{{{element:{_UUID}:name}}}}"
+    )
+    new, count = mod._rewrite(src)
+    assert count == 1
+    assert "Quantity/type=1.5}}" in new
+
+
+def test_leaves_plain_name_lines_alone() -> None:
+    """Lines like `- {{element:UUID:name}}` (no quantity, no Unit
+    token) are passing prose mentions and should be untouched."""
+    mod = _load_module()
+    src = f"- {{{{element:{_UUID}:name}}}}"
+    new, count = mod._rewrite(src)
+    assert count == 0
+    assert new == src
+
+
+def test_multi_line() -> None:
+    mod = _load_module()
+    src = (
+        f"- 500 {{{{element:{_UUID}:attr:attributes/Unit/type}}}} "
+        f"{{{{element:{_UUID}:name}}}}\n"
+        f"- 2 {{{{element:{_UUID}:attr:attributes/Unit/type}}}} "
+        f"{{{{element:{_UUID}:name}}}}"
+    )
+    _, count = mod._rewrite(src)
+    assert count == 2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.21.1",
+	"version": "6.22.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.21.1"
+version = "6.22.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.21.1"
+version = "6.22.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/scripts/backfill_quantity_attribute.py
+++ b/scripts/backfill_quantity_attribute.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Add a blank `Quantity` attribute to every element in a target set.
+
+Issue #211 — meal-plan → shopping-list workflow.
+
+The aggregation engine reads per-use values from smart-markdown
+`=value` overrides (ADR-210). For the workflow to be authorable
+fluently, the *element* needs a Quantity attribute slot the author
+can override per-use. This script adds that slot (blank value,
+scope=Public) idempotently to every element in a given set.
+
+Usage:
+    python3 scripts/backfill_quantity_attribute.py \\
+        --db-url "<postgres-url>" \\
+        --set-id "<uuid>" \\
+        [--dry-run]
+
+Idempotent — re-running is a no-op when every element already has the
+attribute. Operator action; not in the startup migration runner
+because the target set is environment-specific.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import UTC, datetime
+
+
+def _add_quantity_attribute(data: dict | None) -> tuple[dict, bool]:
+    """Return (updated_data, did_change). Idempotent."""
+    if not isinstance(data, dict):
+        data = {}
+    attributes = data.get("attributes") or []
+    if not isinstance(attributes, list):
+        attributes = []
+    for attr in attributes:
+        if isinstance(attr, dict) and attr.get("name") == "Quantity":
+            return data, False
+    attributes.append({
+        "name": "Quantity",
+        "type": "",
+        "scope": "Public",
+        "notes": "",
+        "lower_bound": "",
+        "upper_bound": "",
+    })
+    data["attributes"] = attributes
+    return data, True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db-url", required=True)
+    ap.add_argument("--set-id", required=True)
+    ap.add_argument(
+        "--created-by", default=None,
+        help=(
+            "User UUID to attribute the new element versions to. "
+            "Required when element_versions.created_by is NOT NULL "
+            "(Supabase). If omitted, the script tries to use the "
+            "existing created_by value from elements in this set."
+        ),
+    )
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        import psycopg2
+        import psycopg2.extras
+    except ImportError:
+        print(
+            "psycopg2 not installed. `pip install psycopg2-binary` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    # Resolve created_by to attribute version-bumps to. Falls back to a
+    # creator already present in the target set if the operator didn't
+    # supply one.
+    created_by = args.created_by
+    if created_by is None:
+        cur.execute(
+            "SELECT DISTINCT ev.created_by FROM element_versions ev "
+            "JOIN elements e ON e.id = ev.element_id "
+            "WHERE e.set_id = %s AND ev.created_by IS NOT NULL "
+            "LIMIT 1",
+            (args.set_id,),
+        )
+        row = cur.fetchone()
+        if row:
+            created_by = row["created_by"]
+    if created_by is None:
+        print(
+            "Could not determine created_by; pass --created-by <uuid>.",
+            file=sys.stderr,
+        )
+        return 2
+
+    cur.execute(
+        "SELECT e.id, e.current_version, ev.name, ev.data, ev.metadata, "
+        "ev.description "
+        "FROM elements e "
+        "JOIN element_versions ev "
+        "  ON e.id = ev.element_id AND e.current_version = ev.version "
+        "WHERE e.set_id = %s AND e.is_deleted = FALSE",
+        (args.set_id,),
+    )
+    rows = cur.fetchall()
+    print(f"Found {len(rows)} elements in set {args.set_id}.")
+
+    changed = 0
+    for row in rows:
+        data = row["data"] if isinstance(row["data"], dict) else (
+            json.loads(row["data"]) if row["data"] else {}
+        )
+        new_data, did_change = _add_quantity_attribute(data)
+        if not did_change:
+            continue
+        changed += 1
+        if args.dry_run:
+            print(f"  would add Quantity to {row['name']} ({row['id']})")
+            continue
+        new_version = row["current_version"] + 1
+        now = datetime.now(tz=UTC)
+        version_id = str(uuid.uuid4())  # noqa: F841 — unused, FYI
+        cur.execute(
+            "INSERT INTO element_versions ("
+            "  element_id, version, name, description, data, metadata, "
+            "  change_type, change_summary, created_at, created_by"
+            ") VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)",
+            (
+                row["id"], new_version, row["name"], row["description"],
+                json.dumps(new_data),
+                json.dumps(row["metadata"]) if row["metadata"] else None,
+                "update",
+                "Backfill Quantity attribute (issue #211)",
+                now,
+                created_by,
+            ),
+        )
+        cur.execute(
+            "UPDATE elements SET current_version = %s, updated_at = %s "
+            "WHERE id = %s",
+            (new_version, now, row["id"]),
+        )
+
+    if args.dry_run:
+        print(f"\nDRY RUN: would update {changed} of {len(rows)} elements.")
+        conn.rollback()
+    else:
+        conn.commit()
+        print(f"\nUpdated {changed} of {len(rows)} elements.")
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/backfill_servings_on_recipes.py
+++ b/scripts/backfill_servings_on_recipes.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Set `data.servings` on smart_markdown diagrams in a target set.
+
+Issue #211 — meal-plan → shopping-list workflow.
+
+The Shopping list aggregation profile reads `data.servings` as the
+divisor for the diner-count multiplier. This script sets the field on
+every smart_markdown diagram in the target set, defaulting to a
+uniform value passed via --servings (operator picks the value; the
+seeded default is 4).
+
+Idempotent — running twice is a no-op when `data.servings` is already
+set to the target value.
+
+Usage:
+    python3 scripts/backfill_servings_on_recipes.py \\
+        --db-url "<postgres-url>" \\
+        --set-id "<uuid>" \\
+        --servings 4 \\
+        [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db-url", required=True)
+    ap.add_argument("--set-id", required=True)
+    ap.add_argument("--servings", type=int, default=4)
+    ap.add_argument(
+        "--created-by", default=None,
+        help="User UUID to attribute version-bumps to.",
+    )
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        import psycopg2
+        import psycopg2.extras
+    except ImportError:
+        print(
+            "psycopg2 not installed. `pip install psycopg2-binary` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    created_by = args.created_by
+    if created_by is None:
+        cur.execute(
+            "SELECT DISTINCT dv.created_by FROM diagram_versions dv "
+            "JOIN diagrams d ON d.id = dv.diagram_id "
+            "WHERE d.set_id = %s AND dv.created_by IS NOT NULL "
+            "LIMIT 1",
+            (args.set_id,),
+        )
+        row = cur.fetchone()
+        if row:
+            created_by = row["created_by"]
+    if created_by is None:
+        print(
+            "Could not determine created_by; pass --created-by <uuid>.",
+            file=sys.stderr,
+        )
+        return 2
+
+    cur.execute(
+        "SELECT d.id, d.current_version, dv.name, dv.description, "
+        "dv.data, dv.metadata "
+        "FROM diagrams d "
+        "JOIN diagram_versions dv "
+        "  ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.set_id = %s AND d.is_deleted = FALSE "
+        "AND d.diagram_type = 'smart_markdown'",
+        (args.set_id,),
+    )
+    rows = cur.fetchall()
+    print(f"Found {len(rows)} smart_markdown diagrams in set {args.set_id}.")
+
+    changed = 0
+    for row in rows:
+        data = row["data"] if isinstance(row["data"], dict) else (
+            json.loads(row["data"]) if row["data"] else {}
+        )
+        if data.get("servings") == args.servings:
+            continue
+        changed += 1
+        data["servings"] = args.servings
+        if args.dry_run:
+            print(f"  would set servings={args.servings} on {row['name']}")
+            continue
+        new_version = row["current_version"] + 1
+        now = datetime.now(tz=UTC)
+        cur.execute(
+            "INSERT INTO diagram_versions ("
+            "  diagram_id, version, name, description, data, metadata, "
+            "  change_type, change_summary, created_at, created_by"
+            ") VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)",
+            (
+                row["id"], new_version, row["name"], row["description"],
+                json.dumps(data),
+                json.dumps(row["metadata"]) if row["metadata"] else None,
+                "update",
+                f"Backfill data.servings={args.servings} (issue #211)",
+                now,
+                created_by,
+            ),
+        )
+        cur.execute(
+            "UPDATE diagrams SET current_version = %s, updated_at = %s "
+            "WHERE id = %s",
+            (new_version, now, row["id"]),
+        )
+
+    if args.dry_run:
+        print(f"\nDRY RUN: would update {changed} of {len(rows)} diagrams.")
+        conn.rollback()
+    else:
+        conn.commit()
+        print(f"\nUpdated {changed} of {len(rows)} diagrams.")
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_recipes_to_quantity_tokens.py
+++ b/scripts/migrate_recipes_to_quantity_tokens.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Rewrite legacy free-text quantity prefixes in smart_markdown
+diagrams into ADR-210 structured `=value` overrides.
+
+Issue #211 — meal-plan → shopping-list workflow.
+
+Pre-migration pattern (free text):
+    - NNN {{element:UUID:attr:attributes/Unit/type}} {{element:UUID:name}}
+
+Post-migration pattern (structured override on a Quantity attribute):
+    - {{element:UUID:attr:attributes/Quantity/type=NNN}} {{element:UUID:attr:attributes/Unit/type}} {{element:UUID:name}}
+
+Renders identically for humans (same string output via the smart_markdown
+resolver). Now also machine-parseable by the v6.20.0 aggregation engine.
+
+Usage:
+    python3 scripts/migrate_recipes_to_quantity_tokens.py \\
+        --db-url "<postgres-url>" \\
+        --set-id "<uuid-of-the-recipe-set>" \\
+        [--dry-run]
+
+Idempotent — running twice is a no-op (the regex won't match the
+already-rewritten form).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import UTC, datetime
+
+
+# Matches: `[whitespace]NNN [whitespace] {{element:UUID:attr:.../Unit/type}}`
+# with at least one space between the number and the token.
+# Captures (1) the leading whitespace, (2) the number, (3) the element id.
+_LEGACY_PATTERN = re.compile(
+    r"(^|\s)(\d+(?:\.\d+)?)"          # leading WS + numeric quantity
+    r"\s+"                             # whitespace
+    r"\{\{element:"                    # token start
+    r"([0-9a-fA-F-]+)"                # element UUID
+    r":attr:attributes/Unit/type\}\}", # the Unit attribute token
+    re.MULTILINE,
+)
+
+
+def _rewrite(markdown: str) -> tuple[str, int]:
+    """Return (new_markdown, n_rewrites)."""
+    count = 0
+
+    def repl(m: re.Match) -> str:
+        nonlocal count
+        count += 1
+        leading_ws, qty, elem_id = m.group(1), m.group(2), m.group(3)
+        # Strip trailing .0 from whole numbers.
+        try:
+            if float(qty) == int(float(qty)):
+                qty = str(int(float(qty)))
+        except ValueError:
+            pass
+        return (
+            f"{leading_ws}"
+            f"{{{{element:{elem_id}:attr:attributes/Quantity/type={qty}}}}} "
+            f"{{{{element:{elem_id}:attr:attributes/Unit/type}}}}"
+        )
+
+    return _LEGACY_PATTERN.sub(repl, markdown), count
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--db-url", required=True)
+    ap.add_argument("--set-id", required=True)
+    ap.add_argument(
+        "--created-by", default=None,
+        help="User UUID to attribute version-bumps to. Falls back to a "
+        "creator already present in the target set.",
+    )
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    try:
+        import psycopg2
+        import psycopg2.extras
+    except ImportError:
+        print(
+            "psycopg2 not installed. `pip install psycopg2-binary` first.",
+            file=sys.stderr,
+        )
+        return 2
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = False
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    created_by = args.created_by
+    if created_by is None:
+        cur.execute(
+            "SELECT DISTINCT dv.created_by FROM diagram_versions dv "
+            "JOIN diagrams d ON d.id = dv.diagram_id "
+            "WHERE d.set_id = %s AND dv.created_by IS NOT NULL "
+            "LIMIT 1",
+            (args.set_id,),
+        )
+        row = cur.fetchone()
+        if row:
+            created_by = row["created_by"]
+    if created_by is None:
+        print(
+            "Could not determine created_by; pass --created-by <uuid>.",
+            file=sys.stderr,
+        )
+        return 2
+
+    cur.execute(
+        "SELECT d.id, d.current_version, dv.name, dv.description, "
+        "dv.data, dv.metadata "
+        "FROM diagrams d "
+        "JOIN diagram_versions dv "
+        "  ON d.id = dv.diagram_id AND d.current_version = dv.version "
+        "WHERE d.set_id = %s AND d.is_deleted = FALSE "
+        "AND d.diagram_type = 'smart_markdown'",
+        (args.set_id,),
+    )
+    rows = cur.fetchall()
+    print(f"Found {len(rows)} smart_markdown diagrams in set {args.set_id}.")
+
+    changed = 0
+    total_rewrites = 0
+    for row in rows:
+        data = row["data"] if isinstance(row["data"], dict) else (
+            json.loads(row["data"]) if row["data"] else {}
+        )
+        src = data.get("markdown_source") or ""
+        new_src, count = _rewrite(src)
+        if count == 0:
+            continue
+        changed += 1
+        total_rewrites += count
+        print(f"  {row['name']}: {count} rewrite(s)")
+        if args.dry_run:
+            continue
+        data["markdown_source"] = new_src
+        new_version = row["current_version"] + 1
+        now = datetime.now(tz=UTC)
+        cur.execute(
+            "INSERT INTO diagram_versions ("
+            "  diagram_id, version, name, description, data, metadata, "
+            "  change_type, change_summary, created_at, created_by"
+            ") VALUES (%s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)",
+            (
+                row["id"], new_version, row["name"], row["description"],
+                json.dumps(data),
+                json.dumps(row["metadata"]) if row["metadata"] else None,
+                "update",
+                "Migrate free-text quantity to Quantity-attr override (issue #211)",
+                now,
+                created_by,
+            ),
+        )
+        cur.execute(
+            "UPDATE diagrams SET current_version = %s, updated_at = %s "
+            "WHERE id = %s",
+            (new_version, now, row["id"]),
+        )
+
+    if args.dry_run:
+        print(
+            f"\nDRY RUN: would rewrite {total_rewrites} occurrence(s) "
+            f"across {changed} diagrams.",
+        )
+        conn.rollback()
+    else:
+        conn.commit()
+        print(
+            f"\nRewrote {total_rewrites} occurrence(s) across {changed} "
+            "diagrams.",
+        )
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three operator-run scripts under `scripts/` that prepare existing Iris data for the issue #211 meal-plan → shopping-list workflow:

- **`backfill_quantity_attribute.py`** — adds a blank `Quantity` attribute to every element in a target set so authors can write `=<value>` overrides per use.
- **`migrate_recipes_to_quantity_tokens.py`** — regex-rewrites the legacy free-text quantity pattern `NNN {{element:UUID:attr:.../Unit/type}} {{element:UUID:name}}` into the ADR-210 structured form `{{element:UUID:attr:attributes/Quantity/type=NNN}} {{element:UUID:attr:attributes/Unit/type}} {{element:UUID:name}}`. Renders identically; now machine-parseable.
- **`backfill_servings_on_recipes.py`** — sets `data.servings` on smart_markdown diagrams so the Shopping list profile's diner-count multiplier has a denominator.

All idempotent, dry-run capable, with `--created-by` attribution.

Live data **already migrated** against UAT/prod Supabase:
- 178 grocery elements gained `Quantity`.
- 124 rewrites across 29 of 34 recipes.
- 34 recipes got `data.servings = 4`.

Verified Spaghetti rewritten as: `{{element:a8db…:attr:attributes/Quantity/type=500}} {{element:a8db…:attr:attributes/Unit/type}} {{element:a8db…:name}}`.

**Sixth and final PR** implementing [#211](https://github.com/cgbarlow/iris/issues/211). The end-to-end demo workflow is now exercisable: build a meal-plan smart_markdown diagram referencing existing recipes, then `aggregate(profile=shopping-list, source=<meal-plan>)` returns a deduplicated, summed shopping list.

## References

- [Plan](docs/plans/issue-211-shopping-list-implementation.md) §4.6, §4.7, §4.8, §20.

## Migration

- Operator-run, not in the startup runner. Already applied to the live DB.

## Test plan

- [x] 5 regex unit tests pass (`test_migrate_recipes_regex.py`)
- [x] Dry-run preview against live UAT showed expected counts (178 / 124 across 29 / 34) before applying
- [x] Live data verification post-apply: Spaghetti recipe, Pork mince element
- [x] Genericness invariant still clean
- [ ] End-to-end: build a meal-plan smart_markdown diagram referencing recipes, call `iris aggregate --profile <shopping-list-id> --source <meal-plan-id>`, confirm summed grocery list

🤖 Generated with [Claude Code](https://claude.com/claude-code)