### PR TITLE
feat(v6.34.0): smart-markdown diagram element_count token (ADR-222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.34.0] - 2026-05-29
+
+### Added
+
+- **Smart-markdown `{{diagram:<id>:element_count}}` token** (ADR-222,
+  SPEC-222-A). Renders a live count of the element nodes on a referenced
+  view (excluding `diagram_frame` / `note` decoration), wrapped in a link
+  that drills into that view. Computed on read, so the figure follows the
+  view's contents instead of being hand-maintained. Lets a smart-markdown
+  source show a real "N elements in this view" count.
+
 ## [6.33.1] - 2026-05-29
 
 ### Changed

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -343,6 +343,54 @@ async def _resolve_element_detail_diagram(
     return f'[{text}](iris://diagram/{detail_id} "{title}")'
 
 
+# Canvas node types that are structural decoration, not model elements
+# (ADR-222). Excluded from the element-count.
+_STRUCTURAL_NODE_TYPES = {"diagram_frame", "note"}
+
+
+async def _fetch_diagram_element_count(
+    db: DatabasePort, diagram_id: str,
+) -> str | None:
+    """Count the element nodes on a diagram's canvas (ADR-222).
+
+    Counts nodes that represent real model elements — i.e. nodes whose
+    ``data.entityType`` is set and is not a structural type
+    (``diagram_frame`` / ``note``). Returns the count as a string, or
+    ``None`` when the diagram is missing/deleted (→ strikethrough).
+    """
+    cursor = await db.execute(
+        "SELECT dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.id = ? AND d.is_deleted = 0",
+        (diagram_id,),
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return None
+    raw = row[0]
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return "0"
+    nodes = data.get("nodes")
+    if not isinstance(nodes, list):
+        return "0"
+    count = 0
+    for n in nodes:
+        if not isinstance(n, dict):
+            continue
+        node_data = n.get("data")
+        if not isinstance(node_data, dict):
+            continue
+        etype = node_data.get("entityType")
+        if etype and etype not in _STRUCTURAL_NODE_TYPES:
+            count += 1
+    return str(count)
+
+
 async def _resolve_one(
     db: DatabasePort, entity_type: str, entity_id: str, field_spec: str | None,
 ) -> str | None:
@@ -399,10 +447,14 @@ async def _resolve_one(
             fk="package_id", entity_id=entity_id, field_spec=field_spec_path,
         )
     elif entity_type == "diagram":
-        raw_value = await _fetch_named_field(
-            db, table="diagrams", versions_table="diagram_versions",
-            fk="diagram_id", entity_id=entity_id, field_spec=field_spec_path,
-        )
+        if field_spec_path == "element_count":
+            # ADR-222: live count of element nodes in the referenced view.
+            raw_value = await _fetch_diagram_element_count(db, entity_id)
+        else:
+            raw_value = await _fetch_named_field(
+                db, table="diagrams", versions_table="diagram_versions",
+                fk="diagram_id", entity_id=entity_id, field_spec=field_spec_path,
+            )
     elif entity_type == "set":
         raw_value = await _fetch_set_field(db, entity_id, field_spec_path)
     elif entity_type == "collection":

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.33.1"
+version = "6.34.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -142,6 +142,87 @@ async def test_resolves_element_description(
     assert _unwrap_iris_links(rendered) == "Note: lean cut"
 
 
+# ── ADR-222: diagram element_count token ─────────────────────────────
+
+
+async def _create_canvas_diagram(
+    c: httpx.AsyncClient, h: dict[str, str], set_id: str, *, nodes: list,
+) -> str:
+    r = await c.post(
+        "/api/diagrams",
+        json={
+            "name": "Zone", "set_id": set_id,
+            "diagram_type": "class", "notation": "uml",
+            "data": {"nodes": nodes, "edges": []},
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _node(nid: str, entity_type: str, *, entity_id: str | None = None) -> dict:
+    data: dict = {"entityType": entity_type, "label": nid}
+    if entity_id is not None:
+        data["entityId"] = entity_id
+    return {"id": nid, "type": entity_type, "position": {"x": 0, "y": 0}, "data": data}
+
+
+@pytest.mark.asyncio
+async def test_diagram_element_count_excludes_notes_and_frame(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    nodes = [
+        _node("frame", "diagram_frame"),
+        _node("c1", "capability", entity_id="e1"),
+        _node("c2", "capability", entity_id="e2"),
+        _node("note1", "note", entity_id="x"),
+        _node("cls", "class", entity_id="e3"),
+    ]
+    zone_id = await _create_canvas_diagram(c, h, set_id, nodes=nodes)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"This zone has {{{{diagram:{zone_id}:element_count}}}} capabilities.",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # 3 element nodes (2 capability + 1 class); frame + note excluded.
+    assert _unwrap_iris_links(rendered) == "This zone has 3 capabilities."
+
+
+@pytest.mark.asyncio
+async def test_diagram_element_count_links_to_the_diagram(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    zone_id = await _create_canvas_diagram(
+        c, h, set_id, nodes=[_node("c1", "capability", entity_id="e1")],
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"{{{{diagram:{zone_id}:element_count}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # The count is wrapped in a link back to the source diagram (ADR-209/222).
+    assert f"iris://diagram/{zone_id}" in rendered
+    assert _unwrap_iris_links(rendered) == "1"
+
+
+@pytest.mark.asyncio
+async def test_diagram_element_count_missing_diagram_strikes_through(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    missing = "00000000-0000-0000-0000-000000000000"
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"X {{{{diagram:{missing}:element_count}}}} Y",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+    assert "iris://diagram/" not in rendered
+
+
 @pytest.mark.asyncio
 async def test_resolves_element_attr(
     context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],

--- a/docs/adrs/ADR-222-Diagram-Element-Count-Token.md
+++ b/docs/adrs/ADR-222-Diagram-Element-Count-Token.md
@@ -1,0 +1,76 @@
+# ADR-222: Smart-markdown diagram element-count token
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-222 |
+| **Initiative** | Let smart-markdown show a live count of the elements in a referenced view |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-29 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the #242 capability demo, where a "capability count"
+was a hand-typed literal (`{{element:…:attr:…/Capabilities/type=10}}`)
+claiming to be "real … straight from the elements" when it was not — and
+more generally, authors wanting a smart-markdown figure that reflects the
+*actual* contents of a view rather than a number they have to maintain by
+hand,
+
+**facing** that the smart-markdown resolver (ADR-205/209/210) only renders
+entity *fields* and `=value` overrides, and the aggregation engine
+(ADR-212) only sums/counts values already present as tokens — neither can
+count the nodes drawn on a canvas/class diagram,
+
+**we decided to** add a new smart-markdown field-spec on **diagram**
+tokens: `{{diagram:<id>:element_count}}` resolves to the number of
+**element nodes** on that diagram's current canvas — nodes whose
+`data.entityType` is set and is not a structural decoration
+(`diagram_frame` / `note`). The value is wrapped in the usual
+`iris://diagram/<id>` link (ADR-209), so the count is clickable and drills
+into the view it counts. A missing/deleted diagram resolves to `None` →
+the standard strikethrough fallback.
+
+**to achieve** a genuinely live figure: when the view gains or loses
+elements, the rendered count follows on next read (smart-markdown is
+computed on read, ADR-187). For the #242 demo this lets each **zone**
+heading show the real number of capabilities in that zone's view, instead
+of a hand-maintained per-area literal.
+
+**accepting** that:
+- The count is **per referenced view**, so it reflects whatever that view
+  contains. In the #242 demo the views are *zone* diagrams, so the count
+  is a per-zone figure (the demo places it on the zone heading, not on the
+  individual capability-area lines — those would all show the same zone
+  number).
+- "Element node" is defined structurally (has `entityType`, not
+  `diagram_frame`/`note`). It counts drawn nodes, not distinct underlying
+  elements — if the same element is drawn twice it counts twice. This
+  matches "how many things are on this view".
+- This is a **smart-markdown render** feature only. The aggregation engine
+  is unchanged; rollups that want a real count would need a separate
+  follow-up (the engine still only sees tokenised values).
+
+## Rejected alternatives
+
+- **Teach the aggregation engine to count canvas nodes.** Heavier (engine
+  + profile-schema change) and only needed if rollups must sum live
+  counts. Deferred; the demo's need is a single per-zone figure, which a
+  render-time token covers.
+- **Materialise the count into an element attribute.** A stored snapshot
+  isn't live and needs a recompute path; the whole point was to stop
+  hand-maintaining the number.
+
+## Dependencies
+
+- Builds on ADR-205 (smart-markdown tokens) and ADR-209 (`iris://` link
+  wrapping). Related to ADR-221 (an element's detail view is a natural
+  target for this token).
+
+## Consequences
+
+- Spec: SPEC-222-A. New token documented for the picker/help in a
+  follow-up if needed.
+- No migration, no surface-parity impact (render-only).

--- a/docs/adrs/specs/SPEC-222-A-Diagram-Element-Count-Token.md
+++ b/docs/adrs/specs/SPEC-222-A-Diagram-Element-Count-Token.md
@@ -1,0 +1,40 @@
+# SPEC-222-A: Smart-markdown diagram element-count token
+
+Implements **[ADR-222](../ADR-222-Diagram-Element-Count-Token.md)**.
+
+## Token
+
+`{{diagram:<diagram-id>:element_count}}`
+
+Renders the count of element nodes on the diagram's current-version
+canvas, wrapped as `[<count>](iris://diagram/<id> "<diagram name>")`.
+
+## Counting rule
+
+A node counts when `node.data.entityType` is truthy and **not** in the
+structural set `{"diagram_frame", "note"}`. Implemented in
+`backend/app/diagrams/smart_markdown.py`:
+
+- `_STRUCTURAL_NODE_TYPES = {"diagram_frame", "note"}`
+- `_fetch_diagram_element_count(db, diagram_id)` reads the current
+  `diagram_versions.data`, iterates `data.nodes`, returns the count as a
+  string; `None` if the diagram is missing/deleted (→ strikethrough);
+  `"0"` if the canvas has no nodes.
+- `_resolve_one` routes the `diagram` + `element_count` field-spec to the
+  helper; all other `diagram` field-specs still go to `_fetch_named_field`
+  (name/description). The result flows through the existing
+  link-wrapping.
+
+## Acceptance criteria
+
+1. `{{diagram:<id>:element_count}}` renders the number of element nodes,
+   excluding `diagram_frame` and `note` nodes.
+2. The rendered count links to `iris://diagram/<id>`.
+3. A missing/deleted diagram → strikethrough (`~~…~~`), no link.
+
+## Tests
+
+`backend/tests/test_diagrams/test_smart_markdown.py`:
+- `test_diagram_element_count_excludes_notes_and_frame`
+- `test_diagram_element_count_links_to_the_diagram`
+- `test_diagram_element_count_missing_diagram_strikes_through`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.33.1",
+	"version": "6.34.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.33.1"
+version = "6.34.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.33.1"
+version = "6.34.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Adds a `{{diagram:<id>:element_count}}` smart-markdown token that renders a **live** count of the element nodes on a referenced view (excludes `diagram_frame` / `note`), wrapped in an `iris://diagram/<id>` link. Computed on read, so it tracks the view's contents instead of a hand-typed literal.

Motivated by #242 — lets a zone heading show the real number of capabilities in that zone's view.

## Test plan
- [x] `test_diagram_element_count_excludes_notes_and_frame` (counts element nodes, drops frame+note)
- [x] `test_diagram_element_count_links_to_the_diagram`
- [x] `test_diagram_element_count_missing_diagram_strikes_through`
- [x] Full `test_smart_markdown.py` green (45)

Render-only; no migration, no surface-parity impact. ADR-222 / SPEC-222-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)