### PR TITLE
fix(v6.37.3): preserve fullscreen across link navigation + kill load flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.37.3] - 2026-05-30
+
+### Fixed
+
+- **Fullscreen view persists across iris:// link navigation.** Clicking
+  a `iris://diagram/<id>` link inside a focused view used to drop the
+  user out of fullscreen because the destination URL didn't carry the
+  `?focus=1` flag. `MarkdownView`'s click handler now forwards the
+  flag to view-class destinations so a focused → focused navigation
+  stays focused.
+- **No more unfocused flash before the diagram loads.** Opening a
+  view URL with `?focus=1` used to render the normal layout briefly
+  while the diagram fetch was in flight, then enter focus mode after
+  the data arrived. The `focusMode` state is now initialised from the
+  URL during script init (not in a post-render `$effect`), and the
+  `loading` / `error` branches render inside `FocusView` when the
+  URL says focus, so the focused chrome is on screen from the first
+  paint.
+
 ## [6.37.2] - 2026-05-30
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.37.2"
+version = "6.37.3"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.37.2",
+	"version": "6.37.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/MarkdownView.svelte
+++ b/frontend/src/lib/components/MarkdownView.svelte
@@ -66,6 +66,13 @@
 		else if (kind === 'package') path = `/packages/${id}`;
 		else if (kind === 'collection') path = `/collections/${id}`;
 		else path = `/elements/${id}`;
+		// v6.37.3: preserve `?focus=1` when jumping from one focused view
+		// to another. Only forward to diagram links — other entity routes
+		// don't have a focus concept.
+		if (kind === 'diagram' && typeof window !== 'undefined') {
+			const sp = new URLSearchParams(window.location.search);
+			if (sp.get('focus') === '1') path += '?focus=1';
+		}
 		goto(path);
 	}
 

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -186,14 +186,18 @@
 	// (see backend/app/diagrams/service.py:get_diagram_ancestors).
 	let ancestors = $state<BreadcrumbAncestor[]>([]);
 
-	// Focus view state
-	let focusMode = $state(false);
+	// Focus view state — initialised from the URL during script init so
+	// the *first* render already wears the focused chrome when the
+	// page is opened via a `?focus=1` link. Initialising later (in an
+	// $effect) used to flash the unfocused layout while the diagram
+	// fetch was in flight (v6.37.3 fix).
+	let focusMode = $state(page.url.searchParams.get('focus') === '1');
 
 	// v6.37.2: focus mode <-> URL sync. When focus is active the URL
 	// carries `?focus=1` so the page can be linked to in fullscreen.
 	// Uses replaceState (no history pollution) and a directional guard
 	// to prevent the two effects below from re-firing each other.
-	let focusModeFromURL = false;
+	let focusModeFromURL = focusMode;
 	$effect(() => {
 		// URL → focusMode (mount + back/forward).
 		const urlHas = page.url.searchParams.get('focus') === '1';
@@ -2004,25 +2008,46 @@
 </svelte:head>
 
 {#if loading}
-	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-		<ol class="flex flex-wrap items-baseline gap-1">
-			<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
-			<li aria-hidden="true">/</li>
-			<li aria-current="page">{page.params.id}</li>
-		</ol>
-	</nav>
-	<p style="color: var(--color-muted)">Loading diagram...</p>
+	{#if focusMode}
+		<!-- v6.37.3: keep the loading state inside the focused chrome so a
+			 `?focus=1` URL doesn't flash unfocused while the diagram fetch
+			 is in flight. -->
+		<FocusView onexit={() => (focusMode = false)}>
+			<div class="flex h-full w-full items-center justify-center">
+				<p style="color: var(--color-muted)">Loading diagram...</p>
+			</div>
+		</FocusView>
+	{:else}
+		<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
+			<ol class="flex flex-wrap items-baseline gap-1">
+				<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
+				<li aria-hidden="true">/</li>
+				<li aria-current="page">{page.params.id}</li>
+			</ol>
+		</nav>
+		<p style="color: var(--color-muted)">Loading diagram...</p>
+	{/if}
 {:else if error}
-	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-		<ol class="flex flex-wrap items-baseline gap-1">
-			<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
-			<li aria-hidden="true">/</li>
-			<li aria-current="page">{page.params.id}</li>
-		</ol>
-	</nav>
-	<div role="alert" class="rounded border p-4" style="border-color: var(--color-danger); color: var(--color-danger)">
-		{error}
-	</div>
+	{#if focusMode}
+		<FocusView onexit={() => (focusMode = false)}>
+			<div class="flex h-full w-full items-center justify-center p-8">
+				<div role="alert" class="rounded border p-4" style="border-color: var(--color-danger); color: var(--color-danger)">
+					{error}
+				</div>
+			</div>
+		</FocusView>
+	{:else}
+		<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
+			<ol class="flex flex-wrap items-baseline gap-1">
+				<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
+				<li aria-hidden="true">/</li>
+				<li aria-current="page">{page.params.id}</li>
+			</ol>
+		</nav>
+		<div role="alert" class="rounded border p-4" style="border-color: var(--color-danger); color: var(--color-danger)">
+			{error}
+		</div>
+	{/if}
 {:else if diagram}
 	<!-- Windowed browse sidebar: fixed right panel + margin on page content -->
 	{#if windowedBrowseSidebar && selectedBrowseNode}

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.37.2"
+version = "6.37.3"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.37.2"
+version = "6.37.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Two related polish fixes on top of the v6.37.2 shareable `?focus=1` URL:

1. **iris:// links from inside a focused view stay focused.** `MarkdownView`'s click handler now forwards `?focus=1` to view-class destinations when the current URL carries the flag.
2. **No unfocused flash before the diagram loads.** `focusMode` is now initialised from `page.url` during script init (synchronously), and the `loading` / `error` branches render inside `FocusView` when the URL says focus — so the focused chrome is on screen from the first paint.

Frontend-only. No backend impact.

## Test plan

- [ ] Open `/views/<id>?focus=1` cold — confirm the page renders directly in fullscreen, no unfocused flash while the diagram is loading.
- [ ] From a focused view, click a `↳` (detail diagram) iris:// link to another view — confirm the destination opens in fullscreen, URL carries `?focus=1`.
- [ ] From a focused view, click a non-diagram link (element / set / package / collection) — confirm focus drops as expected (those routes don't have a focus concept).
- [ ] Click *Exit* — focus drops cleanly, URL focus param removed.
- [ ] Back/forward across mixed URLs — focus mode tracks each URL state correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)