### PR TITLE
feat(v6.35.0): element meta/tag/count token surface (ADR-223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.35.0] - 2026-05-29
+
+### Added
+
+- **Element metadata, EA tagged-value, and computed-count tokens**
+  (ADR-223, SPEC-223-A). Smart-markdown gains `{{element:<id>:meta:<key>}}`,
+  `{{element:<id>:tag:<property>}}` (strips Sparx EA's `#NOTES#` template
+  suffix; `""` / `"-"` → strikethrough), `{{element:<id>:relationship_count}}`,
+  and `{{element:<id>:diagram_usage_count}}`. The aggregation engine
+  accepts the same as `value_attribute_path` / `bucket_attribute_path`
+  (e.g. `meta/status`, `tag/Maturity`, `relationship_count`,
+  `diagram_usage_count`) and as `output.group_by` (e.g.
+  `element.meta.status`, `element.tag.Maturity`). Unlocks live rollups of
+  Status (Approved/Proposed), hubs by relationship count, orphan / unused
+  capability lists, and Maturity rollups straight off the element row —
+  no engine algorithm change, no migration, no surface-parity impact.
+
 ## [6.34.0] - 2026-05-29
 
 ### Added

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -33,7 +33,13 @@ from app.aggregation.models import (
     TraversalConfig,
 )
 from app.aggregation.profiles_service import get_aggregation_profile
-from app.diagrams.smart_markdown import _TOKEN_RE  # DRY §13
+from app.diagrams.smart_markdown import (  # DRY §13
+    _TOKEN_RE,
+    _extract_tagged_value,
+    _fetch_element_diagram_usage_count,
+    _fetch_element_relationship_count,
+    _parse_metadata,
+)
 
 if TYPE_CHECKING:
     from app.db.adapter import DatabasePort
@@ -268,9 +274,45 @@ async def _resolve_token_value(
     # paths; for other entity types the path doesn't resolve and we
     # return None.
     if token.entity_type == "element":
-        _, _, data = await _read_element_data(db, token.entity_id)
+        eid = token.entity_id
+        # ADR-223: computed counts + metadata + EA tagged values, exposed
+        # to aggregation profiles via well-known paths.
+        if attribute_path == "relationship_count":
+            return await _fetch_element_relationship_count(db, eid)
+        if attribute_path == "diagram_usage_count":
+            return await _fetch_element_diagram_usage_count(db, eid)
+        if attribute_path.startswith("meta/"):
+            key = attribute_path[len("meta/"):]
+            meta = await _fetch_element_metadata_dict(db, eid)
+            v = meta.get(key)
+            if v is None:
+                return None
+            s = str(v).strip()
+            return s or None
+        if attribute_path.startswith("tag/"):
+            prop = attribute_path[len("tag/"):]
+            meta = await _fetch_element_metadata_dict(db, eid)
+            return _extract_tagged_value(meta, prop)
+        _, _, data = await _read_element_data(db, eid)
         return _walk_attr_path(data, attribute_path)
     return None
+
+
+async def _fetch_element_metadata_dict(
+    db: DatabasePort, element_id: str,
+) -> dict[str, Any]:
+    """Read the current-version metadata of an element (ADR-223)."""
+    cursor = await db.execute(
+        "SELECT ev.metadata FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "  AND e.current_version = ev.version "
+        "WHERE e.id = ? AND e.is_deleted = 0",
+        (element_id,),
+    )
+    row = await cursor.fetchone()
+    if not row:
+        return {}
+    return _parse_metadata(row[0])
 
 
 async def _resolve_multiplier(
@@ -412,6 +454,21 @@ async def _resolve_group_value(
         if value is None:
             return ""
         return str(value)
+    # ADR-223: group by metadata, tagged values, or computed counts.
+    if rest == "relationship_count":
+        return str(await _fetch_element_relationship_count(db, token_id))
+    if rest == "diagram_usage_count":
+        return str(await _fetch_element_diagram_usage_count(db, token_id))
+    if rest.startswith("meta."):
+        key = rest[len("meta."):]
+        meta = await _fetch_element_metadata_dict(db, token_id)
+        v = meta.get(key)
+        return "" if v is None else str(v).strip()
+    if rest.startswith("tag."):
+        prop = rest[len("tag."):]
+        meta = await _fetch_element_metadata_dict(db, token_id)
+        v = _extract_tagged_value(meta, prop)
+        return v or ""
     return ""
 
 

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -121,11 +121,90 @@ def _resolve_attr_path(node: Any, segments: list[str]) -> Any | None:
     return node
 
 
+def _parse_metadata(raw: object) -> dict[str, Any]:
+    """Coerce a (possibly JSON-string) metadata blob to a dict."""
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _extract_tagged_value(
+    metadata: dict[str, Any], prop: str,
+) -> str | None:
+    """Resolve ``metadata.tagged_values[*].value`` for a given property
+    name (ADR-223).
+
+    Sparx EA tagged values are imported as
+    ``{"property": "...", "value": "<raw>"}`` and EA encodes its template
+    defaults / option lists with a ``#NOTES#<description>`` suffix on the
+    value (e.g. ``"3#NOTES#Values: 0,1,2,3,4,5..."``). Split on
+    ``#NOTES#`` and return the prefix. EA's ``"-"`` placeholder and the
+    empty string both mean "unset" — those return ``None`` so callers see
+    a strikethrough in render and a skipped row in aggregation.
+    """
+    tvs = metadata.get("tagged_values") if isinstance(metadata, dict) else None
+    if not isinstance(tvs, list):
+        return None
+    for t in tvs:
+        if not isinstance(t, dict) or t.get("property") != prop:
+            continue
+        v = t.get("value")
+        if v is None:
+            return None
+        s = str(v)
+        if "#NOTES#" in s:
+            s = s.split("#NOTES#", 1)[0]
+        s = s.strip()
+        if not s or s == "-":
+            return None
+        return s
+    return None
+
+
+async def _fetch_element_relationship_count(
+    db: DatabasePort, element_id: str,
+) -> int:
+    """ADR-223 — count of element ↔ element relationships involving this
+    element (mirrors elements/service.get_element)."""
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM relationships "
+        "WHERE (source_element_id = ? OR target_element_id = ?) "
+        "AND is_deleted = 0",
+        (element_id, element_id),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
+async def _fetch_element_diagram_usage_count(
+    db: DatabasePort, element_id: str,
+) -> int:
+    """ADR-223 — count of distinct diagrams whose current-version data
+    references this element (mirrors elements/service.get_element)."""
+    cursor = await db.execute(
+        "SELECT COUNT(DISTINCT d.id) FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.is_deleted = 0 AND dv.data LIKE ?",
+        (f"%{element_id}%",),
+    )
+    row = await cursor.fetchone()
+    return int(row[0]) if row else 0
+
+
 async def _fetch_element_field(
     db: DatabasePort, entity_id: str, field_spec: str,
 ) -> str | None:
     cursor = await db.execute(
-        "SELECT ev.name, ev.description, ev.data FROM elements e "
+        "SELECT ev.name, ev.description, ev.data, ev.metadata FROM elements e "
         "JOIN element_versions ev ON e.id = ev.element_id "
         "  AND e.current_version = ev.version "
         "WHERE e.id = ? AND e.is_deleted = 0",
@@ -138,6 +217,28 @@ async def _fetch_element_field(
         return row[0]
     if field_spec == "description":
         return row[1]
+    # ADR-223: element-level token surface for metadata, EA tagged values,
+    # and computed counts.
+    if field_spec == "relationship_count":
+        return str(await _fetch_element_relationship_count(db, entity_id))
+    if field_spec == "diagram_usage_count":
+        return str(await _fetch_element_diagram_usage_count(db, entity_id))
+    if field_spec.startswith("meta:"):
+        key = field_spec[len("meta:"):].strip()
+        if not key:
+            return None
+        meta = _parse_metadata(row[3])
+        v = meta.get(key)
+        if v is None:
+            return None
+        s = str(v) if not isinstance(v, str) else v
+        s = s.strip()
+        return s or None
+    if field_spec.startswith("tag:"):
+        prop = field_spec[len("tag:"):].strip()
+        if not prop:
+            return None
+        return _extract_tagged_value(_parse_metadata(row[3]), prop)
     if field_spec.startswith("attr:"):
         raw_path = field_spec[len("attr:"):]
         segments = [s for s in raw_path.split("/") if s]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.34.0"
+version = "6.35.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_aggregation/test_engine.py
+++ b/backend/tests/test_aggregation/test_engine.py
@@ -77,7 +77,9 @@ async def _create_package(c, h, set_id, name) -> str:
     return r.json()["id"]
 
 
-async def _create_element(c, h, *, set_id, name, package_id=None, data=None) -> str:
+async def _create_element(
+    c, h, *, set_id, name, package_id=None, data=None, metadata=None,
+) -> str:
     body = {
         "name": name, "element_type": "class", "set_id": set_id,
     }
@@ -85,6 +87,8 @@ async def _create_element(c, h, *, set_id, name, package_id=None, data=None) -> 
         body["data"] = data
     if package_id is not None:
         body["package_id"] = package_id
+    if metadata is not None:
+        body["metadata"] = metadata
     r = await c.post("/api/elements", json=body, headers=h)
     assert r.status_code == 201, r.text
     return r.json()["id"]
@@ -654,3 +658,126 @@ async def test_blank_value_skipped(
         dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
     )
     assert result.row_count == 0
+
+
+# ── ADR-223: aggregation over metadata, tagged values, counts ────────
+
+
+@pytest.mark.asyncio
+async def test_adr223_sum_relationship_count_grouped_by_meta_status(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """Sum relationship_count grouped by element.meta.status — exercises
+    both the new value path (`relationship_count`) and the new group_by
+    path (`element.meta.<key>`)."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    a = await _create_element(
+        c, h, set_id=set_id, name="A", metadata={"status": "Approved"},
+    )
+    b = await _create_element(
+        c, h, set_id=set_id, name="B", metadata={"status": "Proposed"},
+    )
+    # One relationship A ↔ B → each has relationship_count == 1.
+    r = await c.post(
+        "/api/relationships",
+        json={
+            "source_element_id": a, "target_element_id": b,
+            "relationship_type": "association",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    diag_id = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{a}:name}}}}\n- {{{{element:{b}:name}}}}",
+    )
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="rels by status", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {"inner": {
+                "collect_token_type": "element",
+                "value_attribute_path": "relationship_count",
+                "bucket_attribute_path": None,
+                "skip_blank_values": True,
+            }},
+            "output": {
+                "group_by": "element.meta.status",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+                "show_per_source_breakdown": False,
+                "breakdown_format": "",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    md = result.markdown
+    assert "## Approved" in md
+    assert "## Proposed" in md
+    assert "A: 1" in md
+    assert "B: 1" in md
+
+
+@pytest.mark.asyncio
+async def test_adr223_sum_tag_value_with_notes_suffix(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """A `tag:<property>` value path resolves EA tagged values and strips
+    the `#NOTES#` template suffix so they're summable. An EA "-"
+    placeholder is treated as unset and skipped under skip_blank_values."""
+    c, dm, h = env
+    set_id = await _create_set(c, h)
+    a = await _create_element(
+        c, h, set_id=set_id, name="A",
+        metadata={"tagged_values": [
+            {"property": "Maturity", "value": "3#NOTES#Values: 0..5"},
+        ]},
+    )
+    b = await _create_element(
+        c, h, set_id=set_id, name="B",
+        metadata={"tagged_values": [
+            {"property": "Maturity", "value": "-#NOTES#unset"},
+        ]},
+    )
+    diag_id = await _create_smart_md(
+        c, h, set_id,
+        f"- {{{{element:{a}:name}}}}\n- {{{{element:{b}:name}}}}",
+    )
+    profile = await create_aggregation_profile(
+        dm.main_db,
+        name="maturity by name", description=None,
+        set_id=None, is_global=True,
+        profile_data={
+            "traversal": {"inner": {
+                "collect_token_type": "element",
+                "value_attribute_path": "tag/Maturity",
+                "bucket_attribute_path": None,
+                "skip_blank_values": True,
+            }},
+            "output": {
+                "group_by": "element.name",
+                "sort_groups": "alpha",
+                "sort_items_within_group": "alpha",
+                "aggregation_fn": "sum",
+                "line_format": "- {element.name}: {sum_value}",
+                "show_per_source_breakdown": False,
+                "breakdown_format": "",
+            },
+        },
+        is_default_for_set=False, created_by=None,
+    )
+    result = await _engine.run(
+        dm.main_db, profile_id=profile["id"], source_diagram_id=diag_id,
+    )
+    md = result.markdown
+    # A's "3#NOTES#..." → resolves to 3 and contributes a row.
+    assert "A: 3" in md
+    # B's "-#NOTES#..." → treated as unset → no row (skip_blank_values).
+    assert "B:" not in md

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -85,12 +85,15 @@ async def _create_set(c: httpx.AsyncClient, h: dict[str, str], name: str = "S") 
 async def _create_element(
     c: httpx.AsyncClient, h: dict[str, str], set_id: str, *,
     name: str, description: str | None = None, data: dict | None = None,
+    metadata: dict | None = None,
 ) -> str:
     body: dict = {"name": name, "element_type": "application", "set_id": set_id}
     if description is not None:
         body["description"] = description
     if data is not None:
         body["data"] = data
+    if metadata is not None:
+        body["metadata"] = metadata
     r = await c.post("/api/elements", json=body, headers=h)
     assert r.status_code == 201
     return r.json()["id"]
@@ -896,3 +899,122 @@ async def test_override_on_attr_path_with_nested_segments(
     )
     rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
     assert _unwrap_iris_links(rendered) == "2.5"
+
+
+# ── ADR-223: element metadata, EA tagged values, and computed counts ──
+
+
+@pytest.mark.asyncio
+async def test_meta_returns_metadata_value(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X", metadata={"status": "Approved"},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"Status: {{{{element:{eid}:meta:status}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "Status: Approved"
+
+
+@pytest.mark.asyncio
+async def test_meta_missing_key_strikes_through(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X", metadata={"status": "Approved"},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"X {{{{element:{eid}:meta:bogus}}}} Y",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_tag_strips_notes_suffix(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X",
+        metadata={"tagged_values": [
+            {"property": "Maturity", "value": "3#NOTES#Values: 0..5"},
+        ]},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"M: {{{{element:{eid}:tag:Maturity}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "M: 3"
+
+
+@pytest.mark.asyncio
+async def test_tag_dash_placeholder_strikes_through(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X",
+        metadata={"tagged_values": [
+            {"property": "Maturity", "value": "-#NOTES#unset"},
+        ]},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"M {{{{element:{eid}:tag:Maturity}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_relationship_count_returns_count(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    a = await _create_element(c, h, set_id, name="A")
+    b = await _create_element(c, h, set_id, name="B")
+    r = await c.post(
+        "/api/relationships",
+        json={
+            "source_element_id": a, "target_element_id": b,
+            "relationship_type": "association",
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"A has {{{{element:{a}:relationship_count}}}} rels",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered) == "A has 1 rels"
+
+
+@pytest.mark.asyncio
+async def test_diagram_usage_count_returns_count(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="A")
+    # Draw the element on a canvas diagram → diagram_usage_count >= 1.
+    await _create_canvas_diagram(
+        c, h, set_id, nodes=[_node("n", "class", entity_id=eid)],
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"On {{{{element:{eid}:diagram_usage_count}}}} diagrams",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # The diagram_usage_count uses `data LIKE '%<id>%'`, so the canvas
+    # diagram counts, and so does this smart_markdown diagram (its
+    # markdown_source contains the element id verbatim in the token) =>
+    # the count is 2.
+    assert _unwrap_iris_links(rendered) == "On 2 diagrams"

--- a/docs/adrs/ADR-223-Element-Metadata-Tag-Count-Tokens.md
+++ b/docs/adrs/ADR-223-Element-Metadata-Tag-Count-Tokens.md
@@ -1,0 +1,98 @@
+# ADR-223: Element metadata, EA tagged-value, and computed-count tokens
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-223 |
+| **Initiative** | Expose element metadata, Sparx EA tagged values, and computed counts to smart-markdown and aggregation |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-29 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** wanting to build dashboards and rollups over the
+**actual model state** in Iris — Status (Approved/Proposed), Sparx EA
+tagged values (Maturity, Last Review Date, etc.), connection density
+(`relationship_count`), and reuse (`diagram_usage_count`) — rather than
+hand-typed numbers; and finding that the smart-markdown resolver
+(ADR-205/210) only walks ``element.data.attributes`` and the aggregation
+engine (ADR-212) only resolves attribute paths,
+
+**facing** that the data we want lives elsewhere on the element row:
+- `element.metadata` carries `status`, `stereotype`, `author`, dates, and
+  — for Sparx imports — a `tagged_values` array of `{property, value}`
+  pairs. EA encodes its template defaults / option lists with a
+  ``#NOTES#<description>`` suffix on the value, so a populated maturity
+  level reads as ``"3#NOTES#Values: 0..5..."`` and an unset one reads as
+  ``"-#NOTES#..."``.
+- `relationship_count` and `diagram_usage_count` are derived counts the
+  element service already computes, but they're inaccessible to
+  smart-markdown / aggregation,
+
+**we decided to** add a small token-surface extension on `element`
+tokens — three new field-spec families, accepted by both the
+smart-markdown resolver (field-spec `:`-form) and the aggregation engine
+(path `/`-form for `value_attribute_path` / `bucket_attribute_path`, and
+dot-form for `group_by`):
+
+| Concept | Smart-markdown field-spec | Engine value path | Engine group_by |
+|---|---|---|---|
+| Metadata key | `meta:<key>` | `meta/<key>` | `element.meta.<key>` |
+| EA tagged value | `tag:<property>` | `tag/<property>` | `element.tag.<property>` |
+| Relationship count | `relationship_count` | `relationship_count` | `element.relationship_count` |
+| Diagram usage count | `diagram_usage_count` | `diagram_usage_count` | `element.diagram_usage_count` |
+
+**to achieve** a single, small token-surface change that unlocks live
+rollups of *all* of: Status distribution by zone, hub elements ranked by
+`relationship_count`, orphan lists (`diagram_usage_count == 0`),
+documentation coverage (description present), and Maturity rollups
+(populated `Current Maturity Level` tagged values). All of it via the
+existing aggregation engine, with no engine algorithm changes — only
+new resolvers behind the same `_resolve_token_value` / `_resolve_group_value`
+abstractions.
+
+**accepting** that:
+- The EA tagged-value resolver **strips the ``#NOTES#`` suffix** and
+  treats the empty string and the literal ``"-"`` (EA's "unset"
+  placeholder) as None — so unset values render as strikethrough in
+  smart-markdown and are skipped under `skip_blank_values: true` in
+  aggregation. Populated values pass through as-is.
+- `diagram_usage_count` uses the same `data LIKE '%<id>%'` substring
+  match as `elements/service.get_element` — so a smart-markdown source
+  that references an element via a token counts as a "usage" of that
+  element. This is consistent with the existing counter; we did not
+  redefine the metric.
+- This is a **read-only surface** addition: no migration, no surface
+  parity impact (no new write op), no aggregation algorithm change.
+- Caching: each resolution does its own SQL read. For dashboards over
+  ~50 elements the round-trip is negligible; if a future profile fans
+  out to thousands, a per-run cache (mirroring the existing
+  `element_cache` in `_format_output`) is the next step.
+
+## Rejected alternatives
+
+- **Materialise the values into `element.data.attributes`.** A copy that
+  goes stale. The engine would work today against them, but maintaining
+  parity with the source-of-truth on the element row is extra plumbing.
+- **A bespoke "model health" report endpoint.** Hard-codes the questions
+  we asked today and gives the user no way to ask new ones. Tokens
+  compose with smart-markdown and aggregation, so any new question is a
+  new profile or markdown source, not new code.
+
+## Dependencies
+
+- Builds on ADR-205/210 (smart-markdown tokens & overrides), ADR-209
+  (`iris://` link wrapping), ADR-212/213 (aggregation engine and the
+  `aggregation_list` synth-on-read surface), ADR-221 (`detail_diagram_id`
+  is a `meta:` candidate — currently a column, but the pattern is the
+  same), and ADR-222 (the `element_count` precedent for non-attribute
+  token resolution).
+
+## Consequences
+
+- Spec: SPEC-223-A.
+- New profiles authorable for: Status rollup, hub list, orphan list,
+  maturity rollup (when values are populated), documentation coverage
+  (via a follow-up "is-empty" predicate if wanted later).

--- a/docs/adrs/specs/SPEC-223-A-Element-Metadata-Tag-Count-Tokens.md
+++ b/docs/adrs/specs/SPEC-223-A-Element-Metadata-Tag-Count-Tokens.md
@@ -1,0 +1,79 @@
+# SPEC-223-A: Element metadata, EA tagged-value, and computed-count tokens
+
+Implements **[ADR-223](../ADR-223-Element-Metadata-Tag-Count-Tokens.md)**.
+
+## Smart-markdown field-specs (on `element` tokens)
+
+| Field-spec | Resolves to | Notes |
+|---|---|---|
+| `meta:<key>` | `element.metadata[<key>]` as string | Empty / whitespace → strikethrough |
+| `tag:<property>` | EA tagged value `metadata.tagged_values[where property==<property>].value` | Strips `#NOTES#…` suffix; `""` and `"-"` → strikethrough |
+| `relationship_count` | `COUNT(*) FROM relationships WHERE (source_element_id=<id> OR target_element_id=<id>) AND is_deleted=0` | |
+| `diagram_usage_count` | `COUNT(DISTINCT d.id) … data LIKE '%<id>%'` | Same metric as `elements/service.get_element` |
+
+Resolved values pass through `_resolve_one`'s ADR-209 link wrapping → the
+output is an `iris://element/<id>` markdown link with the value as the
+visible text.
+
+## Aggregation engine paths (`value_attribute_path` / `bucket_attribute_path`)
+
+`/`-form on `element` tokens:
+
+| Path | Resolves to |
+|---|---|
+| `meta/<key>` | metadata key |
+| `tag/<property>` | tagged value (with `#NOTES#` strip + `-`/empty → None) |
+| `relationship_count` | computed count |
+| `diagram_usage_count` | computed count |
+
+Anything else falls through to the existing `element.data` walker.
+
+## Aggregation engine `output.group_by`
+
+Dot-form, prefixed `element.`:
+
+| `group_by` | Group key |
+|---|---|
+| `element.meta.<key>` | metadata key |
+| `element.tag.<property>` | tagged value |
+| `element.relationship_count` | computed count (stringified) |
+| `element.diagram_usage_count` | computed count (stringified) |
+
+Existing `element.name`, `element.package_name`, `element.attributes.*`
+all keep working.
+
+## Code anchors
+
+- `backend/app/diagrams/smart_markdown.py`:
+  - `_parse_metadata`, `_extract_tagged_value`,
+    `_fetch_element_relationship_count`,
+    `_fetch_element_diagram_usage_count` — new shared helpers.
+  - `_fetch_element_field` — branches on the new field-specs; selects
+    `ev.metadata` alongside name/description/data.
+- `backend/app/aggregation/engine.py`:
+  - Imports the helpers above (§13 DRY).
+  - `_fetch_element_metadata_dict` — engine-side metadata reader.
+  - `_resolve_token_value` — branches on `meta/`, `tag/`,
+    `relationship_count`, `diagram_usage_count` before falling through to
+    the existing data walker.
+  - `_resolve_group_value` — branches on `meta.`, `tag.`, and the two
+    counts before falling through to the existing `attributes.` walker.
+
+## Acceptance criteria
+
+1. `{{element:<id>:meta:<key>}}` renders the metadata value, linked to
+   the element; missing key strikes through.
+2. `{{element:<id>:tag:<property>}}` returns the tagged value with the
+   `#NOTES#` suffix stripped; empty / `-` → strikethrough.
+3. `{{element:<id>:relationship_count}}` and
+   `{{element:<id>:diagram_usage_count}}` render the computed counts.
+4. Aggregation profiles can `value_attribute_path` and `group_by` against
+   any of the new paths. End-to-end: sum `relationship_count` grouped by
+   `element.meta.status` produces a per-status breakdown.
+
+## Tests
+
+- `backend/tests/test_diagrams/test_smart_markdown.py` — six new cases
+  cover each field-spec and its strikethrough fallback.
+- `backend/tests/test_aggregation/test_engine.py` — two integration
+  tests exercise the new value/group paths end-to-end.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.34.0",
+	"version": "6.35.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.34.0"
+version = "6.35.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.34.0"
+version = "6.35.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Three new element token field-spec families, on both smart-markdown and the aggregation engine — unlocks live rollups straight off the element row instead of hand-typed numbers.

| Concept | Smart-markdown | Engine value path | Engine group_by |
|---|---|---|---|
| Metadata key | `meta:<key>` | `meta/<key>` | `element.meta.<key>` |
| EA tagged value | `tag:<property>` | `tag/<property>` | `element.tag.<property>` |
| Relationship count | `relationship_count` | `relationship_count` | `element.relationship_count` |
| Diagram usage count | `diagram_usage_count` | `diagram_usage_count` | `element.diagram_usage_count` |

Sparx EA's `#NOTES#` template suffix is stripped on tagged values; `""` and `"-"` (EA's "unset" placeholder) → strikethrough in render, skipped under `skip_blank_values` in aggregation.

DRY (§13): helpers live in `smart_markdown` and the engine imports them. No engine algorithm change, no migration, no surface-parity impact.

## Test plan
- [x] `test_smart_markdown.py` — 6 new cases for each field-spec + strikethrough fallback. All green.
- [x] `test_engine.py` — 2 integration tests exercising sum + group_by over the new paths. Green.
- [x] Existing 51 smart-markdown + 10 engine tests still green (63 total).

ADR-223 + SPEC-223-A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)