### PR TITLE
fix(v6.36.2): aggregation-list edit-mode picker spam (422 loop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.36.2] - 2026-05-30
+
+### Fixed
+
+- **Aggregation-list edit-mode picker no longer spams the API**
+  (`AggregationListCanvas.svelte`). Two bugs combined into a runaway
+  request loop on the picker:
+  - The source-diagram fetch sent `page_size=200`, but the backend
+    `/api/diagrams` endpoint caps `page_size` at 100 and returned 422
+    Unprocessable Content on every call.
+  - The `$effect` that triggers the load re-fired whenever
+    `diagrams.length === 0`, which the failed fetch could never
+    populate — producing an infinite retry loop until the user
+    closed the page.
+  Capped the request at `page_size=100` and added one-shot
+  `triedDiagrams` / `triedProfiles` guards so the picker attempts at
+  most one fetch per editing-toggle, regardless of outcome.
+
 ## [6.36.1] - 2026-05-29
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.36.1"
+version = "6.36.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.36.1",
+	"version": "6.36.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/canvas/text/AggregationListCanvas.svelte
+++ b/frontend/src/lib/canvas/text/AggregationListCanvas.svelte
@@ -56,6 +56,11 @@
 	let loadingDiagrams = $state(false);
 	let loadingProfiles = $state(false);
 	let loadError = $state<string | null>(null);
+	// One-shot guards: without these, a failed loadDiagrams/loadProfiles
+	// would re-fire the $effect (diagrams.length stays 0) and spam the
+	// API. The picker should attempt once per editing-toggle.
+	let triedDiagrams = $state(false);
+	let triedProfiles = $state(false);
 
 	onMount(() => {
 		if (editing) {
@@ -64,7 +69,7 @@
 	});
 
 	$effect(() => {
-		if (editing && diagrams.length === 0 && !loadingDiagrams) {
+		if (editing && !triedDiagrams && !loadingDiagrams) {
 			void loadOptions();
 		}
 	});
@@ -82,7 +87,9 @@
 			// expand to global picks.
 			const params = new URLSearchParams();
 			if (setId) params.set('set_id', setId);
-			params.set('page_size', '200');
+			// Backend caps page_size at 100. Anything larger 422s and,
+			// combined with the editing-effect, used to spam the API.
+			params.set('page_size', '100');
 			const data = await apiFetch<{ items: DiagramRow[] }>(
 				`/api/diagrams?${params.toString()}`,
 			);
@@ -92,6 +99,7 @@
 		} catch (e) {
 			loadError = `Failed to load source diagrams: ${(e as Error).message}`;
 		}
+		triedDiagrams = true;
 		loadingDiagrams = false;
 	}
 
@@ -112,6 +120,7 @@
 		} catch (e) {
 			loadError = `${loadError ?? ''}\nFailed to load profiles: ${(e as Error).message}`.trim();
 		}
+		triedProfiles = true;
 		loadingProfiles = false;
 	}
 

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.36.1"
+version = "6.36.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.36.1"
+version = "6.36.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Capped `AggregationListCanvas` source-diagram picker at `page_size=100` (was `200`, which the backend rejects with 422 — `page_size` is validated `<= 100`).
- Added one-shot `triedDiagrams` / `triedProfiles` guards so a failed picker fetch doesn't re-fire forever via the `$effect`.

Without the guards the picker spammed `/api/diagrams?set_id=…&page_size=200` continuously while edit mode was open (see screenshot of console flooded with 422s).

## Test plan

- [ ] Open an aggregation_list view (e.g. *Status rollup* `/views/d3a6aa0c-…` or *Maturity rollup* `/views/73508bc9-…`) — verify view mode still renders the rolled-up groups.
- [ ] Click *Edit* — verify the source-diagram picker fetches once, populates with smart_markdown diagrams in the set, and the console shows a single (successful) `/api/diagrams?set_id=…&page_size=100` request, not a loop of 422s.
- [ ] Toggle back to browse and again to edit — verify the fetch fires once per toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)