### PR TITLE
fix(v6.36.1): MCP + CLI update_element forward metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.36.1] - 2026-05-29
+
+### Fixed
+
+- **MCP `update_element` and CLI `iris update element` now forward `metadata`**.
+  The backend `ElementUpdate` model already accepted `metadata`; the MCP
+  surface (`_ELEMENT_UPDATE_FIELDS`) and the CLI command (`--metadata-json`)
+  were missing it. Lets agents and scripts edit Sparx EA tagged values,
+  status, and other element metadata via the standard surfaces. No new
+  write op, no schema impact beyond exposing the existing backend field.
+
 ## [6.36.0] - 2026-05-29
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.36.0"
+version = "6.36.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -1060,6 +1060,15 @@ def update_element_cmd(
     name: str | None = typer.Option(None, "--name"),
     description: str | None = typer.Option(None, "--description"),
     data_json: str | None = typer.Option(None, "--data-json"),
+    metadata_json: str | None = typer.Option(
+        None, "--metadata-json",
+        help=(
+            "Replacement metadata for the element as a JSON object "
+            "(e.g. Sparx EA fields like status, stereotype, "
+            "tagged_values). Replaces the stored value; omit to leave "
+            "unchanged."
+        ),
+    ),
     package_id: str | None = typer.Option(
         None, "--package-id",
         help=(
@@ -1084,6 +1093,7 @@ def update_element_cmd(
     partial: dict[str, Any] = {
         "name": name, "description": description,
         "data": _parse_json_opt(data_json, "--data-json"),
+        "metadata": _parse_json_opt(metadata_json, "--metadata-json"),
     }
     # package_id / detail_diagram_id are tri-state at the PUT body level:
     # include the key to set (string) or clear (null), omit to leave
@@ -1101,7 +1111,7 @@ def update_element_cmd(
             current_resp = await c._request("GET", f"/api/elements/{element_id}")
             current = current_resp.json()
             body: dict[str, Any] = {}
-            for field in ("name", "description", "data"):
+            for field in ("name", "description", "data", "metadata"):
                 if field in partial and partial[field] is not None:
                     body[field] = partial[field]
                 elif field in current:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.36.0",
+	"version": "6.36.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.36.0"
+version = "6.36.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.36.0"
+version = "6.36.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -863,7 +863,7 @@ _SET_UPDATE_FIELDS = (
 _SET_METADATA_FIELDS = tuple(f for f in _SET_UPDATE_FIELDS if f != "collection_id")
 _PACKAGE_UPDATE_FIELDS = ("name", "description", "metadata")
 _DIAGRAM_UPDATE_FIELDS = ("name", "description", "data", "metadata", "change_summary")
-_ELEMENT_UPDATE_FIELDS = ("name", "description", "data")
+_ELEMENT_UPDATE_FIELDS = ("name", "description", "data", "metadata")
 _ELEMENT_UPDATE_FIELDS_WITH_PACKAGE = (
     "name", "description", "data", "package_id",
 )
@@ -2408,6 +2408,19 @@ TOOLS: list[Tool] = [
             "description": _str_arg("description", "New description", required=False),
             "data": (
                 {"type": "object", "additionalProperties": True},
+                False,
+            ),
+            "metadata": (
+                {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": (
+                        "Replacement metadata for the element (e.g. "
+                        "Sparx EA fields like status, stereotype, "
+                        "tagged_values). Pass the full object — it "
+                        "replaces the stored value. Omit to leave unchanged."
+                    ),
+                },
                 False,
             ),
             "package_id": (

--- a/mcp/tests/test_element_detail_diagram.py
+++ b/mcp/tests/test_element_detail_diagram.py
@@ -131,3 +131,45 @@ class TestUpdateForwarding:
         body = json.loads(put.calls[0].request.content)
         assert "detail_diagram_id" in body
         assert body["detail_diagram_id"] is None
+
+
+# ── v6.36.1: update_element forwards metadata (surface parity fix) ───
+
+
+class TestMetadataForwarding:
+    def test_update_schema_includes_metadata(self) -> None:
+        defs = {t.name: t for t in tools.tool_definitions()}
+        props = defs["update_element"].inputSchema["properties"]
+        assert "metadata" in props
+        assert "metadata" not in defs["update_element"].inputSchema.get(
+            "required", [],
+        )
+
+    @pytest.mark.anyio
+    async def test_forwards_metadata_in_put_body(
+        self, respx_mock: respx.Router,
+    ) -> None:
+        """The handler merges via `_put_merge_partial` (no tristate keys)
+        and now includes ``metadata`` in `_ELEMENT_UPDATE_FIELDS`."""
+        respx_mock.get(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(
+                200, json=_element_response(current_version=1),
+            ),
+        )
+        put = respx_mock.put(f"{BASE}/api/elements/el1").mock(
+            return_value=httpx.Response(
+                200, json=_element_response(current_version=2),
+            ),
+        )
+        new_meta = {
+            "status": "Approved",
+            "tagged_values": [
+                {"property": "Current Maturity Level", "value": "3"},
+            ],
+        }
+        async with IrisClient(BASE) as c:
+            await tools._update_element(
+                c, {"element_id": "el1", "metadata": new_meta},
+            )
+        body = json.loads(put.calls[0].request.content)
+        assert body["metadata"] == new_meta


### PR DESCRIPTION
Surface-parity fix: the backend ElementUpdate already accepted `metadata`; the MCP `update_element` and CLI `iris update element` were missing it. One-line addition to `_ELEMENT_UPDATE_FIELDS` (MCP) + `--metadata-json` option (CLI). 2 new MCP tests; existing surface-parity check still clean.