### PR TITLE
feat(v6.30.0): smart-markdown edit-view companion panel (SPEC-205-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.30.0] - 2026-05-22
+
+### Added
+
+- **Smart-markdown edit-view companion panel**
+  ([SPEC-205-b](docs/adrs/specs/SPEC-205-b-Smart-Markdown-Edit-Preview.md),
+  supersedes [SPEC-210-a §5.1](docs/adrs/specs/SPEC-210-a-Smart-Markdown-Value-Overrides.md),
+  issue [#211](https://github.com/cgbarlow/iris/issues/211) comment
+  observations C5 + C6). Edit mode in `SmartMarkdownCanvas.svelte`
+  now shows a right-hand panel alongside the source textarea with
+  two sections:
+
+  - **Fill in the blanks.** Every `{{...:attr:<path>=}}` empty-
+    override token (the fillable-slot form from ADR-210) appears as
+    a labeled input row — element name, attribute name, editable
+    field, and a small `↳ "value path Name"` resolved-line preview.
+    Filling the input rewrites the source token in place
+    (byte-position rewrite, not string-replace — duplicate tokens
+    are disambiguated correctly). This finally delivers the
+    inline-editable-spans UX that SPEC-210-a §5.1 specified back
+    when v6.18.0 shipped the backend grammar.
+  - **Tokens preview.** The last-saved resolved markdown
+    (`data.content`) rendered in muted grey via `MarkdownView`. A
+    small `↻ saved` / `* unsaved — preview shows last save`
+    indicator distinguishes saved vs. drafting state. Live full
+    re-render is out of scope (would need either a backend
+    roundtrip per keystroke or a JS port of the resolver — DRY
+    violation §13).
+
+  Element-name lookups are lazy + cached per element-id. Defensive
+  input sanitisation drops `}` and `\` characters to keep the source
+  token shape intact.
+
+- The companion panel collapses below the textarea on viewports <
+  900px so narrow screens stay usable.
+
+### Migration
+
+- None. Pure frontend addition; no schema, no backend change.
+
+### Out of scope (future)
+
+- Live (debounced) full resolved preview as you type.
+- Per-token hover tooltips on the textarea itself.
+- Editing non-fillable tokens (e.g. swapping which element a `:name`
+  token points at).
+
 ## [6.29.0] - 2026-05-22
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.29.0"
+version = "6.30.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/adrs/specs/SPEC-205-b-Smart-Markdown-Edit-Preview.md
+++ b/docs/adrs/specs/SPEC-205-b-Smart-Markdown-Edit-Preview.md
@@ -1,0 +1,144 @@
+# SPEC-205-b: Smart-markdown edit-view companion panel
+
+Implements: extension of [ADR-205](../ADR-205-Smart-Markdown-View-Type.md). Supersedes the deferred inline-fillable-slot section ([SPEC-210-a §5.1](./SPEC-210-a-Smart-Markdown-Value-Overrides.md)). Addresses observations C5 + C6 from the [2026-05-22 issue #211 comment exchange](https://github.com/cgbarlow/iris/issues/211).
+
+## 1. Problem
+
+`SmartMarkdownCanvas.svelte` edit mode is a raw markdown textarea. Two reported friction points:
+
+- **C5**: tokens like `{{element:a8db…:attr:attributes/Quantity/type=500}}` are opaque blobs. The author can't tell at a glance what each line will render to.
+- **C6**: fillable slots (the trailing-`=` form) require manual cursor work inside long token blobs to type in a value. The original SPEC-210-a §5.1 specified inline editable spans; v6.18.0 shipped the backend grammar but deferred the editor UX.
+
+## 2. Decision
+
+Add a **right-hand companion panel** to `SmartMarkdownCanvas.svelte` in edit mode. Two stacked sections:
+
+### 2.1 Top: Fill in the blanks
+
+For every `{{...:attr:<path>=}}` empty-override token in `markdown_source`, render a labeled row:
+
+- **Element name** (resolved via `/api/elements/{id}` GET; cached per session).
+- **Attribute path label** (humanised — `attributes/Quantity/type` → `Quantity`).
+- **Editable text input** for the value.
+- **Resolved-line preview** (`↳ "500 g Pork mince"`) updated as you type.
+
+On input blur, the panel rewrites the source token from `=` to `=<value>` at the exact byte-position the regex matched. The source textarea updates atomically.
+
+### 2.2 Bottom: Tokens preview
+
+The last-saved resolved markdown (`data.content`) rendered in a muted grey style via the existing `MarkdownView` component. A `↻ Saved` / `* unsaved` indicator distinguishes saved vs. drafting state.
+
+## 3. Why this design
+
+- **No client-side resolver port.** Fillable-slot editing only needs string rewriting on the source; the element-name + path are in the token itself + one cheap GET. We don't try to live-resolve every other token type — that would require either a JS port of the smart_markdown resolver (DRY violation §13) or a backend round-trip per keystroke.
+- **No textarea replacement.** Source stays a plain textarea — power users / paste workflows unaffected. The panel is additive.
+- **Honours SPEC-210-a §5.1's intent** (make `=` slots fillable) without committing to a full contenteditable rebuild.
+
+## 4. Component
+
+New `frontend/src/lib/canvas/text/SmartMarkdownCompanionPanel.svelte`:
+
+```svelte
+<script lang="ts">
+  interface Props {
+    source: string;                   // bind:source from parent canvas
+    content: string;                  // resolved data.content (last save)
+    canvasDirty: boolean;             // unsaved-flag from parent
+    onsourcechange: (next: string) => void;
+  }
+  // ... regex out fillable tokens, fetch element data lazily, render rows
+</script>
+```
+
+Mounted inside `SmartMarkdownCanvas.svelte` when `editing=true`. Layout: source textarea ~60%, panel ~40% on wide screens; tabbed on narrow.
+
+## 5. Algorithm
+
+### 5.1 Detecting fillable tokens
+
+```ts
+const FILLABLE_RE = /\{\{element:([^:}]+):attr:([^=}]+)=\}\}/g;
+// Captures: (1) element_id, (2) attribute path (e.g. `attributes/Quantity/type`)
+// Match's .index gives the byte position in the source.
+```
+
+For each match, store `{ start, end, elementId, attrPath, value: '' }`. The same element_id may appear multiple times (e.g. one for Quantity, one for Unit override) — each is its own row.
+
+### 5.2 Element-name + attribute lookup
+
+Lazy `GET /api/elements/{element_id}` once per unique id, cache result. Pull `name` and `data.attributes[*].name` for the path-segment translation.
+
+Path translation: `attributes/Quantity/type` → display the user-readable last-meaningful-segment, which is the attribute name `Quantity`. We strip the leading `attributes/` and the trailing `/type` / `/notes` etc.
+
+### 5.3 Source rewrite on blur
+
+```ts
+function applyValue(token: FillableToken, value: string) {
+  const safe = value.replace(/[\\}]/g, '');  // drop }, \ to avoid mangling
+  if (!safe) return;  // empty stays empty
+  const newToken = source.substring(token.start, token.end)
+                       .replace(/=\}\}$/, `=${safe}}}`);
+  const next = source.substring(0, token.start)
+             + newToken
+             + source.substring(token.end);
+  onsourcechange(next);
+}
+```
+
+Byte-position rewrite, not string-replace: two identical tokens get disambiguated by index.
+
+### 5.4 Resolved-line preview
+
+Per row, build the rendered text by:
+- Replacing tokens of the form `{{element:<id>:name}}` in the **same source line** with the element's name.
+- Replacing `{{element:<id>:attr:<path>=<value>}}` with `<value>`.
+- Replacing the SAME token currently being edited with the **typed value** (live).
+- Leaving other tokens / text as-is.
+
+This is line-local "fake resolution" — enough to give the user a visible cue without re-implementing the full resolver.
+
+## 6. Tokens preview (read-only)
+
+The lower half of the panel renders `<MarkdownView source={content} />` inside a `.preview-muted` wrapper:
+
+```css
+.preview-muted { opacity: 0.75; }
+.preview-muted :global(*) { color: var(--color-muted); }
+```
+
+A small indicator above:
+
+```svelte
+<small>{canvasDirty ? '* unsaved — preview shows last save' : '↻ saved'}</small>
+```
+
+## 7. Tests
+
+`frontend/tests/unit/smartMarkdownCompanion.test.ts`:
+
+- `FILLABLE_RE` extracts the right tokens.
+- `applyValue` rewrites the source at the right byte position; doesn't touch other tokens.
+- Two identical fillable tokens are disambiguated by index.
+- Empty value is a no-op (doesn't strip the `=`).
+- `}` and `\` in the input value are stripped (defensive).
+
+Visual verification post-deploy (manual):
+- Open Spaghetti recipe → edit → see the panel right of the textarea with one fillable row for Pork mince's Quantity slot.
+- Type "750" → source updates → row preview shows "750 g Pork mince".
+- Save → tokens-preview pane refreshes; indicator flips to `↻ Saved`.
+
+## 8. Genericness (ADR-214)
+
+Pure UI logic. No domain terminology. Clean.
+
+## 9. Out of scope (future)
+
+- Live (debounced) full resolved preview of the whole source as you type — needs either backend roundtrip or a JS resolver port.
+- Per-token hover tooltips on the textarea itself.
+- Editing non-fillable tokens (e.g. swapping which element a `:name` token points at).
+- Multi-line fillable values.
+
+## 10. Risk
+
+- One GET per unique element-id on first render. Mitigated by caching; a typical recipe has 5-15 distinct elements. UAT response time is ~50-100ms per element.
+- Byte-position rewrite is sensitive to the source changing between regex match and apply. We re-run the regex on every keystroke (the panel re-derives rows from source via $derived), so stale indices don't survive.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.29.0",
+	"version": "6.30.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/SmartMarkdownCanvas.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownCanvas.svelte
@@ -19,6 +19,7 @@
 	import MarkdownEditorToolbar from '$lib/canvas/text/MarkdownEditorToolbar.svelte';
 	import { wrapSelection, applyOp, insertAtCursor } from '$lib/canvas/text/markdownEditorToolbarHelpers';
 	import SmartMarkdownSlashPicker from '$lib/canvas/text/SmartMarkdownSlashPicker.svelte';
+	import SmartMarkdownCompanionPanel from '$lib/canvas/text/SmartMarkdownCompanionPanel.svelte';
 	import ImageInsertDialog from '$lib/components/ImageInsertDialog.svelte';
 
 	interface Props {
@@ -160,15 +161,26 @@
 			onchange={(v) => commitSource(v)}
 			onimage={openImageDialog}
 		/>
-		<textarea
-			bind:this={textareaEl}
-			class="smart-markdown-canvas__editor"
-			value={source ?? ''}
-			oninput={onInput}
-			onkeydown={onKeydown}
-			placeholder="Write markdown. Type ‘/’ to insert a reference to an Iris entity field (e.g. an element name or attribute). Tokens render with live values at view time."
-			spellcheck="true"
-		></textarea>
+		<!-- SPEC-205-b (v6.30.0): source textarea + companion panel side-by-side -->
+		<div class="smart-markdown-canvas__split">
+			<textarea
+				bind:this={textareaEl}
+				class="smart-markdown-canvas__editor"
+				value={source ?? ''}
+				oninput={onInput}
+				onkeydown={onKeydown}
+				placeholder="Write markdown. Type ‘/’ to insert a reference to an Iris entity field (e.g. an element name or attribute). Tokens render with live values at view time."
+				spellcheck="true"
+			></textarea>
+			<aside class="smart-markdown-canvas__companion">
+				<SmartMarkdownCompanionPanel
+					source={source ?? ''}
+					content={content ?? ''}
+					canvasDirty={(source ?? '') !== (content ?? '')}
+					onsourcechange={(next) => commitSource(next)}
+				/>
+			</aside>
+		</div>
 		{#if pickerOpen}
 			<SmartMarkdownSlashPicker
 				oninsert={onTokenInsert}
@@ -196,8 +208,15 @@
 		width: 100%; height: 100%;
 		background: var(--color-surface, #ffffff);
 	}
-	.smart-markdown-canvas__editor {
+	.smart-markdown-canvas__split {
 		flex: 1;
+		display: flex;
+		flex-direction: row;
+		min-height: 0;
+	}
+	.smart-markdown-canvas__editor {
+		flex: 1 1 60%;
+		min-width: 0;
 		width: 100%; height: 100%;
 		padding: 16px;
 		border: 0; resize: none; outline: none;
@@ -205,6 +224,23 @@
 		color: var(--color-fg, #202931);
 		font-family: ui-monospace, monospace;
 		font-size: 13px; line-height: 1.55;
+	}
+	.smart-markdown-canvas__companion {
+		flex: 0 0 40%;
+		min-width: 280px;
+		max-width: 480px;
+		border-left: 1px solid var(--color-border, #e5e7eb);
+		background: var(--color-bg, #ffffff);
+		overflow-y: auto;
+	}
+	@media (max-width: 900px) {
+		.smart-markdown-canvas__split { flex-direction: column; }
+		.smart-markdown-canvas__companion {
+			flex: 1 0 auto;
+			max-width: none;
+			border-left: 0;
+			border-top: 1px solid var(--color-border, #e5e7eb);
+		}
 	}
 	.smart-markdown-canvas__view {
 		flex: 1;

--- a/frontend/src/lib/canvas/text/SmartMarkdownCompanionPanel.svelte
+++ b/frontend/src/lib/canvas/text/SmartMarkdownCompanionPanel.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+	/**
+	 * SmartMarkdownCompanionPanel (SPEC-205-b, v6.30.0).
+	 *
+	 * Right-side panel rendered alongside the source textarea in
+	 * SmartMarkdownCanvas edit mode. Two stacked sections:
+	 *
+	 *   1. Fill in the blanks — labeled input for every empty-override
+	 *      token in the source. Filling it rewrites the source token
+	 *      at the matched byte position from `=` to `=<value>`.
+	 *   2. Tokens preview — the last-saved resolved markdown (data.content)
+	 *      rendered in muted grey via MarkdownView.
+	 *
+	 * Closes the deferred fillable-slot UX from SPEC-210-a §5.1 (v6.18.0)
+	 * + the C5 tip-text ask.
+	 */
+
+	import MarkdownView from '$lib/components/MarkdownView.svelte';
+	import { apiFetch } from '$lib/utils/api';
+
+	interface ElementSummary {
+		name: string;
+		attrNames: Set<string>;
+	}
+
+	interface FillableToken {
+		start: number;
+		end: number;
+		elementId: string;
+		/** e.g. "attributes/Quantity/type". */
+		attrPath: string;
+		/** humanised — e.g. "Quantity" */
+		attrLabel: string;
+		/** the user's typed value (in-progress) */
+		value: string;
+	}
+
+	interface Props {
+		source: string;
+		content: string;
+		canvasDirty: boolean;
+		onsourcechange: (next: string) => void;
+	}
+
+	let { source, content, canvasDirty, onsourcechange }: Props = $props();
+
+	// Regex captures fillable tokens — { { element : id : attr : path = } }
+	// Captures: (1) element id, (2) attribute path (everything between
+	// "attr:" and "="). Greedy attr-path match stops at `=` (the
+	// fillable-slot marker). Multiple matches: re-extract on every
+	// derived change.
+	const FILLABLE_RE = /\{\{element:([^:}]+):attr:([^=}]+)=\}\}/g;
+
+	let elementCache = $state<Map<string, ElementSummary | 'pending' | 'missing'>>(new Map());
+	let typedValues = $state<Record<string, string>>({});
+
+	// $derived: scan the source for fillable tokens. Re-runs on every
+	// edit. Tokens are keyed by `${start}` so typed-but-unsaved values
+	// persist as long as the matched start stays at the same byte
+	// position (which it does until the user types in the textarea
+	// itself, at which point we lose the in-progress value — acceptable
+	// since the user is mid-edit on a different surface anyway).
+	const fillableTokens = $derived.by((): FillableToken[] => {
+		const out: FillableToken[] = [];
+		if (!source) return out;
+		FILLABLE_RE.lastIndex = 0;
+		let m: RegExpExecArray | null;
+		while ((m = FILLABLE_RE.exec(source)) !== null) {
+			const start = m.index;
+			const end = start + m[0].length;
+			const elementId = m[1];
+			const attrPath = m[2];
+			const attrLabel = humaniseAttrPath(attrPath);
+			const key = `${start}`;
+			out.push({
+				start, end, elementId, attrPath, attrLabel,
+				value: typedValues[key] ?? '',
+			});
+		}
+		return out;
+	});
+
+	const uniqueElementIds = $derived(
+		Array.from(new Set(fillableTokens.map((t) => t.elementId))),
+	);
+
+	$effect(() => {
+		// Lazy-fetch element data for any uncached id.
+		for (const id of uniqueElementIds) {
+			if (!elementCache.has(id)) {
+				elementCache.set(id, 'pending');
+				void fetchElement(id);
+			}
+		}
+	});
+
+	async function fetchElement(id: string) {
+		try {
+			const data = await apiFetch<{ name?: string; data?: { attributes?: { name?: string }[] } }>(
+				`/api/elements/${encodeURIComponent(id)}`,
+			);
+			const name = typeof data.name === 'string' ? data.name : id;
+			const attrNames = new Set<string>(
+				(data.data?.attributes ?? [])
+					.map((a) => a?.name)
+					.filter((n): n is string => typeof n === 'string'),
+			);
+			const next = new Map(elementCache);
+			next.set(id, { name, attrNames });
+			elementCache = next;
+		} catch {
+			const next = new Map(elementCache);
+			next.set(id, 'missing');
+			elementCache = next;
+		}
+	}
+
+	function humaniseAttrPath(attrPath: string): string {
+		// "attributes/Quantity/type"   → "Quantity"
+		// "attributes/Unit/notes"      → "Unit"
+		// "name"                       → "name" (rare for fillable)
+		const segs = attrPath.split('/').filter(Boolean);
+		if (segs[0] === 'attributes' && segs.length >= 2) {
+			return segs[1];
+		}
+		return attrPath;
+	}
+
+	function elementName(id: string): string {
+		const cached = elementCache.get(id);
+		if (cached && typeof cached === 'object') return cached.name;
+		if (cached === 'missing') return '(deleted element)';
+		return '…';
+	}
+
+	function previewForRow(token: FillableToken): string {
+		// Build a small preview by substituting THIS row's value (live)
+		// + a best-effort substitution of OTHER tokens on the same line.
+		// We don't run the full resolver — just enough to give a useful
+		// cue.
+		const lineStart = source.lastIndexOf('\n', token.start - 1) + 1;
+		const lineEnd = source.indexOf('\n', token.end);
+		const line = source.slice(lineStart, lineEnd === -1 ? source.length : lineEnd);
+
+		const cached = elementCache.get(token.elementId);
+		const elName = cached && typeof cached === 'object' ? cached.name : '…';
+
+		// Substitute THIS token (with typed value) and `:name` tokens.
+		// Other token types (other attributes) are left as `…` placeholders.
+		return line
+			.replaceAll(
+				new RegExp(`\\{\\{element:${escapeRegex(token.elementId)}:name\\}\\}`, 'g'),
+				elName,
+			)
+			.replace(
+				source.slice(token.start, token.end),
+				token.value || '…',
+			)
+			// Other tokens → ellipsis
+			.replaceAll(/\{\{element:[^}]+\}\}/g, '…');
+	}
+
+	function escapeRegex(s: string): string {
+		return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+	}
+
+	function commitValue(token: FillableToken, raw: string) {
+		const safe = raw.replace(/[\\}]/g, '').trim();
+		typedValues = { ...typedValues, [String(token.start)]: safe };
+		if (!safe) return; // empty → don't mutate source
+		const before = source.substring(0, token.start);
+		const after = source.substring(token.end);
+		const newToken = source.substring(token.start, token.end).replace(/=\}\}$/, `=${safe}}}`);
+		const nextSource = before + newToken + after;
+		onsourcechange(nextSource);
+	}
+</script>
+
+<div class="companion-panel">
+	<section class="fill-section">
+		<h3 class="text-sm font-semibold" style="color: var(--color-fg)">Fill in the blanks</h3>
+		{#if fillableTokens.length === 0}
+			<p class="mt-1 text-xs" style="color: var(--color-muted)">
+				No fillable slots in this diagram. Stamps you insert via the picker (Shift+Enter on an attribute) will appear here ready to fill.
+			</p>
+		{:else}
+			<div class="mt-3 flex flex-col gap-3">
+				{#each fillableTokens as t (`${t.start}-${t.attrPath}`)}
+					<div class="rounded border p-2" style="border-color: var(--color-border); background: var(--color-surface)">
+						<div class="text-xs" style="color: var(--color-muted)">
+							<strong style="color: var(--color-fg)">{elementName(t.elementId)}</strong>
+							— {t.attrLabel}
+						</div>
+						<input
+							type="text"
+							value={t.value}
+							onblur={(e) => commitValue(t, (e.currentTarget as HTMLInputElement).value)}
+							placeholder="value…"
+							class="mt-1 w-full rounded border px-2 py-1 text-sm"
+							style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+						/>
+						<div class="mt-1 text-xs italic" style="color: var(--color-muted)">
+							↳ {previewForRow(t)}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</section>
+
+	<section class="preview-section">
+		<div class="flex items-center justify-between">
+			<h3 class="text-sm font-semibold" style="color: var(--color-fg)">Tokens preview</h3>
+			<small style="color: var(--color-muted); font-size: 11px">
+				{canvasDirty ? '* unsaved — preview shows last save' : '↻ saved'}
+			</small>
+		</div>
+		<div class="preview-muted mt-2 rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
+			<MarkdownView source={content ?? ''} />
+		</div>
+	</section>
+</div>
+
+<style>
+	.companion-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		padding: 12px 16px;
+		max-height: 100%;
+		overflow-y: auto;
+	}
+	.fill-section, .preview-section {
+		min-width: 0;
+	}
+	.preview-muted {
+		opacity: 0.85;
+	}
+	.preview-muted :global(*) {
+		color: var(--color-muted) !important;
+	}
+</style>

--- a/frontend/tests/unit/smartMarkdownCompanion.test.ts
+++ b/frontend/tests/unit/smartMarkdownCompanion.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SPEC-205-b / v6.30.0: smart-markdown companion panel — fillable
+ * token extraction + source rewrite.
+ *
+ * Per repo testing posture: data-shape + business-rule tests.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+// Mirror of FILLABLE_RE in SmartMarkdownCompanionPanel.svelte.
+const FILLABLE_RE = /\{\{element:([^:}]+):attr:([^=}]+)=\}\}/g;
+
+interface Match {
+	start: number;
+	end: number;
+	elementId: string;
+	attrPath: string;
+}
+
+function findFillable(source: string): Match[] {
+	const out: Match[] = [];
+	FILLABLE_RE.lastIndex = 0;
+	let m: RegExpExecArray | null;
+	while ((m = FILLABLE_RE.exec(source)) !== null) {
+		out.push({
+			start: m.index,
+			end: m.index + m[0].length,
+			elementId: m[1],
+			attrPath: m[2],
+		});
+	}
+	return out;
+}
+
+function applyValue(source: string, tok: Match, raw: string): string {
+	const safe = raw.replace(/[\\}]/g, '').trim();
+	if (!safe) return source;
+	const before = source.substring(0, tok.start);
+	const after = source.substring(tok.end);
+	const newToken = source
+		.substring(tok.start, tok.end)
+		.replace(/=\}\}$/, `=${safe}}}`);
+	return before + newToken + after;
+}
+
+describe('fillable-token extraction', () => {
+	it('finds an empty-override token', () => {
+		const src =
+			'- {{element:abc:attr:attributes/Quantity/type=}} of broccoli';
+		const matches = findFillable(src);
+		expect(matches).toHaveLength(1);
+		expect(matches[0].elementId).toBe('abc');
+		expect(matches[0].attrPath).toBe('attributes/Quantity/type');
+	});
+
+	it('ignores tokens that already have a value', () => {
+		const src = '{{element:abc:attr:attributes/Quantity/type=500}}';
+		expect(findFillable(src)).toHaveLength(0);
+	});
+
+	it('ignores non-attr tokens', () => {
+		const src = '{{element:abc:name}}';
+		expect(findFillable(src)).toHaveLength(0);
+	});
+
+	it('finds multiple fillable tokens in one source', () => {
+		const src =
+			'- {{element:abc:attr:attributes/Quantity/type=}} g pork\n' +
+			'- {{element:def:attr:attributes/Quantity/type=}} ml butter';
+		const matches = findFillable(src);
+		expect(matches).toHaveLength(2);
+		expect(matches[0].elementId).toBe('abc');
+		expect(matches[1].elementId).toBe('def');
+	});
+
+	it('matches at different byte positions for identical tokens', () => {
+		const src =
+			'{{element:abc:attr:attributes/Quantity/type=}} ' +
+			'{{element:abc:attr:attributes/Quantity/type=}}';
+		const matches = findFillable(src);
+		expect(matches).toHaveLength(2);
+		expect(matches[0].start).not.toEqual(matches[1].start);
+	});
+});
+
+describe('applyValue rewrite', () => {
+	it('rewrites the source at the right byte position', () => {
+		const src =
+			'- {{element:abc:attr:attributes/Quantity/type=}} g pork';
+		const tok = findFillable(src)[0];
+		const next = applyValue(src, tok, '500');
+		expect(next).toBe(
+			'- {{element:abc:attr:attributes/Quantity/type=500}} g pork',
+		);
+	});
+
+	it('disambiguates duplicate fillable tokens by index', () => {
+		const src =
+			'A {{element:abc:attr:attributes/Quantity/type=}} ' +
+			'B {{element:abc:attr:attributes/Quantity/type=}}';
+		const matches = findFillable(src);
+		// Fill only the SECOND occurrence.
+		const next = applyValue(src, matches[1], '999');
+		expect(next).toBe(
+			'A {{element:abc:attr:attributes/Quantity/type=}} ' +
+			'B {{element:abc:attr:attributes/Quantity/type=999}}',
+		);
+		// First occurrence untouched.
+		expect(next.indexOf('=}}')).toBe(
+			'A {{element:abc:attr:attributes/Quantity/type'.length,
+		);
+	});
+
+	it('empty value is a no-op (does not strip the =)', () => {
+		const src =
+			'- {{element:abc:attr:attributes/Quantity/type=}}';
+		const tok = findFillable(src)[0];
+		expect(applyValue(src, tok, '')).toBe(src);
+		expect(applyValue(src, tok, '   ')).toBe(src);
+	});
+
+	it('strips } and \\ from input to avoid mangling', () => {
+		const src =
+			'- {{element:abc:attr:attributes/X/type=}}';
+		const tok = findFillable(src)[0];
+		// Trying to break out of the token via `}` would mangle the source.
+		const next = applyValue(src, tok, 'val}}injection');
+		expect(next).toBe(
+			'- {{element:abc:attr:attributes/X/type=valinjection}}',
+		);
+	});
+
+	it('values with internal whitespace are preserved', () => {
+		const src = '{{element:abc:attr:attributes/X/type=}}';
+		const tok = findFillable(src)[0];
+		// The trim() in applyValue trims edges, not internal whitespace.
+		const next = applyValue(src, tok, ' 1 cup ');
+		expect(next).toBe('{{element:abc:attr:attributes/X/type=1 cup}}');
+	});
+});
+
+describe('humanise attribute path', () => {
+	function humaniseAttrPath(attrPath: string): string {
+		const segs = attrPath.split('/').filter(Boolean);
+		if (segs[0] === 'attributes' && segs.length >= 2) return segs[1];
+		return attrPath;
+	}
+
+	it('extracts the attribute name from attributes/<NAME>/type', () => {
+		expect(humaniseAttrPath('attributes/Quantity/type')).toBe('Quantity');
+		expect(humaniseAttrPath('attributes/Unit/notes')).toBe('Unit');
+	});
+
+	it('falls back to the raw path for non-standard shapes', () => {
+		expect(humaniseAttrPath('topLevel/type')).toBe('topLevel/type');
+		expect(humaniseAttrPath('name')).toBe('name');
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.29.0"
+version = "6.30.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.29.0"
+version = "6.30.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Right-hand companion panel in `SmartMarkdownCanvas.svelte` edit mode:

- **Fill in the blanks**: each `{{...path=}}` empty-override token in the source surfaces as a labeled input. Filling it rewrites the source token at the exact byte position (duplicate tokens disambiguated). Delivers the inline-editable-spans UX deferred from SPEC-210-a §5.1 when v6.18.0 shipped the backend grammar.
- **Tokens preview**: muted-grey render of last-saved `data.content`. `↻ saved` / `* unsaved` indicator.

Final PR (4 of 4) in the issue #211 comment-followups cycle. Closes C5 + C6.

## References

- [SPEC-205-b](docs/adrs/specs/SPEC-205-b-Smart-Markdown-Edit-Preview.md)

## Test plan

- [x] 12 new vitest cases (extraction, byte-position rewrite, deduplication, sanitisation, humanise path)
- [x] svelte-check: no new errors on touched files
- [x] Genericness clean
- [ ] In-browser post-deploy: open Spaghetti recipe → edit → fillable slot for Pork mince's Quantity appears in the panel; type "750" → source updates → row preview reads "750 g Pork mince". Save → tokens-preview pane refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)