### PR TITLE
fix(v6.32.1): full screen on markdown-notation diagrams (#243)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.32.1] - 2026-05-29
+
+### Fixed
+
+- **Full screen on markdown-notation diagrams** (#243). The "Full screen"
+  toolbar button did nothing on text / smart-markdown / dynamic-list /
+  aggregation-list views: the text render branches never mounted
+  `FocusView`, so toggling focus mode had no visible effect. The text
+  branches (browse and edit) now wrap their content in `FocusView` when
+  focus mode is active, and the editor's canvas focus branch is gated to
+  non-text views so a text view no longer flips to a blank canvas overlay.
+  The four-way text-canvas switch is now shared via a single
+  `{#snippet markdownArea()}` (DRY) instead of being duplicated across the
+  browse, edit, and full-screen variants.
+
 ## [6.32.0] - 2026-05-28
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.32.0"
+version = "6.32.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.32.0",
+	"version": "6.32.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2919,7 +2919,7 @@
 
 				<!-- Canvas area -->
 				{#if editing}
-					{#if focusMode}
+					{#if focusMode && canvasType !== 'text'}
 						<FocusView onexit={() => (focusMode = false)}>
 							<div style="display: flex; flex-direction: column; width: 100%; height: 100%;">
 								<!-- Toolbar inside FocusView so edit controls are visible -->
@@ -3034,82 +3034,19 @@
 						 in the canvas-toolbar above (lines 2687-2862) for all non-
 						 sequence canvases. The duplicates that lived here in v5.4.0
 						 have been removed. -->
-					<div class="flex gap-4">
-						<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: auto">
-							{#if diagram?.diagram_type === 'dynamic_list'}
-								<!-- ADR-186 (issue #147): auto-generated content; the
-									 canvas is read-only and the Source panel appears in
-									 edit mode. -->
-								<DynamicListCanvas
-									content={markdownContent}
-									editing={editing}
-									setId={diagram?.set_id ?? null}
-									source={dynamicSource}
-									onsourcechange={(next: DynamicSource) => {
-										pendingDynamicSource = next;
-										canvasDirty = true;
-									}}
-									onheadings={(h) => (textHeadings = h)}
-								/>
-							{:else if diagram?.diagram_type === 'smart_markdown'}
-								<!-- ADR-205 (issue #185): user authors markdown_source
-									 with tokens; the server resolves tokens at read
-									 time into data.content for view + export pipelines. -->
-								<SmartMarkdownCanvas
-									content={markdownContent}
-									source={(diagram.data?.markdown_source as string | undefined) ?? ''}
-									editing={editing}
-									contextSetId={diagram?.set_id ?? null}
-									onsourcechange={(s: string) => {
-										if (diagram) {
-											diagram.data = { ...(diagram.data ?? {}), markdown_source: s };
-											canvasDirty = true;
-										}
-									}}
-									onheadings={(h) => (textHeadings = h)}
-								/>
-							{:else if diagram?.diagram_type === 'aggregation_list'}
-								<!-- ADR-213 (v6.21.0): pickers in edit mode for source +
-									 profile; engine fills data.content at GET time. -->
-								<AggregationListCanvas
-									content={markdownContent}
-									editing={editing}
-									setId={diagram?.set_id ?? null}
-									source={{
-										source_diagram_id: (diagram.data?.source_diagram_id as string | null | undefined) ?? null,
-										profile_id: (diagram.data?.profile_id as string | null | undefined) ?? null,
-									}}
-									onsourcechange={(next) => {
-										if (diagram) {
-											diagram.data = {
-												...(diagram.data ?? {}),
-												source_diagram_id: next.source_diagram_id ?? null,
-												profile_id: next.profile_id ?? null,
-											};
-											canvasDirty = true;
-										}
-									}}
-									onheadings={(h) => (textHeadings = h)}
-								/>
-							{:else}
-								<TextCanvas
-									bind:textareaEl={textTextareaEl}
-									content={markdownContent}
-									editing={editing}
-									oncontentchange={(c) => {
-										if (diagram) {
-											diagram.data = { ...(diagram.data ?? {}), content: c };
-											canvasDirty = true;
-										}
-									}}
-									onheadings={(h) => (textHeadings = h)}
-								/>
-							{/if}
+					{#if focusMode}
+						<FocusView onexit={() => (focusMode = false)}>
+							<div style="width: 100%; height: 100%; overflow: auto">
+								{@render markdownArea()}
+							</div>
+						</FocusView>
+					{:else}
+						<div class="flex gap-4">
+							<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: auto">
+								{@render markdownArea()}
+							</div>
 						</div>
-						{#if !editing && showTocDrawer}
-							<MarkdownToc headings={textHeadings} onclose={() => (showTocDrawer = false)} />
-						{/if}
-					</div>
+					{/if}
 					{:else if notation === 'bpmn'}
 					<!-- v5.2.0 (issue #37): BPMN authoring shell — palette / canvas /
 						 property panel + bottom problems dock + canConnect toast.
@@ -3173,47 +3110,22 @@
 						 through to `canvasNodes.length === 0` and show "Start Building"
 						 because Text views legitimately have zero canvas nodes. -->
 					{#if markdownContent}
-						<div class="flex gap-4">
-							<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: auto">
-								{#if diagram?.diagram_type === 'dynamic_list'}
-									<!-- ADR-186 (issue #147): browse-mode dynamic_list view. -->
-									<DynamicListCanvas
-										content={markdownContent}
-										editing={false}
-										setId={diagram?.set_id ?? null}
-										source={dynamicSource}
-										onheadings={(h) => (textHeadings = h)}
-									/>
-								{:else if diagram?.diagram_type === 'smart_markdown'}
-									<!-- ADR-205 (issue #185): browse-mode Smart Markdown. -->
-									<SmartMarkdownCanvas
-										content={markdownContent}
-										source={(diagram.data?.markdown_source as string | undefined) ?? ''}
-										editing={false}
-										contextSetId={diagram?.set_id ?? null}
-										onheadings={(h) => (textHeadings = h)}
-									/>
-								{:else if diagram?.diagram_type === 'aggregation_list'}
-									<!-- ADR-213: browse-mode shows the synthesised content only. -->
-									<AggregationListCanvas
-										content={markdownContent}
-										editing={false}
-										setId={diagram?.set_id ?? null}
-										onheadings={(h) => (textHeadings = h)}
-									/>
-								{:else}
-									<TextCanvas
-										content={markdownContent}
-										editing={false}
-										oncontentchange={() => {}}
-										onheadings={(h) => (textHeadings = h)}
-									/>
+						{#if focusMode}
+							<FocusView onexit={() => (focusMode = false)}>
+								<div style="width: 100%; height: 100%; overflow: auto">
+									{@render markdownArea()}
+								</div>
+							</FocusView>
+						{:else}
+							<div class="flex gap-4">
+								<div class="flex-1" style="height: calc(100vh - 317px); border: 1px solid var(--color-border); border-radius: 0.375rem; overflow: auto">
+									{@render markdownArea()}
+								</div>
+								{#if showTocDrawer}
+									<MarkdownToc headings={textHeadings} onclose={() => (showTocDrawer = false)} />
 								{/if}
 							</div>
-							{#if showTocDrawer}
-								<MarkdownToc headings={textHeadings} onclose={() => (showTocDrawer = false)} />
-							{/if}
-						</div>
+						{/if}
 					{:else}
 						<div class="flex flex-col items-center justify-center gap-3 rounded border p-8" style="border-color: var(--color-border); min-height: 300px">
 							<p style="color: var(--color-muted)">This text view is empty.</p>
@@ -3764,3 +3676,71 @@
 	{/if}
 
 {/if}
+
+<!-- Issue #243: shared markdown render area, used by both browse + edit and
+	 their full-screen (FocusView) variants so the 4-way diagram-type switch
+	 isn't duplicated. `editing` drives read-only vs editable; in browse mode
+	 it's always false so onsourcechange/oncontentchange never fire. -->
+{#snippet markdownArea()}
+	{#if diagram?.diagram_type === 'dynamic_list'}
+		<DynamicListCanvas
+			content={markdownContent}
+			editing={editing}
+			setId={diagram?.set_id ?? null}
+			source={dynamicSource}
+			onsourcechange={(next: DynamicSource) => {
+				pendingDynamicSource = next;
+				canvasDirty = true;
+			}}
+			onheadings={(h) => (textHeadings = h)}
+		/>
+	{:else if diagram?.diagram_type === 'smart_markdown'}
+		<SmartMarkdownCanvas
+			content={markdownContent}
+			source={(diagram.data?.markdown_source as string | undefined) ?? ''}
+			editing={editing}
+			contextSetId={diagram?.set_id ?? null}
+			onsourcechange={(s: string) => {
+				if (diagram) {
+					diagram.data = { ...(diagram.data ?? {}), markdown_source: s };
+					canvasDirty = true;
+				}
+			}}
+			onheadings={(h) => (textHeadings = h)}
+		/>
+	{:else if diagram?.diagram_type === 'aggregation_list'}
+		<AggregationListCanvas
+			content={markdownContent}
+			editing={editing}
+			setId={diagram?.set_id ?? null}
+			source={{
+				source_diagram_id: (diagram.data?.source_diagram_id as string | null | undefined) ?? null,
+				profile_id: (diagram.data?.profile_id as string | null | undefined) ?? null,
+			}}
+			onsourcechange={(next) => {
+				if (diagram) {
+					diagram.data = {
+						...(diagram.data ?? {}),
+						source_diagram_id: next.source_diagram_id ?? null,
+						profile_id: next.profile_id ?? null,
+					};
+					canvasDirty = true;
+				}
+			}}
+			onheadings={(h) => (textHeadings = h)}
+		/>
+	{:else}
+		<TextCanvas
+			bind:textareaEl={textTextareaEl}
+			content={markdownContent}
+			editing={editing}
+			oncontentchange={(c) => {
+				if (diagram) {
+					diagram.data = { ...(diagram.data ?? {}), content: c };
+					canvasDirty = true;
+				}
+			}}
+			onheadings={(h) => (textHeadings = h)}
+		/>
+	{/if}
+{/snippet}

--- a/frontend/tests/e2e/markdown-fullscreen.spec.ts
+++ b/frontend/tests/e2e/markdown-fullscreen.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * E2E: Full screen (focus mode) on markdown-notation diagrams (issue #243).
+ *
+ * Regression guard: the "Full screen" toolbar button used to do nothing on
+ * text/markdown views because the text render branches never mounted
+ * <FocusView>. This spec creates a Text (markdown) view, clicks Full screen,
+ * and asserts the focus-view overlay appears with the markdown content, then
+ * that exiting (button + Escape) restores the normal view.
+ */
+
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin, createDiagram } from './fixtures';
+
+const MARKDOWN_SOURCE = [
+	'# Fullscreen Markdown Test',
+	'',
+	'This text view must be able to go full screen (#243).',
+	'',
+	'- one',
+	'- two',
+].join('\n');
+
+let diagramId = '';
+
+test.describe('Markdown view full screen / focus mode (#243)', () => {
+	test.beforeAll(async () => {
+		await seedAdmin();
+		const token = await getAuthToken();
+
+		const body = await createDiagram(undefined, token, {
+			diagram_type: 'text',
+			notation: 'markdown',
+			name: 'Fullscreen Markdown Test',
+			description: 'Created by markdown-fullscreen.spec.ts',
+			data: { content: MARKDOWN_SOURCE },
+		});
+		diagramId = body.id as string;
+	});
+
+	test('Full screen button opens the focus-view overlay with the markdown', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+
+		// Markdown content mounts in normal (non-focus) view first.
+		await expect(page.locator('.md-view').first()).toBeVisible({ timeout: 15_000 });
+
+		// No focus overlay until the button is clicked.
+		const focus = page.locator('[role="dialog"][aria-label="Focus view"]');
+		await expect(focus).toHaveCount(0);
+
+		await page.getByRole('button', { name: 'Full screen' }).click();
+
+		// The overlay appears and renders the markdown inside it.
+		await expect(focus).toBeVisible({ timeout: 10_000 });
+		await expect(focus.locator('.md-view')).toContainText('Fullscreen Markdown Test');
+	});
+
+	test('Exit button and Escape both close the focus-view overlay', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagramId}`);
+		await expect(page.locator('.md-view').first()).toBeVisible({ timeout: 15_000 });
+
+		const focus = page.locator('[role="dialog"][aria-label="Focus view"]');
+
+		// Exit via the close button.
+		await page.getByRole('button', { name: 'Full screen' }).click();
+		await expect(focus).toBeVisible({ timeout: 10_000 });
+		await page.getByRole('button', { name: 'Exit focus view' }).click();
+		await expect(focus).toHaveCount(0);
+		await expect(page.locator('.md-view').first()).toBeVisible();
+
+		// Exit via Escape.
+		await page.getByRole('button', { name: 'Full screen' }).click();
+		await expect(focus).toBeVisible({ timeout: 10_000 });
+		await page.keyboard.press('Escape');
+		await expect(focus).toHaveCount(0);
+		await expect(page.locator('.md-view').first()).toBeVisible();
+	});
+});

--- a/frontend/tests/unit/textViewBrowseRender.test.ts
+++ b/frontend/tests/unit/textViewBrowseRender.test.ts
@@ -30,9 +30,19 @@ describe('Text view browse-mode rendering (issue #32)', () => {
 		expect(textBranchesBefore).toBeGreaterThanOrEqual(2);
 	});
 
-	it('renders TextCanvas with editing=false in browse mode', () => {
-		// The browse-mode branch must mount TextCanvas with editing={false}.
-		expect(SRC).toMatch(/<TextCanvas\b[\s\S]*editing=\{false\}/);
+	it('renders the shared markdownArea snippet in browse mode (read-only via editing state)', () => {
+		// v6.32.1 (#243): the 4-way text-canvas switch is shared via the
+		// {#snippet markdownArea()} so browse + edit + their full-screen
+		// (FocusView) variants don't duplicate it. The snippet mounts
+		// TextCanvas driven by the component's `editing` state, which is
+		// false in browse mode — so the view stays read-only.
+		expect(SRC).toMatch(/\{#snippet markdownArea\(\)\}/);
+		expect(SRC).toMatch(/<TextCanvas\b[\s\S]*editing=\{editing\}/);
+		// The browse-mode Text branch (the last `canvasType === 'text'`
+		// branch) renders the shared snippet.
+		const idxBrowse = SRC.lastIndexOf("{:else if canvasType === 'text'}");
+		expect(idxBrowse).toBeGreaterThan(-1);
+		expect(SRC.slice(idxBrowse)).toMatch(/\{@render markdownArea\(\)\}/);
 	});
 
 	it('shows a "This text view is empty" prompt when content is blank (mirrors canvas Start Building)', () => {

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.32.0"
+version = "6.32.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.32.0"
+version = "6.32.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Fixes #243 — the **Full screen** toolbar button did nothing on markdown-notation views (text / smart-markdown / dynamic-list / aggregation-list).

**Root cause:** the button sets `focusMode = true`, but only the node-edge *canvas* branches ever wrapped their content in `<FocusView>`. The text branches rendered unconditionally and never checked `focusMode`, so nothing happened. (In edit mode it was worse: a text view flipped to a *blank* canvas focus overlay.)

**Fix** (`frontend/src/routes/views/[id]/+page.svelte`):
- Browse and edit text branches now render inside `<FocusView>` when focus mode is active (Escape / × to exit, same as canvas views).
- The editor's canvas focus branch is gated with `canvasType !== 'text'`, so text views no longer hijack into the blank canvas overlay.
- The four-way text-canvas switch (`dynamic_list` / `smart_markdown` / `aggregation_list` / `text`) is consolidated into a single `{#snippet markdownArea()}` so it isn't duplicated across the browse, edit, and full-screen variants (Protocol §13 DRY). No behavioural change for normal canvas diagrams — `focusMode && canvasType !== 'text'` is equivalent to `focusMode` for non-text views.

No ADR: this restores behaviour already intended by the existing FocusView/focus-mode design.

## Test plan

- [x] New Playwright e2e (`tests/e2e/markdown-fullscreen.spec.ts`): opens a markdown view, clicks **Full screen**, asserts the `role="dialog"` `aria-label="Focus view"` overlay appears with the markdown, and that both the exit button and **Escape** close it. (Confirmed red before the fix, green after.)
- [x] Updated `tests/unit/textViewBrowseRender.test.ts` to match the snippet-based structure (intent preserved: browse mode mounts the read-only markdown area).
- [x] `npm run check`: no new type errors introduced (identical error set to `origin/main`, only line numbers shifted).
- [ ] Reviewer: confirm a normal node-edge canvas diagram still goes full screen (unchanged code path).

Note: a handful of pre-existing unit-test failures on `origin/main` (e.g. `hierarchyControls`, `viewsToolbarOrder`, `extensionManagerFields`, `canvasTabFirst`) are unrelated to this change and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)