### PR TITLE
feat(v6.37.1): aggregation `row_count` + set `element_count` tokens (ADR-226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.37.1] - 2026-05-30
+
+### Added
+
+- **Two new smart-markdown tokens for dashboard totals** (ADR-226,
+  SPEC-226-A):
+  - `{{aggregation:<view_id>:row_count[:raw]}}` — total rows across
+    every group from an aggregation_list view's profile output.
+    Mirrors `AggregationResult.row_count` already exposed via
+    `/api/aggregate` and MCP.
+  - `{{set:<set_id>:element_count[:raw]}}` — live count of
+    non-deleted elements in a set.
+  Both compose with the ADR-224 `:raw` modifier so they can be
+  dropped inside Mermaid blocks. Default form wraps in a markdown
+  link back to the view / set (with the entity name as tooltip).
+  Missing/deleted entity → strikethrough; live-but-empty set →
+  `"0"`.
+
+  These let the GEANZ Dashboard's Coverage snapshot table replace
+  the remaining hand-typed cells (Total elements, ArchiMate_Capability
+  stereotype, Maturity values populated, Orphan capabilities) with
+  live tokens.
+
 ## [6.37.0] - 2026-05-30
 
 ### Added

--- a/backend/app/diagrams/smart_markdown.py
+++ b/backend/app/diagrams/smart_markdown.py
@@ -455,19 +455,13 @@ async def _resolve_element_detail_diagram(
 # ─────────────────────────────────────────────────────────────────────
 
 
-async def _resolve_aggregation_group_count(
-    db: DatabasePort, view_id: str, group_value: str, *, raw_mode: bool,
-) -> str | None:
-    """Resolve `{{aggregation:<view_id>:group_count:<group_value>}}` —
-    the count of aggregation rows whose group equals ``group_value``
-    in the aggregation_list view named by ``view_id``.
-
-    Returns ``None`` (→ strikethrough) when the view is missing/deleted,
-    is not an aggregation_list diagram, or has no source/profile bound.
-    Returns ``"0"`` when the group simply has no matching rows — the
-    binding is valid, the bucket is just empty.
-    """
-    # Confirm the view exists and is an aggregation_list.
+async def _fetch_aggregation_list_binding(
+    db: DatabasePort, view_id: str,
+) -> tuple[str, str, str] | None:
+    """Validate that ``view_id`` points to a live aggregation_list view
+    with both ``source_diagram_id`` and ``profile_id`` set. Returns
+    (view_name, source_diagram_id, profile_id) or ``None`` so the caller
+    can render a single strikethrough placeholder."""
     cursor = await db.execute(
         "SELECT dv.name, d.diagram_type, dv.data FROM diagrams d "
         "JOIN diagram_versions dv ON d.id = dv.diagram_id "
@@ -491,6 +485,25 @@ async def _resolve_aggregation_group_count(
     profile_id = data.get("profile_id")
     if not src or not profile_id:
         return None
+    return (name, str(src), str(profile_id))
+
+
+async def _resolve_aggregation_group_count(
+    db: DatabasePort, view_id: str, group_value: str, *, raw_mode: bool,
+) -> str | None:
+    """Resolve `{{aggregation:<view_id>:group_count:<group_value>}}` —
+    the count of aggregation rows whose group equals ``group_value``
+    in the aggregation_list view named by ``view_id``.
+
+    Returns ``None`` (→ strikethrough) when the view is missing/deleted,
+    is not an aggregation_list diagram, or has no source/profile bound.
+    Returns ``"0"`` when the group simply has no matching rows — the
+    binding is valid, the bucket is just empty.
+    """
+    binding = await _fetch_aggregation_list_binding(db, view_id)
+    if binding is None:
+        return None
+    name, src, profile_id = binding
 
     # Lazy import — mirrors the diagrams/service.py pattern for the
     # aggregation_list GET hook (avoids an import cycle in cold-import
@@ -502,7 +515,7 @@ async def _resolve_aggregation_group_count(
     )
     try:
         result = await agg_engine.run(
-            db, profile_id=str(profile_id), source_diagram_id=str(src),
+            db, profile_id=profile_id, source_diagram_id=src,
         )
     except (AggregationProfileNotFound, AggregationSourceNotFound):
         return None
@@ -516,6 +529,70 @@ async def _resolve_aggregation_group_count(
     title = _markdown_escape_title(name)
     text = _markdown_escape_link_text(count_str)
     return f'[{text}](iris://diagram/{view_id} "{title}")'
+
+
+async def _resolve_aggregation_row_count(
+    db: DatabasePort, view_id: str, *, raw_mode: bool,
+) -> str | None:
+    """Resolve `{{aggregation:<view_id>:row_count[:raw]}}` (ADR-226) — the
+    total row count from the bound profile's output, across every
+    group. Same `AggregationResult.row_count` exposed via /api/aggregate
+    and MCP."""
+    binding = await _fetch_aggregation_list_binding(db, view_id)
+    if binding is None:
+        return None
+    name, src, profile_id = binding
+    from app.aggregation import engine as agg_engine
+    from app.aggregation.exceptions import (
+        AggregationProfileNotFound,
+        AggregationSourceNotFound,
+    )
+    try:
+        result = await agg_engine.run(
+            db, profile_id=profile_id, source_diagram_id=src,
+        )
+    except (AggregationProfileNotFound, AggregationSourceNotFound):
+        return None
+    count_str = str(result.row_count)
+    if raw_mode:
+        return count_str
+    title = _markdown_escape_title(name)
+    text = _markdown_escape_link_text(count_str)
+    return f'[{text}](iris://diagram/{view_id} "{title}")'
+
+
+async def _resolve_set_element_count(
+    db: DatabasePort, set_id: str, *, raw_mode: bool,
+) -> str | None:
+    """Resolve `{{set:<id>:element_count[:raw]}}` (ADR-226) — the live
+    count of non-deleted elements in the set.
+
+    Returns ``None`` when the set itself is missing/deleted; returns
+    ``"0"`` for a live but empty set (live binding, empty contents — same
+    pattern as ADR-225 `group_count` for an empty group).
+    """
+    # Validate the set first so a missing set strikes through rather
+    # than silently returning 0.
+    cursor = await db.execute(
+        "SELECT name FROM sets WHERE id = ? AND is_deleted = 0",
+        (set_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    name = row[0]
+    cursor = await db.execute(
+        "SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0",
+        (set_id,),
+    )
+    row = await cursor.fetchone()
+    count = int(row[0]) if row and row[0] is not None else 0
+    count_str = str(count)
+    if raw_mode:
+        return count_str
+    title = _markdown_escape_title(name)
+    text = _markdown_escape_link_text(count_str)
+    return f'[{text}](iris://set/{set_id} "{title}")'
 
 
 # Canvas node types that are structural decoration, not model elements
@@ -622,9 +699,20 @@ async def _resolve_one(
         return await _resolve_aggregation_group_count(
             db, entity_id, group_value, raw_mode=raw_mode,
         )
+    # ADR-226: aggregation `row_count` — total rows across every group.
+    if entity_type == "aggregation" and field_spec == "row_count":
+        return await _resolve_aggregation_row_count(
+            db, entity_id, raw_mode=raw_mode,
+        )
     if entity_type == "aggregation":
         # Any other field-spec on `aggregation` is unsupported.
         return None
+
+    # ADR-226: live count of elements in a set.
+    if entity_type == "set" and field_spec == "element_count":
+        return await _resolve_set_element_count(
+            db, entity_id, raw_mode=raw_mode,
+        )
 
     # ADR-210: parse inline =value override.
     field_spec_path: str = field_spec

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.37.0"
+version = "6.37.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_diagrams/test_smart_markdown.py
+++ b/backend/tests/test_diagrams/test_smart_markdown.py
@@ -1303,3 +1303,132 @@ async def test_aggregation_group_count_default_wraps_link_to_view(
     # Wrapped in a link back to the aggregation_list view.
     assert f"iris://diagram/{view_id}" in rendered
     assert _unwrap_iris_links(rendered).strip() == "2"
+
+
+# ── ADR-226: aggregation `row_count` + set `element_count` tokens ─────
+
+
+@pytest.mark.asyncio
+async def test_aggregation_row_count_returns_total(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    """row_count is the total rows across every group — same as
+    AggregationResult.row_count exposed via /api/aggregate."""
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"total={{{{aggregation:{view_id}:row_count}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # 2 Approved + 1 Proposed = 3 rows total.
+    assert _unwrap_iris_links(rendered).strip() == "total=3"
+    assert f"iris://diagram/{view_id}" in rendered
+
+
+@pytest.mark.asyncio
+async def test_aggregation_row_count_raw_returns_unwrapped(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    view_id = await _setup_status_rollup(c, h, set_id)
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"total={{{{aggregation:{view_id}:row_count:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "total=3"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_aggregation_row_count_missing_view_strikethrough(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    bogus = "00000000-0000-0000-0000-000000000000"
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"n={{{{aggregation:{bogus}:row_count}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_set_element_count_returns_live_count(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h, "Coverage")
+    # Create 3 elements directly in the set.
+    for n in ("A", "B", "C"):
+        await _create_element(c, h, set_id, name=n)
+    # And a smart_markdown diagram (which is NOT counted as an element).
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"size={{{{set:{set_id}:element_count}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert _unwrap_iris_links(rendered).strip() == "size=3"
+    assert f"iris://set/{set_id}" in rendered
+
+
+@pytest.mark.asyncio
+async def test_set_element_count_raw_returns_unwrapped(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    await _create_element(c, h, set_id, name="One")
+    await _create_element(c, h, set_id, name="Two")
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"size={{{{set:{set_id}:element_count:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert rendered.strip() == "size=2"
+    assert "iris://" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_set_element_count_missing_set_strikethrough(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    bogus = "00000000-0000-0000-0000-000000000000"
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"n={{{{set:{bogus}:element_count}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    assert "~~" in rendered
+
+
+@pytest.mark.asyncio
+async def test_set_element_count_excludes_deleted_elements(
+    context: tuple[httpx.AsyncClient, DatabaseManager, dict[str, str]],
+) -> None:
+    c, db_manager, h = context
+    set_id = await _create_set(c, h)
+    keep = await _create_element(c, h, set_id, name="Keep")
+    drop = await _create_element(c, h, set_id, name="Drop")
+    # Soft-delete one element. The API uses DELETE with If-Match.
+    r = await c.delete(
+        f"/api/elements/{drop}",
+        headers={**h, "If-Match": "1"},
+    )
+    assert r.status_code in (200, 204), r.text
+    diag_id = await _create_smart_markdown_diagram(
+        c, h, set_id,
+        f"size={{{{set:{set_id}:element_count:raw}}}}",
+    )
+    rendered = await compute_smart_markdown_content(db_manager.main_db, diag_id)
+    # Only the live element counts.
+    assert rendered.strip() == "size=1"
+    # And the live element is the one we kept.
+    assert keep != drop

--- a/docs/adrs/ADR-226-Aggregation-Row-Count-And-Set-Element-Count-Tokens.md
+++ b/docs/adrs/ADR-226-Aggregation-Row-Count-And-Set-Element-Count-Tokens.md
@@ -1,0 +1,94 @@
+# ADR-226: Smart-markdown `aggregation:…:row_count` and `set:…:element_count` tokens
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-226 |
+| **Initiative** | Make the remaining dashboard "snapshot" cells (set totals, aggregation totals) live |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-30 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** a dashboard that already uses smart-markdown tokens
+for per-element / per-diagram / per-group counts (ADR-222 / ADR-223 /
+ADR-225) but still has hand-typed cells for two common shapes — *total
+elements in a set* and *total rows in an aggregation* — so the dashboard
+tells a half-live story,
+
+**facing** that ADR-225's ``aggregation`` token exposes ``group_count``
+but no aggregate-level total, and there is no token at all for "how
+many elements in this set". The Coverage snapshot table on the GEANZ
+Dashboard still hand-types **50** (set total) and **37**
+(``ArchiMate_Capability`` count, which equals "rows in the Status or
+Maturity rollup"). Drift is silent and visible — adding a capability
+moves the dashboard out of sync without warning,
+
+**we decided to** add two minimal token field-specs:
+
+  - ``{{aggregation:<view_id>:row_count[:raw]}}`` — total rows across
+    every group in the aggregation_list view's profile output.
+  - ``{{set:<id>:element_count[:raw]}}`` — live count of non-deleted
+    elements in the set.
+
+Both compose with the ADR-224 ``:raw`` modifier for Mermaid use. The
+``aggregation:row_count`` value reuses ``AggregationResult.row_count``
+already exposed via ``/api/aggregate`` and MCP — no new traversal,
+just a new field-spec on the existing entity type. The
+``set:element_count`` value is a straight ``SELECT COUNT(*)`` against
+``elements`` filtered by ``set_id`` and ``is_deleted = 0`` — mirrors
+the existing ``set:name`` resolver shape.
+
+**to achieve** four more live cells on the GEANZ Dashboard's Coverage
+snapshot (Total elements, ArchiMate_Capability stereotype, Maturity
+values populated (demo), Orphan capabilities — the last via an
+``aggregation:…:group_count:0`` over a new orphan-rollup profile,
+authoring-only). One small composable token surface, zero schema
+change.
+
+**accepting** that:
+- ``aggregation:row_count`` doesn't filter — it's the total across all
+  groups including ``"(no group)"`` rows. That matches how
+  ``AggregationResult.row_count`` is computed; authors who want a
+  subset use ``group_count`` instead. Documented, not engineered
+  around.
+- ``set:element_count`` counts EVERY non-deleted element regardless
+  of stereotype/type. The GEANZ "50 = capabilities + themes" cell is
+  the right number to render with this token; if a future cell wants
+  "capabilities only" we already have ``aggregation:row_count`` over
+  the rollup-source view (which has 37 capability tokens) — two
+  paths, two intents.
+- Re-running the aggregation engine on every smart-markdown resolve
+  is the same cost as opening the rollup view. Same trade-off as
+  ADR-225, and the same future caching solution applies to both.
+
+## Rejected alternatives
+
+- **Add a new top-level ``count`` token form** (``{{count:elements:set=<id>}}``
+  etc.). More general, much larger surface, doesn't match how the
+  other tokens already encode "entity + field-spec". The two narrow
+  tokens here compose with the existing grammar instead of replacing
+  it.
+- **Expose set/diagram/package-level metrics via element-level token
+  filters** (``{{element:*:meta:status:count}}``). Wildcard token
+  shapes have never existed in smart-markdown and would force a
+  whole new parser branch.
+- **Compute the totals client-side from `group_count` sums in
+  Mermaid blocks.** Mermaid doesn't do arithmetic in values. Same
+  reason ``group_count`` had to be a token: the renderer can't sum.
+
+## Dependencies
+
+- Composes with ADR-224 ``:raw`` and ADR-225 ``aggregation`` entity
+  type. No schema change, no MCP/CLI write surface change (Protocol
+  §14 unaffected).
+
+## Consequences
+
+- Spec: SPEC-226-A.
+- Dashboard's Coverage snapshot table can go from 2 live cells (the
+  ADR-225 Approved / Proposed) to 6 live cells.
+- Future "snapshot" cells on other dashboards can also use the new
+  tokens directly.

--- a/docs/adrs/specs/SPEC-226-A-Aggregation-Row-Count-And-Set-Element-Count-Tokens.md
+++ b/docs/adrs/specs/SPEC-226-A-Aggregation-Row-Count-And-Set-Element-Count-Tokens.md
@@ -1,0 +1,86 @@
+# SPEC-226-A: Smart-markdown `aggregation:…:row_count` + `set:…:element_count`
+
+Implements **[ADR-226](../ADR-226-Aggregation-Row-Count-And-Set-Element-Count-Tokens.md)**.
+
+## Grammar
+
+Two new field-specs on existing entity types:
+
+```
+{{aggregation:<aggregation_list_view_id>:row_count[:raw]}}
+{{set:<set_id>:element_count[:raw]}}
+```
+
+- `:raw` (ADR-224) strips the iris:// link wrap.
+- Default form wraps in `iris://diagram/<view_id>` /
+  `iris://set/<set_id>`.
+
+## Resolution
+
+### `aggregation:<view_id>:row_count`
+
+1. Look up the diagram; require live + `diagram_type ==
+   "aggregation_list"` + `data.source_diagram_id` + `data.profile_id`.
+   Any failure → `None` (strikethrough).
+2. Call `aggregation.engine.run(...)` (same call ADR-225
+   `group_count` already makes).
+3. Return `result.row_count` as a string.
+
+### `set:<set_id>:element_count`
+
+1. `SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0`.
+2. If the set itself is missing/deleted → `None`. Otherwise return
+   the count as a string (`"0"` if the set is empty but exists).
+
+## Examples
+
+- `{{aggregation:d3a6aa0c-…:row_count:raw}}` → `37`
+  (Status rollup over all 37 capabilities)
+- `{{aggregation:73508bc9-…:row_count:raw}}` → `37`
+  (Maturity rollup)
+- `{{set:7f2521de-…:element_count:raw}}` → `50`
+  (every non-deleted element in the GEANZ Sparx set)
+- `{{set:5036a71a-…:element_count}}` → wrapped link to the
+  Aggregation Demo set page
+
+## Code anchors
+
+- `backend/app/diagrams/smart_markdown.py`:
+  - `_resolve_one` aggregation branch (added by ADR-225) gains a
+    second field-spec check: `field_spec == "row_count"` →
+    `_resolve_aggregation_row_count(db, view_id, raw_mode)`.
+  - `_resolve_one` `set` branch routes `field_spec == "element_count"`
+    to a new `_fetch_set_element_count` helper before falling through
+    to `_fetch_set_field`.
+  - New `_resolve_aggregation_row_count` mirrors the existing
+    `_resolve_aggregation_group_count` resolver: validates the view,
+    runs the engine, returns `result.row_count`; wraps in
+    `iris://diagram/<view_id>` unless `raw_mode`.
+  - New `_fetch_set_element_count` runs the COUNT query, wraps in
+    `iris://set/<set_id>` (tooltip = set name) unless `raw_mode`.
+
+## Acceptance criteria
+
+1. `aggregation:<view>:row_count` returns the engine's `row_count`
+   total as a string. Composes with `:raw`.
+2. `aggregation:<view>:row_count` on a missing / non-aggregation_list
+   view → strikethrough.
+3. `set:<id>:element_count` returns the count of non-deleted elements
+   in the set as a string. `0` for an empty (but live) set.
+4. `set:<id>:element_count` on a missing / deleted set →
+   strikethrough.
+5. `:raw` modifier suppresses link wrap on both tokens.
+6. Default form wraps in `iris://diagram/<view_id>` and
+   `iris://set/<set_id>` respectively, with the entity name as the
+   link tooltip.
+
+## Tests
+
+`backend/tests/test_diagrams/test_smart_markdown.py`:
+- `test_aggregation_row_count_returns_total`
+- `test_aggregation_row_count_raw_returns_unwrapped`
+- `test_aggregation_row_count_missing_view_strikethrough`
+- `test_set_element_count_returns_live_count`
+- `test_set_element_count_raw_returns_unwrapped`
+- `test_set_element_count_missing_set_strikethrough`
+- `test_set_element_count_excludes_deleted_elements`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.37.0",
+	"version": "6.37.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.37.0"
+version = "6.37.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.37.0"
+version = "6.37.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Two narrow new smart-markdown tokens that compose with ADR-225 / ADR-224 to make the rest of the GEANZ Dashboard's Coverage snapshot table live:

- `{{aggregation:<view_id>:row_count[:raw]}}` — total rows across every group from an aggregation_list view's profile output.
- `{{set:<set_id>:element_count[:raw]}}` — live count of non-deleted elements in a set.

Both wrap in `iris://diagram/<view>` / `iris://set/<id>` by default and honour `:raw`. Missing/deleted entity → strikethrough; live-but-empty set → `"0"`.

Implementation factors out a `_fetch_aggregation_list_binding` validator shared between the existing `group_count` resolver and the new `row_count` one, so the binding logic stays in one place.

No new write surface — Protocol §14 unaffected.

## Test plan

- [x] 7 new TDD tests in `backend/tests/test_diagrams/test_smart_markdown.py` — all green.
- [x] Existing smart_markdown + aggregation regression suites pass (69 + 22 = 91 tests).
- [ ] Post-deploy: rewire 4 Coverage snapshot rows on the GEANZ Dashboard to use the new tokens; verify live values render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)