### PR TITLE
feat(v6.37.2): shareable fullscreen URL flag for views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.37.2] - 2026-05-30
+
+### Added
+
+- **Shareable fullscreen URLs for views.** Focus mode on
+  `/views/[id]` now syncs with a `?focus=1` query param. Toggling
+  fullscreen updates the URL via `replaceState` (no history
+  pollution); opening any view URL with `?focus=1` lands the page
+  directly in fullscreen. Copy-paste-share a focused canvas without
+  asking the recipient to click the button. Back/forward navigation
+  to a URL without the flag drops out of focus correctly. Frontend
+  only — no backend / API change.
+
 ## [6.37.1] - 2026-05-30
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.37.1"
+version = "6.37.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.37.1",
+	"version": "6.37.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -189,6 +189,33 @@
 	// Focus view state
 	let focusMode = $state(false);
 
+	// v6.37.2: focus mode <-> URL sync. When focus is active the URL
+	// carries `?focus=1` so the page can be linked to in fullscreen.
+	// Uses replaceState (no history pollution) and a directional guard
+	// to prevent the two effects below from re-firing each other.
+	let focusModeFromURL = false;
+	$effect(() => {
+		// URL → focusMode (mount + back/forward).
+		const urlHas = page.url.searchParams.get('focus') === '1';
+		if (urlHas !== focusModeFromURL) {
+			focusMode = urlHas;
+			focusModeFromURL = urlHas;
+		}
+	});
+	$effect(() => {
+		// focusMode → URL (in-app toggle).
+		if (focusMode === focusModeFromURL) return;
+		const url = new URL(page.url);
+		if (focusMode) url.searchParams.set('focus', '1');
+		else url.searchParams.delete('focus');
+		focusModeFromURL = focusMode;
+		void goto(url.pathname + url.search + url.hash, {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true,
+		});
+	});
+
 	/** True when the windowed browse sidebar should be visible (shifts page content). */
 	const windowedBrowseSidebar = $derived(!editing && !focusMode && !!selectedBrowseNode);
 

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.37.1"
+version = "6.37.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.37.1"
+version = "6.37.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Focus mode on `/views/[id]` now syncs with a `?focus=1` query parameter.
- Toggling fullscreen in-app pushes the flag onto the URL via `replaceState` (no history pollution, no scroll/focus shift).
- Opening any view URL with `?focus=1` lands directly in fullscreen — copy-paste-share works.
- Back/forward to a URL without the flag drops out of focus correctly.

Implementation: two reactive `$effect`s with a `focusModeFromURL` directional guard so neither re-fires the other. Frontend-only — zero backend / API change.

## Test plan

- [ ] Open a view, click *Full screen*, confirm URL gains `?focus=1`.
- [ ] Copy the URL, paste into a new tab, confirm the page opens in fullscreen.
- [ ] Click *Exit*, confirm `?focus=1` is removed from the URL.
- [ ] Back/forward through view history that mixes focused and unfocused URLs — focus mode tracks each URL.
- [ ] Confirm browser history isn't polluted with focus toggles (one entry per real navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)