### PR TITLE
feat(v6.37.0): aggregation `group_count` smart-markdown token (ADR-225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.37.0] - 2026-05-30
+
+### Added
+
+- **Smart-markdown `aggregation` token — group counts from
+  aggregation_list views** (ADR-225, SPEC-225-A). New token shape
+  `{{aggregation:<aggregation_list_view_id>:group_count:<group>[:raw]}}`
+  resolves to the row count of the named group within the bound
+  profile's output. Composes with the ADR-224 `:raw` modifier so live
+  group counts can be embedded inside Mermaid pie / xychart / flowchart
+  blocks (e.g. the GEANZ Dashboard's Status pie now reads `"Approved"
+  : {{aggregation:…:group_count:Approved:raw}}` instead of hand-typed
+  values). Default form wraps the count in a markdown link back to the
+  source aggregation_list view. Unknown group → `"0"`; missing /
+  non-aggregation_list view → strikethrough.
+- `AggregationResult.group_counts: dict[str, int]` — the new
+  `{group_value: row_count}` map populated by the engine, surfaced
+  for the smart-markdown token but also available to any other caller
+  via the existing `/api/aggregate` and MCP `aggregate` surfaces.
+
 ## [6.36.2] - 2026-05-30
 
 ### Fixed

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -530,9 +530,10 @@ async def _format_output(
     db: DatabasePort,
     grouped: list[_GroupedRow],
     output: OutputConfig,
-) -> tuple[str, int]:
+) -> tuple[str, int, dict[str, int]]:
     """Group output by output.group_by, sort, format. Returns
-    (markdown, row_count)."""
+    (markdown, row_count, group_counts) — the last is a {group_value:
+    row_count} dict consumed by the ADR-225 aggregation token."""
     element_cache: dict[str, tuple[str | None, str | None, dict[str, Any]]] = {}
 
     # Resolve display data for every token.
@@ -588,7 +589,8 @@ async def _format_output(
             out_lines.append(line)
             row_count += 1
         out_lines.append("")
-    return "\n".join(out_lines).rstrip() + "\n", row_count
+    group_counts = {gv: len(items) for gv, items in groups.items()}
+    return "\n".join(out_lines).rstrip() + "\n", row_count, group_counts
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -647,7 +649,9 @@ async def run(
         )
 
     grouped = _group_and_aggregate(accumulator, p.output.aggregation_fn)
-    markdown, row_count = await _format_output(db, grouped, p.output)
+    markdown, row_count, group_counts = await _format_output(
+        db, grouped, p.output,
+    )
 
     return AggregationResult(
         markdown=markdown,
@@ -655,4 +659,5 @@ async def run(
         source_versions=source_versions,
         row_count=row_count,
         warnings=warnings,
+        group_counts=group_counts,
     )

--- a/backend/app/aggregation/models.py
+++ b/backend/app/aggregation/models.py
@@ -136,3 +136,7 @@ class AggregationResult(BaseModel):
     source_versions: dict[str, int] = Field(default_factory=dict)
     row_count: int = 0
     warnings: list[str] = Field(default_factory=list)
+    # ADR-225: number of rows per group_by bucket — feeds the
+    # `aggregation:<view>:group_count:<group>` smart-markdown token.
+    # Empty when `output.group_by` is unset.
+    group_counts: dict[str, int] = Field(default_factory=dict)

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -49,7 +49,7 @@ _PLACEHOLDER = "_No content yet._"
 # safe because non-image entity types validate field-spec separately in
 # `_resolve_one` (missing/invalid → strikethrough).
 _TOKEN_RE = re.compile(
-    r"\{\{(element|package|diagram|set|collection|image):"
+    r"\{\{(element|package|diagram|set|collection|image|aggregation):"
     r"([^:}]+)"
     r"(?::([^}]*))?"
     r"\}\}"
@@ -450,6 +450,74 @@ async def _resolve_element_detail_diagram(
     return f'[{text}](iris://diagram/{detail_id} "{title}")'
 
 
+# ─────────────────────────────────────────────────────────────────────
+# ADR-225: aggregation `group_count` token
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def _resolve_aggregation_group_count(
+    db: DatabasePort, view_id: str, group_value: str, *, raw_mode: bool,
+) -> str | None:
+    """Resolve `{{aggregation:<view_id>:group_count:<group_value>}}` —
+    the count of aggregation rows whose group equals ``group_value``
+    in the aggregation_list view named by ``view_id``.
+
+    Returns ``None`` (→ strikethrough) when the view is missing/deleted,
+    is not an aggregation_list diagram, or has no source/profile bound.
+    Returns ``"0"`` when the group simply has no matching rows — the
+    binding is valid, the bucket is just empty.
+    """
+    # Confirm the view exists and is an aggregation_list.
+    cursor = await db.execute(
+        "SELECT dv.name, d.diagram_type, dv.data FROM diagrams d "
+        "JOIN diagram_versions dv ON d.id = dv.diagram_id "
+        "  AND d.current_version = dv.version "
+        "WHERE d.id = ? AND d.is_deleted = 0",
+        (view_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    name, diagram_type, raw_data = row
+    if diagram_type != "aggregation_list":
+        return None
+    try:
+        data = json.loads(raw_data) if isinstance(raw_data, str) else raw_data
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    src = data.get("source_diagram_id")
+    profile_id = data.get("profile_id")
+    if not src or not profile_id:
+        return None
+
+    # Lazy import — mirrors the diagrams/service.py pattern for the
+    # aggregation_list GET hook (avoids an import cycle in cold-import
+    # smart_markdown callers).
+    from app.aggregation import engine as agg_engine
+    from app.aggregation.exceptions import (
+        AggregationProfileNotFound,
+        AggregationSourceNotFound,
+    )
+    try:
+        result = await agg_engine.run(
+            db, profile_id=str(profile_id), source_diagram_id=str(src),
+        )
+    except (AggregationProfileNotFound, AggregationSourceNotFound):
+        return None
+    # group_counts is empty when output.group_by is unset, so an unknown
+    # key correctly defaults to 0 (empty bucket), matching the "valid
+    # binding, empty group" semantic in SPEC-225-A.
+    count = result.group_counts.get(group_value, 0)
+    count_str = str(count)
+    if raw_mode:
+        return count_str
+    title = _markdown_escape_title(name)
+    text = _markdown_escape_link_text(count_str)
+    return f'[{text}](iris://diagram/{view_id} "{title}")'
+
+
 # Canvas node types that are structural decoration, not model elements
 # (ADR-222). Excluded from the element-count.
 _STRUCTURAL_NODE_TYPES = {"diagram_frame", "note"}
@@ -544,6 +612,19 @@ async def _resolve_one(
         return await _resolve_element_detail_diagram(
             db, entity_id, raw_mode=raw_mode,
         )
+
+    # ADR-225: aggregation `group_count` token. Resolves to one group's
+    # row count from an aggregation_list view, link-wrapped back to the
+    # view (or plain in raw_mode).
+    if entity_type == "aggregation" and field_spec is not None \
+            and field_spec.startswith("group_count:"):
+        group_value = field_spec[len("group_count:"):]
+        return await _resolve_aggregation_group_count(
+            db, entity_id, group_value, raw_mode=raw_mode,
+        )
+    if entity_type == "aggregation":
+        # Any other field-spec on `aggregation` is unsupported.
+        return None
 
     # ADR-210: parse inline =value override.
     field_spec_path: str = field_spec

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.36.2"
+version = "6.37.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -1125,3 +1125,181 @@ async def test_without_raw_modifier_still_wraps(
     # Link is present.
     assert f"iris://element/{eid}" in rendered
     assert _unwrap_iris_links(rendered).strip() == "Buy some Pork mince today."
+
+
+# ── ADR-225: aggregation `group_count` token ─────────────────────────
+
+
+async def _create_aggregation_profile(
+    c: httpx.AsyncClient, h: dict[str, str], set_id: str, *,
+    name: str = "Status by group",
+    group_by: str = "element.meta.status",
+    value_attribute_path: str | None = "meta/status",
+) -> str:
+    """Profile that counts each element token, grouped by element meta.status."""
+    inner: dict = {"collect_token_type": "element", "skip_blank_values": False}
+    if value_attribute_path is not None:
+        inner["value_attribute_path"] = value_attribute_path
+    pd = {
+        "traversal": {"inner": inner},
+        "output": {
+            "group_by": group_by,
+            "aggregation_fn": "count",
+            "line_format": "- [{element.name}](iris://element/{element.id})",
+        },
+    }
+    r = await c.post(
+        "/api/aggregation/profiles",
+        json={"name": name, "set_id": set_id, "is_global": False,
+              "profile_data": pd},
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _create_aggregation_list_view(
+    c: httpx.AsyncClient, h: dict[str, str], set_id: str, *,
+    source_diagram_id: str, profile_id: str,
+    name: str = "Rollup",
+) -> str:
+    r = await c.post(
+        "/api/diagrams",
+        json={
+            "name": name, "set_id": set_id,
+            "diagram_type": "aggregation_list", "notation": "markdown",
+            "data": {"source_diagram_id": source_diagram_id,
+                     "profile_id": profile_id},
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _setup_status_rollup(
+    c: httpx.AsyncClient, h: dict[str, str], set_id: str,
+) -> str:
+    """Helper: 3 elements (2 Approved, 1 Proposed), a source listing them,
+    a status-count profile, and an aggregation_list view binding them.
+    Returns the aggregation_list view id."""
+    e1 = await _create_element(
+        c, h, set_id, name="A1", metadata={"status": "Approved"},
+    )
+    e2 = await _create_element(
+        c, h, set_id, name="A2", metadata={"status": "Approved"},
+    )
+    e3 = await _create_element(
+        c, h, set_id, name="P1", metadata={"status": "Proposed"},
+    )
+    source_md = (
+        f"- {{{{element:{e1}:name}}}}\n"
+        f"- {{{{element:{e2}:name}}}}\n"
+        f"- {{{{element:{e3}:name}}}}\n"
+    )
+    source_id = await _create_smart_markdown_diagram(c, h, set_id, source_md)
+    profile_id = await _create_aggregation_profile(c, h, set_id)
+    return await _create_aggregation_list_view(
+        c, h, set_id,
+        source_diagram_id=source_id, profile_id=profile_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_returns_named_group_count(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"approved={{{{aggregation:{view_id}:group_count:Approved}}}}, "
+        f"proposed={{{{aggregation:{view_id}:group_count:Proposed}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Two elements Approved, one Proposed.
+    assert _unwrap_iris_links(rendered).strip() == "approved=2, proposed=1"
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_unknown_group_returns_zero(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"pending={{{{aggregation:{view_id}:group_count:Pending:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "pending=0"
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_missing_view_strikethrough(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    bogus = "00000000-0000-0000-0000-000000000000"
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"n={{{{aggregation:{bogus}:group_count:Approved}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Strikethrough placeholder for dangling reference (matches existing UX).
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_non_aggregation_list_diagram_strikethrough(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """Pointing the aggregation token at a non-aggregation_list diagram
+    (a plain smart_markdown one) resolves to strikethrough."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    not_an_agg_view = await _create_smart_markdown_diagram(
+        c, h, set_id, "just markdown",
+    )
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"n={{{{aggregation:{not_an_agg_view}:group_count:Approved}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_raw_returns_unwrapped(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"n={{{{aggregation:{view_id}:group_count:Approved:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "n=2"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_aggregation_group_count_default_wraps_link_to_view(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"{{{{aggregation:{view_id}:group_count:Approved}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Wrapped in a link back to the aggregation_list view.
+    assert f"iris://diagram/{view_id}" in rendered
+    assert _unwrap_iris_links(rendered).strip() == "2"

--- a/docs/adrs/ADR-225-Aggregation-Count-Token.md
+++ b/docs/adrs/ADR-225-Aggregation-Count-Token.md
@@ -1,0 +1,101 @@
+# ADR-225: Smart-markdown `aggregation` token — group counts from aggregation_list views
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-225 |
+| **Initiative** | Make aggregation-derived counts embeddable in smart-markdown (including Mermaid charts) |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-30 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** wanting smart-markdown dashboards to show live
+group counts from an aggregation_list view — "how many capabilities
+are Approved", "how many are at Maturity level 3" — directly in prose
+or inside a Mermaid pie / xychart-beta / flowchart block,
+
+**facing** that the existing token surface (ADR-205 / ADR-222 / ADR-223)
+exposes single-element fields and per-diagram element counts, but has
+no way to read **aggregation engine output**. Authors can today render
+an entire aggregation_list view inline, but cannot pull out one group's
+count to drop into a sentence or a chart cell. The pie chart on the
+GEANZ Dashboard, for instance, ships with hand-typed `"Approved" : 7`
+/ `"Proposed" : 30` because no token resolves those numbers,
+
+**we decided to** add a new smart-markdown entity type, ``aggregation``,
+with a single field-spec ``group_count:<group>`` that runs the
+aggregation profile bound to a named ``aggregation_list`` view and
+returns the count for the named group:
+
+  - `{{aggregation:<view_id>:group_count:Approved}}` → 7
+  - `{{aggregation:<view_id>:group_count:Proposed:raw}}` → 30
+  - `{{aggregation:<view_id>:group_count:3:raw}}` → 15 (Maturity rollup,
+    level 3)
+
+Resolution path: look up the target diagram, require
+``diagram_type == "aggregation_list"``, read its
+``data.source_diagram_id`` + ``data.profile_id``, run
+``aggregation.engine.run(...)``, group the result rows by the profile's
+``output.group_by`` (already done by the engine), and return the row
+count for the matching group as a string. Composes with ADR-224
+``:raw`` for Mermaid use.
+
+**to achieve** one-line embedding of any aggregation group count inside
+prose, tables, or Mermaid charts — exactly the same authoring shape as
+ADR-223's ``relationship_count`` / ``diagram_usage_count``. No new
+aggregation surface, no schema change.
+
+**accepting** that:
+- The token re-runs the aggregation engine on every smart-markdown
+  resolve. The engine is already idempotent and is run on every
+  aggregation_list GET, so the cost is the same as opening the rollup
+  view. Page-level caching (if/when added) covers both.
+- The token binds to a **view**, not directly to a (profile, source)
+  pair. Forces the author to name the view, but keeps the token short
+  and means renaming/moving the binding is a single edit on the view.
+- The group key is matched against the resolved group value
+  ``_resolve_group_value`` would return — string match, case-sensitive.
+  Unknown group → ``"0"`` (consistent with "0 rows in that bucket"),
+  not ``None`` (which would strikethrough). Missing/deleted view →
+  ``None`` (strikethrough — same as a dangling element reference).
+- Group values containing ``:`` would clash with the ``:raw`` suffix.
+  All current group sources (status strings, maturity integers, zone
+  names, package names) are colon-free; if a future group emits
+  colons, the author can switch to a profile whose ``group_by`` maps
+  them to a colon-free dimension. Documented, not engineered around.
+
+## Rejected alternatives
+
+- **Bind to ``(profile_id, source_id)`` directly.** More flexible but
+  verbose and breaks the single-id pattern of every other token. View
+  binding adds one layer of indirection that matches what the user is
+  already authoring.
+- **Reuse the ``diagram`` entity type with a new field-spec.** The
+  resolver already knows about ``element_count``; we could add
+  ``aggregation_group_count:<g>``. Cleaner namespace but worse for
+  discoverability — aggregation isn't a property of every diagram,
+  only of aggregation_list ones. A dedicated entity type sets the
+  expectation right and lets the rejection path say "this only works
+  on aggregation_list diagrams" instead of failing silently.
+- **Inline the full aggregation result and let the author parse it
+  with Mermaid.** Mermaid can't parse markdown lists into chart data.
+  A discrete count token is the only authoring shape that works
+  inside fenced blocks.
+
+## Dependencies
+
+- Builds on ADR-205 (smart-markdown tokens), ADR-209 (link-wrap that
+  ``:raw`` from ADR-224 suppresses), ADR-212 (aggregation profiles),
+  ADR-213 (aggregation_list synth-on-read). Composes with ADR-224.
+
+## Consequences
+
+- Spec: SPEC-225-A.
+- No migration, no MCP/CLI write-surface impact (read-only token,
+  Protocol §14 unaffected), no engine algorithm change. The new
+  resolver delegates to the existing ``aggregation.engine.run``.
+- Authors can now make the GEANZ Dashboard's status pie and any
+  similar chart live against the model.

--- a/docs/adrs/specs/SPEC-225-A-Aggregation-Count-Token.md
+++ b/docs/adrs/specs/SPEC-225-A-Aggregation-Count-Token.md
@@ -1,0 +1,84 @@
+# SPEC-225-A: Smart-markdown `aggregation` token
+
+Implements **[ADR-225](../ADR-225-Aggregation-Count-Token.md)**.
+
+## Grammar
+
+New entity type ``aggregation`` whose id is an ``aggregation_list``
+diagram id. Single supported field-spec ``group_count:<group_value>``:
+
+```
+{{aggregation:<aggregation_list_view_id>:group_count:<group_value>[:raw]}}
+```
+
+- `<group_value>` is matched against the group string produced by the
+  bound profile's `output.group_by`. Match is case-sensitive, exact,
+  trimmed.
+- `:raw` (from ADR-224) is honoured and strips the iris:// link wrap.
+
+## Examples
+
+- `{{aggregation:d3a6aa0c-…:group_count:Approved}}` → `[7](iris://…)`
+- `{{aggregation:d3a6aa0c-…:group_count:Approved:raw}}` → `7`
+- `{{aggregation:73508bc9-…:group_count:3:raw}}` → `15` (Maturity, level 3)
+
+## Resolution path
+
+1. Look up the diagram by id (live, not deleted).
+2. Require `diagram_type == "aggregation_list"`. Anything else → `None`.
+3. Read `data.source_diagram_id` and `data.profile_id`. Either missing
+   → `None`.
+4. Call `aggregation.engine.run(db, profile_id=…, source_diagram_id=…)`.
+5. For each row in the engine result, compute the group value via
+   `_resolve_group_value` (already used by the engine output stage).
+   Count rows whose group equals `<group_value>`.
+6. Return that count as a string.
+
+Unknown group (not present in results) returns ``"0"``. View
+missing/deleted/not-aggregation_list returns ``None`` (strikethrough,
+matching the existing dangling-reference UX).
+
+## Code anchors
+
+- `backend/app/diagrams/smart_markdown.py`:
+  - `_TOKEN_RE` (or equivalent dispatcher) extended to accept
+    ``aggregation`` as an entity_type.
+  - `_resolve_one` gains an `aggregation` branch that delegates to a
+    new `_resolve_aggregation_group_count(db, view_id, group_value)`
+    helper.
+  - Helper imports `app.aggregation.engine` lazily (avoid import
+    cycles, mirroring the lazy import in `app.diagrams.service.get_diagram`
+    ADR-213 aggregation_list hook).
+  - When `raw_mode` is true, the count is returned plain (no link
+    wrap) — same composition rule as ADR-224.
+- `backend/app/aggregation/engine.py`: no algorithm change. Re-uses
+  `run(...)` and (where helpful) `_resolve_group_value`.
+
+## Composition
+
+- With `:raw` for Mermaid pie / bar / flowchart values.
+- Inside element/diagram tables and prose lines.
+- Outside fenced code blocks the default form (link-wrapped) lands the
+  reader on the aggregation_list view itself (`iris://diagram/<view_id>`).
+
+## Acceptance criteria
+
+1. A token with a valid aggregation_list view id and an existing group
+   returns the row count for that group.
+2. A token whose group does not exist in the results returns `"0"`.
+3. A token whose view id is missing/deleted, points at a non-
+   aggregation_list diagram, or whose view is missing
+   `source_diagram_id`/`profile_id`, resolves to `None`
+   (strikethrough).
+4. `:raw` strips the link wrap on the count.
+5. Default form wraps the count in `[N](iris://diagram/<view_id>)`.
+
+## Tests
+
+`backend/tests/test_diagrams/test_smart_markdown.py`:
+- `test_aggregation_group_count_returns_named_group_count`
+- `test_aggregation_group_count_unknown_group_returns_zero`
+- `test_aggregation_group_count_missing_view_strikethrough`
+- `test_aggregation_group_count_non_aggregation_list_diagram_strikethrough`
+- `test_aggregation_group_count_raw_returns_unwrapped`
+- `test_aggregation_group_count_default_wraps_link_to_view`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.36.2",
+	"version": "6.37.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.36.2"
+version = "6.37.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.36.2"
+version = "6.37.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- New token `{{aggregation:<aggregation_list_view_id>:group_count:<group>[:raw]}}` returns the row count of one group from an aggregation_list view's profile output.
- Pairs with ADR-224 `:raw` to drop live group counts into Mermaid pie / xychart / flowchart blocks — e.g. the GEANZ Dashboard's Status pie can stop hand-typing `"Approved" : 7`.
- `AggregationResult.group_counts: dict[str, int]` populated by the engine (also available to existing `/api/aggregate` + MCP `aggregate` callers).
- Unknown group → `"0"`; missing or non-aggregation_list view → strikethrough.

ADR-225 + SPEC-225-A. No new write surface — Protocol §14 unaffected.

## Test plan

- [x] `backend/tests/test_diagrams/test_smart_markdown.py` — 6 new tests, all green.
- [x] Existing `tests/test_diagrams/test_smart_markdown.py` + `tests/test_aggregation/` regression suites — 84 passed.
- [ ] Post-deploy: update GEANZ Dashboard Mermaid pie to `"Approved" : {{aggregation:<status-rollup-id>:group_count:Approved:raw}}` / Proposed equivalent and confirm live values render in the pie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)