### PR TITLE
fix(v6.30.1): UML attribute notes editable in element edit mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.30.1] - 2026-05-22
+
+### Fixed
+
+- **UML attribute `notes` field is editable in element edit mode.**
+  Browse view already displayed the `notes` column under Attributes;
+  the edit view's attribute table had Scope / Name / Type / Lower /
+  Upper but **no Notes input** — values typed via API/CLI persisted
+  fine but couldn't be added or changed in the browser. Edit mode now
+  has a Notes column that round-trips the value. The underlying
+  edit-state mapping in `startEdit` already preserved notes; only the
+  UI was missing.
+
+### Migration
+
+- None. Pure frontend addition (one column + one input).
+
 ## [6.30.0] - 2026-05-22
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.30.0"
+version = "6.30.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.30.0",
+	"version": "6.30.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -697,6 +697,7 @@
 											<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Type</th>
 											<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Lower</th>
 											<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Upper</th>
+											<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Notes</th>
 											<th class="py-1 text-left font-medium" style="color: var(--color-muted)"></th>
 										</tr>
 									</thead>
@@ -715,6 +716,7 @@
 												<td class="py-1 pr-2"><input type="text" bind:value={attr.type} class="w-full rounded border px-1 py-0.5 text-sm" style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" placeholder="type" /></td>
 												<td class="py-1 pr-2" style="width:3rem"><input type="text" bind:value={attr.lower_bound} class="w-full rounded border px-1 py-0.5 text-sm" style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" placeholder="0" /></td>
 												<td class="py-1 pr-2" style="width:3rem"><input type="text" bind:value={attr.upper_bound} class="w-full rounded border px-1 py-0.5 text-sm" style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" placeholder="*" /></td>
+												<td class="py-1 pr-2"><input type="text" bind:value={attr.notes} class="w-full rounded border px-1 py-0.5 text-sm" style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)" placeholder="notes" /></td>
 												<td class="py-1">
 													<button onclick={() => { editAttributes = editAttributes.filter((_, idx) => idx !== i); }} class="text-xs px-1 rounded" style="color: var(--color-danger)" title="Remove attribute">✕</button>
 												</td>

--- a/frontend/tests/unit/elementAttributeNotesEditable.test.ts
+++ b/frontend/tests/unit/elementAttributeNotesEditable.test.ts
@@ -1,0 +1,87 @@
+/**
+ * v6.30.1 fix: element edit-mode UML attribute table now has a Notes
+ * column (the browse view already showed it; the editor was missing
+ * the input — values would be silently dropped on Save).
+ *
+ * Light-touch data-shape test: mirrors the edit-state mapping in
+ * `frontend/src/routes/elements/[id]/+page.svelte::startEdit` and
+ * the save-back flow.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+interface RawAttribute {
+	name?: string;
+	type?: string;
+	scope?: string;
+	notes?: string;
+	lower_bound?: string;
+	upper_bound?: string;
+}
+
+interface EditAttribute {
+	name: string;
+	type: string;
+	scope: string;
+	notes: string;
+	lower_bound: string;
+	upper_bound: string;
+}
+
+function toEditState(src: RawAttribute[]): EditAttribute[] {
+	return src.map((a) => ({
+		name: a.name ?? '',
+		type: a.type ?? '',
+		scope: a.scope ?? 'Public',
+		notes: a.notes ?? '',
+		lower_bound: a.lower_bound ?? '',
+		upper_bound: a.upper_bound ?? '',
+	}));
+}
+
+function toSaveBody(edit: EditAttribute[]): EditAttribute[] {
+	// Mirror of `updatedData.attributes = editAttributes.filter(a => a.name.trim())`.
+	return edit.filter((a) => a.name.trim());
+}
+
+describe('UML attribute notes round-trip', () => {
+	it('preserves notes from stored data into the edit state', () => {
+		const src: RawAttribute[] = [
+			{ name: 'Quantity', type: 'g', scope: 'Public', notes: 'per use override' },
+		];
+		const edit = toEditState(src);
+		expect(edit[0].notes).toBe('per use override');
+	});
+
+	it('defaults missing notes to empty string', () => {
+		const src: RawAttribute[] = [
+			{ name: 'X', type: '' },
+		];
+		const edit = toEditState(src);
+		expect(edit[0].notes).toBe('');
+	});
+
+	it('save-back body carries the (possibly edited) notes value', () => {
+		const edit: EditAttribute[] = [
+			{
+				name: 'Quantity', type: 'g', scope: 'Public',
+				notes: 'edited via the new column',
+				lower_bound: '', upper_bound: '',
+			},
+		];
+		const body = toSaveBody(edit);
+		expect(body[0].notes).toBe('edited via the new column');
+	});
+
+	it('empty-name rows are filtered out on save (existing behaviour)', () => {
+		const edit: EditAttribute[] = [
+			{ name: 'A', type: '', scope: 'Public', notes: 'keeps notes',
+			  lower_bound: '', upper_bound: '' },
+			{ name: '', type: '', scope: 'Public', notes: 'drops the row',
+			  lower_bound: '', upper_bound: '' },
+		];
+		const body = toSaveBody(edit);
+		expect(body).toHaveLength(1);
+		expect(body[0].name).toBe('A');
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.30.0"
+version = "6.30.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.30.0"
+version = "6.30.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Browse view (`/elements/{id}` → Attributes accordion) showed a **Notes** column for UML-style attributes. Edit mode's attribute editor was missing the matching `<input>` — values added via API/CLI persisted but couldn't be set or changed in the browser. Adds the column.

Reported in the conversation after PR 14 ship-time.

## Test plan

- [x] 4 vitest cases for the edit ↔ save round-trip (preserves notes from stored data; defaults missing to ''; saves edited value; empty-name rows still filtered)
- [x] Genericness clean
- [ ] In-browser post-deploy: open a class element with a Notes-bearing attribute, click Edit details, confirm Notes column appears and the value is editable + persists on Save

🤖 Generated with [Claude Code](https://claude.com/claude-code)