### PR TITLE
feat(v6.28.0): set creation inherits the active collection (ADR-216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.28.0] - 2026-05-22
+
+### Changed
+
+- **Set creation inherits the active collection filter**
+  ([ADR-216](docs/adrs/ADR-216-Set-Creation-Inherits-Collection.md),
+  [SPEC-216-a](docs/adrs/specs/SPEC-216-a-Set-Creation-Inherits-Collection.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211) comment
+  observation O5). When the sets list page (`/sets`) is filtered by a
+  collection (via `?collection_id=…` or the active-collection store),
+  clicking "Create new set" now passes that collection id through to
+  the backend so the new set is born in that collection. Sets
+  created from the unfiltered view remain collection-less (current
+  behaviour preserved).
+
+### Migration
+
+- None. Pure frontend change in `frontend/src/routes/sets/+page.svelte`.
+
 ## [6.27.0] - 2026-05-22
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.27.0"
+version = "6.28.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/adrs/ADR-216-Set-Creation-Inherits-Collection.md
+++ b/docs/adrs/ADR-216-Set-Creation-Inherits-Collection.md
@@ -1,0 +1,32 @@
+# ADR-216: Set creation inherits the active collection filter
+
+Status: Accepted (2026-05-22)
+
+Builds on: [ADR-126 / sets-collections] (existing collection scoping).
+
+## Context
+
+The sets list page (`/sets`) supports a `?collection_id=<id>` URL filter and an in-memory active-collection store (the chip at the top of many pages). When a user is viewing sets filtered by a collection and clicks "Create new set", the new set is currently created with `collection_id = NULL`, dropping it out of the filter view. The user then has to navigate to the new set and re-attach it via the set's edit page. Friction reported on the [2026-05-22 issue #211 comment](https://github.com/cgbarlow/iris/issues/211).
+
+## Decision
+
+When the user is viewing the sets list with an active collection filter (URL query param `collection_id` or active-collection-store value), the "Create new set" action passes that collection id through to the backend in the `POST /api/sets` body.
+
+Backend behaviour is unchanged — `SetCreate` already accepts `collection_id: str | None = None`. This is a one-line frontend change.
+
+### Scope
+
+- Active collection filter on `/sets` → carried through.
+- Sets created from the unfiltered list (`/sets` with no collection filter) → still collection-less (current behaviour preserved).
+- `/collections/{id}` page doesn't currently have a create-set affordance — out of scope. If one is added later, it should follow the same pattern.
+
+## Consequences
+
+**Positive:** Closes the reported UX gap. The user's mental model — "I'm working in this collection; new sets live here" — is honoured.
+
+**Negative / accepted trade-offs:** A user with a stale collection filter on `/sets` who didn't realise it was active might create a set "in" that collection unintentionally. The active filter chip is visible at the top of the page, so the surface is honest about scope; we accept this small risk.
+
+## References
+
+- [SPEC-216-a — code change, edge cases, test](./specs/SPEC-216-a-Set-Creation-Inherits-Collection.md)
+- [`docs/plans/issue-211-comment-followups.md`](../plans/issue-211-comment-followups.md) §4

--- a/docs/adrs/specs/SPEC-216-a-Set-Creation-Inherits-Collection.md
+++ b/docs/adrs/specs/SPEC-216-a-Set-Creation-Inherits-Collection.md
@@ -1,0 +1,56 @@
+# SPEC-216-a: Set creation inherits the active collection filter
+
+Implements: [ADR-216](../ADR-216-Set-Creation-Inherits-Collection.md).
+
+## 1. Change
+
+In `frontend/src/routes/sets/+page.svelte::handleCreate`:
+
+```diff
+-async function handleCreate(name: string, description: string | null) {
+-    try {
+-        await apiFetch<IrisSet>('/api/sets', {
+-            method: 'POST',
+-            body: JSON.stringify({ name, description }),
+-        });
++async function handleCreate(name: string, description: string | null) {
++    const body: Record<string, unknown> = { name, description };
++    if (collectionId) {
++        body.collection_id = collectionId;
++    }
++    try {
++        await apiFetch<IrisSet>('/api/sets', {
++            method: 'POST',
++            body: JSON.stringify(body),
++        });
+```
+
+`collectionId` is already derived on the page (line 29):
+
+```ts
+let collectionId = $derived(
+  page.url.searchParams.get('collection_id')
+  || getActiveCollectionId()
+  || ''
+);
+```
+
+So a truthy value means the user has an active filter — either from the URL query param or the in-memory active-collection store. Empty string means no filter; the create payload omits `collection_id` entirely (preserving the current "collection-less set" outcome).
+
+## 2. Backend
+
+Unchanged. `backend/app/sets/models.py::SetCreate.collection_id` is already `str | None = None`. `POST /api/sets` already routes it through `create_set(... collection_id=...)`.
+
+## 3. Tests
+
+`frontend/tests/unit/setCreateInheritsCollection.test.ts`:
+
+- Body shape when `collectionId` is non-empty → `{name, description, collection_id}` present.
+- Body shape when `collectionId` is empty → no `collection_id` key in the body (omitted, not null).
+
+These are data-shape tests aligned with the repo's existing frontend testing posture.
+
+## 4. Out of scope
+
+- A create-set button on `/collections/{id}` if one is added later — follow the same pattern.
+- Allowing the user to *override* the inherited collection at create time. Today they can't change it; they'd have to edit the set after creation. Could be a future enhancement.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.27.0",
+	"version": "6.28.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/sets/+page.svelte
+++ b/frontend/src/routes/sets/+page.svelte
@@ -82,10 +82,17 @@
 	}
 
 	async function handleCreate(name: string, description: string | null) {
+		// ADR-216 (v6.28.0): a new set created from a collection-filtered
+		// view inherits that collection, so the user doesn't have to
+		// re-attach it manually after creation.
+		const body: Record<string, unknown> = { name, description };
+		if (collectionId) {
+			body.collection_id = collectionId;
+		}
 		try {
 			await apiFetch<IrisSet>('/api/sets', {
 				method: 'POST',
-				body: JSON.stringify({ name, description }),
+				body: JSON.stringify(body),
 			});
 			showCreateDialog = false;
 			await loadSets();

--- a/frontend/tests/unit/setCreateInheritsCollection.test.ts
+++ b/frontend/tests/unit/setCreateInheritsCollection.test.ts
@@ -1,0 +1,56 @@
+/**
+ * SPEC-216-a / v6.28.0: set creation inherits active collection.
+ *
+ * Per repo testing posture: data-shape + business-rule tests rather
+ * than full Svelte component renders.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Mirrors the body-construction logic in
+ * `frontend/src/routes/sets/+page.svelte::handleCreate`.
+ */
+function buildCreateSetBody(
+	name: string,
+	description: string | null,
+	collectionId: string,
+): Record<string, unknown> {
+	const body: Record<string, unknown> = { name, description };
+	if (collectionId) {
+		body.collection_id = collectionId;
+	}
+	return body;
+}
+
+describe('POST /api/sets body construction', () => {
+	it('includes collection_id when the active filter is set', () => {
+		const body = buildCreateSetBody('Groceries', null, 'col-123');
+		expect(body).toEqual({
+			name: 'Groceries',
+			description: null,
+			collection_id: 'col-123',
+		});
+	});
+
+	it('omits collection_id when no active filter', () => {
+		const body = buildCreateSetBody('Misc', 'A grab-bag', '');
+		expect(body).toEqual({
+			name: 'Misc',
+			description: 'A grab-bag',
+		});
+		expect('collection_id' in body).toBe(false);
+	});
+
+	it('preserves the description value verbatim', () => {
+		const body = buildCreateSetBody('S', 'with description', 'c');
+		expect(body.description).toBe('with description');
+	});
+
+	it('does not coerce empty collectionId into null (omits key)', () => {
+		const body = buildCreateSetBody('S', null, '');
+		// Backend behaviour treats absent key === collection_id=null.
+		// The frontend omits, doesn't send null.
+		expect('collection_id' in body).toBe(false);
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.27.0"
+version = "6.28.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.27.0"
+version = "6.28.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

When the sets list page is filtered by a collection, "Create new set" now passes that collection id through to the backend. Closes issue #211 comment observation O5.

One-line frontend change; backend `SetCreate.collection_id` already accepted the value.

## References

- [ADR-216](docs/adrs/ADR-216-Set-Creation-Inherits-Collection.md)
- [SPEC-216-a](docs/adrs/specs/SPEC-216-a-Set-Creation-Inherits-Collection.md)

## Test plan

- [x] 4 new vitest cases (body shape with/without collectionId)
- [x] Genericness clean
- [ ] In-browser post-deploy: `/sets?collection_id=…` → Create new set → verify the new row carries the collection chip