### PR TITLE
fix(v6.31.1): expose include_provenance flag in aggregation profile editor UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.31.1] - 2026-05-25
+
+### Added
+
+- Aggregation profile editor surfaces the `output.include_provenance`
+  flag (ADR-217) as a discrete checkbox above the JSON textarea.
+  Lets a non-technical user flip the flag without editing the raw
+  profile_data — patches the parsed JSON on save. SPEC-217-a's UI
+  exposure gap from v6.31.0 closed.
+
 ## [6.31.0] - 2026-05-24
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.31.0"
+version = "6.31.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.31.0",
+	"version": "6.31.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/AggregationProfileEditor.svelte
+++ b/frontend/src/lib/components/AggregationProfileEditor.svelte
@@ -60,8 +60,18 @@
 	let draftDescription = $state('');
 	let draftJson = $state('');
 	let draftIsDefault = $state(false);
+	// SPEC-217-a (v6.31.0) — surface the `output.include_provenance` flag as
+	// a discrete checkbox so a non-technical user can flip it without editing
+	// the JSON. The rest of the profile_data still lives in the textarea below;
+	// this checkbox patches the parsed JSON on save.
+	let draftIncludeProvenance = $state(false);
 	let draftError = $state<string | null>(null);
 	let saving = $state(false);
+
+	function readIncludeProvenance(profileData: Record<string, unknown>): boolean {
+		const output = profileData?.output as Record<string, unknown> | undefined;
+		return output?.include_provenance === true;
+	}
 
 	// SPEC-212-e (v6.29.0): Clone-from-existing picker state.
 	let cloning = $state(false);
@@ -84,6 +94,7 @@
 			line_format: '- {element.name}: {sum_value}{bucket_spaced}',
 			show_per_source_breakdown: false,
 			breakdown_format: ' ({sources_joined})',
+			include_provenance: false,
 		},
 	}, null, 2);
 
@@ -126,6 +137,7 @@
 		draftDescription = '';
 		draftJson = DEFAULT_PROFILE_JSON;
 		draftIsDefault = false;
+		draftIncludeProvenance = false;
 		draftError = null;
 	}
 
@@ -170,6 +182,7 @@
 		draftDescription = source.description ?? '';
 		draftJson = JSON.stringify(source.profile_data, null, 2);
 		draftIsDefault = false;  // copies don't inherit default-for-set
+		draftIncludeProvenance = readIncludeProvenance(source.profile_data);
 		draftError = null;
 	}
 
@@ -180,6 +193,7 @@
 		draftDescription = p.description ?? '';
 		draftJson = JSON.stringify(p.profile_data, null, 2);
 		draftIsDefault = p.is_default_for_set;
+		draftIncludeProvenance = readIncludeProvenance(p.profile_data);
 		draftError = null;
 	}
 
@@ -203,6 +217,12 @@
 			draftError = 'Name is required';
 			return;
 		}
+		// SPEC-217-a: merge the include-provenance checkbox into output.include_provenance.
+		// We ensure the output object exists so a malformed profile_data doesn't
+		// silently drop the flag on save.
+		const outputObj = (parsed.output as Record<string, unknown> | undefined) ?? {};
+		outputObj.include_provenance = draftIncludeProvenance;
+		parsed.output = outputObj;
 		saving = true;
 		try {
 			if (creating) {
@@ -336,6 +356,18 @@
 					class="mt-1 w-full rounded border px-3 py-2 text-sm"
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 				/>
+			</label>
+			<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
+				<input type="checkbox" bind:checked={draftIncludeProvenance} class="mt-1" />
+				<span>
+					<span class="font-medium">Include provenance comments</span>
+					<span class="block text-xs" style="color: var(--color-muted)">
+						When on, each aggregated line is rendered with a trailing HTML
+						comment carrying the source element id, e.g. <code>&lt;!-- iris:element=… --&gt;</code>.
+						Required by downstream orchestrators that need to map output
+						lines back to elements (e.g. the woolies-shopper skill). ADR-217.
+					</span>
+				</span>
 			</label>
 			<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
 				profile_data (JSON)

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.31.0"
+version = "6.31.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.31.0"
+version = "6.31.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Adds a discrete checkbox above the JSON textarea in the aggregation profile editor so users can toggle `output.include_provenance` without hand-editing JSON
- Initialises `draftIncludeProvenance` state correctly on create, clone, and edit
- `save()` merges the checkbox value back into the JSON payload before submitting
- Updates `DEFAULT_PROFILE_JSON` to include `"include_provenance": false` as a visible default

## Context

ADR-217 (v6.31.0) added the backend flag but left no UI surface for it. The woolies-shopper orchestrator needs this flag enabled on the shopping-list aggregation profile — without the checkbox, users had to know to hand-edit the `output` JSON object.

## Test plan

- [ ] Open `/admin/aggregation-profiles`, create a new profile — checkbox defaults to unchecked, `output.include_provenance` is `false` in the saved JSON
- [ ] Edit an existing profile that has `include_provenance: true` — checkbox renders checked
- [ ] Toggle checkbox on, save — `output.include_provenance` flips to `true` in the stored profile
- [ ] Toggle checkbox off, save — `output.include_provenance` flips back to `false`
- [ ] Clone a profile with `include_provenance: true` — clone inherits the checked state

🤖 Generated with [Claude Code](https://claude.com/claude-code)