### PR TITLE
feat(v6.27.0): stamp filter by body-referenced attributes (ADR-215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.27.0] - 2026-05-22
+
+### Changed
+
+- **Smart-markdown picker stamp filter narrowed by body-referenced
+  attributes** ([ADR-215](docs/adrs/ADR-215-Stamp-Filter-By-Body-Attributes.md),
+  [SPEC-211-d](docs/adrs/specs/SPEC-211-d-Stamp-Filter-By-Body-Attributes.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211) comment
+  observation O2/O3). The `/api/element-templates/stamps?element_id=…`
+  endpoint now additionally filters out stamps whose body references
+  attributes the target element doesn't have. Resolves the user-
+  reported case where every grocery element saw all five seeded
+  stamps including ones for sprint points and reading logs.
+  - Attribute requirements are extracted from `{{self:attr:attributes/<NAME>/<rest>}}`
+    tokens in the stamp body via regex. The set must be a subset of
+    the element's `data.attributes` names for the stamp to appear.
+  - Stamps whose body uses no `self:attr:` tokens (e.g. just
+    `{{self:name}}`) pass the body filter trivially.
+  - The five seeded stamps now narrow naturally:
+    - **Quantified item** (Quantity + Unit) → groceries with both
+    - **Sized story** (Points) → story-shaped elements
+    - **Logged work** (Hours) → log-shaped elements
+    - **Line item** (Amount + Currency) → expense-shaped elements
+    - **Read entry** (Pages + Author) → reading-log-shaped elements
+
+### Migration
+
+- None. Pure filter logic change in
+  `backend/app/element_templates/service.py::list_stamps_for_element`.
+
 ## [6.26.1] - 2026-05-22
 
 ### Fixed

--- a/backend/app/element_templates/service.py
+++ b/backend/app/element_templates/service.py
@@ -27,6 +27,14 @@ if TYPE_CHECKING:
 # ADR-211: `{{self:<field-spec>}}` placeholder used in markdown_stamp.
 _SELF_TOKEN_RE = re.compile(r"\{\{self:([^}]+)\}\}")
 
+# ADR-215 (v6.27.0): regex that extracts attribute NAMEs from
+# self:attr:attributes/<NAME>/<rest> tokens in a stamp body. The
+# stamp's required-attribute set drives whether it applies to a
+# given element via SPEC-211-d's body-parsing filter.
+_BODY_ATTR_TOKEN_RE = re.compile(
+    r"\{\{self:attr:attributes/([^/}]+)/[^}]+\}\}",
+)
+
 
 def substitute_self(stamp_body: str, element_id: str) -> str:
     """Rewrite ``{{self:<field-spec>}}`` → ``{{element:<element_id>:<field-spec>}}``.
@@ -38,6 +46,31 @@ def substitute_self(stamp_body: str, element_id: str) -> str:
         lambda m: f"{{{{element:{element_id}:{m.group(1)}}}}}",
         stamp_body,
     )
+
+
+def _required_attr_names(stamp_body: str | None) -> set[str]:
+    """ADR-215: return the set of attribute NAMEs referenced by
+    ``{{self:attr:attributes/<NAME>/<rest>}}`` tokens in the stamp body.
+
+    Empty result means the body uses no attribute references — the
+    body filter is trivially satisfied for any element."""
+    if not stamp_body:
+        return set()
+    return set(_BODY_ATTR_TOKEN_RE.findall(stamp_body))
+
+
+def _element_attr_names(element_data: dict[str, Any]) -> set[str]:
+    """Return the set of attribute names on element.data.attributes."""
+    attrs = element_data.get("attributes")
+    if not isinstance(attrs, list):
+        return set()
+    out: set[str] = set()
+    for a in attrs:
+        if isinstance(a, dict):
+            name = a.get("name")
+            if isinstance(name, str):
+                out.add(name)
+    return out
 
 
 class ElementTemplateScopeError(ValueError):
@@ -459,23 +492,30 @@ def apply_template_to_create_body(
 async def list_stamps_for_element(
     db: DatabasePort, element_id: str,
 ) -> list[dict[str, Any]]:
-    """Return in-scope stamps for an element (ADR-211 scope rules).
+    """Return in-scope stamps for an element.
 
-    A stamp is in-scope when:
-      - The template has a non-empty ``markdown_stamp``.
-      - The template is global (``is_global = 1``) OR set-scoped to
-        the element's set.
-      - The template's captured ``element_type`` matches the element's
-        ``element_type`` (or the template doesn't capture an
-        element_type — then it's offered for any).
+    Filter rules:
+
+    1. Scope (ADR-211): the template is global (``is_global = 1``) OR
+       set-scoped to the element's set.
+    2. Element type (ADR-211): the template's captured ``element_type``
+       matches the element's ``element_type`` (or the template doesn't
+       capture an element_type — then it's offered for any).
+    3. Body attributes (ADR-215): every attribute name referenced by
+       the stamp body via ``{{self:attr:attributes/<NAME>/<rest>}}``
+       must be present on the element's ``data.attributes``. Stamps
+       whose body uses no ``attr:`` references pass trivially.
 
     Each returned ``markdown_stamp`` has ``{{self:…}}`` already
     substituted with the element's ID so the picker can paste it
     directly.
     """
-    # Resolve element's set_id + element_type.
+    # Resolve element's set_id + element_type + data.
     cursor = await db.execute(
-        "SELECT e.set_id, e.element_type FROM elements e "
+        "SELECT e.set_id, e.element_type, ev.data "
+        "FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "  AND e.current_version = ev.version "
         "WHERE e.id = ? AND e.is_deleted = 0",
         (element_id,),
     )
@@ -483,6 +523,16 @@ async def list_stamps_for_element(
     if row is None:
         return []
     set_id, element_type = row[0], row[1]
+    raw_data = row[2]
+    try:
+        element_data: dict[str, Any] = (
+            json.loads(raw_data) if isinstance(raw_data, str) else (raw_data or {})
+        )
+    except (json.JSONDecodeError, TypeError):
+        element_data = {}
+    if not isinstance(element_data, dict):
+        element_data = {}
+    elem_attr_names = _element_attr_names(element_data)
 
     cursor = await db.execute(
         "SELECT id, name, description, set_id, is_global, "
@@ -503,6 +553,11 @@ async def list_stamps_for_element(
         if td_etype and td_etype != element_type:
             continue
         stamp_body = r[6] or ""
+        # ADR-215 body-parsing filter: every attribute name referenced
+        # by the stamp body must exist on the element.
+        required = _required_attr_names(stamp_body)
+        if required and not required.issubset(elem_attr_names):
+            continue
         resolved = substitute_self(stamp_body, element_id)
         out.append({
             "id": r[0],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.26.1"
+version = "6.27.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_element_templates/test_stamps.py
+++ b/backend/tests/test_element_templates/test_stamps.py
@@ -76,17 +76,40 @@ async def _create_set(c: httpx.AsyncClient, h: dict, name: str = "S") -> str:
 async def _create_element(
     c: httpx.AsyncClient, h: dict, *, set_id: str,
     name: str = "E", element_type: str = "class",
+    data: dict | None = None,
 ) -> str:
+    body: dict = {
+        "name": name, "element_type": element_type, "set_id": set_id,
+    }
+    if data is not None:
+        body["data"] = data
     r = await c.post(
-        "/api/elements",
-        json={
-            "name": name, "element_type": element_type,
-            "set_id": set_id,
-        },
-        headers=h,
+        "/api/elements", json=body, headers=h,
     )
     assert r.status_code == 201, r.text
     return r.json()["id"]
+
+
+def _attrs(*names: str) -> dict:
+    """Build an element.data shape with the named attributes (all blank type)."""
+    return {
+        "attributes": [
+            {"name": n, "type": "", "scope": "Public",
+             "notes": "", "lower_bound": "", "upper_bound": ""}
+            for n in names
+        ],
+    }
+
+
+# All five seeded global stamps reference these attributes in their
+# bodies. Used by tests that need ALL seeded stamps to apply at once.
+_ALL_SEEDED_ATTRS = _attrs(
+    "Quantity", "Unit",          # Quantified item / Ingredient
+    "Points",                    # Sized story
+    "Hours",                     # Logged work
+    "Amount", "Currency",        # Line item
+    "Pages", "Author",           # Read entry
+)
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -228,10 +251,13 @@ async def test_update_markdown_stamp(
 async def test_stamps_endpoint_returns_seeded_globals_for_class_element(
     client: httpx.AsyncClient,
 ) -> None:
+    """ADR-215: an element with *all* the attributes the seeded stamps
+    reference in their bodies sees all five seeded stamps."""
     h = await _auth(client)
     set_id = await _create_set(client, h)
     eid = await _create_element(
         client, h, set_id=set_id, element_type="class",
+        data=_ALL_SEEDED_ATTRS,
     )
     r = await client.get(
         f"/api/element-templates/stamps?element_id={eid}", headers=h,
@@ -253,6 +279,7 @@ async def test_stamps_self_substituted_to_element_id(
     set_id = await _create_set(client, h)
     eid = await _create_element(
         client, h, set_id=set_id, name="Pork mince", element_type="class",
+        data=_attrs("Quantity", "Unit"),
     )
     r = await client.get(
         f"/api/element-templates/stamps?element_id={eid}", headers=h,
@@ -335,3 +362,170 @@ async def test_stamps_missing_element_returns_empty_list(
     )
     assert r.status_code == 200
     assert r.json()["items"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# ADR-215 / SPEC-211-d: body-parsing attribute filter
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_body_filter_hides_stamp_when_required_attribute_missing(
+    client: httpx.AsyncClient,
+) -> None:
+    """ADR-215: stamp body requires Points; element has only Quantity+Unit
+    → stamp hidden."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("Quantity", "Unit"),
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    names = sorted(s["name"] for s in r.json()["items"])
+    # Sized story (Points), Logged work (Hours), Line item (Amount/Currency),
+    # Read entry (Pages/Author) — all hidden. Only Quantified item shows.
+    assert names == ["Quantified item"]
+
+
+@pytest.mark.asyncio
+async def test_body_filter_shows_stamp_when_all_required_attrs_present(
+    client: httpx.AsyncClient,
+) -> None:
+    """Quantified item body needs Quantity + Unit; element has both → shown."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("Quantity", "Unit", "Products"),  # extras don't matter
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    names = sorted(s["name"] for s in r.json()["items"])
+    assert "Quantified item" in names
+
+
+@pytest.mark.asyncio
+async def test_body_filter_hides_stamp_when_required_attr_partial(
+    client: httpx.AsyncClient,
+) -> None:
+    """Line item body requires Amount AND Currency; element has only Amount."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("Amount"),  # missing Currency
+    )
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    names = [s["name"] for s in r.json()["items"]]
+    assert "Line item" not in names
+
+
+@pytest.mark.asyncio
+async def test_body_trivial_stamp_applies_without_attrs(
+    client: httpx.AsyncClient,
+) -> None:
+    """A stamp body that uses no `self:attr:` tokens (e.g. just `name`)
+    passes the body filter trivially — applies to any matching-type
+    element regardless of attribute set."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+    )  # no attributes
+    # Create a body-trivial stamp.
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Just the name",
+            "markdown_stamp": "{{self:name}}",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201
+
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    names = [s["name"] for s in r.json()["items"]]
+    assert "Just the name" in names
+    # The seeded stamps reference attributes → hidden from this element.
+    assert "Quantified item" not in names
+
+
+@pytest.mark.asyncio
+async def test_body_filter_user_stamp_referencing_custom_attribute(
+    client: httpx.AsyncClient,
+) -> None:
+    """A user-authored stamp body referencing a custom attribute applies
+    only to elements that have that attribute."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    # Element WITH the custom attribute.
+    eid_with = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("Difficulty"),
+    )
+    # Element WITHOUT the custom attribute.
+    eid_without = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("OtherAttr"),
+    )
+    # Create the user stamp.
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Difficulty-rated",
+            "markdown_stamp":
+                "{{self:attr:attributes/Difficulty/type=}} - {{self:name}}",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201
+
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid_with}", headers=h,
+    )
+    assert "Difficulty-rated" in [s["name"] for s in r.json()["items"]]
+
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid_without}", headers=h,
+    )
+    assert "Difficulty-rated" not in [s["name"] for s in r.json()["items"]]
+
+
+@pytest.mark.asyncio
+async def test_body_filter_dedupes_same_attribute_referenced_twice(
+    client: httpx.AsyncClient,
+) -> None:
+    """A stamp body referencing the same attribute twice — required set is
+    deduplicated, behaviour identical to a single reference."""
+    h = await _auth(client)
+    set_id = await _create_set(client, h)
+    eid = await _create_element(
+        client, h, set_id=set_id, element_type="class",
+        data=_attrs("Quantity"),
+    )
+    r = await client.post(
+        "/api/element-templates",
+        json={
+            "name": "Double-quantity",
+            "markdown_stamp":
+                "{{self:attr:attributes/Quantity/type=}} "
+                "{{self:attr:attributes/Quantity/notes}}",
+            "is_global": True,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201
+    r = await client.get(
+        f"/api/element-templates/stamps?element_id={eid}", headers=h,
+    )
+    assert "Double-quantity" in [s["name"] for s in r.json()["items"]]

--- a/docs/adrs/ADR-215-Stamp-Filter-By-Body-Attributes.md
+++ b/docs/adrs/ADR-215-Stamp-Filter-By-Body-Attributes.md
@@ -1,0 +1,70 @@
+# ADR-215: Stamp scope filter — body-parsing attribute match
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-211](./ADR-211-Element-Template-Stamps.md), [SPEC-211-a](./specs/SPEC-211-a-Element-Template-Stamps.md), [ADR-214](./ADR-214-Genericness-Invariant-Shopping-List.md).
+
+## Context
+
+Per SPEC-211-a §3, `GET /api/element-templates/stamps?element_id=<id>` filters stamps to those in-scope for the element via two checks:
+
+1. Scope (global or matching set).
+2. `template_data.element_type` matches the element's `element_type` (or the template doesn't carry an `element_type`).
+
+In the real Iris data, almost every domain element is `element_type = "class"` (grocery items, stories, log entries — all class). The five seeded stamps all target `element_type=class`. Net effect: in the smart-markdown picker, a user drilling into a "sausages" element sees all five stamps including "Sized story", which makes no sense for a grocery item.
+
+The user-facing report ([issue #211 comment 2026-05-22](https://github.com/cgbarlow/iris/issues/211)) called this out: "picker is showing me stamp for 'sized story' [for a sausages element]". The `element_type` filter is too coarse.
+
+## Decision
+
+Add a third filter step: a stamp is in-scope for an element only when **every** attribute name referenced by the stamp's body (via `{{self:attr:attributes/<NAME>/<...>}}` tokens) is present on the element's `data.attributes` array.
+
+```
+required = { ATTR_NAME for every
+             {{self:attr:attributes/ATTR_NAME/<rest>}} token
+             in stamp.markdown_stamp }
+element_attrs = { a["name"] for a in element.data.attributes
+                  if a is a dict with a "name" key }
+stamp_in_scope_by_body  = required ⊆ element_attrs
+```
+
+A stamp whose body references no `attr:` tokens (e.g. just `{{self:name}}`) passes the body filter trivially — falls back to the pre-existing `element_type` check only.
+
+### Why body-parsing, not template_data blueprint
+
+The template's `template_data.data.attributes` is a snapshot of *every* attribute the source element had at template-creation time. A stamp captured from a sausage element would have Quantity, Unit, Products, Preferred product in its blueprint — but the stamp body usually references only some of them (e.g. Quantity + Unit + name).
+
+Using the blueprint as the required-attributes set would over-constrain: the same "qty + unit + name" stamp would only show up on elements that *also* have Products and Preferred product. Way too narrow — a user wanting to write `{{self:attr:attributes/Quantity/type=}} {{self:attr:attributes/Unit/type}} {{self:name}}` against a butter element (no Products attribute) would be denied.
+
+The stamp **body** is the authoritative statement of which attributes the stamp will actually render. Anything not referenced by the body doesn't matter.
+
+### Why not "any-of" or tag-based
+
+- **Any-of** (stamp shown if at least one referenced attribute is on the element) — admits noise: a generic element with one of many attributes would get unrelated stamps. We want precision.
+- **Tag-based** matching (manual user tags) — new authoring burden; harder to seed; doesn't reuse existing data. Rejected.
+
+## Consequences
+
+**Positive:**
+
+- The user's reported bug closes — sausage shows only the Ingredient/"Quantified item" stamp; story shows only Sized story; etc.
+- The seeded blueprints (Quantity + Unit, Points, Hours, Amount + Currency, Pages + Author) become first-class — they define applicability through the stamp body authors will pick.
+- Composes with the v6.24.0 stamp editor: a user editing a stamp body to add `{{self:attr:attributes/Difficulty/type}}` immediately narrows the stamp's applicability to elements that have Difficulty.
+- No new database field, no new schema migration — pure filter logic on top of existing data.
+
+**Negative / accepted trade-offs:**
+
+- Stamps whose body deliberately uses no `attr:` tokens (only `name`/`description`) match any element that passes the element_type check. Reasonable: a "passing mention" stamp like `{{self:name}}` shouldn't be element-attribute-specific.
+- A user can author a stamp body referencing an attribute that doesn't exist anywhere in their data; the stamp would then never appear. That's a discoverability issue, not a correctness one — author error surfaces by absence rather than failure. Documented in SPEC-211-d.
+
+## Rejected alternatives
+
+- **Blueprint-attribute filter** (rejected, see "Why body-parsing").
+- **Manual `stamp_element_type_filter` column** on element_templates — codifies the same coarseness the user complained about, just at a more granular level. Doesn't address the real signal (which attributes the body uses).
+- **Element-type sub-categorization** (e.g. `element_type` = "class:grocery" vs "class:story") — would require a data migration of every element. Body-parsing achieves the same precision without touching element data.
+
+## References
+
+- [SPEC-211-d — body-parsing algorithm, edge cases, tests](./specs/SPEC-211-d-Stamp-Filter-By-Body-Attributes.md)
+- [SPEC-211-a §3](./specs/SPEC-211-a-Element-Template-Stamps.md) — the original element_type-only filter this ADR extends
+- [`docs/plans/issue-211-comment-followups.md`](../plans/issue-211-comment-followups.md) §3 — plan record

--- a/docs/adrs/specs/SPEC-211-d-Stamp-Filter-By-Body-Attributes.md
+++ b/docs/adrs/specs/SPEC-211-d-Stamp-Filter-By-Body-Attributes.md
@@ -1,0 +1,103 @@
+# SPEC-211-d: Stamp filter by body-referenced attributes
+
+Implements: [ADR-215](../ADR-215-Stamp-Filter-By-Body-Attributes.md). Extends [SPEC-211-a §3](./SPEC-211-a-Element-Template-Stamps.md).
+
+## 1. Algorithm
+
+In `backend/app/element_templates/service.py::list_stamps_for_element`, after the existing scope and `element_type` filters, apply:
+
+```python
+import re
+
+_BODY_ATTR_TOKEN_RE = re.compile(
+    r"\{\{self:attr:attributes/([^/}]+)/[^}]+\}\}"
+)
+
+
+def _required_attr_names(stamp_body: str | None) -> set[str]:
+    """Return the set of attribute NAMEs referenced by self:attr tokens
+    in the stamp body. Matches {{self:attr:attributes/<NAME>/<anything>}}
+    — the same shape the seeded stamps use and that ADR-210 documented."""
+    if not stamp_body:
+        return set()
+    return set(_BODY_ATTR_TOKEN_RE.findall(stamp_body))
+
+
+def _element_attr_names(element_data: dict[str, Any]) -> set[str]:
+    """Return the set of attribute names on element.data.attributes."""
+    attrs = element_data.get("attributes")
+    if not isinstance(attrs, list):
+        return set()
+    out: set[str] = set()
+    for a in attrs:
+        if isinstance(a, dict):
+            name = a.get("name")
+            if isinstance(name, str):
+                out.add(name)
+    return out
+```
+
+The filter inside `list_stamps_for_element`:
+
+```python
+# After fetching candidate stamps in scope, before returning:
+required = _required_attr_names(stamp_body)
+if required and not required.issubset(element_attr_names):
+    continue   # stamp doesn't apply
+```
+
+- `required` is empty → no `attr:` tokens in the body → the body filter passes trivially (stamps that only reference `name`/`description` still show).
+- `required` non-empty but a subset of `element_attr_names` → stamp applies.
+- `required` non-empty and at least one name missing on the element → stamp hidden.
+
+## 2. Endpoint shape
+
+Unchanged. `GET /api/element-templates/stamps?element_id=<id>` still returns `{items: [...]}` with the same shape; the body filter is purely a server-side narrowing.
+
+## 3. Backwards compatibility
+
+- Existing five seeded stamps each reference attributes in their bodies. After the filter ships:
+  - **Ingredient** (a.k.a. Quantified item — being renamed in PR 13): body references Quantity + Unit. Shows for elements with both.
+  - **Sized story**: body references Points.
+  - **Logged work**: body references Hours.
+  - **Line item**: body references Amount + Currency.
+  - **Read entry**: body references Pages + Author.
+- The 178 live grocery items in the user's UAT have Quantity + Unit (after the v6.22.0 backfill) → Ingredient stamp will show; the other four won't. Exactly the requested behaviour.
+- User-authored stamps whose body uses attributes the element doesn't have → silently hidden. Documented in the stamp-editor help text in a future polish PR.
+
+## 4. Tests
+
+`backend/tests/test_element_templates/test_stamps.py` gains a new section `test_body_attribute_filter` with cases:
+
+- Stamp body referencing only `name` → applies to any matching-element_type element.
+- Stamp body referencing `{{self:attr:attributes/Points/type=}}` → applies only to elements that have a `Points` attribute.
+- Stamp body referencing `{{self:attr:attributes/Quantity/type=}} {{self:attr:attributes/Unit/type}}` → applies to elements with both Quantity and Unit; hidden from elements missing either.
+- Stamp body that doesn't follow the `attributes/<NAME>/<path>` shape (e.g. `{{self:attr:topLevel/type}}`) — required set is empty (regex doesn't match top-level paths), filter is permissive. Documented as an edge case.
+
+`SPEC-211-a §7` tests assertion that the seeded globals all appear for a `class`-typed element with no attributes: this assertion gets refined — only the body-trivial seeded stamps appear (none of them are body-trivial), so an `element_type=class` element with no attributes now sees zero seeded stamps. Updated to assert this matches the spec.
+
+## 5. Edge cases
+
+| Case | Behaviour |
+|---|---|
+| Stamp body has multiple references to the same attribute | `required` is a set → deduplicated, no effect. |
+| Stamp body has a typo in attribute name | Required set contains the typo → no element has that attribute → stamp hidden. The author sees absence and fixes the body. |
+| Element has the attribute name with different case (e.g. `quantity` vs `Quantity`) | Case-sensitive match. Mismatch → hidden. Iris's existing attribute model is case-sensitive everywhere. |
+| Stamp body references an attribute path that uses non-trivial drill (e.g. `attributes/Products/0/name`) | Regex captures the first segment after `attributes/` → `Products`. Hidden unless the element has a `Products` attribute. Reasonable. |
+| Empty stamp body (rare — should be rejected at write time by SPEC-211-a §3) | `required` empty → passes the body filter. Element_type filter still applies. |
+| Stamp body uses `{{element:UUID:attr:...}}` (concrete element, not `self`) | Regex matches on `self:attr:`, not `element:`; concrete-element tokens contribute nothing to `required`. This is correct — concrete-element stamps don't templatise. |
+
+## 6. Genericness (ADR-214)
+
+The filter logic is generic — no domain terminology. The seeded stamps' applicability flows from data, not code.
+
+## 7. Risk
+
+- Low. Pure additional filter on top of existing logic. Stamps that previously appeared and shouldn't have will now be hidden; stamps that previously appeared and should appear continue to do so (the seeded stamps' bodies all reference attributes that exist in the user's data).
+- If a stamp body is authored badly (e.g. references an attribute that no element has), it disappears entirely. Mitigation: stamp editor could surface "this stamp will apply to N elements" as a hint — future polish.
+
+## 8. Out of scope
+
+- Updating the stamp editor UI to warn when a body references attributes not on the source element.
+- Bulk previewing "which elements would see this stamp" for a given stamp.
+- Mixing "any-of" semantics for some stamps.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.26.1",
+	"version": "6.27.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.26.1"
+version = "6.27.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.26.1"
+version = "6.27.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Resolves user-reported bug: the `/` picker offered all five seeded class-typed stamps on every grocery element, including 'Sized story' on a sausage. The `element_type` filter is too coarse (every grocery is `class`-typed; so are stories).

New filter: a stamp is in-scope for an element only if every attribute name referenced in the stamp body via `{{self:attr:attributes/<NAME>/...}}` is present on the element's `data.attributes`. The five seeded stamps narrow naturally; user-authored stamps gain the same precision.

PR 11 of 4 in the issue #211 comment-followups plan.

## References

- [ADR-215](docs/adrs/ADR-215-Stamp-Filter-By-Body-Attributes.md)
- [SPEC-211-d](docs/adrs/specs/SPEC-211-d-Stamp-Filter-By-Body-Attributes.md)

## Test plan

- [x] 19/19 stamp tests pass (13 pre-existing + 6 new body-filter cases)
- [x] 99/99 wider regression (element_templates + smart_markdown + aggregation)
- [x] Genericness invariant clean

## What changes for the user

- Open Spaghetti recipe → `/` → drill into Pork mince → see only **Quantified item** (the sole seeded stamp whose body's required attributes — Quantity + Unit — are present on Pork mince).
- Going forward: any user-authored stamp whose body references attribute `Foo` only appears on elements that have `Foo` on their `data.attributes`. Body-trivial stamps (just `{{self:name}}`) still appear everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)