### PR TITLE
feat(v6.33.0): element → detail diagram drill link (ADR-221, #242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.33.0] - 2026-05-29
+
+### Added
+
+- **Element → detail diagram drill link** (ADR-221, SPEC-221-A, issue
+  #242). An element can now declare a navigable "detail diagram" — the
+  Sparx EA "composite element" concept — so you can drill from an element
+  into the diagram that elaborates it, and back out. Surfaced as a new
+  nullable `elements.detail_diagram_id` column (migration m080 / Supabase
+  m086), tri-state on update like `package_id`:
+  - **API/MCP/CLI** (§14 surface parity): `create_element` /
+    `update_element` accept `detail_diagram_id` (MCP) /
+    `--detail-diagram-id` (CLI), set/clear via JSON `null`. Cross-set
+    links are allowed; the target diagram is validated to exist.
+  - **Element page** shows a "Detail diagram" drill-in (and a picker to
+    set/clear it); the **diagram page** lists referencing elements under
+    "Referenced by" (`get_diagram` gains `referenced_by_elements`).
+  - **Smart-markdown**: a new `{{element:<id>:detail_diagram}}` token
+    renders a link straight to the element's detail diagram.
+  - **Sparx EA import**: composite elements (`t_diagram.ParentID` in
+    `.qea`; the diagram `owner` in native XMI) now populate
+    `detail_diagram_id` automatically, so imported models light up the
+    drill.
+
 ## [6.32.1] - 2026-05-29
 
 ### Fixed

--- a/backend/app/diagrams/models.py
+++ b/backend/app/diagrams/models.py
@@ -55,6 +55,9 @@ class DiagramResponse(BaseModel):
     notation: str = "simple"
     detected_notations: list[str] = Field(default_factory=list)
     metadata: dict[str, object] | None = None
+    # ADR-221: elements that point at this diagram as their detail diagram
+    # (the inbound "Referenced by" side of the element → diagram drill).
+    referenced_by_elements: list[dict[str, str]] = Field(default_factory=list)
 
 
 class DiagramHierarchyNode(BaseModel):

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -171,6 +171,19 @@ async def get_diagram(
     tag_rows = await tag_cursor.fetchall()
     tags = [t[0] for t in tag_rows]
 
+    # ADR-221: elements that declare this diagram as their detail diagram
+    # ("Referenced by" — the inbound side of the element → diagram drill).
+    ref_cursor = await db.execute(
+        "SELECT e.id, ev.name FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "  AND e.current_version = ev.version "
+        "WHERE e.detail_diagram_id = ? AND e.is_deleted = 0 "
+        "ORDER BY ev.name",
+        (diagram_id,),
+    )
+    ref_rows = await ref_cursor.fetchall()
+    referenced_by_elements = [{"id": r[0], "name": r[1]} for r in ref_rows]
+
     # Parse detected_notations JSON
     detected_raw = row[16]
     try:
@@ -197,6 +210,7 @@ async def get_diagram(
         "notation": row[15] or "simple",
         "detected_notations": detected,
         "metadata": json.loads(row[14]) if row[14] else None,
+        "referenced_by_elements": referenced_by_elements,
     }
     # ADR-218 (issue #238): auto-heal legacy diagrams persisted with the
     # flat AI node shape (no per-node `data` object) so they render

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -315,6 +315,34 @@ def _markdown_escape_title(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
+async def _resolve_element_detail_diagram(
+    db: DatabasePort, element_id: str,
+) -> str | None:
+    """Resolve ``{{element:<id>:detail_diagram}}`` (ADR-221).
+
+    Unlike other element tokens — which link back to the element — this
+    resolves to a link to the element's *detail diagram* so the rendered
+    markdown drills into the diagram that elaborates the element. Returns
+    ``None`` (→ strikethrough) when the element has no detail diagram, or
+    the target diagram is missing/soft-deleted.
+    """
+    cursor = await db.execute(
+        "SELECT detail_diagram_id FROM elements "
+        "WHERE id = ? AND is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if not row or not row[0]:
+        return None
+    detail_id = row[0]
+    name = await _fetch_entity_display_name(db, "diagram", detail_id)
+    if name is None:
+        return None
+    title = _markdown_escape_title(name)
+    text = _markdown_escape_link_text(name)
+    return f'[{text}](iris://diagram/{detail_id} "{title}")'
+
+
 async def _resolve_one(
     db: DatabasePort, entity_type: str, entity_id: str, field_spec: str | None,
 ) -> str | None:
@@ -342,6 +370,12 @@ async def _resolve_one(
     # Non-image entity types require a field_spec.
     if field_spec is None or field_spec == "":
         return None
+
+    # ADR-221: an element's detail-diagram drill. Resolves to a link to
+    # the *target diagram*, not the element — so it's handled before the
+    # generic element-field path (which would wrap in an element link).
+    if entity_type == "element" and field_spec == "detail_diagram":
+        return await _resolve_element_detail_diagram(db, entity_id)
 
     # ADR-210: parse inline =value override.
     field_spec_path: str = field_spec

--- a/backend/app/elements/models.py
+++ b/backend/app/elements/models.py
@@ -27,6 +27,7 @@ class ElementCreate(BaseModel):
     data: dict[str, object] = Field(default_factory=dict)
     set_id: str | None = None
     package_id: str | None = None
+    detail_diagram_id: str | None = None
     metadata: dict[str, object] | None = None
     notation: str = "simple"
     template_id: str | None = None
@@ -35,10 +36,10 @@ class ElementCreate(BaseModel):
 class ElementUpdate(BaseModel):
     """Request body for updating an element.
 
-    ``package_id`` is tri-state: omit the key to leave the column
-    untouched, pass ``null`` (JSON) to clear, or pass a string to set.
-    The router translates these three states into a kwarg passed to the
-    service layer.
+    ``package_id`` and ``detail_diagram_id`` are tri-state: omit the key
+    to leave the column untouched, pass ``null`` (JSON) to clear, or pass
+    a string to set. The router translates these three states into a
+    kwarg passed to the service layer.
     """
 
     name: str = Field(min_length=1, max_length=255)
@@ -47,6 +48,7 @@ class ElementUpdate(BaseModel):
     change_summary: str | None = None
     metadata: dict[str, object] | None = None
     package_id: Any = _UNSET
+    detail_diagram_id: Any = _UNSET
 
 
 class ElementRollback(BaseModel):
@@ -76,6 +78,7 @@ class ElementResponse(BaseModel):
     set_name: str | None = None
     package_id: str | None = None
     package_name: str | None = None
+    detail_diagram_id: str | None = None
     metadata: dict[str, object] | None = None
     notation: str = "simple"
 

--- a/backend/app/elements/router.py
+++ b/backend/app/elements/router.py
@@ -23,6 +23,7 @@ from app.element_templates.service import (
     get_element_template,
 )
 from app.elements.service import (
+    ElementDetailDiagramError,
     ElementPackageInvariantError,
     cascade_delete_element,
     create_element,
@@ -88,10 +89,11 @@ async def create(
             created_by=current_user["id"],
             set_id=fields.get("set_id"),
             package_id=fields.get("package_id"),
+            detail_diagram_id=fields.get("detail_diagram_id"),
             metadata=fields.get("metadata"),
             notation=fields.get("notation") or "simple",
         )
-    except ElementPackageInvariantError as exc:
+    except (ElementPackageInvariantError, ElementDetailDiagramError) as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
 
     # Apply template-supplied tags (if any) to the element_tags table.
@@ -394,9 +396,11 @@ async def update(
     }
     if body.package_id is not _ELEMENT_UPDATE_UNSET:
         update_kwargs["package_id"] = body.package_id
+    if body.detail_diagram_id is not _ELEMENT_UPDATE_UNSET:
+        update_kwargs["detail_diagram_id"] = body.detail_diagram_id
     try:
         result = await update_element(db, element_id, **update_kwargs)
-    except ElementPackageInvariantError as exc:
+    except (ElementPackageInvariantError, ElementDetailDiagramError) as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
     if result is None:
         raise HTTPException(status_code=409, detail="Version conflict")

--- a/backend/app/elements/service.py
+++ b/backend/app/elements/service.py
@@ -25,6 +25,37 @@ class ElementPackageInvariantError(ValueError):
     """
 
 
+class ElementDetailDiagramError(ValueError):
+    """Raised when an element's detail_diagram_id points at a diagram
+    that does not exist or is soft-deleted (ADR-221).
+
+    The router translates this into HTTP 422 with the message intact.
+    Cross-set targets are allowed — only existence is checked.
+    """
+
+
+async def _validate_detail_diagram_exists(
+    db: DatabasePort,
+    detail_diagram_id: str | None,
+) -> None:
+    """Ensure ``detail_diagram_id`` references a live diagram (ADR-221).
+
+    ``None`` (clear / unset) is always valid. A non-null id must resolve
+    to a non-deleted ``diagrams`` row, else
+    :class:`ElementDetailDiagramError`. No set constraint — cross-set
+    drill links are intentionally allowed.
+    """
+    if detail_diagram_id is None:
+        return
+    cursor = await db.execute(
+        "SELECT 1 FROM diagrams WHERE id = ? AND is_deleted = 0",
+        (detail_diagram_id,),
+    )
+    if await cursor.fetchone() is None:
+        msg = f"Detail diagram {detail_diagram_id} not found"
+        raise ElementDetailDiagramError(msg)
+
+
 async def _validate_element_package_set_consistency(
     db: DatabasePort,
     *,
@@ -71,6 +102,7 @@ async def create_element(
     created_by: str,
     set_id: str | None = None,
     package_id: str | None = None,
+    detail_diagram_id: str | None = None,
     metadata: dict[str, object] | None = None,
     change_summary: str | None = None,
     notation: str = "simple",
@@ -85,13 +117,15 @@ async def create_element(
     await _validate_element_package_set_consistency(
         db, set_id=effective_set_id, package_id=package_id,
     )
+    await _validate_detail_diagram_exists(db, detail_diagram_id)
 
     await db.execute(
         "INSERT INTO elements (id, element_type, current_version, "
-        "created_at, created_by, updated_at, set_id, package_id, notation) "
-        "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?)",
+        "created_at, created_by, updated_at, set_id, package_id, "
+        "detail_diagram_id, notation) "
+        "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?)",
         (element_id, element_type, now, created_by, now,
-         effective_set_id, package_id, notation),
+         effective_set_id, package_id, detail_diagram_id, notation),
     )
     await db.execute(
         "INSERT INTO element_versions (element_id, version, name, description, "
@@ -119,6 +153,7 @@ async def create_element(
         "is_deleted": False,
         "set_id": effective_set_id,
         "package_id": package_id,
+        "detail_diagram_id": detail_diagram_id,
         "metadata": metadata,
         "notation": notation,
     }
@@ -134,7 +169,7 @@ async def get_element(
         "ev.name, ev.description, ev.data, "
         "e.created_at, e.created_by, e.updated_at, e.is_deleted, "
         "u.username, e.set_id, s.name, ev.metadata, e.notation, "
-        "e.package_id, "
+        "e.package_id, e.detail_diagram_id, "
         "(SELECT pv.name FROM packages p "
         "  JOIN package_versions pv ON p.id = pv.package_id "
         "    AND p.current_version = pv.version "
@@ -168,7 +203,8 @@ async def get_element(
         "metadata": json.loads(row[13]) if row[13] else None,
         "notation": row[14] or "simple",
         "package_id": row[15],
-        "package_name": row[16],
+        "detail_diagram_id": row[16],
+        "package_name": row[17],
     }
 
     # Enrich with tags
@@ -270,7 +306,7 @@ async def list_elements(
         "ev.name, ev.description, ev.data, "
         "e.created_at, e.created_by, e.updated_at, e.is_deleted, "
         "e.set_id, s.name, ev.metadata, e.notation, "
-        "e.package_id, "
+        "e.package_id, e.detail_diagram_id, "
         "(SELECT pv.name FROM packages p "
         "  JOIN package_versions pv ON p.id = pv.package_id "
         "    AND p.current_version = pv.version "
@@ -302,7 +338,8 @@ async def list_elements(
             "metadata": json.loads(r[12]) if r[12] else None,
             "notation": r[13] or "simple",
             "package_id": r[14],
-            "package_name": r[15],
+            "detail_diagram_id": r[15],
+            "package_name": r[16],
         }
         for r in rows
     ]
@@ -342,6 +379,7 @@ async def list_elements(
 
 
 _UNSET_PACKAGE_ID: Any = object()
+_UNSET_DETAIL_DIAGRAM_ID: Any = object()
 
 
 async def update_element(
@@ -356,13 +394,15 @@ async def update_element(
     expected_version: int,
     metadata: dict[str, object] | None = None,
     package_id: Any = _UNSET_PACKAGE_ID,
+    detail_diagram_id: Any = _UNSET_DETAIL_DIAGRAM_ID,
 ) -> dict[str, object] | None:
     """Update an element with optimistic concurrency. Returns None on conflict.
 
-    ``package_id`` is tri-state. The sentinel ``_UNSET_PACKAGE_ID`` means
-    "do not touch the column"; an explicit ``None`` clears the column;
-    a string sets it. The invariant against ``set_id`` runs whenever
-    ``package_id`` is being touched.
+    ``package_id`` and ``detail_diagram_id`` are tri-state. The sentinel
+    means "do not touch the column"; an explicit ``None`` clears the
+    column; a string sets it. The package/set invariant runs whenever
+    ``package_id`` is being touched; ``detail_diagram_id`` is validated to
+    reference a live diagram whenever it is being touched (ADR-221).
     """
     # Check current version (OCC)
     cursor = await db.execute(
@@ -382,23 +422,30 @@ async def update_element(
         await _validate_element_package_set_consistency(
             db, set_id=current_set_id, package_id=package_id,
         )
+    if detail_diagram_id is not _UNSET_DETAIL_DIAGRAM_ID:
+        await _validate_detail_diagram_exists(db, detail_diagram_id)
 
     new_version = current_version + 1
     now = datetime.now(tz=UTC).isoformat()
     data_json = json.dumps(data)
     metadata_json = json.dumps(metadata) if metadata else None
 
-    if package_id is _UNSET_PACKAGE_ID:
-        await db.execute(
-            "UPDATE elements SET current_version = ?, updated_at = ? WHERE id = ?",
-            (new_version, now, element_id),
-        )
-    else:
-        await db.execute(
-            "UPDATE elements SET current_version = ?, updated_at = ?, "
-            "package_id = ? WHERE id = ?",
-            (new_version, now, package_id, element_id),
-        )
+    # Build the SET clause dynamically so package_id and detail_diagram_id
+    # can each be touched (or left untouched) independently. All clause
+    # fragments are literal column assignments — no user text in the SQL.
+    set_clauses = ["current_version = ?", "updated_at = ?"]
+    set_params: list[object] = [new_version, now]
+    if package_id is not _UNSET_PACKAGE_ID:
+        set_clauses.append("package_id = ?")
+        set_params.append(package_id)
+    if detail_diagram_id is not _UNSET_DETAIL_DIAGRAM_ID:
+        set_clauses.append("detail_diagram_id = ?")
+        set_params.append(detail_diagram_id)
+    set_params.append(element_id)
+    await db.execute(
+        f"UPDATE elements SET {', '.join(set_clauses)} WHERE id = ?",  # noqa: S608
+        set_params,
+    )
     await db.execute(
         "INSERT INTO element_versions (element_id, version, name, description, "
         "data, change_type, change_summary, created_at, created_by, metadata) "

--- a/backend/app/import_sparx/reader.py
+++ b/backend/app/import_sparx/reader.py
@@ -98,6 +98,10 @@ class QeaDiagram:
     Notes: str | None = None
     cx: int | None = None
     cy: int | None = None
+    # ADR-221: t_diagram.ParentID points at the owning element's
+    # Object_ID when the diagram is a "composite" child of an element.
+    # Used to populate that element's detail_diagram_id on import.
+    ParentID: int | None = None
 
 
 @dataclass
@@ -245,12 +249,21 @@ async def read_connectors(db_path: str) -> list[QeaConnector]:
 
 
 async def read_diagrams(db_path: str) -> list[QeaDiagram]:
-    """Read all diagrams from a .qea file."""
+    """Read all diagrams from a .qea file.
+
+    ``ParentID`` (ADR-221: the owning element of a composite diagram) is a
+    standard EA column but may be absent in older/minimal databases, so it
+    is selected only when present.
+    """
     async with aiosqlite.connect(db_path) as db:
-        cursor = await db.execute(
-            "SELECT Diagram_ID, Name, Diagram_Type, Package_ID, ea_guid, Notes, cx, cy "
-            "FROM t_diagram"
+        info = await db.execute("PRAGMA table_info(t_diagram)")
+        cols = {row[1] for row in await info.fetchall()}
+        has_parent = "ParentID" in cols
+        select = (
+            "SELECT Diagram_ID, Name, Diagram_Type, Package_ID, ea_guid, "
+            "Notes, cx, cy" + (", ParentID" if has_parent else "") + " FROM t_diagram"
         )
+        cursor = await db.execute(select)
         rows = await cursor.fetchall()
         return [
             QeaDiagram(
@@ -262,6 +275,7 @@ async def read_diagrams(db_path: str) -> list[QeaDiagram]:
                 Notes=row[5],
                 cx=row[6],
                 cy=row[7],
+                ParentID=(row[8] or None) if has_parent else None,
             )
             for row in rows
         ]

--- a/backend/app/import_sparx/service.py
+++ b/backend/app/import_sparx/service.py
@@ -994,4 +994,23 @@ async def import_sparx_model(
                 )
         await db.commit()
 
+    # 7. Post-process: populate elements.detail_diagram_id from composite
+    # diagrams (ADR-221). t_diagram.ParentID points at the owning element's
+    # Object_ID; now that both elements and diagrams have Iris UUIDs, link
+    # the owning element to its child (detail) diagram. Idempotent.
+    linked_detail = False
+    for diag in diagrams:
+        if not diag.ParentID:
+            continue
+        owner_iris_id = element_map.get(diag.ParentID)
+        diagram_iris_id = ea_diagram_id_to_iris.get(diag.Diagram_ID)
+        if owner_iris_id and diagram_iris_id:
+            await db.execute(
+                "UPDATE elements SET detail_diagram_id = ? WHERE id = ?",
+                (diagram_iris_id, owner_iris_id),
+            )
+            linked_detail = True
+    if linked_detail:
+        await db.commit()
+
     return summary

--- a/backend/app/import_sparx_xml/reader.py
+++ b/backend/app/import_sparx_xml/reader.py
@@ -314,6 +314,19 @@ def parse_sparx_xmi(path: str) -> SparxXmiModel:
         m = _child(dg, "model")
         props = _child(dg, "properties")
         pkg_guid = m.get("package") if m is not None else None
+        # ADR-221: a composite (element-owned) diagram carries an `owner`
+        # GUID that differs from its containing package. Map it to the
+        # owning element's int id so the orchestrator can set that
+        # element's detail_diagram_id. A package-owned diagram (owner ==
+        # package) is not composite → leave ParentID unset. The
+        # orchestrator further filters to element ids, so a stray
+        # non-element owner is harmless.
+        owner_guid = m.get("owner") if m is not None else None
+        parent_id = (
+            guid_to_int.get(owner_guid)
+            if owner_guid and owner_guid != pkg_guid
+            else None
+        )
 
         cx = cy = None
         style1 = _child(dg, "style1")
@@ -334,6 +347,7 @@ def parse_sparx_xmi(path: str) -> SparxXmiModel:
                 Notes=props.get("documentation") if props is not None else None,
                 cx=cx,
                 cy=cy,
+                ParentID=parent_id,
             )
         )
 

--- a/backend/app/migrations/m080_element_detail_diagram.py
+++ b/backend/app/migrations/m080_element_detail_diagram.py
@@ -1,0 +1,33 @@
+"""Migration 080: Element → detail diagram drill link (ADR-221).
+
+Adds nullable ``detail_diagram_id`` column to ``elements`` plus an index.
+No back-fill — every existing element keeps ``detail_diagram_id = NULL``.
+This is the Sparx EA "composite element" drill: an element points at the
+diagram that elaborates it. Carried on the element row (like
+``package_id``, ADR-184), not versioned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m080_element_detail_diagram"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    cursor = await db.execute("PRAGMA table_info(elements)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "detail_diagram_id" not in cols:
+        await db.execute(
+            "ALTER TABLE elements ADD COLUMN detail_diagram_id TEXT "
+            "REFERENCES diagrams(id)"
+        )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_elements_detail_diagram "
+        "ON elements(detail_diagram_id)"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m086_element_detail_diagram.sql
+++ b/backend/app/migrations/supabase/m086_element_detail_diagram.sql
@@ -1,0 +1,14 @@
+-- Migration 086: Element → detail diagram drill link (ADR-221).
+--
+-- Adds nullable ``detail_diagram_id`` column to ``elements`` plus an
+-- index. The Sparx EA "composite element" drill: an element points at
+-- the diagram that elaborates it.
+-- Mirrors SQLite m080.
+--
+-- Idempotent.
+
+ALTER TABLE public.elements
+    ADD COLUMN IF NOT EXISTS detail_diagram_id TEXT REFERENCES public.diagrams(id);
+
+CREATE INDEX IF NOT EXISTS idx_elements_detail_diagram
+    ON public.elements(detail_diagram_id);

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -84,6 +84,7 @@ from app.migrations.m076_aggregation_profiles import up as m076_up
 from app.migrations.m077_seed_global_aggregation_profiles import up as m077_up
 from app.migrations.m078_aggregation_list_diagram_type import up as m078_up
 from app.migrations.m079_rename_quantified_item_to_ingredient import up as m079_up
+from app.migrations.m080_element_detail_diagram import up as m080_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -194,6 +195,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m077_up(main)  # issue #211, v6.20.0: seed 5 global aggregation profiles (ADR-212)
     await m078_up(main)  # issue #211, v6.21.0: register aggregation_list diagram type (ADR-213)
     await m079_up(main)  # issue #211, v6.29.0: rename seeded "Quantified item" → "Ingredient"
+    await m080_up(main)  # issue #242, v6.33.0: elements.detail_diagram_id drill link (ADR-221)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.32.1"
+version = "6.33.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_elements/test_detail_diagram.py
+++ b/backend/tests/test_elements/test_detail_diagram.py
@@ -1,0 +1,315 @@
+"""Integration tests for element → detail diagram drill link (ADR-221).
+
+Covers:
+- creating/updating an element with ``detail_diagram_id`` (tri-state);
+- validation that the target diagram exists (422 otherwise);
+- cross-set drill links are allowed;
+- ``get_diagram`` exposes ``referenced_by_elements``;
+- the smart-markdown ``{{element:<id>:detail_diagram}}`` token renders a
+  link to the target diagram (and strikes through when unset).
+
+Real FastAPI app + temp SQLite database (no mocks — protocol 9).
+TDD: written alongside the implementation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test",
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _create_set(
+    client: httpx.AsyncClient, headers: dict, name: str = "S",
+) -> str:
+    resp = await client.post("/api/sets", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_diagram(
+    client: httpx.AsyncClient,
+    headers: dict,
+    *,
+    set_id: str,
+    name: str = "D",
+    diagram_type: str = "component",
+    data: dict | None = None,
+) -> str:
+    resp = await client.post(
+        "/api/diagrams",
+        json={
+            "diagram_type": diagram_type,
+            "name": name,
+            "set_id": set_id,
+            "data": data or {"nodes": [], "edges": []},
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_element(
+    client: httpx.AsyncClient,
+    headers: dict,
+    *,
+    name: str = "E",
+    set_id: str | None = None,
+    detail_diagram_id: str | None = None,
+    element_type: str = "component",
+) -> dict[str, object]:
+    body: dict[str, object] = {
+        "element_type": element_type,
+        "name": name,
+        "data": {},
+    }
+    if set_id is not None:
+        body["set_id"] = set_id
+    if detail_diagram_id is not None:
+        body["detail_diagram_id"] = detail_diagram_id
+    resp = await client.post("/api/elements", json=body, headers=headers)
+    return {"status": resp.status_code, "body": resp.json()}
+
+
+class TestCreateAndRead:
+    async def test_create_with_detail_diagram_persists(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        diag = await _create_diagram(client, headers, set_id=set_id)
+
+        created = await _create_element(
+            client, headers, set_id=set_id, detail_diagram_id=diag,
+        )
+        assert created["status"] == 201, created
+        assert created["body"]["detail_diagram_id"] == diag
+
+        # And it round-trips on GET.
+        resp = await client.get(f"/api/elements/{created['body']['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["detail_diagram_id"] == diag
+
+    async def test_create_with_missing_diagram_returns_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        created = await _create_element(
+            client, headers, set_id=set_id,
+            detail_diagram_id="00000000-0000-0000-0000-000000000000",
+        )
+        assert created["status"] == 422, created
+
+    async def test_cross_set_detail_diagram_allowed(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_a = await _create_set(client, headers, name="A")
+        set_b = await _create_set(client, headers, name="B")
+        diag_in_b = await _create_diagram(client, headers, set_id=set_b)
+
+        created = await _create_element(
+            client, headers, set_id=set_a, detail_diagram_id=diag_in_b,
+        )
+        assert created["status"] == 201, created
+        assert created["body"]["detail_diagram_id"] == diag_in_b
+
+
+class TestUpdate:
+    async def test_update_sets_detail_diagram(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        diag = await _create_diagram(client, headers, set_id=set_id)
+        created = await _create_element(client, headers, set_id=set_id)
+        eid = created["body"]["id"]
+        ver = created["body"]["current_version"]
+
+        resp = await client.put(
+            f"/api/elements/{eid}",
+            json={"name": "E", "data": {}, "detail_diagram_id": diag},
+            headers={**headers, "If-Match": str(ver)},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["detail_diagram_id"] == diag
+
+    async def test_update_clears_detail_diagram(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        diag = await _create_diagram(client, headers, set_id=set_id)
+        created = await _create_element(
+            client, headers, set_id=set_id, detail_diagram_id=diag,
+        )
+        eid = created["body"]["id"]
+        ver = created["body"]["current_version"]
+
+        resp = await client.put(
+            f"/api/elements/{eid}",
+            json={"name": "E", "data": {}, "detail_diagram_id": None},
+            headers={**headers, "If-Match": str(ver)},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["detail_diagram_id"] is None
+
+    async def test_update_omitting_leaves_untouched(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        diag = await _create_diagram(client, headers, set_id=set_id)
+        created = await _create_element(
+            client, headers, set_id=set_id, detail_diagram_id=diag,
+        )
+        eid = created["body"]["id"]
+        ver = created["body"]["current_version"]
+
+        resp = await client.put(
+            f"/api/elements/{eid}",
+            json={"name": "Renamed", "data": {}},  # detail_diagram_id omitted
+            headers={**headers, "If-Match": str(ver)},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["detail_diagram_id"] == diag
+
+    async def test_update_missing_diagram_returns_422(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        created = await _create_element(client, headers, set_id=set_id)
+        eid = created["body"]["id"]
+        ver = created["body"]["current_version"]
+
+        resp = await client.put(
+            f"/api/elements/{eid}",
+            json={
+                "name": "E", "data": {},
+                "detail_diagram_id": "00000000-0000-0000-0000-000000000000",
+            },
+            headers={**headers, "If-Match": str(ver)},
+        )
+        assert resp.status_code == 422, resp.text
+
+
+class TestReferencedBy:
+    async def test_get_diagram_lists_referencing_elements(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        diag = await _create_diagram(client, headers, set_id=set_id, name="Zone")
+        e1 = await _create_element(
+            client, headers, set_id=set_id, name="E1", detail_diagram_id=diag,
+        )
+        # E2 has no detail diagram → must not appear.
+        await _create_element(client, headers, set_id=set_id, name="E2")
+
+        resp = await client.get(f"/api/diagrams/{diag}")
+        assert resp.status_code == 200, resp.text
+        refs = resp.json()["referenced_by_elements"]
+        ids = {r["id"] for r in refs}
+        assert e1["body"]["id"] in ids
+        assert all(r["name"] == "E1" for r in refs)
+        assert len(refs) == 1
+
+
+class TestSmartMarkdownToken:
+    async def test_detail_diagram_token_renders_diagram_link(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        target = await _create_diagram(
+            client, headers, set_id=set_id, name="Target Zone",
+        )
+        elem = await _create_element(
+            client, headers, set_id=set_id, name="Cap", detail_diagram_id=target,
+        )
+        eid = elem["body"]["id"]
+        source = f"# Demo\n\n- Cap {{{{element:{eid}:detail_diagram}}}}\n"
+        smd = await _create_diagram(
+            client, headers, set_id=set_id, name="SMD",
+            diagram_type="smart_markdown", data={"markdown_source": source},
+        )
+
+        resp = await client.get(f"/api/diagrams/{smd}")
+        assert resp.status_code == 200, resp.text
+        content = resp.json()["data"]["content"]
+        assert f"iris://diagram/{target}" in content
+        assert "Target Zone" in content
+
+    async def test_detail_diagram_token_strikes_through_when_unset(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        headers = await _auth_headers(client)
+        set_id = await _create_set(client, headers)
+        elem = await _create_element(client, headers, set_id=set_id, name="Cap")
+        eid = elem["body"]["id"]
+        source = f"- Cap {{{{element:{eid}:detail_diagram}}}}\n"
+        smd = await _create_diagram(
+            client, headers, set_id=set_id, name="SMD",
+            diagram_type="smart_markdown", data={"markdown_source": source},
+        )
+
+        resp = await client.get(f"/api/diagrams/{smd}")
+        assert resp.status_code == 200, resp.text
+        content = resp.json()["data"]["content"]
+        # Unresolvable token → strikethrough fallback.
+        assert "~~" in content
+        assert "iris://diagram/" not in content

--- a/backend/tests/test_import_sparx_xml/sample_ea_xmi_composite.xml
+++ b/backend/tests/test_import_sparx_xml/sample_ea_xmi_composite.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<xmi:XMI xmi:version="2.1" xmlns:xmi="http://schema.omg.org/spec/XMI/2.1" xmlns:uml="http://schema.omg.org/spec/UML/2.1">
+	<xmi:Documentation exporter="Enterprise Architect" exporterVersion="6.5" exporterID="1627"/>
+	<uml:Model xmi:type="uml:Model" name="EA_Model" visibility="public">
+		<packagedElement xmi:type="uml:Package" xmi:id="EAPK_PKG1" name="Sample Package" visibility="public">
+			<packagedElement xmi:type="uml:Class" xmi:id="EAID_A" name="Capability A" visibility="public"/>
+		</packagedElement>
+	</uml:Model>
+	<xmi:Extension extender="Enterprise Architect" extenderID="6.5">
+		<elements>
+			<element xmi:idref="EAPK_PKG1" xmi:type="uml:Package" name="Sample Package" scope="public">
+				<model package="EAPK_ROOT" tpos="0" ea_localid="1" ea_eleType="package"/>
+				<properties isSpecification="false" sType="Package" nType="0" scope="public" documentation="Top level."/>
+			</element>
+			<element xmi:idref="EAID_A" xmi:type="uml:Class" name="Capability A" scope="public">
+				<model package="EAPK_PKG1" tpos="0" ea_localid="10" ea_eleType="element"/>
+				<properties documentation="A composite capability." isSpecification="false" sType="Class" nType="0" scope="public"/>
+			</element>
+		</elements>
+		<connectors/>
+		<diagrams>
+			<diagram xmi:id="EAID_DIAG2">
+				<model package="EAPK_PKG1" localID="201" owner="EAID_A"/>
+				<properties name="Capability A Detail" type="Logical" documentation="Composite detail diagram owned by Capability A."/>
+				<project author="Tester" version="1.0" created="2026-01-01 10:00:00" modified="2026-01-02 10:00:00"/>
+				<style1 value="DocSize.cx=800;DocSize.cy=600;Zoom=100;"/>
+				<elements/>
+			</diagram>
+		</diagrams>
+	</xmi:Extension>
+</xmi:XMI>

--- a/backend/tests/test_import_sparx_xml/test_detail_diagram_import.py
+++ b/backend/tests/test_import_sparx_xml/test_detail_diagram_import.py
@@ -1,0 +1,76 @@
+"""ADR-221: Sparx EA composite elements import as element → detail diagram
+drill links.
+
+A diagram whose ``<model owner="...">`` is an element (rather than its
+containing package) is a "composite" child diagram. The reader records
+the owning element's int id as ``QeaDiagram.ParentID``; the orchestrator
+sets that element's ``detail_diagram_id`` to the imported diagram.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from app.import_sparx_xml.reader import parse_sparx_xmi
+from app.import_sparx_xml.service import import_sparx_xml_file
+
+from .conftest import auth_headers
+
+if TYPE_CHECKING:
+    import httpx
+
+COMPOSITE_XMI = os.path.join(os.path.dirname(__file__), "sample_ea_xmi_composite.xml")
+
+
+class TestReader:
+    def test_composite_diagram_records_owning_element_as_parent(self) -> None:
+        model = parse_sparx_xmi(COMPOSITE_XMI)
+        diagrams = {d.Name: d for d in model.diagrams}
+        detail = diagrams["Capability A Detail"]
+        # The owner GUID EAID_A interns to the element's ea_localid (10).
+        assert detail.ParentID == 10
+
+    def test_package_owned_diagram_has_no_parent(self) -> None:
+        # The stock sample diagram is owned by its package → not composite.
+        stock = parse_sparx_xmi(
+            os.path.join(os.path.dirname(__file__), "sample_ea_xmi.xml"),
+        )
+        sample_diag = next(d for d in stock.diagrams if d.Name == "Sample Diagram")
+        assert sample_diag.ParentID is None
+
+
+class TestOrchestrator:
+    async def test_import_populates_detail_diagram_id(
+        self, client: httpx.AsyncClient,
+    ) -> None:
+        await auth_headers(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+        cursor = await db.execute("SELECT id FROM users WHERE username = 'admin'")
+        user_id = (await cursor.fetchone())[0]
+
+        await import_sparx_xml_file(db, COMPOSITE_XMI, imported_by=user_id)
+
+        # Element "Capability A" should now point at the imported detail diagram.
+        cursor = await db.execute(
+            "SELECT e.id, e.detail_diagram_id FROM elements e "
+            "JOIN element_versions ev ON e.id = ev.element_id "
+            "  AND e.current_version = ev.version "
+            "WHERE ev.name = 'Capability A' AND e.is_deleted = 0",
+        )
+        elem_row = await cursor.fetchone()
+        assert elem_row is not None
+        detail_id = elem_row[1]
+        assert detail_id is not None, "detail_diagram_id was not populated"
+
+        # And that id resolves to the composite diagram.
+        cursor = await db.execute(
+            "SELECT dv.name FROM diagrams d "
+            "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+            "  AND d.current_version = dv.version "
+            "WHERE d.id = ?",
+            (detail_id,),
+        )
+        diag_row = await cursor.fetchone()
+        assert diag_row is not None
+        assert diag_row[0] == "Capability A Detail"

--- a/backend/tests/test_migrations/test_element_detail_diagram_schema.py
+++ b/backend/tests/test_migrations/test_element_detail_diagram_schema.py
@@ -1,0 +1,57 @@
+"""ADR-221: assert the Supabase migration ``m086_element_detail_diagram.sql``
+mirrors the SQLite migration ``m080_element_detail_diagram.py`` — both add a
+nullable ``detail_diagram_id`` column to ``elements`` with a matching index,
+idempotently.
+
+Mirrors the pattern in ``test_element_bookmarks_schema.py`` — a static-parser
+guard so a SQLite-only column-add can't slip through and 500 on Supabase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_supabase_migration() -> str:
+    path = ROOT / "app" / "migrations" / "supabase" / "m086_element_detail_diagram.sql"
+    return path.read_text(encoding="utf-8")
+
+
+def _read_sqlite_migration() -> str:
+    path = ROOT / "app" / "migrations" / "m080_element_detail_diagram.py"
+    return path.read_text(encoding="utf-8")
+
+
+def test_supabase_m086_adds_detail_diagram_column_idempotently() -> None:
+    sql = _read_supabase_migration()
+    assert "ADD COLUMN IF NOT EXISTS detail_diagram_id" in sql, sql
+    # FK to diagrams.
+    assert "REFERENCES public.diagrams(id)" in sql, sql
+
+
+def test_supabase_m086_creates_index() -> None:
+    sql = _read_supabase_migration()
+    assert "idx_elements_detail_diagram" in sql, sql
+    assert "ON public.elements(detail_diagram_id)" in sql, sql
+    assert "CREATE INDEX IF NOT EXISTS" in sql, sql
+
+
+def test_supabase_m086_declares_mirror_of_sqlite() -> None:
+    sql = _read_supabase_migration()
+    assert "Mirrors SQLite m080" in sql, sql
+
+
+def test_sqlite_m080_adds_detail_diagram_column_idempotently() -> None:
+    py = _read_sqlite_migration()
+    # PRAGMA-guarded ADD COLUMN.
+    assert "PRAGMA table_info(elements)" in py, py
+    assert 'ADD COLUMN detail_diagram_id TEXT' in py, py
+    assert "REFERENCES diagrams(id)" in py, py
+
+
+def test_sqlite_m080_creates_index_if_not_exists() -> None:
+    py = _read_sqlite_migration()
+    assert "CREATE INDEX IF NOT EXISTS idx_elements_detail_diagram" in py, py
+    assert "ON elements(detail_diagram_id)" in py, py

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -813,6 +813,14 @@ def create_element_cmd(
         None, "--package-id",
         help="Optional package membership for the new element (ADR-184).",
     ),
+    detail_diagram_id: str | None = typer.Option(
+        None, "--detail-diagram-id",
+        help=(
+            "Optional diagram this element drills into — the Sparx EA "
+            "'composite element' link (v6.33.0, ADR-221). May point at a "
+            "diagram in another set."
+        ),
+    ),
     notation: str | None = typer.Option(None, "--notation"),
     description: str | None = typer.Option(None, "--description"),
     data_json: str | None = typer.Option(None, "--data-json"),
@@ -843,6 +851,8 @@ def create_element_cmd(
         body["set_id"] = set_id
     if package_id is not None:
         body["package_id"] = package_id
+    if detail_diagram_id is not None:
+        body["detail_diagram_id"] = detail_diagram_id
     if notation is not None:
         body["notation"] = notation
     if description is not None:
@@ -1059,6 +1069,15 @@ def update_element_cmd(
             "(ADR-178 invariant)."
         ),
     ),
+    detail_diagram_id: str | None = typer.Option(
+        None, "--detail-diagram-id",
+        help=(
+            "Set or clear the element's detail-diagram drill link "
+            "(v6.33.0, ADR-221). Pass a diagram UUID to set (may be in "
+            "another set), the literal 'null' to clear, or omit to leave "
+            "unchanged."
+        ),
+    ),
 ) -> None:
     """Update an Element. Note: elements cannot be moved between
     diagrams — they travel with their parent diagram (ADR-178 invariant)."""
@@ -1066,16 +1085,19 @@ def update_element_cmd(
         "name": name, "description": description,
         "data": _parse_json_opt(data_json, "--data-json"),
     }
-    # package_id is tri-state at the PUT body level: include the key to
-    # set (string) or clear (null), omit to leave untouched. The
-    # _put_merge_partial helper strips None so we wire package_id by
-    # hand.
+    # package_id / detail_diagram_id are tri-state at the PUT body level:
+    # include the key to set (string) or clear (null), omit to leave
+    # untouched. The _put_merge_partial helper strips None so we wire them
+    # by hand.
     raw_package_id = _resolve_null(package_id) if package_id is not None else _UNSET
+    raw_detail_diagram_id = (
+        _resolve_null(detail_diagram_id) if detail_diagram_id is not None else _UNSET
+    )
 
     async def _do() -> Any:
         async with _client() as c:
-            # Build the body from the GET-then-merge path, then graft
-            # package_id on if the user passed --package-id.
+            # Build the body from the GET-then-merge path, then graft the
+            # tri-state fields on if the user passed them.
             current_resp = await c._request("GET", f"/api/elements/{element_id}")
             current = current_resp.json()
             body: dict[str, Any] = {}
@@ -1086,6 +1108,8 @@ def update_element_cmd(
                     body[field] = current[field]
             if raw_package_id is not _UNSET:
                 body["package_id"] = raw_package_id
+            if raw_detail_diagram_id is not _UNSET:
+                body["detail_diagram_id"] = raw_detail_diagram_id
             headers = {"If-Match": str(current.get("current_version", 1))}
             resp = await c._request(
                 "PUT", f"/api/elements/{element_id}", json=body, headers=headers,

--- a/docs/adrs/ADR-221-Element-Detail-Diagram-Link.md
+++ b/docs/adrs/ADR-221-Element-Detail-Diagram-Link.md
@@ -1,0 +1,125 @@
+# ADR-221: Element → Detail Diagram Link (composite-element drill)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-221 |
+| **Initiative** | Let an element declare a navigable "detail diagram" so users can drill in and out of the model |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-29 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** issue #242 — a user saw "10 capabilities" reported
+against the element *CSE.04 Cyber Security* and expected to be able to
+drill from there into the diagram that elaborates those capabilities
+(*CSE.00 Security capability zone*), but found no link and an empty
+Relationships panel; the user's framing is that iris is meant to let you
+"drill in and out" and here discoverability failed,
+
+**facing** that iris relationships are strictly **element ↔ element**
+(`app/relationships/`, an edge between two element rows created from a
+canvas edge), so there is no way to represent or surface a navigable link
+from an element to a *diagram*. A view is not a valid relationship
+endpoint, and overloading relationships to point at diagrams would muddy
+their semantics and ripple through `relationship_count`, the canvas
+edge → relationship auto-creation, and every relationship consumer. The
+thing the user actually wants is a **navigation link** (drill-down), which
+is a different concept from a semantic relationship. Sparx EA — which iris
+imports (ADR-059/084/219) — models exactly this as a **composite element**
+(`t_diagram.ParentID` points at the owning element), and iris currently
+**discards** that information on import,
+
+**we decided to**:
+1. Add an optional, nullable **`detail_diagram_id`** column to the
+   `elements` table (FK → `diagrams(id)`), carried on the element row
+   exactly like `package_id` (ADR-184) — i.e. **not** versioned in
+   `element_versions`. Migration `m080` (SQLite) + `m086` (Supabase
+   mirror), idempotent, no back-fill (protocol §15).
+2. Treat it as **tri-state on update** (omit = leave untouched, `null` =
+   clear, string = set), reusing the `package_id` sentinel pattern in
+   `ElementUpdate` / `update_element` / the `PUT` router.
+3. Surface it across all three write surfaces (protocol §14): the
+   `create_element` / `update_element` MCP tools and the `iris create
+   element` / `iris update element` CLI commands gain a
+   `detail_diagram_id` / `--detail-diagram-id` field. No new write *op*,
+   so the parity script is unaffected, but the field must exist on all
+   three surfaces.
+4. Surface it for **reading** as a drill-in on the element detail page
+   (a "Detail diagram" link to `/views/<id>`) and as a "Referenced by"
+   list on the diagram (`get_diagram` gains `referenced_by_elements`,
+   computed from `SELECT … FROM elements WHERE detail_diagram_id = ?`).
+5. Let **smart-markdown** emit the drill inline: a new
+   `{{element:<id>:detail_diagram}}` token resolves to a link to the
+   element's detail diagram (`[name](iris://diagram/<id>)`), so authored
+   views like the #242 demo can show a clickable drill beside a value.
+6. **Preserve the link on Sparx import**: the `.qea` reader and the
+   native XMI reader read `t_diagram.ParentID` / the composite parent,
+   and `import_sparx_model` maps element `ea_guid` → diagram iris id to
+   populate `detail_diagram_id` after diagrams are created. Composite
+   elements imported from EA light up the drill automatically.
+
+**to achieve** a first-class, queryable, navigable element → diagram
+drill that matches the user's "drill in and out" mental model, restores
+the discoverability gap from #242, and turns the previously-discarded
+Sparx composite-element semantics into a real iris feature — without
+distorting the element ↔ element relationship model.
+
+**accepting** that:
+- **Cross-set links are allowed.** The #242 demo links an element in the
+  "Aggregation Demo" set to a diagram in the "GEANZ Sparx EA" set. The FK
+  is to `diagrams(id)` with no same-set constraint; validation only checks
+  the target diagram exists and is not soft-deleted. (Contrast ADR-178's
+  no-cross-set-*move* rule — a navigation pointer is not a move.)
+- It is a **single** pointer per element (one detail diagram), mirroring
+  Sparx's one-composite-diagram-per-element. Multiple detail diagrams are
+  out of scope; the `referenced_by_elements` direction is naturally
+  many-to-one and needs no extra storage.
+- The "10" in the #242 demo is a **hard-coded literal** in the
+  smart-markdown source, not a computed count; making it a real count is a
+  separate concern (aggregation, ADR-212) and explicitly **not** fixed
+  here. This ADR fixes the *navigation* gap only.
+- `detail_diagram_id` is **not** a relationship and does not affect
+  `relationship_count` or canvas edge auto-creation.
+
+## Rejected alternatives
+
+- **Store the pointer in `elements.metadata` (JSON).** Cheaper (no
+  migration) and the Sparx importer already writes `metadata.ea_guid`.
+  Rejected: it is not first-class — not a validated field, not indexable,
+  and the diagram-side "Referenced by" query would require scanning JSON
+  blobs instead of an indexed column. "First-class drill link" was the
+  explicit ask.
+- **Generalise relationships to accept diagram endpoints
+  (element↔diagram, diagram↔diagram).** This is literally what the issue
+  asked for ("inbound diagram relationship"). Rejected: high blast radius
+  (every relationship query and the canvas auto-creation assume
+  element↔element) and conceptually muddy — a view is not a model element.
+  Keep navigation links distinct from semantic relationships.
+- **Smart-markdown authored link only (no schema).** A
+  `{{diagram:<id>:name}}` token already produces a clickable diagram link
+  today with zero code. Rejected as the *primary* solution: it is manual
+  per-line, doesn't populate the element's drill affordance or the
+  diagram's "Referenced by", and can't be auto-populated from Sparx
+  imports. Retained as the *inline surfacing* of the real field (decision
+  5), not as a substitute for it.
+
+## Dependencies
+
+- Builds on ADR-184 (`elements.package_id` — the column + tri-state
+  pattern this mirrors).
+- Builds on ADR-205/209/210 (smart-markdown tokens + `iris://` links) for
+  the inline `detail_diagram` token.
+- Builds on ADR-219/059/084 (Sparx import pipeline) for auto-population.
+- Relates to ADR-023 (`linkedModelId` per-canvas-node drill) — a *node*
+  level pointer; this ADR adds the *element* level pointer. They are
+  distinct and complementary.
+
+## Consequences
+
+- Spec: see SPEC-221-A.
+- Surface parity (§14) preserved: field added to API + MCP + CLI.
+- Migration parity (§15): `m080` SQLite + `m086` Supabase ship together
+  with a schema test.

--- a/docs/adrs/specs/SPEC-221-A-Element-Detail-Diagram-Link.md
+++ b/docs/adrs/specs/SPEC-221-A-Element-Detail-Diagram-Link.md
@@ -1,0 +1,113 @@
+# SPEC-221-A: Element → Detail Diagram Link
+
+Implements **[ADR-221](../ADR-221-Element-Detail-Diagram-Link.md)**.
+Status: living document.
+
+## 1. Data model
+
+`elements` gains a nullable `detail_diagram_id TEXT REFERENCES diagrams(id)`
+column plus an index `idx_elements_detail_diagram`. Carried on the element
+row (like `package_id`), **not** in `element_versions`.
+
+- SQLite migration `m080_element_detail_diagram.py` — `PRAGMA table_info`
+  guard + `ALTER TABLE elements ADD COLUMN detail_diagram_id …`, idempotent;
+  registered in `app/startup.py` after `m079_up`.
+- Supabase mirror `m086_element_detail_diagram.sql` — `ADD COLUMN IF NOT
+  EXISTS` + `CREATE INDEX IF NOT EXISTS`. Header: `-- Mirrors SQLite m080.`
+- Schema test `backend/tests/test_migrations/test_element_detail_diagram_schema.py`.
+
+## 2. Backend API
+
+- `ElementCreate`: add `detail_diagram_id: str | None = None`.
+- `ElementUpdate`: add `detail_diagram_id: Any = _UNSET` (tri-state).
+- `ElementResponse`: add `detail_diagram_id: str | None = None`.
+- `create_element(...)`: new `detail_diagram_id` kwarg → persisted in the
+  `elements` INSERT; validated (target diagram must exist + not deleted)
+  via `_validate_detail_diagram_exists`; returned in the dict.
+- `get_element(...)` / `list_elements(...)`: select `e.detail_diagram_id`
+  and include in the returned dict.
+- `update_element(...)`: tri-state `detail_diagram_id` kwarg (sentinel =
+  leave untouched, `None` = clear, str = set + validate). The `UPDATE`
+  `SET` clause is built dynamically so `package_id` and `detail_diagram_id`
+  can each be touched independently.
+- `PUT /api/elements/{id}`: forward `body.detail_diagram_id` only when not
+  `_UNSET` (mirrors `package_id`). Validation error → HTTP 422 via a new
+  `ElementDetailDiagramError(ValueError)`.
+
+Validation: a missing/deleted target diagram raises
+`ElementDetailDiagramError` → 422. Cross-set is allowed (no set check).
+
+## 3. Diagram "Referenced by"
+
+`get_diagram(...)` gains `referenced_by_elements: list[{id, name}]` from
+`SELECT e.id, ev.name FROM elements e JOIN element_versions ev … WHERE
+e.detail_diagram_id = ? AND e.is_deleted = 0`. Positional row access only
+(Supabase parity, §15). `DiagramResponse` gains the field (default `[]`).
+
+## 4. Smart-markdown token
+
+`{{element:<id>:detail_diagram}}` (ADR-205/209). In `_resolve_one`, a
+special case for `entity_type == "element"` and `field_spec ==
+"detail_diagram"` resolves the element's `detail_diagram_id`, looks up the
+target diagram name via `_fetch_entity_display_name(db, "diagram", …)`, and
+returns `[name](iris://diagram/<id> "name")`. No detail diagram / missing
+/ deleted target → `None` → strikethrough fallback (consistent with other
+unresolvable tokens).
+
+## 5. MCP + CLI (§14)
+
+- MCP `create_element` / `update_element` (`mcp/src/iris_mcp/tools.py`):
+  add `detail_diagram_id` to the input schema and request body. `update`
+  uses the same tri-state merge as `package_id` (explicit key forwarded,
+  including `null`).
+- CLI (`cli/src/iris_cli/main.py`): `create element` and `update element`
+  gain `--detail-diagram-id`. Tri-state on update mirrors `--package-id`.
+- `scripts/check_surface_parity.py`: no change (no new write op).
+
+## 6. Sparx import auto-population
+
+- `.qea`: `QeaDiagram` gains `parent_element_id: int | None`; `read_diagrams`
+  adds `ParentID` to its SELECT.
+- Native XMI (`app/import_sparx_xml/reader.py`): extract the composite
+  parent element for a diagram where present; set `parent_element_id`.
+- `import_sparx_model(...)`: after diagrams are created and the
+  element-guid → iris-id and diagram maps exist, for each diagram with a
+  `parent_element_id`, resolve the owning element's iris id and set its
+  `detail_diagram_id` to the diagram's iris id (idempotent; skip if the
+  element or diagram is missing).
+
+## 7. Frontend
+
+- `routes/elements/[id]/+page.svelte`: a "Detail diagram" section (reuse
+  the "Used in Views" pattern) showing a drill link to
+  `/views/{detail_diagram_id}` when set; an edit control to set/clear it
+  reusing the `DiagramPicker` used by `LinkedDiagramPanel.svelte`. The
+  `ElementDetail`/types gain `detail_diagram_id`.
+- Diagram/view side: render `referenced_by_elements` as a "Referenced by"
+  list linking back to `/elements/{id}`.
+
+## 8. Acceptance criteria
+
+1. Creating/updating an element with `detail_diagram_id` persists and is
+   returned by `get_element`; clearing with `null` works; setting a
+   missing diagram → 422.
+2. `get_diagram` lists referencing elements under `referenced_by_elements`.
+3. `{{element:<id>:detail_diagram}}` renders a link to the target view;
+   no/deleted target → strikethrough.
+4. MCP + CLI can set/clear `detail_diagram_id`.
+5. Element page shows + edits the drill; diagram shows "Referenced by".
+6. Importing a Sparx model with composite elements populates
+   `detail_diagram_id`.
+7. SQLite + Supabase migrations both add the column idempotently; schema
+   test passes.
+
+## 9. Tests
+
+- `backend/tests/test_elements/`: create/update/get round-trip, tri-state
+  clear, missing-diagram 422, cross-set allowed.
+- `backend/tests/test_diagrams/`: `referenced_by_elements`.
+- `backend/tests/test_diagrams/` (smart-markdown): `detail_diagram` token
+  render + strikethrough.
+- `backend/tests/test_migrations/test_element_detail_diagram_schema.py`.
+- `backend/tests/test_import_sparx*/`: composite-element population.
+- Frontend: element drill + diagram referenced-by.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.32.1",
+	"version": "6.33.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -32,6 +32,8 @@ export interface Element {
 	set_name?: string;
 	metadata?: Record<string, unknown> | null;
 	notation?: string;
+	// ADR-221: the diagram this element drills into (Sparx composite element).
+	detail_diagram_id?: string | null;
 }
 
 export interface Diagram {
@@ -53,6 +55,8 @@ export interface Diagram {
 	notation?: string;
 	detected_notations?: string[];
 	metadata?: Record<string, unknown> | null;
+	// ADR-221: elements that point at this diagram as their detail diagram.
+	referenced_by_elements?: { id: string; name: string }[];
 }
 
 export interface Package {

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -20,6 +20,8 @@
 	import CommentsPanel from '$lib/components/CommentsPanel.svelte';
 	import VersionHistory from '$lib/components/VersionHistory.svelte';
 	import CreateTemplateDialog from '$lib/components/CreateTemplateDialog.svelte';
+	import DiagramPicker from '$lib/components/DiagramPicker.svelte';
+	import type { Diagram } from '$lib/types/api';
 	import { Accordion } from 'bits-ui';
 	import DOMPurify from 'dompurify';
 	import {
@@ -69,6 +71,13 @@
 	interface PackageOption { id: string; name: string }
 	let setPackages = $state<PackageOption[]>([]);
 	let editElementType = $state('');
+	// ADR-221 — element → detail diagram drill link. ``detailDiagramName``
+	// is the resolved name shown in read mode; the edit-mode picker
+	// updates ``editDetailDiagramId`` / ``editDetailDiagramName``.
+	let detailDiagramName = $state<string | null>(null);
+	let editDetailDiagramId = $state<string | null>(null);
+	let editDetailDiagramName = $state<string | null>(null);
+	let showDetailDiagramPicker = $state(false);
 
 	/** Entity type options for the current element's notation. */
 	const entityTypeOptions = $derived.by(() => {
@@ -111,7 +120,8 @@
 		);
 		const typeChanged = editElementType !== entity.element_type;
 		const pkgChanged = (editPackageId ?? null) !== ((entity as any).package_id ?? null);
-		detailsDirty = nameChanged || descChanged || tagsChanged || attrsChanged || typeChanged || pkgChanged;
+		const detailDiagramChanged = (editDetailDiagramId ?? null) !== (entity.detail_diagram_id ?? null);
+		detailsDirty = nameChanged || descChanged || tagsChanged || attrsChanged || typeChanged || pkgChanged || detailDiagramChanged;
 	});
 
 	async function loadEntity(id: string) {
@@ -126,6 +136,7 @@
 				loadRelationships(id),
 				loadDiagrams(id),
 				loadPackageMemberships(id),
+				loadDetailDiagramName(),
 				loadAllTags(),
 				loadBookmarkStatus(id),
 			]);
@@ -160,6 +171,22 @@
 			packageMemberships = await apiFetch<{id: string; name: string}[]>(`/api/elements/${id}/package-memberships`);
 		} catch {
 			packageMemberships = [];
+		}
+	}
+
+	// ADR-221: resolve the detail diagram's name for the read-mode drill
+	// link. Element responses carry only the id.
+	async function loadDetailDiagramName() {
+		const detailId = entity?.detail_diagram_id ?? null;
+		if (!detailId) {
+			detailDiagramName = null;
+			return;
+		}
+		try {
+			const d = await apiFetch<Diagram>(`/api/diagrams/${detailId}`);
+			detailDiagramName = d.name;
+		} catch {
+			detailDiagramName = null;
 		}
 	}
 
@@ -265,6 +292,8 @@
 			? srcAttrs.map((a: any) => ({ name: a.name ?? '', type: a.type ?? '', scope: a.scope ?? 'Public', notes: a.notes ?? '', lower_bound: a.lower_bound ?? '', upper_bound: a.upper_bound ?? '' }))
 			: [];
 		editPackageId = (entity as any).package_id ?? null;
+		editDetailDiagramId = entity.detail_diagram_id ?? null;
+		editDetailDiagramName = detailDiagramName;
 		// Load packages scoped to the element's set so the picker stays
 		// constrained to a consistent group (ADR-184).
 		try {
@@ -314,6 +343,9 @@
 			// untouched" but we initialise it to either the current
 			// value or null on entry, so always include it here.
 			putBody.package_id = editPackageId ?? null;
+			// ADR-221 tri-state — same convention as package_id: always
+			// include the key (set / null) since we seed it on edit entry.
+			putBody.detail_diagram_id = editDetailDiagramId ?? null;
 			await apiFetch(`/api/elements/${entity.id}`, {
 				method: 'PUT',
 				headers: { 'If-Match': String(entity.current_version) },
@@ -643,6 +675,50 @@
 										style="background: var(--color-surface); color: var(--color-fg)"
 									>
 										{(entity as any).package_name ?? (entity as any).package_id}
+									</a>
+								{:else}
+									<span style="color: var(--color-muted)">None</span>
+								{/if}
+							</dd>
+
+							<dt class="text-sm font-medium" style="color: var(--color-muted)">Detail diagram</dt>
+							<dd>
+								{#if editingDetails}
+									{#if editDetailDiagramId}
+										<div class="flex items-center gap-1.5">
+											<span class="truncate text-sm" style="color: var(--color-fg)" title={editDetailDiagramName ?? editDetailDiagramId}>
+												{editDetailDiagramName ?? editDetailDiagramId}
+											</span>
+											<button
+												type="button"
+												onclick={() => (showDetailDiagramPicker = true)}
+												class="shrink-0 rounded border px-2 py-0.5 text-xs"
+												style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+											>Change</button>
+											<button
+												type="button"
+												onclick={() => { editDetailDiagramId = null; editDetailDiagramName = null; }}
+												title="Clear detail diagram"
+												class="shrink-0 px-1 text-sm leading-none"
+												style="color: var(--color-muted); background: none; border: none; cursor: pointer"
+											>&times;</button>
+										</div>
+									{:else}
+										<button
+											type="button"
+											onclick={() => (showDetailDiagramPicker = true)}
+											class="rounded border px-2 py-1 text-xs"
+											style="border-color: var(--color-border); border-style: dashed; background: none; color: var(--color-primary); cursor: pointer"
+										>Set detail diagram</button>
+									{/if}
+								{:else if entity.detail_diagram_id}
+									<a
+										href={`/views/${entity.detail_diagram_id}`}
+										class="rounded px-2 py-0.5 text-sm underline"
+										style="background: var(--color-surface); color: var(--color-fg)"
+										title="Drill into the diagram that elaborates this element"
+									>
+										{detailDiagramName ?? entity.detail_diagram_id}
 									</a>
 								{:else}
 									<span style="color: var(--color-muted)">None</span>
@@ -1008,5 +1084,17 @@
 			showSaveTemplateDialog = false;
 			goto(`/element-templates/${templateId}`);
 		}}
+	/>
+
+	<!-- ADR-221: pick the element's detail diagram (cross-set allowed). -->
+	<DiagramPicker
+		open={showDetailDiagramPicker}
+		title="Set detail diagram"
+		onselect={(d: Diagram) => {
+			editDetailDiagramId = d.id;
+			editDetailDiagramName = d.name;
+			showDetailDiagramPicker = false;
+		}}
+		oncancel={() => (showDetailDiagramPicker = false)}
 	/>
 {/if}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2304,6 +2304,20 @@
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">Notation</dt>
 							<dd style="color: var(--color-fg)">{diagram.notation ?? 'simple'}</dd>
 
+							{#if diagram.referenced_by_elements && diagram.referenced_by_elements.length > 0}
+								<!-- ADR-221: elements that drill into this diagram. -->
+								<dt class="text-sm font-medium" style="color: var(--color-muted)">Referenced by</dt>
+								<dd>
+									<ul class="flex flex-col gap-1">
+										{#each diagram.referenced_by_elements as ref}
+											<li>
+												<a href={`/elements/${ref.id}`} class="text-sm underline" style="color: var(--color-fg)" title="Element that drills into this diagram">{ref.name}</a>
+											</li>
+										{/each}
+									</ul>
+								</dd>
+							{/if}
+
 							{#if diagram.detected_notations && diagram.detected_notations.length > 0}
 								<dt class="text-sm font-medium" style="color: var(--color-muted)">Detected Notations</dt>
 								<dd>

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.32.1"
+version = "6.33.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.32.1"
+version = "6.33.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -425,7 +425,7 @@ async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
         body["name"] = args["name"]
     for key in (
         "description", "data", "set_id", "metadata", "notation",
-        "package_id", "template_id",
+        "package_id", "detail_diagram_id", "template_id",
     ):
         if args.get(key) is not None:
             body[key] = args[key]
@@ -923,14 +923,16 @@ async def _update_element(c: IrisClient, args: dict[str, Any]) -> str:
     """ADR-178 (v6.3.0): update an Element's metadata or data.
 
     ADR-184 (v6.7.0): also accepts ``package_id`` (set / clear via JSON
-    null). Because the standard ``_put_merge_partial`` helper drops
-    ``None`` overrides, ``package_id`` is wired through a small special
-    case so the caller can explicitly clear membership.
+    null). ADR-221 (v6.33.0): also accepts ``detail_diagram_id`` (set /
+    clear via JSON null). Because the standard ``_put_merge_partial``
+    helper drops ``None`` overrides, both tri-state fields are wired
+    through a small special case so the caller can explicitly clear them.
     """
     try:
-        # Special-case ``package_id``: only forward to the body if the
-        # caller actually supplied the key (including JSON null).
-        if "package_id" in args:
+        # Special-case the tri-state fields: only forward to the body the
+        # ones the caller actually supplied (including JSON null).
+        tristate = [k for k in ("package_id", "detail_diagram_id") if k in args]
+        if tristate:
             current_resp = await c._request(
                 "GET", f"/api/elements/{args['element_id']}",
             )
@@ -941,7 +943,8 @@ async def _update_element(c: IrisClient, args: dict[str, Any]) -> str:
                     body[field] = args[field]
                 elif field in current:
                     body[field] = current[field]
-            body["package_id"] = args["package_id"]
+            for key in tristate:
+                body[key] = args[key]
             headers = {"If-Match": str(current.get("current_version", 1))}
             resp = await c._request(
                 "PUT", f"/api/elements/{args['element_id']}",
@@ -1699,6 +1702,15 @@ TOOLS: list[Tool] = [
                 "`update_element` call.",
                 required=False,
             ),
+            "detail_diagram_id": _str_arg(
+                "detail_diagram_id",
+                "Optional diagram this element drills into — the Sparx "
+                "EA 'composite element' link (v6.33.0, ADR-221 / issue "
+                "#242). The element page shows it as a drill-in and the "
+                "diagram lists the element under 'Referenced by'. May "
+                "point at a diagram in another set.",
+                required=False,
+            ),
             "notation": _str_arg(
                 "notation",
                 "Notation id (default 'simple'). Should match the "
@@ -2385,9 +2397,10 @@ TOOLS: list[Tool] = [
     Tool(
         name="update_element",
         description=(
-            "Update an Element's metadata, data, and/or package "
-            "membership (ADR-184). Note: elements cannot be moved "
-            "between diagrams — see ADR-178."
+            "Update an Element's metadata, data, package membership "
+            "(ADR-184), and/or detail-diagram drill link (ADR-221). "
+            "Note: elements cannot be moved between diagrams — see "
+            "ADR-178."
         ),
         input_schema=_schema({
             "element_id": _str_arg("element_id", "Element id"),
@@ -2404,6 +2417,18 @@ TOOLS: list[Tool] = [
                         "Set or clear the element's package membership "
                         "(ADR-184). Pass a UUID to set, JSON null to "
                         "clear, or omit to leave unchanged."
+                    ),
+                },
+                False,
+            ),
+            "detail_diagram_id": (
+                {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Set or clear the element's detail-diagram drill "
+                        "link (v6.33.0, ADR-221 / issue #242). Pass a "
+                        "diagram UUID to set (may be in another set), "
+                        "JSON null to clear, or omit to leave unchanged."
                     ),
                 },
                 False,

--- a/mcp/tests/test_element_detail_diagram.py
+++ b/mcp/tests/test_element_detail_diagram.py
@@ -1,0 +1,133 @@
+"""MCP tests for the v6.33.0 element ``detail_diagram_id`` field
+(ADR-221, issue #242).
+
+Asserts the create + update tool schemas advertise ``detail_diagram_id``
+and that the handlers forward it (create: non-null only; update:
+tri-state including JSON null for clear).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+from iris_client import IrisClient
+
+from iris_mcp import tools
+
+BASE = "http://iris.test"
+
+
+def _element_response(**overrides):
+    base = {
+        "id": "el1",
+        "element_type": "component",
+        "current_version": 1,
+        "name": "Cap",
+        "description": None,
+        "data": {},
+        "set_id": "s1",
+        "package_id": None,
+        "package_name": None,
+        "detail_diagram_id": None,
+        "notation": "simple",
+        "created_at": "2026-05-29T00:00:00+00:00",
+        "created_by": "u",
+        "updated_at": "2026-05-29T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSchema:
+    def test_create_and_update_schemas_include_detail_diagram_id(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        for tool_name in ("create_element", "update_element"):
+            props = defs[tool_name].inputSchema["properties"]
+            assert "detail_diagram_id" in props, tool_name
+            assert "detail_diagram_id" not in defs[tool_name].inputSchema.get(
+                "required", [],
+            )
+
+
+class TestCreateForwarding:
+    @pytest.mark.anyio
+    async def test_forwards_detail_diagram_id(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(
+                201, json=_element_response(detail_diagram_id="d1"),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._create_element(
+                c,
+                {
+                    "element_type": "component",
+                    "name": "Cap",
+                    "set_id": "s1",
+                    "detail_diagram_id": "d1",
+                },
+            )
+        body = json.loads(route.calls[0].request.content)
+        assert body["detail_diagram_id"] == "d1"
+
+    @pytest.mark.anyio
+    async def test_omitting_keeps_it_out_of_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        route = respx_mock.post(f"{BASE}/api/elements").mock(
+            return_value=httpx.Response(201, json=_element_response()),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._create_element(
+                c, {"element_type": "component", "name": "Cap", "set_id": "s1"},
+            )
+        body = json.loads(route.calls[0].request.content)
+        assert "detail_diagram_id" not in body
+
+
+class TestUpdateForwarding:
+    @pytest.mark.anyio
+    async def test_sets_detail_diagram_id(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(200, json=_element_response()),
+        )
+        put = respx_mock.put(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(
+                200, json=_element_response(detail_diagram_id="d1", current_version=2),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._update_element(
+                c, {"element_id": "el1", "detail_diagram_id": "d1"},
+            )
+        body = json.loads(put.calls[0].request.content)
+        assert body["detail_diagram_id"] == "d1"
+
+    @pytest.mark.anyio
+    async def test_clears_detail_diagram_id_with_null(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        respx_mock.get(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(
+                200, json=_element_response(detail_diagram_id="d1"),
+            ),
+        )
+        put = respx_mock.put(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(
+                200, json=_element_response(detail_diagram_id=None, current_version=2),
+            ),
+        )
+        async with IrisClient(BASE) as c:
+            await tools._update_element(
+                c, {"element_id": "el1", "detail_diagram_id": None},
+            )
+        body = json.loads(put.calls[0].request.content)
+        assert "detail_diagram_id" in body
+        assert body["detail_diagram_id"] is None


### PR DESCRIPTION
## Summary

Closes the discoverability gap from #242 by adding a first-class, navigable **detail diagram** pointer on elements — the Sparx EA "composite element" concept. You can now drill from an element into the diagram that elaborates it, and back out. (Option B from the #242 discussion.)

Relationships in Iris are strictly element↔element, so a *navigation link* to a diagram is modelled as its own concept rather than overloading relationships (see ADR-221 for the rejected alternatives).

## What's included

- **Schema**: nullable `elements.detail_diagram_id` (FK → `diagrams.id`), SQLite `m080` + Supabase mirror `m086`, idempotent, with a schema-parity test. Tri-state on update like `package_id`. Cross-set links allowed; target diagram validated to exist.
- **Surface parity (§14)**: `create_element` / `update_element` MCP tools gain `detail_diagram_id`; CLI gains `--detail-diagram-id` (set / clear via `null`). Parity script clean.
- **Read surfaces**: `get_diagram` returns `referenced_by_elements`; the **element page** shows a "Detail diagram" drill-in with a `DiagramPicker` to set/clear; the **diagram page** lists "Referenced by".
- **Smart-markdown**: new `{{element:<id>:detail_diagram}}` token renders a link straight to the detail diagram.
- **Sparx import**: composite elements auto-populate `detail_diagram_id` — `.qea` `t_diagram.ParentID` and native XMI diagram `owner`. `read_diagrams` is defensive about the optional `ParentID` column (older/minimal DBs).

## Test plan

- [x] Backend: element create/update/get round-trip, tri-state clear, missing-diagram 422, cross-set allowed; `referenced_by_elements`; smart-markdown token render + strikethrough; migration schema parity; importer composite (reader + orchestrator). All green.
- [x] MCP: schema advertises `detail_diagram_id` on create/update; handler forwards set + null. Green.
- [x] CLI element tests green; surface-parity check clean.
- [x] Frontend: `svelte-check` adds no new errors; vitest unchanged (only the 4 pre-existing failures); new Playwright e2e `element-detail-diagram.spec.ts` (element drill + diagram "Referenced by") passes.
- [ ] Reviewer: confirm the element-page picker UX and the view "Referenced by" list.

## Release ordering (Supabase)

Per Protocol §15: apply Supabase `m086` **before** rolling the code forward.

Note: a handful of pre-existing failures on `main` are unrelated and out of scope (`.eap`/JET conversion needs Access tooling; `test_search` fixtures lack a `collections` table; `test_ai` network tests; the stale `ask` anchor in `test_no_unregistered_iris_tool_refs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)