### PR TITLE
fix(v6.31.5): normalize canvas shape for create_diagram (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.31.5] - 2026-05-28
+
+### Fixed
+
+- **Diagrams generated via the MCP `create_diagram` tool failed to
+  load** (issue [#238](https://github.com/cgbarlow/iris/issues/238),
+  ADR-218). The shared creation prompt teaches models the *flat* AI node
+  shape (`{id, type, label, position, size, visual}`) that
+  `apply_diagram_creation` converts to canvas shape — but
+  `create_diagram` persisted its `data` verbatim, so flat nodes reached
+  storage with no per-node `data` object and the canvas crashed with
+  `Cannot read properties of undefined (reading 'entityType')`.
+  `create_diagram` / `update_diagram` now normalise the flat shape to
+  canvas shape on write, and `get_diagram` auto-heals legacy flat
+  diagrams on read (non-destructive). A new shared
+  `normalize_canvas_data` is the single source of truth; the
+  `apply_diagram_creation` builder now delegates to it (DRY).
+
+- `UnifiedCanvas` `fitViewOptions` now optional-chains `n.data` so a
+  dataless node can never hard-crash the canvas on mount
+  (defense-in-depth behind the backend fix).
+
+### Repair (UAT/prod)
+
+- The three already-broken diagrams named in issue #238 are repaired in
+  place — and only those — by
+  `scripts/repair_flat_diagram_shape.py --diagram-id <id> …`, which
+  reuses `normalize_canvas_data` and regenerates the affected diagrams'
+  thumbnails. The script refuses to run without explicit ids and never
+  scans all diagrams. No database schema migration is required.
+
 ## [6.31.4] - 2026-05-26
 
 ### Fixed

--- a/backend/app/ai/creation.py
+++ b/backend/app/ai/creation.py
@@ -12,6 +12,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from app.diagrams.canvas_normalize import flat_edge_to_canvas, flat_node_to_canvas
 from app.elements.materialise import materialise_element, materialise_relationship
 
 if TYPE_CHECKING:
@@ -383,65 +384,36 @@ def _nodes_edges_to_sequence(canvas_data: dict) -> dict:
 
 
 def _build_canvas_nodes(ai_nodes: list[dict]) -> list[dict]:
-    """Convert AI node format to Iris canvas node format."""
+    """Convert AI node format to Iris canvas node format.
+
+    Delegates the flat → canvas transform to the shared
+    ``flat_node_to_canvas`` (protocols §13 DRY); the doview default
+    entity type and the phase-2 ``_linkedDiagramIndex`` stash are the
+    apply-path specifics layered on top.
+    """
     canvas_nodes = []
     for ai_node in ai_nodes:
-        node_id = ai_node.get("id", str(uuid.uuid4()))
-        entity_type = ai_node.get("type", "outcome_box")
-        label = ai_node.get("label", "")
-        position = ai_node.get("position", {"x": 0, "y": 0})
-        size = ai_node.get("size", {"width": 200, "height": 86})
-        visual = ai_node.get("visual", {})
-
-        node_data: dict = {
-            "label": label,
-            "entityType": entity_type,
-        }
-        description = ai_node.get("description", "")
-        if description:
-            node_data["description"] = description
-        if visual:
-            node_data["visual"] = visual
-
-        # Stash linkedDiagramIndex for phase-2 resolution
-        linked_idx = ai_node.get("linkedDiagramIndex")
+        node = dict(ai_node)
+        node.setdefault("id", str(uuid.uuid4()))
+        linked_idx = node.pop("linkedDiagramIndex", None)
+        canvas = flat_node_to_canvas(node, default_entity_type="outcome_box")
         if linked_idx is not None:
-            node_data["_linkedDiagramIndex"] = linked_idx
-
-        canvas_nodes.append({
-            "id": node_id,
-            "type": entity_type,
-            "position": position,
-            "data": node_data,
-            "width": size.get("width", 200),
-            "height": size.get("height", 86),
-        })
+            canvas["data"]["_linkedDiagramIndex"] = linked_idx
+        canvas_nodes.append(canvas)
     return canvas_nodes
 
 
 def _build_canvas_edges(ai_edges: list[dict]) -> list[dict]:
-    """Convert AI edge format to Iris canvas edge format."""
+    """Convert AI edge format to Iris canvas edge format.
+
+    Delegates to the shared ``flat_edge_to_canvas`` (protocols §13 DRY);
+    the doview default relationship type is the apply-path specific.
+    """
     canvas_edges = []
     for ai_edge in ai_edges:
-        edge_id = ai_edge.get("id", str(uuid.uuid4()))
-        edge_type = ai_edge.get("type", "causal_link")
-        source = ai_edge.get("source", "")
-        target = ai_edge.get("target", "")
-        visual = ai_edge.get("visual", {})
-
-        edge_data: dict = {
-            "relationshipType": edge_type,
-        }
-        if visual:
-            edge_data["visual"] = visual
-
-        canvas_edges.append({
-            "id": edge_id,
-            "type": edge_type,
-            "source": source,
-            "target": target,
-            "sourceHandle": "center",
-            "targetHandle": "center",
-            "data": edge_data,
-        })
+        edge = dict(ai_edge)
+        edge.setdefault("id", str(uuid.uuid4()))
+        canvas_edges.append(
+            flat_edge_to_canvas(edge, default_relationship_type="causal_link")
+        )
     return canvas_edges

--- a/backend/app/diagrams/canvas_normalize.py
+++ b/backend/app/diagrams/canvas_normalize.py
@@ -1,0 +1,155 @@
+"""Canvas-data shape normalization (ADR-218, issue #238).
+
+The shared creation prompt (``backend/app/seed/creation_prompts.py``)
+teaches models the *flat* AI/MCP node shape::
+
+    {"id", "type", "label", "position", "size", "visual"}
+
+That shape is consumed by ``apply_diagram_creation`` →
+``_build_canvas_nodes`` (``app/ai/creation.py``), which converts it into
+the Svelte-Flow *canvas* shape the frontend canvas requires::
+
+    {"id", "type", "position", "width", "height",
+     "data": {"label", "entityType", ...}}
+
+But ``create_diagram`` (ADR-162) persists its ``data`` payload verbatim.
+A model that follows the creation prompt and then saves via
+``create_diagram`` stored flat nodes with no ``data`` object, so
+``UnifiedCanvas.svelte`` crashed reading ``n.data.entityType`` and the
+diagram "failed to load" (issue #238).
+
+This module is the single authority for the flat → canvas transform.
+``normalize_canvas_data`` is shape-detecting and idempotent: nodes/edges
+that already carry a dict ``data`` are returned untouched, so it is safe
+to apply on write (``create_diagram`` / ``update_diagram``), on read
+(``get_diagram`` auto-heal), in the targeted repair script, and
+repeatedly. ``app/ai/creation.py`` delegates its per-item conversion
+here too (protocols §13 DRY).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_NODE_WIDTH = 200
+DEFAULT_NODE_HEIGHT = 86
+
+# Top-level keys relocated into `data`/`width`/`height` during conversion.
+_RELOCATED_NODE_KEYS = ("label", "size", "visual", "description")
+
+
+def flat_node_to_canvas(node: dict, *, default_entity_type: str = "") -> dict:
+    """Convert a single flat AI node into Svelte-Flow canvas shape.
+
+    Moves ``label`` → ``data.label``, ``type`` → ``data.entityType``,
+    ``size`` → top-level ``width``/``height``, and a non-empty ``visual``
+    / ``description`` into ``data``. Unknown top-level structural keys
+    (e.g. ``parentId``) are preserved. ``default_entity_type`` is used
+    when the node has no ``type`` (the doview apply path passes
+    ``"outcome_box"``).
+    """
+    entity_type = node.get("type") or default_entity_type
+    label = node.get("label", "")
+    size = node.get("size") or {}
+    visual = node.get("visual")
+    description = node.get("description")
+
+    data: dict[str, Any] = {"label": label, "entityType": entity_type}
+    if description:
+        data["description"] = description
+    if visual:
+        data["visual"] = visual
+
+    out = {k: v for k, v in node.items() if k not in _RELOCATED_NODE_KEYS}
+    out["type"] = entity_type
+    out["data"] = data
+    out.setdefault("position", {"x": 0, "y": 0})
+    if "width" not in out:
+        out["width"] = size.get("width", DEFAULT_NODE_WIDTH)
+    if "height" not in out:
+        out["height"] = size.get("height", DEFAULT_NODE_HEIGHT)
+    return out
+
+
+def flat_edge_to_canvas(edge: dict, *, default_relationship_type: str = "") -> dict:
+    """Convert a single flat AI edge into Svelte-Flow canvas shape.
+
+    Moves ``type`` → ``data.relationshipType`` (keeping ``type`` for the
+    edge renderer), a non-empty ``visual`` into ``data``, and adds the
+    ``center`` handles the canvas uses for AI-authored edges.
+    """
+    rel_type = edge.get("type") or default_relationship_type
+    visual = edge.get("visual")
+
+    data: dict[str, Any] = {"relationshipType": rel_type}
+    if visual:
+        data["visual"] = visual
+
+    out = {k: v for k, v in edge.items() if k != "visual"}
+    out["type"] = rel_type
+    out["data"] = data
+    out.setdefault("sourceHandle", "center")
+    out.setdefault("targetHandle", "center")
+    return out
+
+
+def _normalize_node(node: Any) -> Any:
+    if not isinstance(node, dict):
+        return node
+    # Already canvas-shaped — leave untouched (idempotent).
+    if isinstance(node.get("data"), dict):
+        return node
+    return flat_node_to_canvas(node)
+
+
+def _normalize_edge(edge: Any) -> Any:
+    if not isinstance(edge, dict):
+        return edge
+    if isinstance(edge.get("data"), dict):
+        return edge
+    return flat_edge_to_canvas(edge)
+
+
+def needs_normalization(data: Any) -> bool:
+    """True iff ``data`` contains at least one flat node or edge.
+
+    Lets callers (e.g. the repair script) skip a rewrite when the
+    payload is already canvas-shaped.
+    """
+    if not isinstance(data, dict):
+        return False
+    nodes = data.get("nodes")
+    edges = data.get("edges")
+    if isinstance(nodes, list) and any(
+        isinstance(n, dict) and not isinstance(n.get("data"), dict) for n in nodes
+    ):
+        return True
+    return bool(
+        isinstance(edges, list)
+        and any(
+            isinstance(e, dict) and not isinstance(e.get("data"), dict) for e in edges
+        )
+    )
+
+
+def normalize_canvas_data(data: Any) -> Any:
+    """Return ``data`` with any flat nodes/edges converted to canvas shape.
+
+    Shape-detecting and idempotent. Non-dict payloads and dicts without
+    ``nodes``/``edges`` lists (markdown ``{content}``, sequence
+    ``{participants, ...}``) are returned unchanged. The input is not
+    mutated — a shallow copy is returned when changes apply.
+    """
+    if not isinstance(data, dict):
+        return data
+    nodes = data.get("nodes")
+    edges = data.get("edges")
+    if not isinstance(nodes, list) and not isinstance(edges, list):
+        return data
+
+    result = dict(data)
+    if isinstance(nodes, list):
+        result["nodes"] = [_normalize_node(n) for n in nodes]
+    if isinstance(edges, list):
+        result["edges"] = [_normalize_edge(e) for e in edges]
+    return result

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.migrations.m012_sets import DEFAULT_SET_ID
+from app.diagrams.canvas_normalize import normalize_canvas_data
 from app.diagrams.thumbnail import VALID_THEMES, generate_and_store_thumbnail
 from app.package_relationships.service import create_package_relationship
 from app.relationships.service import create_relationship
@@ -38,6 +39,11 @@ async def create_diagram(
     """Create a new diagram with initial version."""
     diagram_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
+    # ADR-218 (issue #238): models following the shared creation prompt
+    # emit the flat AI node shape; create_diagram persists `data`
+    # verbatim. Normalise flat → canvas shape so the stored payload is
+    # always renderable. Idempotent: canvas-shaped data passes through.
+    data = normalize_canvas_data(data)
     data_json = json.dumps(data)
     metadata_json = json.dumps(metadata) if metadata else None
     effective_set_id = set_id or DEFAULT_SET_ID
@@ -192,6 +198,11 @@ async def get_diagram(
         "detected_notations": detected,
         "metadata": json.loads(row[14]) if row[14] else None,
     }
+    # ADR-218 (issue #238): auto-heal legacy diagrams persisted with the
+    # flat AI node shape (no per-node `data` object) so they render
+    # instead of crashing the canvas. Non-destructive — storage is
+    # untouched; idempotent for already-canvas data.
+    result["data"] = normalize_canvas_data(result["data"])
     # ADR-187 — compute-on-read overlay for dynamic_list (and future
     # opt-in computed diagram types).
     await _maybe_synthesise_content(db, result)
@@ -445,6 +456,10 @@ async def update_diagram(
 
     new_version = row[0] + 1
     now = datetime.now(tz=UTC).isoformat()
+    # ADR-218 (issue #238): normalise flat → canvas shape on write so an
+    # update carrying the flat AI node shape can't persist unrenderable
+    # data. Idempotent for already-canvas payloads.
+    data = normalize_canvas_data(data)
     data_json = json.dumps(data)
     metadata_json = json.dumps(metadata) if metadata else None
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.31.4"
+version = "6.31.5"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_canvas_normalize.py
+++ b/backend/tests/test_diagrams/test_canvas_normalize.py
@@ -1,0 +1,217 @@
+"""Tests for canvas-data shape normalization (ADR-218, issue #238).
+
+`normalize_canvas_data` converts the flat AI/MCP node shape
+(`{id, type, label, position, size, visual}`) into the Svelte-Flow
+canvas shape (`{id, type, position, width, height, data: {label,
+entityType, ...}}`) that the frontend canvas requires. It is
+shape-detecting and idempotent: nodes that already carry a dict
+`data` are left untouched, so it is safe to run on read, on write,
+and repeatedly.
+
+Root cause it guards: `create_diagram` persists its `data` payload
+verbatim, but the shared creation prompt teaches models the flat
+shape consumed by `apply_diagram_creation`/`_build_canvas_nodes`.
+Saving that flat shape via `create_diagram` produced nodes with no
+`data` object, crashing `UnifiedCanvas.svelte` on `n.data.entityType`.
+"""
+
+from __future__ import annotations
+
+from app.diagrams.canvas_normalize import (
+    flat_edge_to_canvas,
+    flat_node_to_canvas,
+    normalize_canvas_data,
+)
+
+
+def _issue_238_node() -> dict:
+    """A node exactly as persisted for the diagram in issue #238."""
+    return {
+        "id": "st1",
+        "type": "stakeholder",
+        "label": "New Zealanders (service users)",
+        "position": {"x": 60, "y": 20},
+        "size": {"width": 180, "height": 80},
+        "visual": {},
+    }
+
+
+class TestFlatNodeToCanvas:
+    def test_relocates_label_and_type_into_data(self) -> None:
+        out = flat_node_to_canvas(_issue_238_node())
+        assert out["data"]["label"] == "New Zealanders (service users)"
+        assert out["data"]["entityType"] == "stakeholder"
+
+    def test_keeps_type_and_position_and_id(self) -> None:
+        out = flat_node_to_canvas(_issue_238_node())
+        assert out["id"] == "st1"
+        assert out["type"] == "stakeholder"
+        assert out["position"] == {"x": 60, "y": 20}
+
+    def test_size_becomes_top_level_width_height(self) -> None:
+        out = flat_node_to_canvas(_issue_238_node())
+        assert out["width"] == 180
+        assert out["height"] == 80
+        assert "size" not in out
+
+    def test_empty_visual_is_omitted(self) -> None:
+        out = flat_node_to_canvas(_issue_238_node())
+        assert "visual" not in out
+        assert "visual" not in out["data"]
+
+    def test_non_empty_visual_moves_into_data(self) -> None:
+        node = _issue_238_node()
+        node["visual"] = {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}
+        out = flat_node_to_canvas(node)
+        assert out["data"]["visual"] == {"bgColor": "#FFF2CC", "borderColor": "#D6B656"}
+        assert "visual" not in out
+
+    def test_description_moves_into_data(self) -> None:
+        node = _issue_238_node()
+        node["description"] = "A service user persona"
+        out = flat_node_to_canvas(node)
+        assert out["data"]["description"] == "A service user persona"
+        assert "description" not in out
+
+    def test_missing_size_defaults_dimensions(self) -> None:
+        node = _issue_238_node()
+        del node["size"]
+        out = flat_node_to_canvas(node)
+        assert out["width"] == 200
+        assert out["height"] == 86
+
+    def test_preserves_unknown_structural_keys(self) -> None:
+        node = _issue_238_node()
+        node["parentId"] = "pool1"
+        out = flat_node_to_canvas(node)
+        assert out["parentId"] == "pool1"
+
+    def test_default_entity_type_used_when_type_missing(self) -> None:
+        node = _issue_238_node()
+        del node["type"]
+        out = flat_node_to_canvas(node, default_entity_type="outcome_box")
+        assert out["data"]["entityType"] == "outcome_box"
+        assert out["type"] == "outcome_box"
+
+
+class TestFlatEdgeToCanvas:
+    def test_type_becomes_relationship_type(self) -> None:
+        out = flat_edge_to_canvas(
+            {"id": "e1", "type": "influence", "source": "a", "target": "b"}
+        )
+        assert out["data"]["relationshipType"] == "influence"
+
+    def test_adds_center_handles(self) -> None:
+        out = flat_edge_to_canvas(
+            {"id": "e1", "type": "influence", "source": "a", "target": "b"}
+        )
+        assert out["sourceHandle"] == "center"
+        assert out["targetHandle"] == "center"
+
+    def test_preserves_source_target_id(self) -> None:
+        out = flat_edge_to_canvas(
+            {"id": "e1", "type": "influence", "source": "a", "target": "b"}
+        )
+        assert out["id"] == "e1"
+        assert out["source"] == "a"
+        assert out["target"] == "b"
+
+    def test_keeps_top_level_type_for_renderer_dispatch(self) -> None:
+        out = flat_edge_to_canvas(
+            {"id": "e1", "type": "influence", "source": "a", "target": "b"}
+        )
+        assert out["type"] == "influence"
+
+
+class TestNormalizeCanvasData:
+    def test_issue_238_full_payload_gets_data_on_every_node(self) -> None:
+        data = {
+            "nodes": [
+                _issue_238_node(),
+                {
+                    "id": "goal",
+                    "type": "goal",
+                    "label": "Create user-focused services",
+                    "position": {"x": 300, "y": 160},
+                    "size": {"width": 260, "height": 80},
+                    "visual": {},
+                },
+            ],
+            "edges": [
+                {"id": "e3", "type": "influence", "source": "st1", "target": "goal"},
+            ],
+        }
+        out = normalize_canvas_data(data)
+        for node in out["nodes"]:
+            assert isinstance(node["data"], dict)
+            assert node["data"]["entityType"]
+            # The exact access that crashed UnifiedCanvas.svelte:114
+            assert node["data"]["entityType"] != "diagram_frame"
+        assert out["edges"][0]["data"]["relationshipType"] == "influence"
+
+    def test_already_canvas_node_is_untouched(self) -> None:
+        canvas_node = {
+            "id": "n1",
+            "type": "stakeholder",
+            "position": {"x": 0, "y": 0},
+            "width": 200,
+            "data": {"label": "Existing", "entityType": "stakeholder"},
+        }
+        out = normalize_canvas_data({"nodes": [canvas_node], "edges": []})
+        assert out["nodes"][0] == canvas_node
+
+    def test_mixed_nodes_only_flat_converted(self) -> None:
+        canvas_node = {
+            "id": "n1",
+            "type": "goal",
+            "position": {"x": 0, "y": 0},
+            "data": {"label": "Canvas", "entityType": "goal"},
+        }
+        out = normalize_canvas_data({"nodes": [canvas_node, _issue_238_node()]})
+        assert out["nodes"][0] == canvas_node
+        assert out["nodes"][1]["data"]["entityType"] == "stakeholder"
+
+    def test_already_canvas_edge_is_untouched(self) -> None:
+        canvas_edge = {
+            "id": "e1",
+            "type": "influence",
+            "source": "a",
+            "target": "b",
+            "sourceHandle": "center",
+            "targetHandle": "center",
+            "data": {"relationshipType": "influence"},
+        }
+        out = normalize_canvas_data({"nodes": [], "edges": [canvas_edge]})
+        assert out["edges"][0] == canvas_edge
+
+    def test_markdown_data_untouched(self) -> None:
+        data = {"content": "# Heading\n\nSome **markdown** body."}
+        assert normalize_canvas_data(data) == data
+
+    def test_sequence_data_untouched(self) -> None:
+        data = {"participants": [{"id": "p1"}], "messages": [], "activations": []}
+        assert normalize_canvas_data(data) == data
+
+    def test_non_dict_passthrough(self) -> None:
+        assert normalize_canvas_data(None) is None
+        assert normalize_canvas_data([1, 2, 3]) == [1, 2, 3]
+
+    def test_empty_dict_passthrough(self) -> None:
+        assert normalize_canvas_data({}) == {}
+
+    def test_idempotent(self) -> None:
+        data = {
+            "nodes": [_issue_238_node()],
+            "edges": [{"id": "e1", "type": "influence", "source": "a", "target": "b"}],
+        }
+        once = normalize_canvas_data(data)
+        twice = normalize_canvas_data(once)
+        assert once == twice
+
+    def test_does_not_mutate_input(self) -> None:
+        node = _issue_238_node()
+        data = {"nodes": [node], "edges": []}
+        normalize_canvas_data(data)
+        # original flat node still flat (no data key added in place)
+        assert "data" not in node
+        assert node["label"] == "New Zealanders (service users)"

--- a/backend/tests/test_diagrams/test_repair_flat_diagram_shape.py
+++ b/backend/tests/test_diagrams/test_repair_flat_diagram_shape.py
@@ -1,0 +1,168 @@
+"""Tests for the targeted flat-diagram repair script (ADR-218, issue #238).
+
+Exercises the core `repair_diagram` against a real temporary SQLite
+database (no mocks, Protocol §9). Validates in-place normalization of
+every version, idempotency, dry-run safety, and strict scoping (an
+unknown id is reported, never guessed at).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.db.adapter import SqliteAdapter
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2].parent
+    / "scripts"
+    / "repair_flat_diagram_shape.py"
+)
+_spec = importlib.util.spec_from_file_location("repair_flat_diagram_shape", _SCRIPT)
+assert _spec and _spec.loader
+_repair_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_repair_mod)
+repair_diagram = _repair_mod.repair_diagram
+
+_FLAT_DATA = {
+    "nodes": [
+        {
+            "id": "st1",
+            "type": "stakeholder",
+            "label": "Users",
+            "position": {"x": 60, "y": 20},
+            "size": {"width": 180, "height": 80},
+            "visual": {"bgColor": "#DAE8FC", "borderColor": "#6C8EBF"},
+        },
+        {
+            "id": "goal",
+            "type": "goal",
+            "label": "Quality services",
+            "position": {"x": 300, "y": 160},
+            "size": {"width": 260, "height": 80},
+            "visual": {},
+        },
+    ],
+    "edges": [{"id": "e1", "type": "influence", "source": "st1", "target": "goal"}],
+}
+
+
+async def _setup(conn: aiosqlite.Connection) -> None:
+    await conn.execute(
+        "CREATE TABLE diagrams (id TEXT PRIMARY KEY, diagram_type TEXT, "
+        "current_version INTEGER, is_deleted INTEGER DEFAULT 0)"
+    )
+    await conn.execute(
+        "CREATE TABLE diagram_versions (diagram_id TEXT, version INTEGER, "
+        "data TEXT, PRIMARY KEY (diagram_id, version))"
+    )
+    await conn.commit()
+
+
+async def _insert_diagram(
+    conn: aiosqlite.Connection, diagram_id: str, *, versions: int, data: dict
+) -> None:
+    await conn.execute(
+        "INSERT INTO diagrams (id, diagram_type, current_version) VALUES (?, ?, ?)",
+        (diagram_id, "motivation", versions),
+    )
+    for v in range(1, versions + 1):
+        await conn.execute(
+            "INSERT INTO diagram_versions (diagram_id, version, data) VALUES (?, ?, ?)",
+            (diagram_id, v, json.dumps(data)),
+        )
+    await conn.commit()
+
+
+@pytest_asyncio.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        await _setup(conn)
+        yield SqliteAdapter(conn), conn
+
+
+async def _stored(conn: aiosqlite.Connection, diagram_id: str, version: int) -> dict:
+    cur = await conn.execute(
+        "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = ?",
+        (diagram_id, version),
+    )
+    return json.loads((await cur.fetchone())[0])
+
+
+class TestRepairDiagram:
+    @pytest.mark.asyncio
+    async def test_normalizes_all_versions_in_place(self, db) -> None:
+        adapter, conn = db
+        await _insert_diagram(conn, "d1", versions=2, data=_FLAT_DATA)
+
+        summary = await repair_diagram(adapter, "d1")
+        await adapter.commit()
+
+        assert summary["found"] is True
+        assert summary["versions_changed"] == [1, 2]
+        for v in (1, 2):
+            stored = await _stored(conn, "d1", v)
+            for node in stored["nodes"]:
+                assert isinstance(node["data"], dict)
+                assert node["data"]["entityType"]
+            assert stored["edges"][0]["data"]["relationshipType"] == "influence"
+
+    @pytest.mark.asyncio
+    async def test_visual_relocated_into_data(self, db) -> None:
+        adapter, conn = db
+        await _insert_diagram(conn, "d1", versions=1, data=_FLAT_DATA)
+        await repair_diagram(adapter, "d1")
+        await adapter.commit()
+        stored = await _stored(conn, "d1", 1)
+        assert stored["nodes"][0]["data"]["visual"] == {
+            "bgColor": "#DAE8FC",
+            "borderColor": "#6C8EBF",
+        }
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_run_changes_nothing(self, db) -> None:
+        adapter, conn = db
+        await _insert_diagram(conn, "d1", versions=1, data=_FLAT_DATA)
+        await repair_diagram(adapter, "d1")
+        await adapter.commit()
+        again = await repair_diagram(adapter, "d1")
+        assert again["versions_changed"] == []
+
+    @pytest.mark.asyncio
+    async def test_dry_run_writes_nothing(self, db) -> None:
+        adapter, conn = db
+        await _insert_diagram(conn, "d1", versions=1, data=_FLAT_DATA)
+        summary = await repair_diagram(adapter, "d1", dry_run=True)
+        assert summary["versions_changed"] == [1]
+        stored = await _stored(conn, "d1", 1)
+        assert "data" not in stored["nodes"][0]  # untouched
+
+    @pytest.mark.asyncio
+    async def test_unknown_id_reported_not_guessed(self, db) -> None:
+        adapter, _ = db
+        summary = await repair_diagram(adapter, "does-not-exist")
+        assert summary["found"] is False
+
+    @pytest.mark.asyncio
+    async def test_already_canvas_shaped_no_change(self, db) -> None:
+        adapter, conn = db
+        canvas_data = {
+            "nodes": [
+                {
+                    "id": "n1",
+                    "type": "goal",
+                    "position": {"x": 0, "y": 0},
+                    "width": 200,
+                    "data": {"label": "Already", "entityType": "goal"},
+                }
+            ],
+            "edges": [],
+        }
+        await _insert_diagram(conn, "d1", versions=1, data=canvas_data)
+        summary = await repair_diagram(adapter, "d1")
+        assert summary["versions_changed"] == []

--- a/backend/tests/test_diagrams/test_shape_normalization.py
+++ b/backend/tests/test_diagrams/test_shape_normalization.py
@@ -1,0 +1,225 @@
+"""Integration tests for canvas-shape normalization on the diagram
+write/read paths (ADR-218, issue #238).
+
+These exercise the full FastAPI stack: a flat AI/MCP `data` payload
+posted to `create_diagram` / `update_diagram` must round-trip as
+Svelte-Flow canvas shape, and a legacy diagram already persisted flat
+must be auto-healed on read without mutating storage.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def app_and_client(
+    app_config: AppConfig,
+) -> AsyncIterator[tuple[httpx.AsyncClient, DatabaseManager]]:
+    """Yield (client, db_manager) so tests can inject legacy rows."""
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c, db_manager
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+def _flat_data() -> dict:
+    """The flat AI/MCP shape that crashed the canvas in issue #238."""
+    return {
+        "nodes": [
+            {
+                "id": "st1",
+                "type": "stakeholder",
+                "label": "New Zealanders (service users)",
+                "position": {"x": 60, "y": 20},
+                "size": {"width": 180, "height": 80},
+                "visual": {},
+            },
+            {
+                "id": "goal",
+                "type": "goal",
+                "label": "Create user-focused services",
+                "position": {"x": 300, "y": 160},
+                "size": {"width": 260, "height": 80},
+                "visual": {},
+            },
+        ],
+        "edges": [
+            {"id": "e1", "type": "influence", "source": "st1", "target": "goal"},
+        ],
+    }
+
+
+def _assert_canvas_shaped(data: dict) -> None:
+    nodes = data["nodes"]
+    assert len(nodes) == 2
+    for node in nodes:
+        assert isinstance(node["data"], dict), "node missing data object"
+        # The exact access that threw in UnifiedCanvas.svelte:114.
+        assert node["data"]["entityType"]
+        assert node["data"]["entityType"] != "diagram_frame"
+    assert data["edges"][0]["data"]["relationshipType"] == "influence"
+
+
+class TestCreateNormalizesFlatNodes:
+    async def test_posted_flat_nodes_round_trip_canvas_shaped(
+        self, app_and_client: tuple[httpx.AsyncClient, DatabaseManager]
+    ) -> None:
+        client, _ = app_and_client
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "motivation",
+                "notation": "archimate",
+                "name": "Issue 238 repro",
+                "data": _flat_data(),
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 201
+        diagram_id = resp.json()["id"]
+        got = await client.get(f"/api/diagrams/{diagram_id}", headers=headers)
+        assert got.status_code == 200
+        _assert_canvas_shaped(got.json()["data"])
+
+    async def test_stored_payload_is_canvas_shaped(
+        self, app_and_client: tuple[httpx.AsyncClient, DatabaseManager]
+    ) -> None:
+        client, db_manager = app_and_client
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "motivation",
+                "notation": "archimate",
+                "name": "Issue 238 repro",
+                "data": _flat_data(),
+            },
+            headers=headers,
+        )
+        diagram_id = resp.json()["id"]
+        cur = await db_manager.main_db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (diagram_id,),
+        )
+        stored = json.loads((await cur.fetchone())[0])
+        # Write-time normalization means storage itself is canvas-shaped.
+        assert isinstance(stored["nodes"][0]["data"], dict)
+
+
+class TestReadHealsLegacyFlatData:
+    async def test_legacy_flat_storage_healed_on_get(
+        self, app_and_client: tuple[httpx.AsyncClient, DatabaseManager]
+    ) -> None:
+        client, db_manager = app_and_client
+        headers = await _auth_headers(client)
+        # Create normally, then overwrite the stored version with the
+        # legacy flat shape to simulate a pre-fix create_diagram save.
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "motivation",
+                "notation": "archimate",
+                "name": "Legacy flat",
+                "data": {},
+            },
+            headers=headers,
+        )
+        diagram_id = resp.json()["id"]
+        db = db_manager.main_db
+        await db.execute(
+            "UPDATE diagram_versions SET data = ? WHERE diagram_id = ? AND version = 1",
+            (json.dumps(_flat_data()), diagram_id),
+        )
+        await db.commit()
+
+        got = await client.get(f"/api/diagrams/{diagram_id}", headers=headers)
+        assert got.status_code == 200
+        _assert_canvas_shaped(got.json()["data"])
+
+        # Read-time heal is non-destructive: storage stays flat.
+        cur = await db.execute(
+            "SELECT data FROM diagram_versions WHERE diagram_id = ? AND version = 1",
+            (diagram_id,),
+        )
+        stored = json.loads((await cur.fetchone())[0])
+        assert "data" not in stored["nodes"][0]
+
+
+class TestUpdateNormalizesFlatNodes:
+    async def test_put_flat_nodes_round_trip_canvas_shaped(
+        self, app_and_client: tuple[httpx.AsyncClient, DatabaseManager]
+    ) -> None:
+        client, _ = app_and_client
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "motivation",
+                "notation": "archimate",
+                "name": "To update",
+                "data": {},
+            },
+            headers=headers,
+        )
+        diagram_id = resp.json()["id"]
+        version = resp.json()["current_version"]
+        put = await client.put(
+            f"/api/diagrams/{diagram_id}",
+            json={
+                "name": "To update",
+                "description": None,
+                "data": _flat_data(),
+                "change_summary": "add flat nodes",
+            },
+            headers={**headers, "If-Match": str(version)},
+        )
+        assert put.status_code == 200
+        _assert_canvas_shaped(put.json()["data"])

--- a/docs/adrs/ADR-218-Canvas-Shape-Normalization.md
+++ b/docs/adrs/ADR-218-Canvas-Shape-Normalization.md
@@ -1,0 +1,139 @@
+# ADR-218: Canvas shape normalization for create_diagram
+
+Status: Accepted (2026-05-28)
+
+Builds on: [ADR-162](./ADR-162-Generic-MCP-Diagram-Creation-Workflow.md)
+(generic `create_diagram` MCP workflow),
+[ADR-094](./ADR-094-DoView-Notation-AI-Creation.md) /
+[ADR-100](./ADR-100-DoView-Element-Backed-Nodes.md) (the
+`apply_diagram_creation` path and its `_build_canvas_nodes` builder).
+
+## WH(Y)
+
+**In the context of** diagrams authored by MCP clients, where the shared
+creation-format prompt (`backend/app/seed/creation_prompts.py`) teaches
+models to emit the *flat* AI node shape
+(`{id, type, label, position, size, visual}`) — the shape consumed by
+`apply_diagram_creation` → `_build_canvas_nodes`, which converts it into
+the Svelte-Flow *canvas* shape the frontend requires
+(`{id, type, position, width, height, data: {label, entityType, ...}}`),
+
+**facing** the fact that the generic `create_diagram` tool (ADR-162)
+persists its `data` payload **verbatim** with no such conversion, so a
+model that follows the creation prompt and then saves via
+`create_diagram` stored nodes with no per-node `data` object — and the
+frontend canvas crashed reading `n.data.entityType`
+(`UnifiedCanvas.svelte` `fitViewOptions`), so the diagram "failed to
+load" (issue [#238](https://github.com/cgbarlow/iris/issues/238)),
+
+**we decided for** a single shape-detecting, idempotent normalizer
+`normalize_canvas_data` (`backend/app/diagrams/canvas_normalize.py`)
+applied at the **write** boundary (`create_diagram` + `update_diagram`)
+so new saves are always canvas-shaped, and at the **read** boundary
+(`get_diagram`) so legacy flat diagrams auto-heal on load without
+touching storage; the existing `apply_diagram_creation` builder is
+refactored to delegate its per-item conversion to the same authority
+(protocols §13 DRY), a one-line frontend optional-chain guard is added
+as defense-in-depth, and the three already-broken diagrams named in
+issue #238 are repaired in place by a targeted, explicitly-scoped
+script,
+
+**and neglected** guarding only the frontend (turns the crash into a
+blank canvas but leaves the data unrenderable and unfixed), rewriting
+the creation prompt to emit canvas shape directly (brittle — relies on
+every model transforming perfectly every time, and heals nothing
+already stored), rejecting flat payloads in `create_diagram` (breaks
+the documented MCP authoring flow), and a global startup data migration
+that rewrites every diagram (would touch data the issue reporter
+explicitly asked us to leave alone, and a nested-jsonb rewrite in
+Postgres is error-prone),
+
+**to achieve** MCP-authored diagrams that always render — regardless of
+which save tool the model picks — plus immediate, zero-risk recovery of
+every existing flat diagram on read, with the three reported diagrams
+also physically repaired,
+
+**accepting that** `create_diagram` now tolerates two input shapes
+(flat and canvas) rather than one, that read-time normalization runs on
+every diagram GET (a cheap shape check that is a no-op for
+already-canvas data), and that the physical repair is a manual
+out-of-band script run rather than an automatic migration.
+
+## Decision
+
+Add `backend/app/diagrams/canvas_normalize.py` as the single authority
+for the flat → canvas transform:
+
+- `flat_node_to_canvas(node, *, default_entity_type="")` — relocates
+  `label` → `data.label`, `type` → `data.entityType`, `size` →
+  top-level `width`/`height`, and non-empty `visual`/`description` into
+  `data`; preserves unknown structural keys.
+- `flat_edge_to_canvas(edge, *, default_relationship_type="")` — moves
+  `type` → `data.relationshipType` (keeping the top-level `type` for
+  renderer dispatch) and adds the `center` handles AI-authored edges use.
+- `needs_normalization(data)` / `normalize_canvas_data(data)` —
+  shape-detecting and idempotent: nodes/edges that already carry a dict
+  `data` pass through untouched; non-canvas payloads (markdown
+  `{content}`, sequence `{participants, ...}`) pass through untouched;
+  input is never mutated.
+
+Wiring:
+
+- **Write:** `service.create_diagram` and `service.update_diagram`
+  normalise `data` before persisting (so storage, notation detection,
+  and thumbnails all see canvas shape).
+- **Read:** `service.get_diagram` normalises the loaded `data` before
+  returning (non-destructive auto-heal for legacy rows).
+- **DRY:** `app/ai/creation.py::_build_canvas_nodes` /
+  `_build_canvas_edges` delegate to `flat_node_to_canvas` /
+  `flat_edge_to_canvas` (apply-path specifics — doview defaults, the
+  phase-2 `_linkedDiagramIndex` stash — layered around the shared call).
+- **Frontend:** `UnifiedCanvas.svelte` `fitViewOptions` filter
+  optional-chains `n.data?.entityType` so a stray dataless node can
+  never hard-crash the canvas on mount.
+- **Repair:** `scripts/repair_flat_diagram_shape.py` rewrites every
+  version of the EXPLICITLY-NAMED diagrams in place via the same
+  normalizer and regenerates their thumbnails. It refuses to run without
+  `--diagram-id` arguments and never scans all diagrams.
+
+## Consequences
+
+**Positive:**
+
+- MCP-authored diagrams render whether saved via `apply_diagram_creation`
+  or `create_diagram`.
+- Every existing flat diagram renders the moment the fix deploys (read
+  heal), with no data-rewrite risk.
+- One transform authority, reused on write, read, the apply path, and
+  the repair script.
+- No new write endpoints → surface-parity (ADR-182, §14) unaffected.
+
+**Negative / accepted trade-offs:**
+
+- `create_diagram` accepts both flat and canvas input shapes.
+- A cheap shape check runs on every diagram GET.
+- The physical repair is a one-off operational script run, not an
+  automatic migration (a deliberate choice to keep the blast radius to
+  the three named diagrams).
+
+## Rejected alternatives
+
+- **Frontend guard only.** Stops the crash but renders dataless nodes
+  (no label/type) and leaves the stored data broken.
+- **Rewrite the creation prompt to emit canvas shape.** Pushes a fragile
+  per-token transform onto every model on every run and heals nothing
+  already persisted.
+- **Reject flat payloads in `create_diagram`.** Breaks the documented
+  ADR-162 authoring flow that the shared creation prompt teaches.
+- **Global startup data migration.** Would rewrite diagrams the issue
+  reporter asked us not to touch, and a nested-jsonb rewrite in Postgres
+  is error-prone versus reusing the Python normalizer on the few named
+  rows.
+
+## References
+
+- [SPEC-218-a — normalizer contract, wiring, repair scope, acceptance criteria](./specs/SPEC-218-a-Canvas-Shape-Normalization.md)
+- Issue [#238](https://github.com/cgbarlow/iris/issues/238) — "diagram failed to load as generated by Iris MCP"
+- [ADR-162](./ADR-162-Generic-MCP-Diagram-Creation-Workflow.md) — generic `create_diagram` workflow
+- [ADR-094](./ADR-094-DoView-Notation-AI-Creation.md) — AI diagram creation / `_build_canvas_nodes`
+- [ADR-182](./ADR-182-Surface-Parity-Discipline.md) — surface parity (unaffected: no new write endpoint)

--- a/docs/adrs/specs/SPEC-218-a-Canvas-Shape-Normalization.md
+++ b/docs/adrs/specs/SPEC-218-a-Canvas-Shape-Normalization.md
@@ -1,0 +1,110 @@
+# SPEC-218-a: Canvas shape normalization
+
+Implements: [ADR-218](../ADR-218-Canvas-Shape-Normalization.md).
+
+## 1. Problem
+
+The shared creation prompt teaches the **flat** AI node shape:
+
+```json
+{ "id": "st1", "type": "stakeholder", "label": "Users",
+  "position": {"x": 60, "y": 20},
+  "size": {"width": 180, "height": 80}, "visual": {} }
+```
+
+`apply_diagram_creation` converts it (via `_build_canvas_nodes`) to the
+**canvas** shape the frontend needs:
+
+```json
+{ "id": "st1", "type": "stakeholder",
+  "position": {"x": 60, "y": 20}, "width": 180, "height": 80,
+  "data": {"label": "Users", "entityType": "stakeholder"} }
+```
+
+`create_diagram` (ADR-162) persisted `data` verbatim, so flat nodes
+reached storage with no `data` object and `UnifiedCanvas.svelte`
+`fitViewOptions` crashed on `n.data.entityType` (issue #238).
+
+## 2. Normalizer — `backend/app/diagrams/canvas_normalize.py`
+
+### `flat_node_to_canvas(node, *, default_entity_type="") -> dict`
+
+- `data.label` ← `node["label"]` (default `""`).
+- `data.entityType` ← `node["type"]` or `default_entity_type`.
+- top-level `type` ← same resolved entity type (renderer dispatch).
+- `width`/`height` ← `node["size"].{width,height}` (defaults 200 / 86)
+  when not already top-level.
+- `data.description` ← `node["description"]` only when truthy.
+- `data.visual` ← `node["visual"]` only when truthy (empty `{}` dropped).
+- `position` defaults to `{"x":0,"y":0}` when absent.
+- Unknown top-level keys (e.g. `parentId`) are preserved; relocated
+  keys (`label`, `size`, `visual`, `description`) are removed from the
+  top level.
+
+### `flat_edge_to_canvas(edge, *, default_relationship_type="") -> dict`
+
+- `data.relationshipType` ← `edge["type"]` or `default_relationship_type`.
+- top-level `type` ← same resolved value.
+- `data.visual` ← `edge["visual"]` only when truthy.
+- `sourceHandle` / `targetHandle` default to `"center"`.
+
+### `needs_normalization(data) -> bool`
+
+True iff `data` is a dict with a `nodes` or `edges` list containing at
+least one dict item lacking a dict `data` key.
+
+### `normalize_canvas_data(data) -> data`
+
+- Non-dict input → returned unchanged.
+- dict without `nodes`/`edges` lists (markdown `{content}`, sequence
+  `{participants, ...}`) → returned unchanged.
+- Otherwise returns a shallow copy with each node/edge passed through
+  the per-item helper **only when it is flat** (no dict `data`);
+  already-canvas items pass through identically.
+- **Idempotent**: `normalize(normalize(x)) == normalize(x)`.
+- **Non-mutating**: the input object is not modified in place.
+
+## 3. Wiring
+
+| Boundary | Location | Behaviour |
+|---|---|---|
+| Write | `service.create_diagram` | `data = normalize_canvas_data(data)` before serialize / detect / thumbnail |
+| Write | `service.update_diagram` | same, before serialize |
+| Read | `service.get_diagram` | `result["data"] = normalize_canvas_data(result["data"])` before `_maybe_synthesise_content` (non-destructive auto-heal) |
+| DRY | `ai/creation.py::_build_canvas_nodes` / `_build_canvas_edges` | delegate per-item conversion to the shared helpers; keep doview defaults + `_linkedDiagramIndex` stash |
+| Frontend | `UnifiedCanvas.svelte` `fitViewOptions` | `n.data?.entityType !== 'diagram_frame'` (defense-in-depth) |
+
+## 4. Repair script — `scripts/repair_flat_diagram_shape.py`
+
+- `repair_diagram(db, diagram_id, *, dry_run=False)` normalises **every
+  version** of one diagram in place (no version bump, no commit — caller
+  commits once). Returns `{found, diagram_type, current_version,
+  total_versions, versions_changed, current_data}`.
+- `regenerate_thumbnails(db, diagram_id, diagram_type, data)` rebuilds
+  all-theme thumbnails from the normalized current-version data.
+- `main()` requires ≥1 `--diagram-id`; errors out otherwise. Never scans
+  all diagrams. Supports `--dry-run` and `--skip-thumbnails`. Connects
+  via `app.config.get_config` + `DatabaseManager` so it runs against both
+  SQLite and Supabase.
+- **Issue #238 scope (the only diagrams to repair):**
+  - `13024153-b328-41a4-bd37-0cbc6d2fbedc`
+  - `330fe369-0b03-457c-8692-62e67f9fcdb0`
+  - `6b9917d7-f7c9-4dfc-a769-49fa571f28e5`
+
+## 5. Acceptance criteria
+
+1. Posting flat `{nodes, edges}` to `POST /api/diagrams` round-trips as
+   canvas shape on `GET` — every node has `data.entityType`. ✓
+   (`test_shape_normalization.py`)
+2. A diagram whose stored data is flat is auto-healed on `GET` without
+   mutating storage. ✓
+3. `PUT /api/diagrams/{id}` with flat `data` persists canvas shape. ✓
+4. `normalize_canvas_data` is idempotent and leaves markdown/sequence
+   and already-canvas payloads untouched. ✓ (`test_canvas_normalize.py`)
+5. The apply path (`create_diagrams_from_ai`) still materialises
+   elements/relationships and emits `data.entityId` /
+   `data.relationshipType`. ✓ (`test_creation.py` unchanged & green)
+6. `repair_diagram` normalises all versions in place, is idempotent,
+   honours `--dry-run`, and reports (never guesses) an unknown id. ✓
+   (`test_repair_flat_diagram_shape.py`)
+7. Surface parity (§14) stays clean — no new write endpoint. ✓

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.31.4",
+	"version": "6.31.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/UnifiedCanvas.svelte
+++ b/frontend/src/lib/canvas/UnifiedCanvas.svelte
@@ -109,9 +109,13 @@
 			: nodes
 	);
 
-	/** fitView options: exclude diagram_frame nodes from bounding box calculation. */
+	/** fitView options: exclude diagram_frame nodes from bounding box calculation.
+	 *  ADR-218 (issue #238): optional-chain `n.data` so a node that somehow
+	 *  arrives without a data object (legacy flat AI/MCP payloads) can't
+	 *  hard-crash the canvas on mount. Backend normalization is the real
+	 *  fix; this is defense-in-depth. */
 	const fitViewOptions = $derived({
-		nodes: nodes.filter((n) => n.data.entityType !== 'diagram_frame'),
+		nodes: nodes.filter((n) => n.data?.entityType !== 'diagram_frame'),
 		padding: 0.15,
 	});
 

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.31.4"
+version = "6.31.5"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.31.4"
+version = "6.31.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/scripts/repair_flat_diagram_shape.py
+++ b/scripts/repair_flat_diagram_shape.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Repair diagrams persisted with the flat AI/MCP node shape (issue #238).
+
+Some diagrams created via the MCP `create_diagram` tool were stored with
+the *flat* AI node shape (`{id, type, label, position, size, visual}`)
+instead of the Svelte-Flow canvas shape the frontend requires
+(`{id, type, position, width, height, data: {label, entityType, ...}}`).
+With no per-node `data` object, `UnifiedCanvas.svelte` crashed reading
+`n.data.entityType` and the diagram "failed to load".
+
+ADR-218 fixes the cause (write- and read-time normalization in the
+diagram service). This script repairs the *already-persisted* rows: it
+rewrites every version of the EXPLICITLY-NAMED diagrams in place using
+the same `normalize_canvas_data` authority, then regenerates their
+thumbnails so list/preview surfaces reflect the corrected shape.
+
+SAFETY: operates ONLY on the diagram ids passed via `--diagram-id`
+(repeatable). It never scans or rewrites any other diagram. Idempotent:
+a diagram already in canvas shape is left untouched. Use `--dry-run`
+first to preview.
+
+Works against both deployment modes (reads `IRIS_DB_BACKEND` and the
+Supabase env vars via `app.config.get_config`).
+
+Usage (local SQLite):
+    cd backend && IRIS_DATA_DIR=./data \\
+      .venv/bin/python ../scripts/repair_flat_diagram_shape.py \\
+        --diagram-id <uuid> [--diagram-id <uuid> ...] [--dry-run]
+
+Usage (Supabase/UAT — creds from .env):
+    cd backend && set -a && source ../.env && set +a && \\
+      IRIS_DB_BACKEND=supabase \\
+      .venv/bin/python ../scripts/repair_flat_diagram_shape.py \\
+        --diagram-id 13024153-b328-41a4-bd37-0cbc6d2fbedc \\
+        --diagram-id 330fe369-0b03-457c-8692-62e67f9fcdb0 \\
+        --diagram-id 6b9917d7-f7c9-4dfc-a769-49fa571f28e5
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make the backend `app` package importable when run from the repo root.
+_BACKEND = Path(__file__).resolve().parents[1] / "backend"
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.diagrams.canvas_normalize import (  # noqa: E402
+    needs_normalization,
+    normalize_canvas_data,
+)
+
+
+def _parse_data(raw: Any) -> dict:
+    """Decode a diagram_versions.data cell (TEXT on SQLite, str on
+    Supabase via the adapter) into a dict."""
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+async def repair_diagram(db: Any, diagram_id: str, *, dry_run: bool = False) -> dict:
+    """Normalize every version of one diagram in place.
+
+    Returns a summary dict. Does not commit — the caller commits once all
+    diagrams are processed (so a dry-run touches nothing).
+    """
+    cursor = await db.execute(
+        "SELECT diagram_type, current_version FROM diagrams "
+        "WHERE id = ? AND is_deleted = 0",
+        (diagram_id,),
+    )
+    head = await cursor.fetchone()
+    if head is None:
+        return {"id": diagram_id, "found": False}
+
+    diagram_type = head[0]
+    current_version = head[1]
+
+    cursor = await db.execute(
+        "SELECT version, data FROM diagram_versions WHERE diagram_id = ? "
+        "ORDER BY version",
+        (diagram_id,),
+    )
+    rows = await cursor.fetchall()
+
+    versions_changed: list[int] = []
+    current_data: dict = {}
+    for row in rows:
+        version = row[0]
+        data = _parse_data(row[1])
+        if version == current_version:
+            current_data = data
+        if not needs_normalization(data):
+            continue
+        normalized = normalize_canvas_data(data)
+        if version == current_version:
+            current_data = normalized
+        versions_changed.append(version)
+        if not dry_run:
+            await db.execute(
+                "UPDATE diagram_versions SET data = ? "
+                "WHERE diagram_id = ? AND version = ?",
+                (json.dumps(normalized), diagram_id, version),
+            )
+
+    return {
+        "id": diagram_id,
+        "found": True,
+        "diagram_type": diagram_type,
+        "current_version": current_version,
+        "total_versions": len(rows),
+        "versions_changed": versions_changed,
+        "current_data": current_data,
+    }
+
+
+async def regenerate_thumbnails(
+    db: Any, diagram_id: str, diagram_type: str, data: dict
+) -> None:
+    """Regenerate all-theme thumbnails for one diagram from its
+    (already-normalized) current-version data."""
+    from app.diagrams.thumbnail import (  # noqa: PLC0415
+        VALID_THEMES,
+        generate_and_store_thumbnail,
+    )
+
+    for theme in VALID_THEMES:
+        await generate_and_store_thumbnail(db, diagram_id, data, diagram_type, theme=theme)
+
+
+async def _run(diagram_ids: list[str], *, dry_run: bool, skip_thumbnails: bool) -> int:
+    from app.config import get_config  # noqa: PLC0415
+    from app.database import DatabaseManager  # noqa: PLC0415
+
+    manager = DatabaseManager(get_config())
+    await manager.connect()
+    mode = "supabase" if manager.is_supabase else "sqlite"
+    print(f"Connected ({mode}). Repairing {len(diagram_ids)} diagram(s). "
+          f"dry_run={dry_run}")
+
+    repaired = 0
+    try:
+        db = manager.main_db
+        for diagram_id in diagram_ids:
+            summary = await repair_diagram(db, diagram_id, dry_run=dry_run)
+            if not summary["found"]:
+                print(f"  ! {diagram_id}: NOT FOUND (skipped)")
+                continue
+            changed = summary["versions_changed"]
+            if not changed:
+                print(f"  = {diagram_id} ({summary['diagram_type']}): "
+                      f"already canvas-shaped, no change")
+                continue
+            repaired += 1
+            print(f"  + {diagram_id} ({summary['diagram_type']}): normalized "
+                  f"version(s) {changed} of {summary['total_versions']}")
+            if not dry_run and not skip_thumbnails:
+                await regenerate_thumbnails(
+                    db, diagram_id, summary["diagram_type"], summary["current_data"]
+                )
+                print(f"    └ thumbnails regenerated")
+        if not dry_run:
+            await db.commit()
+    finally:
+        await manager.close()
+
+    if dry_run:
+        print(f"\nDRY RUN: would repair {repaired} diagram(s). Nothing written.")
+    else:
+        print(f"\nDone. Repaired {repaired} diagram(s).")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--diagram-id",
+        action="append",
+        dest="diagram_ids",
+        metavar="UUID",
+        help="Diagram id to repair (repeatable). At least one required.",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="Preview only; write nothing.")
+    ap.add_argument(
+        "--skip-thumbnails",
+        action="store_true",
+        help="Repair data only; do not regenerate thumbnails.",
+    )
+    args = ap.parse_args()
+
+    if not args.diagram_ids:
+        ap.error("at least one --diagram-id is required (this script never scans all diagrams)")
+
+    return asyncio.run(
+        _run(args.diagram_ids, dry_run=args.dry_run, skip_thumbnails=args.skip_thumbnails)
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes #238 — diagrams generated via the MCP `create_diagram` tool failed to load with `Cannot read properties of undefined (reading 'entityType')`.

**Root cause:** the shared creation prompt teaches models the *flat* AI node shape (`{id, type, label, position, size, visual}`) that `apply_diagram_creation` → `_build_canvas_nodes` converts to canvas shape. But `create_diagram` (ADR-162) persisted its `data` payload **verbatim**, so flat nodes reached storage with no per-node `data` object and `UnifiedCanvas.svelte` crashed on `n.data.entityType` at mount.

## Changes (ADR-218 / SPEC-218-a)

- **New `normalize_canvas_data()`** (`backend/app/diagrams/canvas_normalize.py`) — one shape-detecting, idempotent, non-mutating authority for the flat → canvas transform.
- **Write-time:** `create_diagram` + `update_diagram` normalize before persisting → new saves are always canvas-shaped.
- **Read-time:** `get_diagram` auto-heals legacy flat diagrams on load (non-destructive — storage untouched).
- **DRY:** `apply_diagram_creation`'s `_build_canvas_nodes` / `_build_canvas_edges` now delegate to the shared helpers.
- **Frontend:** `UnifiedCanvas` `fitViewOptions` optional-chains `n.data` (defense-in-depth).
- **Repair:** `scripts/repair_flat_diagram_shape.py` rewrites the three diagrams named in #238 in place (and **only** those — it refuses to run without explicit `--diagram-id`s and never scans) and regenerates their thumbnails.
- ADR-218, SPEC-218-a, CHANGELOG, and all four versions bumped to 6.31.5.

No DB schema migration. Surface parity (§14) unaffected — no new write endpoint.

## Test plan

- [x] 23 unit tests for `normalize_canvas_data` (incl. exact #238 shapes, idempotency, non-mutation, markdown/sequence passthrough)
- [x] Integration: POST/PUT flat `{nodes,edges}` round-trips canvas-shaped; legacy flat storage auto-heals on GET without mutating storage
- [x] 6 tests for the repair script core (in-place all-version normalize, idempotency, dry-run, unknown-id reported not guessed)
- [x] `apply_diagram_creation` tests unchanged & green (contract preserved through the refactor)
- [x] Surface-parity check clean
- [ ] Browser verification on UAT post-deploy (read-time heal renders the three diagrams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)