### PR TITLE
feat(v6.31.0): aggregate output provenance flag (ADR-217)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.31.0] - 2026-05-24
+
+### Added
+
+- Aggregate output provenance flag (ADR-217) — opt-in per-line
+  element_id surfacing for downstream consumers.
+
 ## [6.30.2] - 2026-05-22
 
 ### Fixed

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -523,6 +523,11 @@ async def _format_output(
             )
             if output.show_per_source_breakdown:
                 line += _render_breakdown(output.breakdown_format, r.sources)
+            if output.include_provenance:
+                # ADR-217: trailing HTML comment carrying the row's
+                # element_id. Appended LAST so it never interrupts the
+                # visible text or any per-source breakdown.
+                line += f" <!-- iris:element={r.token_id} -->"
             out_lines.append(line)
             row_count += 1
         out_lines.append("")

--- a/backend/app/aggregation/models.py
+++ b/backend/app/aggregation/models.py
@@ -62,6 +62,11 @@ class OutputConfig(BaseModel):
     line_format: str = "- {element.name}: {sum_value}{bucket_spaced}"
     show_per_source_breakdown: bool = False
     breakdown_format: str = " ({sources_joined})"
+    # ADR-217: opt-in per-line provenance — appends
+    # ` <!-- iris:element=<uuid> -->` to each rendered shopping-list
+    # line so downstream consumers can look the row's element up
+    # (e.g. for cached SKU notes) without an LLM round-trip.
+    include_provenance: bool = False
 
 
 class ProfileData(BaseModel):

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.30.2"
+version = "6.31.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_aggregation/test_engine.py
+++ b/backend/tests/test_aggregation/test_engine.py
@@ -463,6 +463,163 @@ async def test_run_missing_source_raises(
         )
 
 
+# ─────────────────────────────────────────────────────────────────────
+# Provenance comments (ADR-217)
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_include_provenance_off_omits_comments(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Default behaviour: no `<!-- iris:element=...` substring anywhere."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    aisle_meat = await _create_package(c, h, set_id, "Meat & Poultry")
+    aisle_produce = await _create_package(c, h, set_id, "Produce")
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince",
+        package_id=aisle_meat, data=_ATTR_BLUEPRINT,
+    )
+    carrot_id = await _create_element(
+        c, h, set_id=set_id, name="Carrot",
+        package_id=aisle_produce, data=_ATTR_BLUEPRINT,
+    )
+    source = (
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}}\n"
+        f"- {{{{element:{carrot_id}:attr:attributes/Quantity/type=3}}}}"
+    )
+    diag_id = await _create_smart_md(c, h, set_id, source)
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Default no provenance", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    assert "<!-- iris:element=" not in result.markdown
+
+
+@pytest.mark.asyncio
+async def test_include_provenance_on_appends_comment_per_line(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """With include_provenance=True, every rendered shopping-list line
+    ends with a `<!-- iris:element=<uuid> -->` comment carrying the row's
+    element_id. Headings and section dividers MUST NOT get the comment.
+    Per-source breakdown text (when enabled) appears UNAFFECTED, before
+    the trailing comment."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    aisle_meat = await _create_package(c, h, set_id, "Meat & Poultry")
+    aisle_produce = await _create_package(c, h, set_id, "Produce")
+    pork_id = await _create_element(
+        c, h, set_id=set_id, name="Pork mince",
+        package_id=aisle_meat, data=_ATTR_BLUEPRINT,
+    )
+    carrot_id = await _create_element(
+        c, h, set_id=set_id, name="Carrot",
+        package_id=aisle_produce, data=_ATTR_BLUEPRINT,
+    )
+    # Two recipes so per-source breakdown has substance.
+    rec_a = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}}\n"
+        f"- {{{{element:{carrot_id}:attr:attributes/Quantity/type=2}}}}",
+        name="Recipe A",
+    )
+    rec_b = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{carrot_id}:attr:attributes/Quantity/type=1}}}}",
+        name="Recipe B",
+    )
+    plan_id = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{diagram:{rec_a}}}}}\n- {{{{diagram:{rec_b}}}}}",
+        name="Plan",
+    )
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="Provenance on", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {
+                "outer": {
+                    "collect_token_type": "diagram",
+                },
+                "inner": {
+                    "collect_token_type": "element",
+                    "value_attribute_path": "attributes/Quantity/type",
+                    "bucket_attribute_path": None,
+                    "skip_blank_values": True,
+                },
+            },
+            "output": {
+                "group_by": "element.package_name",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+                "show_per_source_breakdown": True,
+                "breakdown_format": " ({sources_joined})",
+                "include_provenance": True,
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=plan_id,
+    )
+    md = result.markdown
+    # Heading lines must NOT carry the comment.
+    for line in md.splitlines():
+        if line.startswith("## "):
+            assert "<!-- iris:element=" not in line, (
+                f"Heading carried provenance comment: {line!r}"
+            )
+        if line.strip() == "":
+            assert "<!-- iris:element=" not in line
+    # Every list line (starts with "- ") ends with the comment, and the
+    # element_id matches the correct row.
+    list_lines = [ln for ln in md.splitlines() if ln.startswith("- ")]
+    assert list_lines, "no shopping-list lines rendered"
+    for line in list_lines:
+        assert line.endswith(" -->"), f"missing trailing comment: {line!r}"
+        assert "<!-- iris:element=" in line
+    # Verify the right element_id is on each row by matching name.
+    pork_lines = [ln for ln in list_lines if "Pork mince" in ln]
+    carrot_lines = [ln for ln in list_lines if "Carrot" in ln]
+    assert pork_lines and carrot_lines
+    for ln in pork_lines:
+        assert f"<!-- iris:element={pork_id} -->" in ln, ln
+    for ln in carrot_lines:
+        assert f"<!-- iris:element={carrot_id} -->" in ln, ln
+    # Per-source breakdown text MUST appear before the comment, not
+    # after it (comment is the very last thing on the line).
+    for ln in list_lines:
+        comment_start = ln.index("<!-- iris:element=")
+        breakdown_idx = ln.find("(Recipe ")
+        if breakdown_idx != -1:
+            assert breakdown_idx < comment_start, (
+                f"breakdown text appeared after the comment: {ln!r}"
+            )
+
+
 @pytest.mark.asyncio
 async def test_blank_value_skipped(
     env: tuple[httpx.AsyncClient, DatabaseManager, dict],

--- a/docs/adrs/ADR-217-Aggregate-Output-Provenance.md
+++ b/docs/adrs/ADR-217-Aggregate-Output-Provenance.md
@@ -1,0 +1,100 @@
+# ADR-217: Aggregate output provenance flag
+
+Status: Accepted (2026-05-24)
+
+Builds on: [ADR-212](./ADR-212-Aggregation-Profiles-And-Engine.md), [ADR-214](./ADR-214-Genericness-Invariant-Shopping-List.md).
+
+## WH(Y)
+
+**In the context of** the generic aggregation engine (ADR-212), which
+renders deduplicated, summed-up markdown shopping-list output from
+meal-plan-style smart-markdown diagrams,
+
+**facing** the need for downstream bash orchestrators to look up
+per-row metadata — for example, retailer-cached SKU values that the
+maintainer pins inside each element's Product-attribute `notes` —
+*without* an LLM round-trip to map "Pork mince 500 g" back onto an
+element id,
+
+**we decided for** an opt-in `output.include_provenance` flag on the
+aggregation profile that causes each rendered list line to end with
+` <!-- iris:element=<uuid> -->`, while leaving headings and blank
+lines untouched and preserving any per-source breakdown text in front
+of the comment,
+
+**and neglected** embedding retailer-specific SKU data directly in
+the aggregate output (would re-introduce domain coupling and drift
+toward the risk codified in ADR-214), a JSON sidecar response shape
+that returns rows + element ids structurally (bigger API surface
+change for a marginal gain when consumers are already grepping
+markdown), and making the comment mandatory on every aggregate run
+(would alter every existing consumer's output without consent),
+
+**to achieve** LLM-free per-line provenance lookup for downstream
+consumers, with zero impact on existing aggregate consumers and zero
+new write endpoints,
+
+**accepting that** the trailing HTML comment slightly inflates each
+rendered line (typically ~50 bytes) and that any future renderer
+choosing to strip HTML comments would silently drop the provenance —
+both deemed acceptable as the flag is opt-in and the format is widely
+recognisable.
+
+## Decision
+
+Add `include_provenance: bool = False` to
+`backend/app/aggregation/models.py::OutputConfig`. When true, the
+aggregation engine appends ` <!-- iris:element=<element_id> -->` to
+each rendered shopping-list line *after* any per-source breakdown
+text, so the comment is always the last thing on the line. Headings
+(`## ...`) and blank section dividers are untouched. The flag defaults
+to false; no migration flips seeded profiles in this change. A future
+PR may opt specific seeded profiles in via a paired migration.
+
+### Genericness invariant (ADR-214)
+
+The comment carries only the opaque `element_id` UUID and the literal
+prefix `iris:element=`. No retailer terminology, no domain vocabulary,
+no banned strings (per ADR-214's word-boundary check). The flag is
+named `include_provenance`, not `include_skus` or similar — the
+mechanism is generic and the downstream use (Woolworths SKU lookup,
+EAN barcodes, supplier codes, whatever) lives entirely in the
+consumer.
+
+## Consequences
+
+**Positive:**
+
+- Downstream bash orchestrators get cheap, structural per-line
+  provenance without parsing or LLM mapping.
+- Mechanism is reusable beyond the meal-plan workflow — any
+  aggregation consumer wanting element traceability can flip the flag
+  on its own profile.
+- No new endpoints, no surface-parity exception needed.
+
+**Negative / accepted trade-offs:**
+
+- Lines get slightly longer when the flag is on.
+- A markdown renderer that strips HTML comments would lose the
+  provenance silently. The expected consumers are bash/grep pipelines
+  and CLI/MCP callers, not browser-rendered markdown, so we accept it.
+
+## Rejected alternatives
+
+- **Embed retailer-specific SKU data in aggregate output.** Would
+  drag domain terminology into the engine and break the ADR-214
+  genericness invariant. The whole point of putting SKUs in element
+  attribute notes is so the engine doesn't need to know about them.
+- **JSON sidecar response shape (rows + element ids structurally).**
+  Larger API surface change for marginal benefit; existing consumers
+  already work in markdown; a sidecar adds a parallel format to
+  maintain.
+- **Mandatory comment on every aggregate run.** Would alter every
+  existing consumer's output without consent — opt-in via the profile
+  is friction-free.
+
+## References
+
+- [SPEC-217-a — flag shape, comment format, acceptance criteria](./specs/SPEC-217-a-Aggregate-Output-Provenance.md)
+- [ADR-212](./ADR-212-Aggregation-Profiles-And-Engine.md) — aggregation engine
+- [ADR-214](./ADR-214-Genericness-Invariant-Shopping-List.md) — genericness invariant (explicitly satisfied: comment carries only opaque element_id)

--- a/docs/adrs/specs/SPEC-217-a-Aggregate-Output-Provenance.md
+++ b/docs/adrs/specs/SPEC-217-a-Aggregate-Output-Provenance.md
@@ -1,0 +1,92 @@
+# SPEC-217-a: Aggregate output provenance
+
+Implements: [ADR-217](../ADR-217-Aggregate-Output-Provenance.md).
+
+## 1. Profile shape
+
+A new optional boolean field on `OutputConfig` in
+`backend/app/aggregation/models.py`:
+
+```python
+class OutputConfig(BaseModel):
+    # … existing fields …
+    show_per_source_breakdown: bool = False
+    breakdown_format: str = " ({sources_joined})"
+    include_provenance: bool = False
+```
+
+- Type: `bool`.
+- Default: `False` — existing consumers see no change.
+- Scope: per-profile. Each aggregation profile opts in (or not)
+  independently via `profile_data.output.include_provenance`.
+- No migration in this change. Seeded profiles keep their existing
+  `profile_data` shape; pydantic supplies the default at load time.
+
+## 2. Comment format
+
+When `include_provenance` is `True`, every rendered shopping-list line
+in the engine's output has the following string appended verbatim
+*after* any per-source breakdown text:
+
+```
+ <!-- iris:element=<element_id> -->
+```
+
+- Single leading space.
+- Literal prefix `<!-- iris:element=`.
+- `<element_id>` is the row's token id (a UUID).
+- Literal closing ` -->`.
+
+The comment is always the **last** thing on the line.
+
+## 3. Engine behaviour
+
+In `backend/app/aggregation/engine.py::_format_output`, after the
+existing per-source breakdown append:
+
+```python
+if output.show_per_source_breakdown:
+    line += _render_breakdown(output.breakdown_format, r.sources)
+if output.include_provenance:
+    line += f" <!-- iris:element={r.token_id} -->"
+out_lines.append(line)
+```
+
+The comment is appended only to lines produced by `_render_line` (the
+shopping-list rows). Group headings (`## <group>`) and blank section
+dividers are produced separately and are unaffected.
+
+## 4. Acceptance criteria
+
+Mirrored from the two new tests in
+`backend/tests/test_aggregation/test_engine.py`:
+
+1. **`test_include_provenance_off_omits_comments`** — With
+   `include_provenance` unset (or `False`), the rendered markdown
+   contains zero occurrences of the substring `<!-- iris:element=`.
+2. **`test_include_provenance_on_appends_comment_per_line`** — With
+   `include_provenance=True`:
+   - Every line beginning with `- ` (a rendered list row) ends with
+     ` -->` and contains a `<!-- iris:element=<uuid> -->` comment.
+   - The `<uuid>` matches the correct row's element id (verified by
+     matching the visible element name on the line).
+   - No heading line (`## ...`) carries the comment.
+   - No blank line carries the comment.
+   - When per-source breakdown is also enabled, the breakdown text
+     (e.g. `(Recipe A 500)`) appears in the line *before* the
+     provenance comment.
+
+## 5. Out of scope
+
+- Flipping any seeded profile's `include_provenance` to `True`. That
+  would be a paired SQLite/Supabase migration in a future PR.
+- A frontend toggle in the profile editor — the editor already
+  round-trips arbitrary `profile_data` JSON; a labelled checkbox can
+  be added later.
+- An MCP/CLI flag override at run time. The flag is per-profile by
+  design — the consumer that wants provenance configures its own
+  profile.
+- Carrying additional metadata in the comment (bucket, source label,
+  etc.). Out of scope; the element id is sufficient for the
+  downstream lookup use case in ADR-217. A v2 comment format could be
+  added later if needed.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,9 +92,26 @@ Config resolution order (first match wins):
 | `iris export diagram\|element\|package\|set\|collection <id> --format json\|markdown [-o PATH]` | Headless export |
 | `iris ask "<question>"` | AI question (`--set S` repeatable, `--mode discuss\|creation`, `--stream/--no-stream`) |
 | `iris conversations list --set <id>` | History |
+| `iris aggregate --profile <id> --source <diagram-id>` | Run a generic aggregation profile (ADR-212) |
+| `iris aggregation-profile list` / `get <id>` | Browse aggregation profiles |
+| `iris create aggregation-profile` / `iris update aggregation-profile` / `iris delete aggregation-profile` | Manage aggregation profiles |
 
 Add `--json` to any command for machine-parsable output. `-o -` on
 `iris export` writes to stdout.
+
+### Aggregate output provenance (ADR-217)
+
+An aggregation profile can opt in to per-line provenance by setting
+`output.include_provenance: true` in its `profile_data` (e.g. via
+`iris update aggregation-profile <id> --profile-data-file path.json`).
+When enabled, `iris aggregate` returns markdown where every rendered
+list line ends with `<!-- iris:element=<element-uuid> -->`. Headings
+and blank lines stay clean, and any per-source breakdown text is
+preserved in front of the comment. Bash orchestrators can extract the
+element id from each line to fetch related data (for example, cached
+SKU values stored on the element's attribute notes) without an LLM
+round-trip. The flag is off by default; existing consumers see no
+change.
 
 ## Exit codes
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -53,9 +53,23 @@ Or use `iris login` from `iris-cli` (mints + saves a PAT in one step).
 | `ask` | Multi-set AI question with optional file contexts |
 | `apply_diagram_creation` | Apply an AI-generated diagram bundle (`mode="creation"` output of `ask`) |
 | `list_conversations` | AI conversation history for a set |
+| `aggregate` / `create_aggregation_profile` / `list_aggregation_profiles` / `get_aggregation_profile` / `update_aggregation_profile` / `delete_aggregation_profile` | Run and manage generic aggregation profiles (ADR-212) |
 
 Each tool ships with an LLM-facing description with "when to use"
 guidance so an agent picks the right tool without manual prompting.
+
+### Aggregate output provenance (ADR-217)
+
+An aggregation profile can opt in to per-line provenance by setting
+`output.include_provenance: true` in its `profile_data`. When enabled,
+the `aggregate` tool's returned markdown appends
+`<!-- iris:element=<element-uuid> -->` to every rendered list line —
+headings and blank lines are untouched, and any per-source breakdown
+text stays in front of the comment. Downstream consumers can grep the
+comments to look up each row's element (for example, to fetch cached
+SKU values stored on the element's attribute notes) without parsing
+the visible text. The flag is off by default; existing consumers see
+no change.
 
 ## Resources
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.30.2",
+	"version": "6.31.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.30.2"
+version = "6.31.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.30.2"
+version = "6.31.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- New opt-in `output.include_provenance` flag on aggregation profile `OutputConfig`. When true, each rendered shopping-list line ends with ` <!-- iris:element=<uuid> -->` (after any per-source breakdown text). Headings and blank section dividers are untouched.
- Lets downstream bash orchestrators look up per-row element metadata (e.g. cached SKUs held in element attribute notes) without an LLM round-trip. Genericness invariant preserved (ADR-214): comment carries only the opaque element_id, no domain terminology.
- ADR-217 + SPEC-217-a, docs updates for `iris aggregate` (CLI) and `aggregate` (MCP), CHANGELOG entry, and the standard four-package version bump to v6.31.0.

## Test plan

- [x] `cd backend && pytest tests/test_aggregation/test_engine.py -v` — all 10 tests pass, including the two new ones (`test_include_provenance_off_omits_comments`, `test_include_provenance_on_appends_comment_per_line`).
- [x] `python3 scripts/check_surface_parity.py` — exit 0 (no new write endpoints).
- [x] `python3 scripts/check_aggregation_genericness.py` — clean (comment carries only `iris:element=<uuid>`, no banned strings).
- [x] All four `version` fields (frontend/package.json, backend/pyproject.toml, mcp/pyproject.toml, iris-client/pyproject.toml) read `6.31.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)