### PR TITLE
fix(v6.31.4): enable RLS on aggregation_profiles + two other gap tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.31.4] - 2026-05-26
+
+### Fixed
+
+- **Row Level Security enabled on three Supabase tables that slipped past
+  the m030 sweep** (issue [#236](https://github.com/cgbarlow/iris/issues/236),
+  ADR-095). `artefacts` (m064, v6.2.0), `element_templates` (m071, v6.11.0),
+  and `aggregation_profiles` (m081, v6.28.0) were created without
+  `ENABLE ROW LEVEL SECURITY`, so the public Supabase `anon` key could
+  reach those rows directly via PostgREST, bypassing the FastAPI RBAC
+  layer. Migration m085 enables the standard deny-all policy on all
+  three; the backend still bypasses RLS as table owner, so no
+  application code changes are needed.
+
+- The `test_rls_policies.py` structural test now scans the full Supabase
+  migration set instead of just m001–m029, so any future table that
+  ships without RLS is caught in CI.
+
+### Migration
+
+- **Supabase only.** Run `scripts/supabase-migrate.sh` against UAT/prod
+  after deploy to apply m085. SQLite installations are unaffected (no
+  RLS in SQLite).
+
 ## [6.31.3] - 2026-05-25
 
 ### Fixed

--- a/backend/app/migrations/supabase/m085_aggregation_profiles_rls.sql
+++ b/backend/app/migrations/supabase/m085_aggregation_profiles_rls.sql
@@ -1,0 +1,21 @@
+-- Migration 085: enable Row Level Security on tables that slipped past
+-- the m030 sweep (issue #236).
+--
+-- Three tables were created after m030 without `ENABLE ROW LEVEL
+-- SECURITY`:
+--   - public.artefacts            (m064, v6.2.0)
+--   - public.element_templates    (m071, v6.11.0)
+--   - public.aggregation_profiles (m081, v6.28.0)
+--
+-- Per ADR-095, every Supabase table uses the deny-all strategy: RLS is
+-- enabled with no policies, so the embedded `anon` key (and any
+-- `authenticated` JWT) cannot reach the table via PostgREST. The
+-- FastAPI backend connects as the `postgres` role (table owner) and
+-- bypasses RLS — application-layer RBAC is unchanged.
+--
+-- Idempotent: PostgreSQL ignores ENABLE ROW LEVEL SECURITY when it is
+-- already enabled on a table.
+
+ALTER TABLE public.artefacts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.element_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.aggregation_profiles ENABLE ROW LEVEL SECURITY;

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.31.3"
+version = "6.31.4"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_migrations/test_rls_policies.py
+++ b/backend/tests/test_migrations/test_rls_policies.py
@@ -1,17 +1,23 @@
-"""Tests for m030_rls_policies.sql — ensure every Supabase table has RLS enabled.
+"""Structural validation for Supabase RLS coverage (ADR-095).
 
-This is a structural validation test (the SQLite test environment cannot test
-actual PostgreSQL RLS enforcement). It parses the migration SQL and verifies
-that every table created by m001–m029 has a corresponding
-ALTER TABLE ... ENABLE ROW LEVEL SECURITY statement in m030.
+The SQLite test environment cannot exercise PostgreSQL RLS enforcement,
+so these tests parse the migration SQL instead. They verify that every
+table created by any Supabase migration has a corresponding
+``ALTER TABLE ... ENABLE ROW LEVEL SECURITY`` statement somewhere in the
+migration set.
+
+History: the original sweep landed in m030 covering m001–m029. Later
+migrations enable RLS in the same file that creates the table. Issue
+#236 surfaced three tables (artefacts, element_templates,
+aggregation_profiles) that slipped through; m085 backfills them and
+this test now scans the full migration tree so future drift is caught
+in CI.
 """
 
 from __future__ import annotations
 
 import os
 import re
-
-import pytest
 
 _MIGRATIONS_DIR = os.path.join(
     os.path.dirname(__file__),
@@ -25,24 +31,34 @@ _MIGRATIONS_DIR = os.path.join(
 _RLS_FILE = os.path.join(_MIGRATIONS_DIR, "m030_rls_policies.sql")
 
 
-def _get_created_tables() -> set[str]:
-    """Parse all m001–m029 .sql files and extract table names from CREATE TABLE."""
+def _migration_files() -> list[str]:
+    return sorted(
+        os.path.join(_MIGRATIONS_DIR, fn)
+        for fn in os.listdir(_MIGRATIONS_DIR)
+        if fn.endswith(".sql")
+    )
+
+
+def _get_created_tables(max_migration: int | None = None) -> set[str]:
+    """Extract table names from CREATE TABLE statements across migrations.
+
+    ``max_migration`` (exclusive) limits the scan — used by the legacy
+    m001–m029 check. Strips an optional ``public.`` schema prefix so
+    tables created with and without it compare equal.
+    """
     tables: set[str] = set()
-    for filename in sorted(os.listdir(_MIGRATIONS_DIR)):
-        if not filename.endswith(".sql"):
-            continue
-        # Only include m001 through m029 (exclude m030+ which is the RLS file itself)
+    for filepath in _migration_files():
+        filename = os.path.basename(filepath)
         match = re.match(r"m(\d+)", filename)
         if not match:
             continue
         num = int(match.group(1))
-        if num >= 30:
+        if max_migration is not None and num >= max_migration:
             continue
-        filepath = os.path.join(_MIGRATIONS_DIR, filename)
         with open(filepath) as f:
             content = f.read()
         for m in re.finditer(
-            r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)",
+            r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?(\w+)",
             content,
             re.IGNORECASE,
         ):
@@ -50,17 +66,23 @@ def _get_created_tables() -> set[str]:
     return tables
 
 
-def _get_rls_tables() -> set[str]:
-    """Parse m030_rls_policies.sql and extract table names from ALTER TABLE ... ENABLE ROW LEVEL SECURITY."""
-    with open(_RLS_FILE) as f:
-        content = f.read()
+def _get_rls_tables(file: str | None = None) -> set[str]:
+    """Extract table names from ENABLE ROW LEVEL SECURITY statements.
+
+    If ``file`` is given, scan only that file (legacy m030 check).
+    Otherwise scan every Supabase migration.
+    """
+    files = [file] if file else _migration_files()
     tables: set[str] = set()
-    for m in re.finditer(
-        r"ALTER\s+TABLE\s+(\w+)\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY",
-        content,
-        re.IGNORECASE,
-    ):
-        tables.add(m.group(1))
+    for filepath in files:
+        with open(filepath) as f:
+            content = f.read()
+        for m in re.finditer(
+            r"ALTER\s+TABLE\s+(?:public\.)?(\w+)\s+ENABLE\s+ROW\s+LEVEL\s+SECURITY",
+            content,
+            re.IGNORECASE,
+        ):
+            tables.add(m.group(1))
     return tables
 
 
@@ -69,10 +91,10 @@ def test_rls_migration_file_exists() -> None:
     assert os.path.isfile(_RLS_FILE), f"Missing: {_RLS_FILE}"
 
 
-def test_every_table_has_rls() -> None:
+def test_every_m001_m029_table_has_rls_in_m030() -> None:
     """Every table created by m001–m029 must have RLS enabled in m030."""
-    created = _get_created_tables()
-    rls = _get_rls_tables()
+    created = _get_created_tables(max_migration=30)
+    rls = _get_rls_tables(file=_RLS_FILE)
 
     missing = created - rls
     assert not missing, (
@@ -80,12 +102,16 @@ def test_every_table_has_rls() -> None:
     )
 
 
-def test_no_extra_rls_tables() -> None:
-    """m030 should not enable RLS on tables that don't exist in m001–m029."""
+def test_every_supabase_table_has_rls_enabled() -> None:
+    """Every table created by any Supabase migration must have RLS enabled
+    somewhere in the migration set (ADR-095)."""
     created = _get_created_tables()
     rls = _get_rls_tables()
 
-    extra = rls - created
-    assert not extra, (
-        f"RLS enabled on tables not created by m001–m029: {sorted(extra)}"
+    missing = created - rls
+    assert not missing, (
+        "Supabase tables missing ENABLE ROW LEVEL SECURITY anywhere in "
+        f"the migration set: {sorted(missing)}. Add the ALTER TABLE in "
+        "the same migration that creates the table, or in a follow-up "
+        "RLS-fix migration like m085."
     )

--- a/docs/adrs/ADR-095-Row-Level-Security.md
+++ b/docs/adrs/ADR-095-Row-Level-Security.md
@@ -79,7 +79,18 @@ bundle and can be used to bypass all Iris security.
 ## Verification
 
 1. Structural test (`tests/test_migrations/test_rls_policies.py`) verifies every table from
-   m001–m029 has a corresponding `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` in m030
+   m001–m029 has a corresponding `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` in m030, AND
+   that every table created across the full Supabase migration set has RLS enabled
+   somewhere (the broader check was added in v6.31.4 after issue #236 surfaced three
+   post-m030 tables that had drifted without it)
 2. Manual verification: after applying m030, query any table with the `anon` key via REST —
    should return empty result with no error (PostgREST returns `[]` when RLS denies access)
 3. Backend CRUD operations continue to work (backend connects as `postgres`, bypasses RLS)
+
+## History
+
+- **2026-03-21 (v5.4.x):** m030 enabled RLS on the 34 tables that existed at that point.
+- **2026-05-26 (v6.31.4):** m085 backfilled three tables that were created after m030
+  without their own `ENABLE ROW LEVEL SECURITY`: `artefacts` (m064), `element_templates`
+  (m071), `aggregation_profiles` (m081). The structural test was broadened at the same
+  time so subsequent migrations can't recreate the gap (issue #236).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.31.3",
+	"version": "6.31.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.31.3"
+version = "6.31.4"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.31.3"
+version = "6.31.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Closes #236 — `aggregation_profiles` had no Row Level Security, leaving rows reachable via the public Supabase `anon` key.
- A migration audit found two more tables in the same boat (`artefacts` from m064, `element_templates` from m071); m085 enables RLS deny-all on all three.
- The structural test in `test_rls_policies.py` now scans the full Supabase migration set so the next post-m030 table can't slip past without RLS.

## Why this matters

ADR-095 mandates RLS on every Supabase table — the embedded frontend `anon` key would otherwise be a master read/write credential via PostgREST. The FastAPI backend connects as table owner and bypasses RLS, so no application code changes are needed (and existing behaviour is unchanged) — this purely closes the direct-PostgREST path.

## Test plan

- [x] `pytest backend/tests/test_migrations/test_rls_policies.py` — three structural tests pass, including the new broad-scan check.
- [ ] Apply `m085_aggregation_profiles_rls.sql` to UAT/prod via `scripts/supabase-migrate.sh` after merge.
- [ ] Manual: with the migration applied, `curl` the Supabase REST endpoint for `artefacts` / `element_templates` / `aggregation_profiles` with only the `anon` key — should return `[]` (RLS denies).
- [ ] Backend CRUD against the three tables continues to work (table owner bypasses RLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)