### PR TITLE
feat(v6.29.0): UX consistency pass + Ingredient rename (PR 13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.29.0] - 2026-05-22
+
+### Added
+
+- **Clone-from-existing for aggregation profiles**
+  ([SPEC-212-e](docs/adrs/specs/SPEC-212-e-Aggregation-Profile-Editor-Polish.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211) comment
+  observation O7). A new **+ Clone from existing** button sits next
+  to **+ New profile** in `AggregationProfileEditor.svelte`. Selecting
+  a profile prefills the editor with `name + " (copy)"`, description,
+  and `profile_data`. The clone is always created in the parent's
+  scope (set-scoped when invoked from the set page; global when from
+  admin) — so you can clone a seeded global into a customised
+  set-scoped profile in one move. `is_default_for_set` resets to
+  false on every clone.
+- **Clone-from-existing for element templates**
+  ([SPEC-211-e](docs/adrs/specs/SPEC-211-e-Element-Template-Clone.md),
+  observation C4). `TemplatesListDialog` (elements list → Templates
+  button) gains a **Clone** action per row, parallel to **Use**. The
+  parent page hosts a small mini-dialog asking only for the new name;
+  the body is reused from the source (description, template_data,
+  markdown_stamp, scope). After creation the page navigates to the
+  new template's detail page.
+
+### Changed
+
+- **Friendlier aggregation-profile editor help text** (O6). Replaced
+  the ADR/SPEC-mentioning paragraph in `AggregationProfileEditor.svelte`
+  and the admin home card description with copy that talks in product
+  terms (rollups across documents, totals, etc.).
+- **Seeded "Quantified item" element template renamed to "Ingredient"**
+  (C3). Same id, same stamp body, same scope; updated name +
+  description only. New paired migrations **SQLite m079 / Supabase
+  m084** (idempotent: WHERE clause guards on the original name so
+  re-running doesn't double-rename).
+
+### Migration
+
+- **SQLite m079** + **Supabase m084**: rename the seeded global
+  template row `ea8829e5-…` from "Quantified item" to "Ingredient".
+- Supabase migration applied to the live DB before this merge per
+  `feedback_render_supabase_ordering`.
+
 ## [6.28.0] - 2026-05-22
 
 ### Changed

--- a/backend/app/migrations/m079_rename_quantified_item_to_ingredient.py
+++ b/backend/app/migrations/m079_rename_quantified_item_to_ingredient.py
@@ -1,0 +1,43 @@
+"""Migration 079: rename seeded 'Quantified item' element template → 'Ingredient'.
+
+User reported (issue #211 comment, 2026-05-22) that with the workflow
+now framed as Recipes / Weekly Meal Plan, the seeded "Quantified item"
+template should be named "Ingredient" so the picker and the elements
+list use a user-facing name that matches the domain.
+
+The rename is purely cosmetic — same deterministic id, same stamp body,
+same scope. m075 seeded the row originally with name='Quantified item';
+this migration updates it in place. Idempotent: the WHERE clause guards
+on the original name so re-running does nothing once the rename has
+been applied.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m079_rename_quantified_item_to_ingredient"
+
+# Deterministic UUIDv5 from m075's _STAMP_NAMESPACE for
+# "global-stamp:Quantified item".
+_QUANTIFIED_ITEM_ID = "ea8829e5-6e3f-5cf6-b1cc-a5ad92312dbf"
+_NEW_DESCRIPTION = (
+    "Element with a numeric quantity + unit (groceries, ingredients, "
+    "parts, stock items, line items in a list with totals). Pairs with "
+    "the 'Shopping list' / sum-by-unit aggregation profile."
+)
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent — WHERE clause guards on the
+    pre-rename name."""
+    await db.execute(
+        "UPDATE element_templates "
+        "SET name = ?, description = ? "
+        "WHERE id = ? AND name = 'Quantified item'",
+        ("Ingredient", _NEW_DESCRIPTION, _QUANTIFIED_ITEM_ID),
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m084_rename_quantified_item_to_ingredient.sql
+++ b/backend/app/migrations/supabase/m084_rename_quantified_item_to_ingredient.sql
@@ -1,0 +1,11 @@
+-- Migration 084: rename seeded 'Quantified item' element template → 'Ingredient'.
+--
+-- Mirrors SQLite m079. User-facing rename only; same row, same stamp body,
+-- same scope. Idempotent — WHERE clause guards on the pre-rename name.
+
+UPDATE public.element_templates
+SET
+    name = 'Ingredient',
+    description = 'Element with a numeric quantity + unit (groceries, ingredients, parts, stock items, line items in a list with totals). Pairs with the ''Shopping list'' / sum-by-unit aggregation profile.'
+WHERE id = 'ea8829e5-6e3f-5cf6-b1cc-a5ad92312dbf'
+  AND name = 'Quantified item';

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -82,6 +82,7 @@ from app.migrations.m075_seed_global_element_template_stamps import up as m075_u
 from app.migrations.m076_aggregation_profiles import up as m076_up
 from app.migrations.m077_seed_global_aggregation_profiles import up as m077_up
 from app.migrations.m078_aggregation_list_diagram_type import up as m078_up
+from app.migrations.m079_rename_quantified_item_to_ingredient import up as m079_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -191,6 +192,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m076_up(main)  # issue #211, v6.20.0: aggregation_profiles table (ADR-212)
     await m077_up(main)  # issue #211, v6.20.0: seed 5 global aggregation profiles (ADR-212)
     await m078_up(main)  # issue #211, v6.21.0: register aggregation_list diagram type (ADR-213)
+    await m079_up(main)  # issue #211, v6.29.0: rename seeded "Quantified item" → "Ingredient"
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.28.0"
+version = "6.29.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_element_templates/test_stamps.py
+++ b/backend/tests/test_element_templates/test_stamps.py
@@ -266,7 +266,7 @@ async def test_stamps_endpoint_returns_seeded_globals_for_class_element(
     names = sorted(s["name"] for s in r.json()["items"])
     # Five seeded global stamps all target element_type=class.
     assert names == [
-        "Line item", "Logged work", "Quantified item",
+        "Ingredient", "Line item", "Logged work",
         "Read entry", "Sized story",
     ]
 
@@ -286,7 +286,7 @@ async def test_stamps_self_substituted_to_element_id(
     )
     assert r.status_code == 200
     quantified = next(
-        s for s in r.json()["items"] if s["name"] == "Quantified item"
+        s for s in r.json()["items"] if s["name"] == "Ingredient"
     )
     # `self` is rewritten to `element:<eid>` in the returned stamp body.
     assert f"element:{eid}:attr:attributes/Quantity/type=" in (
@@ -387,7 +387,7 @@ async def test_body_filter_hides_stamp_when_required_attribute_missing(
     names = sorted(s["name"] for s in r.json()["items"])
     # Sized story (Points), Logged work (Hours), Line item (Amount/Currency),
     # Read entry (Pages/Author) — all hidden. Only Quantified item shows.
-    assert names == ["Quantified item"]
+    assert names == ["Ingredient"]
 
 
 @pytest.mark.asyncio
@@ -405,7 +405,7 @@ async def test_body_filter_shows_stamp_when_all_required_attrs_present(
         f"/api/element-templates/stamps?element_id={eid}", headers=h,
     )
     names = sorted(s["name"] for s in r.json()["items"])
-    assert "Quantified item" in names
+    assert "Ingredient" in names
 
 
 @pytest.mark.asyncio
@@ -456,7 +456,7 @@ async def test_body_trivial_stamp_applies_without_attrs(
     names = [s["name"] for s in r.json()["items"]]
     assert "Just the name" in names
     # The seeded stamps reference attributes → hidden from this element.
-    assert "Quantified item" not in names
+    assert "Ingredient" not in names
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_migrations/test_rename_quantified_to_ingredient_schema.py
+++ b/backend/tests/test_migrations/test_rename_quantified_to_ingredient_schema.py
@@ -1,0 +1,110 @@
+"""Test for m079_rename_quantified_item_to_ingredient.
+
+Verifies the migration:
+  - Renames "Quantified item" → "Ingredient" on the deterministic row id.
+  - Is idempotent (running twice doesn't double-rename / break).
+  - Doesn't touch other rows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiosqlite
+import pytest
+
+from app.migrations.m001_roles_users import up as m001
+from app.migrations.m067_element_templates import up as m067
+from app.migrations.m074_element_template_markdown_stamp import up as m074
+from app.migrations.m075_seed_global_element_template_stamps import up as m075
+from app.migrations.m079_rename_quantified_item_to_ingredient import (
+    up as m079,
+)
+
+if TYPE_CHECKING:
+    pass
+
+_QUANTIFIED_ITEM_ID = "ea8829e5-6e3f-5cf6-b1cc-a5ad92312dbf"
+
+
+@pytest.fixture
+async def db() -> aiosqlite.Connection:
+    conn = await aiosqlite.connect(":memory:")
+    await m001(conn)
+    await m067(conn)
+    await m074(conn)
+    await m075(conn)
+    yield conn
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_rename_renames_the_seeded_row(db: aiosqlite.Connection) -> None:
+    # Pre: row is "Quantified item".
+    cur = await db.execute(
+        "SELECT name FROM element_templates WHERE id = ?",
+        (_QUANTIFIED_ITEM_ID,),
+    )
+    row = await cur.fetchone()
+    assert row is not None
+    assert row[0] == "Quantified item"
+
+    await m079(db)
+
+    # Post: row is "Ingredient".
+    cur = await db.execute(
+        "SELECT name FROM element_templates WHERE id = ?",
+        (_QUANTIFIED_ITEM_ID,),
+    )
+    row = await cur.fetchone()
+    assert row[0] == "Ingredient"
+
+
+@pytest.mark.asyncio
+async def test_rename_is_idempotent(db: aiosqlite.Connection) -> None:
+    await m079(db)
+    # Re-running should be a no-op (WHERE guards on the old name).
+    await m079(db)
+
+    cur = await db.execute(
+        "SELECT name FROM element_templates WHERE id = ?",
+        (_QUANTIFIED_ITEM_ID,),
+    )
+    row = await cur.fetchone()
+    assert row[0] == "Ingredient"
+
+
+@pytest.mark.asyncio
+async def test_rename_leaves_other_seeded_stamps_alone(
+    db: aiosqlite.Connection,
+) -> None:
+    await m079(db)
+    # The other four seeded stamps keep their names.
+    cur = await db.execute(
+        "SELECT name FROM element_templates "
+        "WHERE is_global = 1 AND id != ? ORDER BY name",
+        (_QUANTIFIED_ITEM_ID,),
+    )
+    rows = await cur.fetchall()
+    names = sorted(r[0] for r in rows)
+    assert "Line item" in names
+    assert "Logged work" in names
+    assert "Read entry" in names
+    assert "Sized story" in names
+    # The renamed row's old name doesn't reappear.
+    assert "Quantified item" not in names
+
+
+@pytest.mark.asyncio
+async def test_rename_updates_description_too(
+    db: aiosqlite.Connection,
+) -> None:
+    await m079(db)
+    cur = await db.execute(
+        "SELECT description FROM element_templates WHERE id = ?",
+        (_QUANTIFIED_ITEM_ID,),
+    )
+    row = await cur.fetchone()
+    # Description should mention "ingredients" in the new copy.
+    assert row[0] is not None
+    assert "ingredients" in row[0].lower()

--- a/docs/adrs/specs/SPEC-211-e-Element-Template-Clone.md
+++ b/docs/adrs/specs/SPEC-211-e-Element-Template-Clone.md
@@ -1,0 +1,64 @@
+# SPEC-211-e: Clone-from-existing for element templates
+
+Implements: extension of [SPEC-211-a](./SPEC-211-a-Element-Template-Stamps.md). Addresses observation C4 from the [2026-05-22 issue #211 comment exchange](https://github.com/cgbarlow/iris/issues/211).
+
+## 1. UX
+
+`TemplatesListDialog.svelte` (the dialog opened by the "Templates" button on the elements list) gains a **Clone** button per row, next to the existing **Use** button.
+
+- **Use** (existing) — creates a new *element* from the template.
+- **Clone** (new) — creates a new *template* from the source template, prefilled with the source's `name + " (copy)"`, `description`, `template_data`, and `markdown_stamp`.
+
+On Clone, the dialog closes and the elements page surfaces a small inline mini-dialog asking for the new template name (defaulted to `<source> (copy)`). On submit:
+
+```
+POST /api/element-templates
+{
+  name: "<user-entered>",
+  description: <source.description>,
+  template_data: <source.template_data>,
+  markdown_stamp: <source.markdown_stamp>,
+  is_global: <source.is_global>,
+  set_id: source.is_global ? null : <currentSetId>
+}
+```
+
+After success, the page navigates to `/element-templates/<new-id>` so the user can edit further (e.g. adjust the stamp body).
+
+## 2. Why a mini-dialog, not a full create form
+
+The existing `CreateTemplateDialog` is built around the "snapshot from element" path (it requires `sourceElementId`). The clone case is structurally different — no source element, just a source template. Rather than complicating CreateTemplateDialog with a clone mode, the elements list hosts a tiny inline form for the rename. Implementation footprint stays small.
+
+## 3. State additions
+
+`elements/+page.svelte` gains:
+
+```ts
+let cloneSource = $state<CloneSource | null>(null);
+let cloneNewName = $state('');
+let cloneSubmitting = $state(false);
+let cloneError = $state<string | null>(null);
+
+function startCloneTemplate(source: CloneSource) { ... }
+function cancelCloneTemplate() { ... }
+async function confirmCloneTemplate(event: SubmitEvent) { ... }
+```
+
+`TemplatesListDialog` gains an optional `onclone: (source: ElementTemplate) => void` prop — emitted on Clone-button click. The button only renders when `onclone` is provided (so other callers of TemplatesListDialog, if any future ones, don't gain the button by accident).
+
+## 4. Backend
+
+Unchanged. The existing `POST /api/element-templates` endpoint accepts the body shape (ADR-211 §"source-element optionality"). No new MCP / CLI parity needed — same write surface as today.
+
+## 5. Tests
+
+`frontend/tests/unit/elementTemplateClone.test.ts` covers the clone body construction:
+
+- Body includes `markdown_stamp` when the source has one.
+- Body's `is_global` matches the source.
+- Body's `set_id` is `null` when the source is global; equals current set id otherwise.
+- Default name is `"<source> (copy)"`.
+
+## 6. Genericness (ADR-214)
+
+UI logic only — no domain terminology. Clean.

--- a/docs/adrs/specs/SPEC-212-e-Aggregation-Profile-Editor-Polish.md
+++ b/docs/adrs/specs/SPEC-212-e-Aggregation-Profile-Editor-Polish.md
@@ -1,0 +1,64 @@
+# SPEC-212-e: Aggregation profile editor polish
+
+Implements: extension of [SPEC-212-d](./SPEC-212-d-Aggregation-Profile-Editor.md). Addresses observations O6 + O7 from the [2026-05-22 issue #211 comment](https://github.com/cgbarlow/iris/issues/211).
+
+## 1. Friendly copy (O6)
+
+Replace the help text in `AggregationProfileEditor.svelte` and the admin home card description. Both currently mention ADR-212 / SPEC-212-a directly in the UX — fine in spec docs, jarring in product copy.
+
+**Before** (`AggregationProfileEditor.svelte`):
+
+> "Profiles drive the aggregation engine (ADR-212). Edit as JSON; schema is documented in SPEC-212-a. Seeded global profiles are good clone templates — duplicate one and edit the fields you need."
+
+**After**:
+
+> "Aggregation profiles describe how to roll up data across a group of documents — deduplicated lists with summed quantities, points totals, time-tracking rollups, and so on. Pick a seeded profile as a starting point with **Clone from existing** and duplicate-and-edit it for your use case, or start blank with **New profile**."
+
+**Admin home card before**:
+
+> "Manage global aggregation profiles (ADR-212) — rulesets that drive cross-document rollups (sum / count by attribute, optionally scaled by a multiplier)."
+
+**After**:
+
+> "Manage global aggregation profiles — rulesets that roll up data across many documents (summed quantities, points totals, time-tracking, expenses, and so on)."
+
+Neither mentions ADR/SPEC IDs. Genericness invariant (`ingredient` etc.) still clean — the copy uses generic concepts ("documents", "groups", "totals").
+
+## 2. Clone-from-existing (O7)
+
+A parallel **+ Clone from existing** button alongside **+ New profile**:
+
+- Clicking opens an inline picker listing in-scope profiles (set-scoped + globals).
+- Selecting a row prefills the editor with `name + " (copy)"`, `description`, and `profile_data`.
+- `is_default_for_set` resets to `false` on the copy.
+- User customises and saves → POST `/api/aggregation/profiles` with the appropriate scope (set-scoped when invoked from the set page; global when invoked from admin).
+
+The editor's existing scope rules apply unchanged — a clone is always created in the parent's scope, never inheriting the source's scope. (A user cloning the global "Shopping list" while on the Recipes set edit page gets a set-scoped copy in Recipes.)
+
+### State additions to `AggregationProfileEditor.svelte`
+
+```ts
+let cloning = $state(false);
+let cloneCandidates = $state<AggregationProfile[]>([]);
+
+async function startClone() { ... fetch candidates ... }
+function cancelClone() { ... }
+function commitClone(source: AggregationProfile) {
+  creating = true;
+  draftName = `${source.name} (copy)`;
+  draftDescription = source.description ?? '';
+  draftJson = JSON.stringify(source.profile_data, null, 2);
+  draftIsDefault = false;
+  draftError = null;
+}
+```
+
+When the editor is in set-mode, `startClone` re-fetches with `include_global=true` so the user can clone from a seeded global (the typical use case: "give me a recipe-set copy of the Shopping list profile to customise").
+
+## 3. Tests
+
+`frontend/tests/unit/aggregationProfileEditor.test.ts` extended with:
+
+- Clone state transitions: `startClone` → `cloning=true`, candidate list populated; `commitClone` → editor open in create mode with prefilled name/description/json.
+- Default-for-set is reset on a clone (never inherits).
+- The cloned name suffix is `" (copy)"`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.28.0",
+	"version": "6.29.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/AggregationProfileEditor.svelte
+++ b/frontend/src/lib/components/AggregationProfileEditor.svelte
@@ -53,7 +53,7 @@
 	let listError = $state<string | null>(null);
 
 	// Editor state — when editingId is non-null we're editing a row;
-	// when creating is true we're creating a new one.
+	// when creating is true we're creating a new one (blank or cloned).
 	let editingId = $state<string | null>(null);
 	let creating = $state(false);
 	let draftName = $state('');
@@ -62,6 +62,10 @@
 	let draftIsDefault = $state(false);
 	let draftError = $state<string | null>(null);
 	let saving = $state(false);
+
+	// SPEC-212-e (v6.29.0): Clone-from-existing picker state.
+	let cloning = $state(false);
+	let cloneCandidates = $state<AggregationProfile[]>([]);
 
 	const DEFAULT_PROFILE_JSON = JSON.stringify({
 		traversal: {
@@ -117,10 +121,55 @@
 	function startCreate() {
 		creating = true;
 		editingId = null;
+		cloning = false;
 		draftName = '';
 		draftDescription = '';
 		draftJson = DEFAULT_PROFILE_JSON;
 		draftIsDefault = false;
+		draftError = null;
+	}
+
+	// SPEC-212-e: open the clone-source picker. Candidates are the
+	// in-scope profiles already loaded in `profiles`, plus globals when
+	// we're in set-mode (so the user can clone from a seeded global
+	// into a set-scoped copy).
+	async function startClone() {
+		cloning = true;
+		creating = false;
+		editingId = null;
+		// In set mode, also fetch globals so the user can clone from
+		// a seeded global into a new set-scoped profile.
+		if (setId) {
+			try {
+				const params = new URLSearchParams();
+				params.set('set_id', setId);
+				params.set('include_global', 'true');
+				const data = await apiFetch<ListResponse>(
+					`/api/aggregation/profiles?${params}`,
+				);
+				cloneCandidates = data.items ?? [];
+			} catch {
+				cloneCandidates = profiles;
+			}
+		} else {
+			cloneCandidates = profiles;
+		}
+	}
+
+	function cancelClone() {
+		cloning = false;
+		cloneCandidates = [];
+	}
+
+	function commitClone(source: AggregationProfile) {
+		creating = true;
+		editingId = null;
+		cloning = false;
+		cloneCandidates = [];
+		draftName = `${source.name} (copy)`;
+		draftDescription = source.description ?? '';
+		draftJson = JSON.stringify(source.profile_data, null, 2);
+		draftIsDefault = false;  // copies don't inherit default-for-set
 		draftError = null;
 	}
 
@@ -212,18 +261,56 @@
 		<h2 class="text-base font-semibold" style="color: var(--color-fg)">
 			{globalsMode ? 'Global aggregation profiles' : 'Aggregation profiles for this set'}
 		</h2>
-		{#if !creating && !editingId}
-			<button onclick={startCreate} class="rounded px-3 py-1 text-sm text-white" style="background: var(--color-primary)">
-				+ New profile
-			</button>
+		{#if !creating && !editingId && !cloning}
+			<div class="flex gap-2">
+				<button onclick={startClone} class="rounded px-3 py-1 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+					+ Clone from existing
+				</button>
+				<button onclick={startCreate} class="rounded px-3 py-1 text-sm text-white" style="background: var(--color-primary)">
+					+ New profile
+				</button>
+			</div>
 		{/if}
 	</div>
 	<p class="mt-1 text-xs" style="color: var(--color-muted)">
-		Profiles drive the aggregation engine (ADR-212). Edit as JSON;
-		schema is documented in SPEC-212-a. Seeded global profiles are
-		good clone templates — duplicate one and edit the fields you
-		need.
+		Aggregation profiles describe how to roll up data across a group
+		of documents — deduplicated lists with summed quantities, points
+		totals, time-tracking rollups, and so on. Pick a seeded profile
+		as a starting point with <strong>Clone from existing</strong> and
+		duplicate-and-edit it for your use case, or start blank with
+		<strong>New profile</strong>.
 	</p>
+
+	{#if cloning}
+		<div class="mt-3 rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
+			<p class="text-sm" style="color: var(--color-fg)">Clone from which profile?</p>
+			<div class="mt-2 flex flex-col gap-1">
+				{#each cloneCandidates as p (p.id)}
+					<button
+						onclick={() => commitClone(p)}
+						class="rounded px-3 py-2 text-left text-sm"
+						style="border: 1px solid var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					>
+						<span style="color: var(--color-fg)">{p.name}</span>
+						{#if p.is_global}
+							<span class="ml-2 rounded px-1 text-xs" style="background: var(--color-surface); color: var(--color-muted)">global</span>
+						{/if}
+						{#if p.description}
+							<div class="mt-0.5 text-xs" style="color: var(--color-muted)">{p.description}</div>
+						{/if}
+					</button>
+				{/each}
+				{#if cloneCandidates.length === 0}
+					<p class="text-xs" style="color: var(--color-muted)">No profiles available to clone.</p>
+				{/if}
+			</div>
+			<div class="mt-3 flex justify-end">
+				<button onclick={cancelClone} class="rounded px-3 py-1 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+					Cancel
+				</button>
+			</div>
+		</div>
+	{/if}
 
 	{#if listError}
 		<p class="mt-3 text-sm" style="color: var(--color-danger)">{listError}</p>

--- a/frontend/src/lib/components/TemplatesListDialog.svelte
+++ b/frontend/src/lib/components/TemplatesListDialog.svelte
@@ -24,6 +24,9 @@
 		source_element_name: string | null;
 		included_fields: string[];
 		template_data: Record<string, unknown>;
+		/** ADR-211 (v6.19.0): stamp body using {{self:…}} placeholders.
+		 *  Surfaced here for the clone flow (SPEC-211-e, v6.29.0). */
+		markdown_stamp?: string | null;
 		created_at: string;
 		updated_at: string;
 		created_by_username: string;
@@ -41,9 +44,15 @@
 		setId: string;
 		oncancel: () => void;
 		onuse: (createdElementId: string) => void;
+		/** SPEC-211-e (v6.29.0): when the user picks Clone from a row,
+		 * the parent navigates to the create-template flow with the
+		 * source's name + markdown_stamp prefilled. The parent is
+		 * `/elements/+page.svelte`, which composes the existing
+		 * `CreateTemplateDialog`. */
+		onclone?: (source: ElementTemplate) => void;
 	}
 
-	let { open, setId, oncancel, onuse }: Props = $props();
+	let { open, setId, oncancel, onuse, onclone }: Props = $props();
 
 	let dialogEl: HTMLDialogElement | undefined = $state();
 	let templates = $state<ElementTemplate[]>([]);
@@ -240,6 +249,17 @@
 								>
 									Use
 								</button>
+								{#if onclone}
+									<button
+										type="button"
+										onclick={() => onclone(t)}
+										class="ml-2 rounded px-3 py-1 text-xs"
+										style="border: 1px solid var(--color-border); color: var(--color-fg)"
+										title="Clone — open the create-template form prefilled with this template's content"
+									>
+										Clone
+									</button>
+								{/if}
 							</td>
 						</tr>
 					{/each}

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -36,6 +36,6 @@
 		style="border-color: var(--color-border); color: var(--color-fg)"
 	>
 		<div class="text-lg font-semibold" style="color: var(--color-primary)">Aggregation profiles</div>
-		<p class="mt-1 text-sm" style="color: var(--color-muted)">Manage global aggregation profiles (ADR-212) — rulesets that drive cross-document rollups (sum / count by attribute, optionally scaled by a multiplier).</p>
+		<p class="mt-1 text-sm" style="color: var(--color-muted)">Manage global aggregation profiles — rulesets that roll up data across many documents (summed quantities, points totals, time-tracking, expenses, and so on).</p>
 	</a>
 </div>

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -27,6 +27,65 @@
 	let sortField = $state<'name' | 'element_type' | 'updated_at'>('name');
 	let showCreateDialog = $state(false);
 	let showTemplatesDialog = $state(false);
+
+	// SPEC-211-e (v6.29.0): Clone an existing element template into a
+	// new one. Triggered from TemplatesListDialog's per-row Clone
+	// button. The source carries the markdown_stamp + template_data;
+	// we just need a new name from the user.
+	interface CloneSource {
+		id: string;
+		name: string;
+		description: string | null;
+		is_global: boolean;
+		markdown_stamp?: string | null;
+		template_data: Record<string, unknown>;
+	}
+	let cloneSource = $state<CloneSource | null>(null);
+	let cloneNewName = $state('');
+	let cloneSubmitting = $state(false);
+	let cloneError = $state<string | null>(null);
+
+	function startCloneTemplate(source: CloneSource) {
+		cloneSource = source;
+		cloneNewName = `${source.name} (copy)`;
+		cloneError = null;
+		showTemplatesDialog = false;
+	}
+
+	function cancelCloneTemplate() {
+		cloneSource = null;
+		cloneNewName = '';
+		cloneError = null;
+	}
+
+	async function confirmCloneTemplate(event: SubmitEvent) {
+		event.preventDefault();
+		if (!cloneSource || !cloneNewName.trim() || cloneSubmitting) return;
+		cloneSubmitting = true;
+		cloneError = null;
+		try {
+			const body: Record<string, unknown> = {
+				name: cloneNewName.trim(),
+				description: cloneSource.description,
+				template_data: cloneSource.template_data,
+				is_global: cloneSource.is_global,
+				set_id: cloneSource.is_global ? null : currentSetId,
+			};
+			if (cloneSource.markdown_stamp) {
+				body.markdown_stamp = cloneSource.markdown_stamp;
+			}
+			const created = await apiFetch<{ id: string }>(
+				'/api/element-templates',
+				{ method: 'POST', body: JSON.stringify(body) },
+			);
+			cloneSource = null;
+			cloneNewName = '';
+			goto(`/element-templates/${created.id}`);
+		} catch (e) {
+			cloneError = e instanceof ApiError ? e.message : 'Failed to clone template';
+		}
+		cloneSubmitting = false;
+	}
 	let groupMode = $state<'none' | 'type' | 'tag'>(
 		(typeof window !== 'undefined' &&
 			(localStorage.getItem('iris-elements-group') as 'none' | 'type' | 'tag')) ||
@@ -610,7 +669,49 @@
 		showTemplatesDialog = false;
 		goto(`/elements/${newId}`);
 	}}
+	onclone={(source) => startCloneTemplate(source)}
 />
+
+{#if cloneSource}
+	<!-- SPEC-211-e (v6.29.0): inline mini-dialog for naming the cloned template -->
+	<div
+		style="position: fixed; inset: 0; z-index: 50; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,0.4)"
+		onclick={(e) => { if (e.target === e.currentTarget) cancelCloneTemplate(); }}
+		onkeydown={(e) => { if (e.key === 'Escape') cancelCloneTemplate(); }}
+		role="presentation"
+	>
+		<form
+			onsubmit={confirmCloneTemplate}
+			class="rounded-lg p-6 shadow-lg"
+			style="background: var(--color-bg); border: 1px solid var(--color-border); width: 460px; max-width: 90vw"
+		>
+			<h3 class="text-lg font-semibold" style="color: var(--color-fg)">Clone template</h3>
+			<p class="mt-1 text-sm" style="color: var(--color-muted)">
+				Create a new template by cloning <strong style="color: var(--color-fg)">{cloneSource.name}</strong>. The new template carries the same stamp body and content; you can edit either after creation.
+			</p>
+			<label for="clone-tpl-name" class="mt-4 block text-sm font-medium" style="color: var(--color-fg)">New template name</label>
+			<input
+				id="clone-tpl-name"
+				bind:value={cloneNewName}
+				required
+				autocomplete="off"
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			/>
+			{#if cloneError}
+				<p class="mt-2 text-sm" style="color: var(--color-danger)">{cloneError}</p>
+			{/if}
+			<div class="mt-4 flex justify-end gap-2">
+				<button type="button" onclick={cancelCloneTemplate} class="rounded px-4 py-2 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
+					Cancel
+				</button>
+				<button type="submit" disabled={cloneSubmitting || !cloneNewName.trim()} class="rounded px-4 py-2 text-sm text-white disabled:opacity-50" style="background-color: var(--color-primary)">
+					{cloneSubmitting ? 'Cloning…' : 'Create clone'}
+				</button>
+			</div>
+		</form>
+	</div>
+{/if}
 
 <BatchSetDialog
 	open={showBatchSetDialog}

--- a/frontend/tests/unit/aggregationProfileEditor.test.ts
+++ b/frontend/tests/unit/aggregationProfileEditor.test.ts
@@ -144,3 +144,66 @@ describe('JSON parse-validate', () => {
 		expect(parsed.output.aggregation_fn).toBe('sum');
 	});
 });
+
+
+// ─────────────────────────────────────────────────────────────────────
+// SPEC-212-e (v6.29.0): Clone-from-existing
+// ─────────────────────────────────────────────────────────────────────
+
+
+interface AggregationProfileLite {
+	id: string;
+	name: string;
+	description: string | null;
+	is_default_for_set: boolean;
+	profile_data: Record<string, unknown>;
+}
+
+function buildCloneDraft(
+	source: AggregationProfileLite,
+): { name: string; description: string; json: string; isDefault: boolean } {
+	return {
+		name: `${source.name} (copy)`,
+		description: source.description ?? '',
+		json: JSON.stringify(source.profile_data, null, 2),
+		isDefault: false, // copies don't inherit default-for-set
+	};
+}
+
+describe('clone-from-existing draft construction', () => {
+	it('name carries " (copy)" suffix', () => {
+		const d = buildCloneDraft({
+			id: 's', name: 'Shopping list', description: null,
+			is_default_for_set: true,
+			profile_data: { traversal: { inner: { collect_token_type: 'element' } }, output: {} },
+		});
+		expect(d.name).toBe('Shopping list (copy)');
+	});
+
+	it('description is copied verbatim', () => {
+		const d = buildCloneDraft({
+			id: 's', name: 'X', description: 'A specific blurb',
+			is_default_for_set: false,
+			profile_data: { traversal: { inner: { collect_token_type: 'element' } }, output: {} },
+		});
+		expect(d.description).toBe('A specific blurb');
+	});
+
+	it('is_default_for_set always resets to false on clone', () => {
+		const d = buildCloneDraft({
+			id: 's', name: 'X', description: null,
+			is_default_for_set: true,
+			profile_data: { traversal: { inner: { collect_token_type: 'element' } }, output: {} },
+		});
+		expect(d.isDefault).toBe(false);
+	});
+
+	it('profile_data round-trips via JSON.stringify', () => {
+		const pd = { traversal: { inner: { collect_token_type: 'element', value_attribute_path: 'attributes/Quantity/type' } }, output: { line_format: '- {element.name}' } };
+		const d = buildCloneDraft({
+			id: 's', name: 'X', description: null,
+			is_default_for_set: false, profile_data: pd,
+		});
+		expect(JSON.parse(d.json)).toEqual(pd);
+	});
+});

--- a/frontend/tests/unit/elementTemplateClone.test.ts
+++ b/frontend/tests/unit/elementTemplateClone.test.ts
@@ -1,0 +1,95 @@
+/**
+ * SPEC-211-e / v6.29.0: element-template clone request body shape.
+ *
+ * Per repo testing posture: data-shape tests, not full component
+ * renders.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+interface CloneSource {
+	id: string;
+	name: string;
+	description: string | null;
+	is_global: boolean;
+	markdown_stamp?: string | null;
+	template_data: Record<string, unknown>;
+}
+
+/**
+ * Mirrors the body-construction logic in
+ * `frontend/src/routes/elements/+page.svelte::confirmCloneTemplate`.
+ */
+function buildCloneBody(
+	source: CloneSource,
+	newName: string,
+	currentSetId: string,
+): Record<string, unknown> {
+	const body: Record<string, unknown> = {
+		name: newName.trim(),
+		description: source.description,
+		template_data: source.template_data,
+		is_global: source.is_global,
+		set_id: source.is_global ? null : currentSetId,
+	};
+	if (source.markdown_stamp) {
+		body.markdown_stamp = source.markdown_stamp;
+	}
+	return body;
+}
+
+describe('POST /api/element-templates — clone body shape', () => {
+	it('includes markdown_stamp when source has one', () => {
+		const body = buildCloneBody({
+			id: 's', name: 'Ingredient', description: 'desc',
+			is_global: true,
+			markdown_stamp: '{{self:attr:attributes/Quantity/type=}}',
+			template_data: { element_type: 'class' },
+		}, 'My ingredient', 'set-A');
+		expect(body.markdown_stamp).toBe(
+			'{{self:attr:attributes/Quantity/type=}}',
+		);
+	});
+
+	it('omits markdown_stamp when source has none', () => {
+		const body = buildCloneBody({
+			id: 's', name: 'Plain', description: null,
+			is_global: true, template_data: {},
+		}, 'Copy', 'set-A');
+		expect('markdown_stamp' in body).toBe(false);
+	});
+
+	it('clone of global → still global (set_id null)', () => {
+		const body = buildCloneBody({
+			id: 's', name: 'G', description: null, is_global: true,
+			template_data: {},
+		}, 'G2', 'set-A');
+		expect(body.is_global).toBe(true);
+		expect(body.set_id).toBeNull();
+	});
+
+	it('clone of set-scoped → set-scoped in current set', () => {
+		const body = buildCloneBody({
+			id: 's', name: 'S', description: null, is_global: false,
+			template_data: {},
+		}, 'S2', 'set-A');
+		expect(body.is_global).toBe(false);
+		expect(body.set_id).toBe('set-A');
+	});
+
+	it('default name suffix is " (copy)"', () => {
+		const defaultName = (source: CloneSource) => `${source.name} (copy)`;
+		expect(defaultName({
+			id: 's', name: 'Ingredient', description: null,
+			is_global: true, template_data: {},
+		})).toBe('Ingredient (copy)');
+	});
+
+	it('description is preserved verbatim', () => {
+		const body = buildCloneBody({
+			id: 's', name: 'X', description: 'A specific blurb',
+			is_global: true, template_data: {},
+		}, 'X2', 'set-A');
+		expect(body.description).toBe('A specific blurb');
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.28.0"
+version = "6.29.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.28.0"
+version = "6.29.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes four of the issue #211 comment items in one coherent PR:

| Item | Fix |
|---|---|
| O6 | Friendlier help copy on `AggregationProfileEditor.svelte` + admin home card (no ADR/SPEC refs in UI) |
| O7 | + Clone from existing on aggregation profile editor — SPEC-212-e |
| C4 | + Clone on `TemplatesListDialog` rows — SPEC-211-e |
| C3 | Seeded "Quantified item" → "Ingredient" — paired migration SQLite m079 / Supabase m084 |

## References

- [SPEC-212-e](docs/adrs/specs/SPEC-212-e-Aggregation-Profile-Editor-Polish.md)
- [SPEC-211-e](docs/adrs/specs/SPEC-211-e-Element-Template-Clone.md)

## Migration

- **SQLite m079** + **Supabase m084** — rename the seeded template row `ea8829e5-…`.
- Supabase **already applied** to live; row name now reads "Ingredient" (verified).

## Test plan

- [x] 4 new migration tests pass (rename idempotency, other rows untouched, description updated)
- [x] 6 new vitest cases for the clone flows (4 profile-editor clone draft + 6 element-template clone body shape)
- [x] Backend regression: 318 tests, 316 pass, 2 pre-existing unrelated failures
- [x] Genericness invariant clean
- [x] Live UAT: row renamed; m084 idempotent on re-run
- [ ] In-browser post-deploy: open `/admin/aggregation-profiles` → Clone from existing → pick Shopping list → editor prefills name + (copy); open `/elements` → Templates → see Clone button next to Use; click Clone on Ingredient → mini-dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)