### PR TITLE
fix(v6.30.2): thumbnail regen runs in background, unblocks Render port-bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.30.2] - 2026-05-22
+
+### Fixed
+
+- **Render deploys no longer get marked `canceled` by the
+  port-detection timeout.** `_initialize_supabase` was awaiting
+  `regenerate_all_thumbnails` synchronously inside the FastAPI
+  lifespan; with 1100+ diagrams on UAT the regen took ~5–6 minutes
+  per deploy, well past Render's port-binding deadline. Render
+  printed `==> No open ports detected, continuing to scan…` three
+  times and cancelled the deploy, despite the process being healthy
+  and reaching `Application startup complete` shortly afterwards.
+
+  v6.30.2 dispatches the regen as a fire-and-forget background task
+  via `asyncio.create_task(...)`. The lifespan returns immediately
+  after scheduling — the port binds in seconds. Thumbnails update
+  silently over the next few minutes; any new or changed diagram
+  still renders fresh on first GET regardless of whether the
+  background sweep has finished. Errors inside the background task
+  are logged + swallowed (no unhandled-exception warnings on
+  SIGTERM mid-regen).
+
+- The SQLite startup path is unchanged — small dev/self-hosted
+  databases don't hit the timeout and the seed example diagrams
+  benefit from being rendered synchronously on first run.
+
+### Migration
+
+- None. Pure backend startup-flow change.
+
 ## [6.30.1] - 2026-05-22
 
 ### Fixed

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 from app.audit.service import verify_audit_chain
@@ -343,10 +344,39 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
 
     # v6.17.8 (issue #208): regenerate PNG thumbnails so changes to
     # ``generate_svg_from_diagram_data`` propagate to pre-existing
-    # diagrams (the markdown-notation preview branch added in v6.17.6
-    # was otherwise dormant on Supabase deployments).
+    # diagrams.
+    #
+    # v6.30.2: dispatched as a background task instead of awaited in
+    # the lifespan. With 1000+ diagrams the synchronous regen can
+    # take 5–6 minutes per deploy and exceed Render's port-detection
+    # deadline (deploys getting cancelled mid-startup despite the
+    # process being healthy). Moving it off the critical path lets
+    # the API bind its port in seconds; thumbnails update silently
+    # in the background. Any new/changed diagram still renders fresh
+    # on first GET regardless of whether the background sweep has
+    # finished.
+    asyncio.create_task(_regenerate_thumbnails_background(port))
+    print(
+        "[STARTUP] thumbnail regeneration scheduled in background",
+        flush=True,
+    )
+
+
+async def _regenerate_thumbnails_background(port: object) -> None:
+    """Fire-and-forget thumbnail regen.
+
+    Errors are logged + swallowed. If the lifespan tears down mid-regen
+    (e.g. SIGTERM during a deploy) the partial work is discarded and
+    the next deploy starts fresh.
+    """
     try:
-        count = await regenerate_all_thumbnails(port)
-        print(f"[STARTUP] regenerated {count} diagram thumbnails", flush=True)
+        count = await regenerate_all_thumbnails(port)  # type: ignore[arg-type]
+        print(
+            f"[STARTUP] regenerated {count} diagram thumbnails (background)",
+            flush=True,
+        )
     except Exception as exc:  # noqa: BLE001
-        print(f"[STARTUP] thumbnail regeneration skipped: {exc}", flush=True)
+        print(
+            f"[STARTUP] thumbnail regeneration skipped: {exc}",
+            flush=True,
+        )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.30.1"
+version = "6.30.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_startup/test_thumbnail_background_regen.py
+++ b/backend/tests/test_startup/test_thumbnail_background_regen.py
@@ -1,0 +1,66 @@
+"""v6.30.2: thumbnail regeneration runs in the background.
+
+Verifies the contract introduced in v6.30.2 — `_initialize_supabase`
+schedules thumbnail regeneration as a background task instead of
+awaiting it synchronously. The fix unblocks Render port-binding when
+the diagram count is large (1000+ thumbnails took 5–6 min, exceeding
+Render's port-detection deadline).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from app.startup import _regenerate_thumbnails_background
+
+
+@pytest.mark.asyncio
+async def test_background_regen_calls_through_to_thumbnail_module() -> None:
+    """The background coroutine awaits regenerate_all_thumbnails and
+    logs the resulting count."""
+    seen: list[object] = []
+
+    async def fake(port: object) -> int:
+        seen.append(port)
+        return 7
+
+    sentinel = object()
+    with patch("app.startup.regenerate_all_thumbnails", new=fake):
+        await _regenerate_thumbnails_background(sentinel)
+
+    assert seen == [sentinel], "the same port should be passed through"
+
+
+@pytest.mark.asyncio
+async def test_background_regen_swallows_exceptions() -> None:
+    """If the thumbnail module raises, the background task logs and
+    returns — never propagates. Otherwise a failure would crash an
+    unawaited Task and surface as an unhandled-exception warning."""
+    async def boom(port: object) -> int:
+        raise RuntimeError("cairosvg not available")
+
+    with patch("app.startup.regenerate_all_thumbnails", new=boom):
+        # Should not raise.
+        await _regenerate_thumbnails_background(object())
+
+
+@pytest.mark.asyncio
+async def test_background_regen_can_be_scheduled_via_create_task() -> None:
+    """The fix uses asyncio.create_task(...) — the call site shouldn't
+    block on completion. Verify the task scheduling pattern itself."""
+    done = asyncio.Event()
+
+    async def slow(port: object) -> int:
+        await asyncio.sleep(0.05)
+        done.set()
+        return 1
+
+    with patch("app.startup.regenerate_all_thumbnails", new=slow):
+        task = asyncio.create_task(_regenerate_thumbnails_background(object()))
+        # Caller proceeds immediately; the task hasn't completed yet.
+        assert not done.is_set()
+        await task
+        assert done.is_set()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.30.1",
+	"version": "6.30.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.30.1"
+version = "6.30.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.30.1"
+version = "6.30.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Render was marking deploys `canceled` mid-startup with `==> No open ports detected`, even though the process was healthy. Root cause: `regenerate_all_thumbnails` was awaited synchronously inside the lifespan and takes ~5–6 minutes for the ~1100 diagrams on UAT — well past Render's port-binding deadline.

Fix: dispatch as `asyncio.create_task(...)`. Lifespan returns in seconds; the port binds; thumbnails update silently in the background.

## Behaviour

| | Before | After |
|---|---|---|
| Time to first 200 on `/api/version` | ~5–6 min after deploy | seconds |
| Thumbnails after a redeploy | ready when lifespan returns | trickle in over the next few minutes |
| New/changed diagrams | rendered fresh on first GET | rendered fresh on first GET (unchanged) |
| SIGTERM mid-regen | could leave the task half-done | task aborts, swallowed log line, next deploy starts fresh |

## Test plan

- [x] 3 unit tests under `tests/test_startup/` cover pass-through, exception swallow, and the `create_task` scheduling pattern
- [x] Genericness clean
- [ ] Post-deploy: watch Render logs for `[STARTUP] thumbnail regeneration scheduled in background` shortly after `Started server process`; `/api/version` responds immediately; eventually `[STARTUP] regenerated N diagram thumbnails (background)` lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)