### PR TITLE
fix(v6.26.1): seed admin re-run survives user content under seed pkgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.26.1] - 2026-05-22
+
+### Fixed
+
+- **Admin → Settings → Seed Example Diagrams** no longer 500s with a
+  `ForeignKeyViolationError` when the user has placed any non-seed
+  diagram or element under a seed package. The seed's
+  `_clear_old_seed_data` flow now NULLs out non-seed FK references to
+  seed packages (diagrams.parent_package_id, elements.package_id) and
+  to seed elements (element_templates.source_element_id, bookmarks)
+  before deleting them, so orphaned user content survives the
+  clear-and-re-seed cycle (reparented to "no package") while the seed
+  packages go away cleanly.
+- The browser-side symptom — "No access control origin header" CORS
+  error — was a downstream effect of Render returning a 500 without
+  CORS headers when the backend exception fired. The fix is on the
+  backend; CORS is unchanged.
+
+### Migration
+
+- None. Pure logic fix in `backend/app/seed/example_models.py`.
+
+### Test plan
+
+- Regression tests added in
+  `backend/tests/test_seed/test_example_models.py` cover both the
+  "non-seed diagram parented to a seed package" and "user template
+  referencing a seed element" cases.
+
 ## [6.26.0] - 2026-05-22
 
 ### Added

--- a/backend/app/seed/example_models.py
+++ b/backend/app/seed/example_models.py
@@ -1805,10 +1805,53 @@ async def _clear_old_seed_data(db: DatabasePort) -> None:
         for (orphan_rid,) in await cursor.fetchall():
             await db.execute("DELETE FROM relationship_versions WHERE relationship_id = ?", (orphan_rid,))
             await db.execute("DELETE FROM relationships WHERE id = ?", (orphan_rid,))
+        # Sever indirect FK references that aren't iterated above:
+        # element_templates point at an element via source_element_id;
+        # bookmarks may target an element. NULL/delete them rather than
+        # blocking the element delete. Tables may not exist on minimal
+        # test setups — tolerate "no such table" since their absence
+        # means no rows could be blocking anyway.
+        for stmt, params in (
+            ("UPDATE element_templates SET source_element_id = NULL "
+             "WHERE source_element_id = ?", (eid,)),
+            ("DELETE FROM bookmarks WHERE element_id = ?", (eid,)),
+        ):
+            try:
+                await db.execute(stmt, params)
+            except Exception:  # noqa: BLE001
+                pass
         await db.execute("DELETE FROM element_tags WHERE element_id = ?", (eid,))
         await db.execute("DELETE FROM element_versions WHERE element_id = ?", (eid,))
         await db.execute("DELETE FROM elements_fts WHERE element_id = ?", (eid,))
         await db.execute("DELETE FROM elements WHERE id = ?", (eid,))
+
+    # Sever non-seed references to seed packages before deleting them.
+    # The seed only iterates known seed IDs; if a user has placed any
+    # non-seed diagram or element under a seed package, FK constraints
+    # will block the package delete (issue surfaced when a DoView seed
+    # package picked up a hand-created diagram). NULL'ing the FK first
+    # lets the orphan stay (now reparented to "no package") while the
+    # seed package goes away cleanly. Also clear bookmarks that target
+    # the package directly.
+    for pid in package_ids:
+        # diagrams.parent_package_id always exists.
+        await db.execute(
+            "UPDATE diagrams SET parent_package_id = NULL "
+            "WHERE parent_package_id = ?",
+            (pid,),
+        )
+        # elements.package_id and bookmarks.package_id may be missing
+        # on minimal test setups — tolerate their absence (no rows to
+        # block the package delete in that case).
+        for stmt, params in (
+            ("UPDATE elements SET package_id = NULL "
+             "WHERE package_id = ?", (pid,)),
+            ("DELETE FROM bookmarks WHERE package_id = ?", (pid,)),
+        ):
+            try:
+                await db.execute(stmt, params)
+            except Exception:  # noqa: BLE001
+                pass
 
     # Delete packages (children first — all children have parent = pkg-0)
     for pid in reversed(package_ids):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.26.0"
+version = "6.26.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_seed/test_example_models.py
+++ b/backend/tests/test_seed/test_example_models.py
@@ -566,3 +566,137 @@ async def test_v2_seed_upgraded_to_v3(main_db: aiosqlite.Connection) -> None:
         (_DEFAULT_SET_ID,),
     )
     assert (await cursor.fetchone())[0] == 39
+
+
+@pytest.mark.asyncio
+async def test_seed_re_runs_when_user_diagram_under_seed_package(
+    main_db: aiosqlite.Connection,
+) -> None:
+    """Regression for the 2026-05-22 seed-clear FK violation.
+
+    If a user has created a non-seed diagram with `parent_package_id`
+    pointing at a seed package (here the DoView Notation package),
+    the seed's clear-and-re-seed flow must not FK-fail on the package
+    delete. `_clear_old_seed_data` now NULLs out non-seed references
+    before deleting seed packages.
+    """
+    await _run_migrations(main_db)
+    await _create_active_user(main_db)
+
+    # First seed populates everything.
+    await seed_example_models(main_db)
+
+    # Simulate the user-created scenario: a non-seed diagram pointing
+    # at one of the seed packages. DoView Notation is pkg-5.
+    doview_pkg_id = _gen_id("pkg", 5)
+    user_diag_id = "11111111-1111-1111-1111-111111111111"
+    now = "2026-05-22T00:00:00+00:00"
+    await main_db.execute(
+        "INSERT INTO diagrams (id, diagram_type, set_id, current_version, "
+        "created_at, created_by, updated_at, parent_package_id, notation, "
+        "sequence_order) "
+        "VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)",
+        (user_diag_id, "outcomes_map", _DEFAULT_SET_ID, now,
+         _SYSTEM_USER_ID, now, doview_pkg_id, "doview", 999),
+    )
+    await main_db.execute(
+        "INSERT INTO diagram_versions (diagram_id, version, name, "
+        "description, data, metadata, change_type, created_at, created_by) "
+        "VALUES (?, 1, ?, ?, ?, ?, 'create', ?, ?)",
+        (user_diag_id, "User-created DoView", "User content",
+         "{}", None, now, _SYSTEM_USER_ID),
+    )
+    await main_db.commit()
+
+    # Wipe the v8 marker so the next seed call runs the clear-and-re-seed
+    # path (mirroring what happens when an older seed version had been
+    # left behind in prod).
+    await main_db.execute(
+        "UPDATE diagram_versions SET metadata = NULL WHERE diagram_id = ?",
+        (_gen_id("diagram", 33),),
+    )
+    await main_db.commit()
+
+    # Should NOT raise — the fix reparents the user diagram before
+    # deleting the seed package.
+    await seed_example_models(main_db)
+    await main_db.commit()
+
+    # User diagram still exists, but its parent_package_id is now NULL.
+    cursor = await main_db.execute(
+        "SELECT parent_package_id FROM diagrams WHERE id = ?",
+        (user_diag_id,),
+    )
+    row = await cursor.fetchone()
+    assert row is not None, "User diagram should survive the seed re-run"
+    assert row[0] is None, (
+        "User diagram's parent_package_id should be NULL after the seed "
+        "package was deleted (the cleanup nulls non-seed references)."
+    )
+
+    # And the seed is back to a complete state.
+    cursor = await main_db.execute(
+        "SELECT COUNT(*) FROM packages WHERE set_id = ? AND is_deleted = 0",
+        (_DEFAULT_SET_ID,),
+    )
+    assert (await cursor.fetchone())[0] == 6
+
+
+@pytest.mark.asyncio
+async def test_seed_re_runs_when_user_element_template_references_seed_element(
+    main_db: aiosqlite.Connection,
+) -> None:
+    """Regression: element_template.source_element_id pointing at a
+    seed element previously FK-blocked the element delete during the
+    seed clear-and-re-seed flow.
+    """
+    await _run_migrations(main_db)
+    await _create_active_user(main_db)
+
+    # The seed-test fixture's migration list doesn't include m067 (element
+    # templates). Create a minimal table inline for this regression test.
+    await main_db.execute(
+        "CREATE TABLE IF NOT EXISTS element_templates ("
+        "id TEXT PRIMARY KEY, name TEXT NOT NULL, description TEXT, "
+        "set_id TEXT, is_global INTEGER NOT NULL DEFAULT 0, "
+        "source_element_id TEXT, included_fields TEXT NOT NULL, "
+        "template_data TEXT NOT NULL, created_by TEXT, "
+        "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, "
+        "is_deleted INTEGER NOT NULL DEFAULT 0)",
+    )
+    await main_db.commit()
+
+    await seed_example_models(main_db)
+
+    # Pick a seed element and create a template referencing it.
+    seed_eid = _gen_id("element", 0)
+    template_id = "22222222-2222-2222-2222-222222222222"
+    now = "2026-05-22T00:00:00+00:00"
+    await main_db.execute(
+        "INSERT INTO element_templates ("
+        "id, name, description, set_id, is_global, source_element_id, "
+        "included_fields, template_data, created_by, created_at, updated_at"
+        ") VALUES (?, ?, ?, NULL, 1, ?, '[\"name\"]', '{}', ?, ?, ?)",
+        (template_id, "Stamps-on-seed", "Test",
+         seed_eid, _SYSTEM_USER_ID, now, now),
+    )
+    await main_db.commit()
+
+    # Wipe v8 marker → trigger the clear flow.
+    await main_db.execute(
+        "UPDATE diagram_versions SET metadata = NULL WHERE diagram_id = ?",
+        (_gen_id("diagram", 33),),
+    )
+    await main_db.commit()
+
+    await seed_example_models(main_db)
+    await main_db.commit()
+
+    # Template survives but its source_element_id is now NULL.
+    cursor = await main_db.execute(
+        "SELECT source_element_id FROM element_templates WHERE id = ?",
+        (template_id,),
+    )
+    row = await cursor.fetchone()
+    assert row is not None
+    assert row[0] is None

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.26.0",
+	"version": "6.26.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.26.0"
+version = "6.26.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.26.0"
+version = "6.26.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

User clicked Admin → Settings → Seed Example Diagrams → got a CORS error followed by 500. Render logs traced to:

```
asyncpg.exceptions.ForeignKeyViolationError:
update or delete on table "packages" violates foreign key constraint "diagrams_parent_package_id_fkey" on table "diagrams"
DETAIL: Key (id)=(581421d5-36ee-589b-9f07-33a96aa03997) is still referenced from table "diagrams".
```

The id is the seeded **DoView Notation** package. The user had hand-created a DoView diagram parented under that seed package; the seed's `_clear_old_seed_data` only iterates known seed-deterministic IDs so it never severed the FK. Browser saw the 500 as a CORS error because Render's error response dropped the `Access-Control-Allow-Origin` header.

## Fix

Before deleting seed packages, NULL out non-seed references:
- `diagrams.parent_package_id WHERE parent_package_id = <seed-pkg>`
- `elements.package_id WHERE package_id = <seed-pkg>`
- `bookmarks WHERE package_id = <seed-pkg>`

Before deleting seed elements, NULL out / clear indirect references:
- `element_templates.source_element_id WHERE source_element_id = <seed-el>`
- `bookmarks WHERE element_id = <seed-el>`

Orphan user content is preserved (parented to "no package" / template with cleared source) while the seed packages go away cleanly.

`element_templates` and `bookmarks` UPDATE/DELETE calls are wrapped in try/except so the minimal-migration seed-test fixture (which doesn't run m067) keeps working.

## Test plan

- [x] 22/22 seed tests pass (20 pre-existing + 2 new regression tests)
- [x] 305/305 broader regression (test_seed + test_diagrams + test_element_templates + test_aggregation)
- [x] Genericness invariant clean
- [ ] Post-deploy: click Admin → Settings → Seed Example Diagrams in UAT; expect 200 + populated seed

## Out of band

The pre-existing `is_active = 1` query in `seed_example_models` line 1838 is a SQL syntax error on Postgres (boolean vs int) but is currently caught by the try/except fallback to `profiles`. Not part of this fix; could be cleaned up in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)