### PR TITLE
fix(v6.33.1): rename element "Detail diagram" label to "Detail view"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.33.1] - 2026-05-29
+
+### Changed
+
+- Renamed the element-page label "Detail diagram" to **"Detail view"**
+  (ADR-221 follow-up). UI label only — the `detail_diagram_id` field /
+  API / MCP / CLI surface is unchanged.
+
 ## [6.33.0] - 2026-05-29
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.33.0"
+version = "6.33.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.33.0",
+	"version": "6.33.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -681,7 +681,7 @@
 								{/if}
 							</dd>
 
-							<dt class="text-sm font-medium" style="color: var(--color-muted)">Detail diagram</dt>
+							<dt class="text-sm font-medium" style="color: var(--color-muted)">Detail view</dt>
 							<dd>
 								{#if editingDetails}
 									{#if editDetailDiagramId}
@@ -698,7 +698,7 @@
 											<button
 												type="button"
 												onclick={() => { editDetailDiagramId = null; editDetailDiagramName = null; }}
-												title="Clear detail diagram"
+												title="Clear detail view"
 												class="shrink-0 px-1 text-sm leading-none"
 												style="color: var(--color-muted); background: none; border: none; cursor: pointer"
 											>&times;</button>
@@ -709,7 +709,7 @@
 											onclick={() => (showDetailDiagramPicker = true)}
 											class="rounded border px-2 py-1 text-xs"
 											style="border-color: var(--color-border); border-style: dashed; background: none; color: var(--color-primary); cursor: pointer"
-										>Set detail diagram</button>
+										>Set detail view</button>
 									{/if}
 								{:else if entity.detail_diagram_id}
 									<a
@@ -1089,7 +1089,7 @@
 	<!-- ADR-221: pick the element's detail diagram (cross-set allowed). -->
 	<DiagramPicker
 		open={showDetailDiagramPicker}
-		title="Set detail diagram"
+		title="Set detail view"
 		onselect={(d: Diagram) => {
 			editDetailDiagramId = d.id;
 			editDetailDiagramName = d.name;

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.33.0"
+version = "6.33.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.33.0"
+version = "6.33.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Renames the element-page label **"Detail diagram" → "Detail view"** (ADR-221 follow-up). UI label only — the `detail_diagram_id` field, API, MCP, and CLI surface are unchanged.

Changed strings (element page): the row label, the "Set detail view" button, the clear-button title, and the picker dialog title.

## Test plan
- [x] No user-facing "Detail diagram" strings remain (`grep`); "Detail view" present.
- [x] Existing `element-detail-diagram.spec.ts` e2e is unaffected (asserts the drill link by href + diagram name, and the tab by role — not the renamed label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)