### PR TITLE
feat(v6.36.0): smart-markdown :raw modifier (ADR-224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.36.0] - 2026-05-29
+
+### Added
+
+- **Smart-markdown `:raw` modifier** (ADR-224, SPEC-224-A). A trailing
+  `:raw` on any token's field-spec returns the resolved value **without**
+  the `iris://` markdown-link wrap (ADR-209), so tokens can be embedded
+  inside fenced code blocks (Mermaid `pie` / `xychart-beta` / `flowchart`)
+  where the link syntax would otherwise break the parser. Composes with
+  every existing token form — `meta:`, `tag:`, `attr:`, the ADR-210
+  `=value` override, the ADR-221 `detail_diagram` short-circuit, the
+  ADR-222 `element_count`, and so on. Lets dashboard charts drive their
+  values live from the model.
+
 ## [6.35.0] - 2026-05-29
 
 ### Added

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -417,7 +417,7 @@ def _markdown_escape_title(value: str) -> str:
 
 
 async def _resolve_element_detail_diagram(
-    db: DatabasePort, element_id: str,
+    db: DatabasePort, element_id: str, *, raw_mode: bool = False,
 ) -> str | None:
     """Resolve ``{{element:<id>:detail_diagram}}`` (ADR-221).
 
@@ -426,6 +426,10 @@ async def _resolve_element_detail_diagram(
     markdown drills into the diagram that elaborates the element. Returns
     ``None`` (→ strikethrough) when the element has no detail diagram, or
     the target diagram is missing/soft-deleted.
+
+    ADR-224 (v6.36.0): with ``raw_mode=True`` (set by a trailing ``:raw``
+    on the token's field-spec), the diagram name is returned unwrapped so
+    the value can be embedded inside Mermaid fenced code blocks etc.
     """
     cursor = await db.execute(
         "SELECT detail_diagram_id FROM elements "
@@ -439,6 +443,8 @@ async def _resolve_element_detail_diagram(
     name = await _fetch_entity_display_name(db, "diagram", detail_id)
     if name is None:
         return None
+    if raw_mode:
+        return name
     title = _markdown_escape_title(name)
     text = _markdown_escape_link_text(name)
     return f'[{text}](iris://diagram/{detail_id} "{title}")'
@@ -520,11 +526,24 @@ async def _resolve_one(
     if field_spec is None or field_spec == "":
         return None
 
+    # ADR-224 (v6.36.0): a trailing ``:raw`` modifier returns the resolved
+    # value without the iris:// markdown-link wrap. Useful for embedding
+    # a token's value inside a fenced code block (e.g. Mermaid) where the
+    # ``[N](iris://…)`` link syntax would break the renderer.
+    raw_mode = False
+    if field_spec.endswith(":raw"):
+        raw_mode = True
+        field_spec = field_spec[:-len(":raw")]
+        if field_spec == "":
+            return None
+
     # ADR-221: an element's detail-diagram drill. Resolves to a link to
     # the *target diagram*, not the element — so it's handled before the
     # generic element-field path (which would wrap in an element link).
     if entity_type == "element" and field_spec == "detail_diagram":
-        return await _resolve_element_detail_diagram(db, entity_id)
+        return await _resolve_element_detail_diagram(
+            db, entity_id, raw_mode=raw_mode,
+        )
 
     # ADR-210: parse inline =value override.
     field_spec_path: str = field_spec
@@ -566,13 +585,18 @@ async def _resolve_one(
     if raw_value is None:
         return None
 
-    # Wrap in an iris:// markdown link so the rendered output is a
-    # clickable, tooltip-bearing reference to the source entity.
     # ADR-210: even with an override, look up the entity to confirm it
     # exists — a dangling reference should strike through regardless.
     name = await _fetch_entity_display_name(db, entity_type, entity_id)
     if name is None:
         return None
+
+    # ADR-224: raw mode returns the plain value (no markdown-link wrap).
+    if raw_mode:
+        return str(raw_value)
+
+    # Wrap in an iris:// markdown link so the rendered output is a
+    # clickable, tooltip-bearing reference to the source entity.
     title = _markdown_escape_title(name)
     text = _markdown_escape_link_text(str(raw_value))
     return f'[{text}](iris://{entity_type}/{entity_id} "{title}")'

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.35.0"
+version = "6.36.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -1018,3 +1018,110 @@ async def test_diagram_usage_count_returns_count(
     # markdown_source contains the element id verbatim in the token) =>
     # the count is 2.
     assert _unwrap_iris_links(rendered) == "On 2 diagrams"
+
+
+# ── ADR-224: :raw modifier (unwrapped values for Mermaid etc.) ───────
+
+
+@pytest.mark.asyncio
+async def test_raw_modifier_returns_unwrapped_name(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """A plain `:raw` suffix returns the value without the iris:// link
+    wrap — usable inside Mermaid fenced code blocks."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="Pork mince")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"Buy some {{{{element:{eid}:name:raw}}}} today.",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # No iris:// link wrapping.
+    assert rendered.strip() == "Buy some Pork mince today."
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_raw_modifier_with_meta_status(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(
+        c, h, set_id, name="X", metadata={"status": "Approved"},
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"S: {{{{element:{eid}:meta:status:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "S: Approved"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_raw_modifier_with_diagram_element_count(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    zone_id = await _create_canvas_diagram(
+        c, h, set_id, nodes=[
+            _node("c1", "capability", entity_id="e1"),
+            _node("c2", "capability", entity_id="e2"),
+        ],
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"N={{{{diagram:{zone_id}:element_count:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "N=2"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_raw_modifier_with_detail_diagram(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """`detail_diagram:raw` returns the *diagram* name (the target), not
+    the element's name — without link wrapping."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    target = await _create_canvas_diagram(c, h, set_id, nodes=[])
+    # Rename the diagram so we can distinguish.
+    r = await c.put(
+        f"/api/diagrams/{target}",
+        json={"name": "Detail Zone", "data": {"nodes": [], "edges": []}},
+        headers={**h, "If-Match": "1"},
+    )
+    assert r.status_code == 200, r.text
+    eid = await _create_element(c, h, set_id, name="X")
+    # Wire the detail diagram via PUT.
+    r = await c.put(
+        f"/api/elements/{eid}",
+        json={"name": "X", "data": {}, "detail_diagram_id": target},
+        headers={**h, "If-Match": "1"},
+    )
+    assert r.status_code == 200, r.text
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"D: {{{{element:{eid}:detail_diagram:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "D: Detail Zone"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_without_raw_modifier_still_wraps(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """Regression: omitting `:raw` keeps the existing link-wrap behaviour."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    eid = await _create_element(c, h, set_id, name="Pork mince")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id, f"Buy some {{{{element:{eid}:name}}}} today.",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Link is present.
+    assert f"iris://element/{eid}" in rendered
+    assert _unwrap_iris_links(rendered).strip() == "Buy some Pork mince today."

--- a/docs/adrs/ADR-224-Raw-Token-Modifier.md
+++ b/docs/adrs/ADR-224-Raw-Token-Modifier.md
@@ -1,0 +1,79 @@
+# ADR-224: Smart-markdown `:raw` modifier
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-224 |
+| **Initiative** | Let smart-markdown tokens be embedded inside Mermaid fenced code blocks |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-29 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** wanting smart-markdown dashboards to drive **Mermaid
+charts** (pie / xychart-beta / flowchart) from live model state — counts
+of approved capabilities, per-zone element counts, hub relationship
+counts — so the charts track the model instead of being a snapshot,
+
+**facing** that smart-markdown resolves tokens BEFORE the markdown
+renderer hits fenced code blocks, and the resolver wraps every value in
+an ``[N](iris://…)`` markdown link (ADR-209). That link syntax is
+correct for prose but **breaks Mermaid's parser** inside a ` ```mermaid `
+block, so today's chart values have to be hand-typed,
+
+**we decided to** add a tiny modifier to the token grammar: a trailing
+``:raw`` suffix on the field-spec returns the resolved value **without**
+the iris:// link wrap.
+
+  - `{{element:<id>:meta:status:raw}}` → `Approved`
+  - `{{element:<id>:relationship_count:raw}}` → `19`
+  - `{{diagram:<id>:element_count:raw}}` → `13`
+  - `{{element:<id>:detail_diagram:raw}}` → `CSE.00 Security capability zone`
+
+Stripping happens **before** the ADR-210 ``=value`` override split and
+before the ADR-221 ``detail_diagram`` special-case, so the modifier
+composes with every existing token form. Outside fenced blocks the
+default link-wrapped form is unchanged.
+
+**to achieve** a one-line authoring change for any chart that wants live
+numbers — wrap the chart's value with `{{…:raw}}` instead of hand-typing
+it. No new tokens, no new entity types, no schema change.
+
+**accepting** that:
+- The ``:raw`` value carries no link, so the reader can't click through
+  to the source — that's the point inside a chart, but it's a UX
+  trade-off the author chooses per use. Outside fenced blocks, the
+  default (link-wrapped) form remains the right pick.
+- Aggregation engine values are already unwrapped, so the engine needs
+  no change. The modifier is a render-time concern only.
+- The modifier is on the **trailing** end of the field-spec. So
+  ``meta:status:raw`` parses as field-spec ``meta:status`` with raw on.
+  Reserving the literal token suffix ``:raw`` means a hypothetical
+  future field named ``raw`` would collide; not a concern today
+  (no such field exists), and we keep the option of a non-suffix
+  alternative (``{{!element:…}}``, etc.) if it ever comes up.
+
+## Rejected alternatives
+
+- **Skip token substitution inside fenced code blocks.** Cleaner in
+  theory — Mermaid blocks would be inert — but it ALSO loses the live
+  numbers we wanted there. The whole point was to inject live values.
+- **A separate token prefix** (``{{=element:…}}`` or ``{{!element:…}}``).
+  Cleaner grammatically but it duplicates every existing token form;
+  the suffix modifier is one regex, one branch.
+
+## Dependencies
+
+- Builds on ADR-205 (smart-markdown tokens) and ADR-209 (the link wrap
+  this modifier suppresses). Composes with ADR-210 (``=value``
+  overrides) and the special-case resolvers in ADR-221 / ADR-222 /
+  ADR-223.
+
+## Consequences
+
+- Spec: SPEC-224-A.
+- No migration, no surface-parity impact, no engine algorithm change.
+- Authors can now make Mermaid pie/bar/flowchart values dynamic against
+  the model.

--- a/docs/adrs/specs/SPEC-224-A-Raw-Token-Modifier.md
+++ b/docs/adrs/specs/SPEC-224-A-Raw-Token-Modifier.md
@@ -1,0 +1,59 @@
+# SPEC-224-A: Smart-markdown `:raw` modifier
+
+Implements **[ADR-224](../ADR-224-Raw-Token-Modifier.md)**.
+
+## Grammar
+
+Any smart-markdown token's field-spec gains an optional trailing `:raw`
+modifier:
+
+```
+{{<entity-type>:<id>:<field-spec>[:raw]}}
+```
+
+With `:raw` present, the resolver returns the **plain string value**.
+Without it, the existing ADR-209 link-wrapped form is returned
+unchanged.
+
+## Code anchors
+
+- `backend/app/diagrams/smart_markdown.py`:
+  - `_resolve_one` strips a trailing `:raw` from `field_spec` **before**
+    the ADR-221 `detail_diagram` short-circuit and **before** the
+    ADR-210 `=value` override split, then sets a `raw_mode` flag for
+    the wrap step.
+  - At the wrap step, when `raw_mode` is true the resolved value is
+    returned plain (not wrapped in `[…](iris://…)`).
+  - `_resolve_element_detail_diagram(..., raw_mode=False)` honours the
+    flag and returns the target diagram name unwrapped when set.
+- Aggregation engine: unchanged. Its values are already unwrapped.
+
+## Composition
+
+- `{{element:<id>:name:raw}}` → `Cyber Security`
+- `{{element:<id>:meta:status:raw}}` → `Approved`
+- `{{element:<id>:relationship_count:raw}}` → `19`
+- `{{diagram:<id>:element_count:raw}}` → `13`
+- `{{element:<id>:detail_diagram:raw}}` → `CSE.00 Security capability zone`
+- `{{element:<id>:attr:attributes/Capabilities/type=10:raw}}` → `10`
+  (the ADR-210 override still applies; the `:raw` strip happens first)
+- Token without `:raw` keeps existing wrap behaviour (regression).
+
+## Acceptance criteria
+
+1. A token ending in `:raw` resolves to the plain string value (no
+   `iris://` link in the output).
+2. A token without `:raw` keeps the existing link-wrap behaviour
+   verbatim.
+3. The modifier composes with `meta:`, `tag:`, `attr:`, `:element_count`,
+   `:detail_diagram`, the ADR-210 `=value` override, and the ADR-222
+   `diagram:<id>:element_count`.
+
+## Tests
+
+`backend/tests/test_diagrams/test_smart_markdown.py`:
+- `test_raw_modifier_returns_unwrapped_name`
+- `test_raw_modifier_with_meta_status`
+- `test_raw_modifier_with_diagram_element_count`
+- `test_raw_modifier_with_detail_diagram`
+- `test_without_raw_modifier_still_wraps` (regression)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.35.0",
+	"version": "6.36.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.35.0"
+version = "6.36.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.35.0"
+version = "6.36.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Trailing `:raw` on a token's field-spec returns the value **without** the `iris://` link wrap (ADR-209) — so smart-markdown tokens can be embedded inside Mermaid fenced code blocks (pie / xychart-beta / flowchart) where the link syntax would break the parser.

Composes with everything: `meta:`, `tag:`, `attr:`, ADR-210 `=value` overrides, ADR-221 `detail_diagram`, ADR-222 `element_count`. Strip happens before override split. Outside fenced blocks the default link-wrap remains.

## Test plan
- [x] 4 new positive tests (name, meta:status, diagram:element_count, detail_diagram) + 1 regression test confirming no `:raw` still wraps. All green.
- [x] Existing 51 smart-markdown tests still green (56 total).

ADR-224 / SPEC-224-A. Render-only; no migration, no surface-parity impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)