### PR TITLE
feat(v6.39.0): element metadata edit UI (ADR-228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.39.0] - 2026-05-31
+
+### Added
+
+- **Element metadata edit UI** (ADR-228, SPEC-228-A). Closes the
+  long-standing frontend gap where `metadata.status`, the Extended
+  section's eleven scalars (stereotype / version / scope / abstract /
+  persistence / author / complexity / phase / EA created+modified
+  dates / gen_type), and the `metadata.tagged_values` table were
+  display-only despite the backend accepting `metadata` on
+  `ElementUpdate` since v6.36.1. Now:
+  - Status edits via a free-text `<input list="status-suggestions">`
+    with a `<datalist>` of common Sparx values (Approved, Proposed,
+    Implemented, Validated, Mandatory).
+  - Each Extended scalar gets a plain `<input>` in edit mode,
+    initialised from `entity.metadata`. Blanking a field deletes the
+    key from `metadata` on save (matches the existing Attributes
+    pattern).
+  - Tagged-values table becomes an editable grid: per-row `property`,
+    `value`, `notes` inputs + ✕ delete + footer `+ Add Tagged Value`
+    button. Rows with a blank property are dropped at save.
+  - The Sparx `#NOTES#` convention (a `value` like `"3#NOTES#Values:
+    1,2,3"`) is preserved across the edit boundary via a new
+    `frontend/src/lib/utils/taggedValues.ts` util — `splitTaggedValue`
+    surfaces the meaningful value and the prescriptive description in
+    their own controls; `joinTaggedValue` reassembles on save; empty
+    notes omits the marker. `isUnsetTaggedValue` mirrors the backend's
+    `_extract_tagged_value` (`null` / `""` / `"-"` / `"-#NOTES#…"`).
+
+### Fixed
+
+- **Element PUT body no longer sends `element_type`** — `ElementUpdate`
+  doesn't accept it (element type is immutable per ADR-178), so the
+  field was a no-op. Dropped from `saveEntityMetadata`'s body
+  construction. The element-type edit control on the page is
+  unchanged for now (its no-op-on-save behaviour predates this PR
+  and is tracked as a follow-up affordance cleanup).
+
 ## [6.38.0] - 2026-05-31
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.38.0"
+version = "6.39.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/adrs/ADR-228-Element-Metadata-Edit-UI.md
+++ b/docs/adrs/ADR-228-Element-Metadata-Edit-UI.md
@@ -1,0 +1,119 @@
+# ADR-228: Element metadata edit UI (status, extended scalars, tagged values)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-228 |
+| **Initiative** | Close the frontend gap on element metadata editing exposed by the *C&A (alternative name)* incident |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-31 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** Iris users editing imported Sparx EA elements via
+the `/elements/<id>` page — the GEANZ capability-area elements all
+carry a `metadata.status` (Proposed / Approved / …), eleven extended-
+section scalars (stereotype, version, scope, abstract, persistence,
+author, complexity, phase, EA created+modified dates, gen_type), and a
+`metadata.tagged_values` array of `{property, value}` rows that often
+encode review notes, maturity levels, and EA tagged-value defaults,
+
+**facing** that the page renders every one of those fields as
+**display-only** (`frontend/src/routes/elements/[id]/+page.svelte`
+lines 866-953) even though the backend has accepted `metadata` on
+`PUT /api/elements/<id>` since v6.36.1 (ADR-184 followup —
+`ElementUpdate.metadata` in `backend/app/elements/models.py:36-51`,
+persisted by `service.update_element`). MCP / CLI agents can already
+write `metadata`; humans can't. The page's `saveEntityMetadata()`
+never includes `metadata` in the PUT body and `enterDetailsEdit()`
+never seeds edit state for it. The same function also includes
+`element_type` in the PUT body even though `ElementUpdate` rejects it
+— dead bytes,
+
+**we decided to** mirror the existing `editAttributes` pattern
+(`+page.svelte:66, 290-293, 327-332, 781-809`) for the three metadata
+buckets:
+
+  - **Status** — free-text `<input list="status-suggestions">` plus a
+    `<datalist>` of common Sparx values (Approved, Proposed,
+    Implemented, Validated, Mandatory). Doesn't lock the model — the
+    backend column accepts any string, and a strict dropdown would
+    reject imports from other tools.
+  - **Extended-section scalars** — every existing display block gets
+    a sibling `<input>` in edit mode. Same Tailwind / `var(--color-…)`
+    class set as the Attributes editor.
+  - **Tagged values** — the table becomes an editable grid: per-row
+    `property`, `value`, `notes` inputs + ✕ delete; footer `+ Add
+    Tagged Value` button. The wire format keeps a single string
+    `value` per row; the editor splits on the Sparx `#NOTES#` marker
+    so the prescriptive description (`"Values: -,0,1,2,3,4,5\nDefault:
+    -\nDescription: …"`) can live in its own textarea without
+    fat-fingering the meaningful value. A row whose property is blank
+    is filtered out on save (matches the Attributes pattern).
+
+  Tagged-value split/join + the "unset" check (matches `_extract_
+  tagged_value` in `backend/app/diagrams/smart_markdown.py:139`) are
+  factored into `frontend/src/lib/utils/taggedValues.ts` so future
+  callers reuse them (DRY §13). The `element_type` key is dropped
+  from the PUT body builder while we're in the same function.
+
+**to achieve** human parity with the existing MCP / CLI metadata edit
+surface, close the gap the user hit on *C&A (alternative name)*, and
+remove the false `element_type` send. Backend untouched.
+
+**accepting** that:
+- A tagged-value whose *meaningful* value contains the literal
+  substring `#NOTES#` would be split incorrectly. The Sparx
+  convention reserves the marker for the description separator;
+  treating it as a delimiter is consistent with EA tooling and
+  matches what `_extract_tagged_value` already does on the read
+  path.
+- Long edits that race a concurrent writer (>5 min, edit-then-save)
+  hit the existing `If-Match` 409. Surfaced by the existing
+  top-of-page `error` div. No new UX work in this ADR.
+- Status accepts any string — no enum constraint. The `<datalist>`
+  is suggestion-only.
+- The Extended scalars are simple `<input>`s (not date pickers for
+  the EA dates). Sparx writes dates as `"2023-04-14 09:08:57"` —
+  not strict ISO 8601 — so a date picker would mangle the round
+  trip. Power users only edit these by hand; the schema is
+  preserved.
+
+## Rejected alternatives
+
+- **Strict status dropdown** — would reject values from non-Sparx
+  importers. The backend doesn't constrain the column; the UI
+  shouldn't either.
+- **Single textarea per tagged-value row holding the raw value
+  including `#NOTES#…`** — power-user-only, foot-gunny: easy to
+  delete the description by accident. The split editor protects the
+  description without losing access to it.
+- **Raw-JSON metadata editor** — flexible but defers the UX problem
+  rather than solving it. The 80% of edits hit status + tagged
+  values + a handful of scalars; targeted controls beat a
+  textarea-of-JSON for that path. Raw editor is a clean follow-up if
+  needed.
+
+## Dependencies
+
+- Backend write surface (`ElementUpdate.metadata`) shipped in v6.36.1.
+- Read-side parity: `_extract_tagged_value` in
+  `backend/app/diagrams/smart_markdown.py:139` is the canonical "is
+  this value unset" check; the new `taggedValues.ts:isUnsetTaggedValue`
+  mirrors it.
+- Pattern source of truth: the existing Attributes editor on the
+  same page. Same DRY §13 idiom applies.
+
+## Consequences
+
+- Spec: SPEC-228-A.
+- No backend change, no DB migration, no MCP / CLI surface change
+  (Protocol §14 unaffected).
+- Closes the user-reported gap on `metadata.status` and Extended.
+- Removes the `element_type` false send from the PUT body — minor
+  hygiene.
+- Establishes `frontend/src/lib/utils/taggedValues.ts` as the
+  authoritative place for `#NOTES#` parsing on the frontend. Reused
+  by any future caller (export views, search snippets, etc.).

--- a/docs/adrs/specs/SPEC-228-A-Element-Metadata-Edit-UI.md
+++ b/docs/adrs/specs/SPEC-228-A-Element-Metadata-Edit-UI.md
@@ -1,0 +1,244 @@
+# SPEC-228-A: Element metadata edit UI
+
+Implements **[ADR-228](../ADR-228-Element-Metadata-Edit-UI.md)**.
+
+## Helper module
+
+`frontend/src/lib/utils/taggedValues.ts` (new):
+
+```ts
+/** Split a Sparx tagged-value `value` string on the `#NOTES#` marker.
+ *  Returns the meaningful value and the prescriptive notes separately
+ *  so the UI can edit each in its own control. */
+export function splitTaggedValue(
+  raw: string | null | undefined,
+): { value: string; notes: string } {
+  if (raw == null || raw === '' || raw === '-') {
+    return { value: '', notes: '' };
+  }
+  const idx = raw.indexOf('#NOTES#');
+  if (idx < 0) return { value: raw, notes: '' };
+  return {
+    value: raw.slice(0, idx),
+    notes: raw.slice(idx + '#NOTES#'.length),
+  };
+}
+
+/** Reassemble a tagged-value string from the editor's split form.
+ *  Empty notes → omit the `#NOTES#` marker entirely. */
+export function joinTaggedValue(value: string, notes: string): string {
+  if (!notes) return value;
+  return `${value}#NOTES#${notes}`;
+}
+
+/** Match `_extract_tagged_value` in
+ *  backend/app/diagrams/smart_markdown.py:139 — treat `null`, `""`,
+ *  `"-"`, and `"-#NOTES#…"` all as unset. */
+export function isUnsetTaggedValue(
+  raw: string | null | undefined,
+): boolean {
+  if (raw == null || raw === '' || raw === '-') return true;
+  const { value } = splitTaggedValue(raw);
+  return value === '' || value === '-';
+}
+```
+
+Pure functions — no I/O, no DOM. Co-located vitest at `taggedValues.test.ts`.
+
+## Page wiring
+
+Mirror the `editAttributes` pattern in
+`frontend/src/routes/elements/[id]/+page.svelte`.
+
+### State (declare alongside `editAttributes` near line 66)
+
+```ts
+let editStatus = $state('');
+let editStereotype = $state('');
+let editMetaVersion = $state('');
+let editScope = $state('');
+let editAbstract = $state('');
+let editPersistence = $state('');
+let editAuthor = $state('');
+let editComplexity = $state('');
+let editPhase = $state('');
+let editCreatedDate = $state('');
+let editModifiedDate = $state('');
+let editGenType = $state('');
+let editTaggedValues = $state<
+  { property: string; value: string; notes: string }[]
+>([]);
+```
+
+### Seed (`enterDetailsEdit`, ~line 284)
+
+```ts
+const m = (entity.metadata ?? {}) as Record<string, unknown>;
+editStatus = (m.status as string | undefined) ?? '';
+editStereotype = (m.stereotype as string | undefined) ?? '';
+editMetaVersion = (m.version as string | undefined) ?? '';
+editScope = (m.scope as string | undefined) ?? '';
+editAbstract = (m.abstract as string | undefined) ?? '';
+editPersistence = (m.persistence as string | undefined) ?? '';
+editAuthor = (m.author as string | undefined) ?? '';
+editComplexity = (m.complexity as string | undefined) ?? '';
+editPhase = (m.phase as string | undefined) ?? '';
+editCreatedDate = (m.created_date as string | undefined) ?? '';
+editModifiedDate = (m.modified_date as string | undefined) ?? '';
+editGenType = (m.gen_type as string | undefined) ?? '';
+const tvs = Array.isArray(m.tagged_values) ? m.tagged_values : [];
+editTaggedValues = (tvs as Array<{ property?: string; value?: string | null }>)
+  .map(tv => ({
+    property: tv.property ?? '',
+    ...splitTaggedValue(tv.value),
+  }));
+```
+
+### Save (`saveEntityMetadata`, ~line 315)
+
+```ts
+const m = (entity.metadata ?? {}) as Record<string, unknown>;
+const updatedMeta: Record<string, unknown> = { ...m };
+const setOrDelete = (k: string, v: string) => {
+  if (v.trim()) updatedMeta[k] = v;
+  else delete updatedMeta[k];
+};
+setOrDelete('status', editStatus);
+setOrDelete('stereotype', editStereotype);
+setOrDelete('version', editMetaVersion);
+setOrDelete('scope', editScope);
+setOrDelete('abstract', editAbstract);
+setOrDelete('persistence', editPersistence);
+setOrDelete('author', editAuthor);
+setOrDelete('complexity', editComplexity);
+setOrDelete('phase', editPhase);
+setOrDelete('created_date', editCreatedDate);
+setOrDelete('modified_date', editModifiedDate);
+setOrDelete('gen_type', editGenType);
+
+const rebuiltTV = editTaggedValues
+  .filter(r => r.property.trim())
+  .map(r => ({
+    property: r.property,
+    value: joinTaggedValue(r.value, r.notes) || null,
+  }));
+if (rebuiltTV.length) updatedMeta.tagged_values = rebuiltTV;
+else delete updatedMeta.tagged_values;
+
+putBody.metadata = updatedMeta;
+// v6.39.0: drop element_type — ElementUpdate doesn't accept it.
+// (was line 335 before this PR)
+```
+
+### Render (Details + Extended display blocks, ~lines 866-953)
+
+Each existing `{#if meta?.field}<dd>{value}</dd>{/if}` block becomes:
+
+```svelte
+<dt>Status</dt>
+<dd>
+  {#if editingDetails}
+    <input
+      type="text"
+      list="status-suggestions"
+      bind:value={editStatus}
+      aria-label="Status"
+      class="w-full rounded border px-2 py-1 text-sm"
+      style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+    />
+  {:else if (entity.metadata as Record<string, unknown> | null | undefined)?.status}
+    {(entity.metadata as Record<string, unknown>).status}
+  {/if}
+</dd>
+```
+
+One `<datalist id="status-suggestions">` declared near the top of the
+template:
+
+```svelte
+<datalist id="status-suggestions">
+  <option value="Approved" />
+  <option value="Proposed" />
+  <option value="Implemented" />
+  <option value="Validated" />
+  <option value="Mandatory" />
+</datalist>
+```
+
+Tagged-values table (replacing the read-only block ~932-953) — three
+columns + delete + add-row, same Tailwind classes as the Attributes
+table at lines 781-809.
+
+## Acceptance criteria
+
+1. In view mode, every metadata field renders exactly as today (no
+   regression in the display layout).
+2. In edit mode, every field listed in *Scope* has a writable
+   control bound to a `$state` initialised from `entity.metadata`.
+3. The Status input has `aria-label="Status"` (so the Playwright
+   locator `getByLabel('Status')` finds it).
+4. Tagged-values table: `+ Add Tagged Value` button appends a fresh
+   `{ property: '', value: '', notes: '' }`; per-row `✕` removes
+   the row.
+5. On save, the PUT body's `metadata` field is the merged object:
+   pre-existing `metadata` keys are preserved; edited keys are
+   overwritten; blanked scalars are deleted from `metadata`;
+   `tagged_values` reflects the edited rows (blank-property rows
+   dropped, `joinTaggedValue` reapplied per row).
+6. On save, the PUT body MUST NOT contain `element_type` (regression
+   guard: when the page loads, no `element_type` key on the next
+   request payload).
+7. Concurrency: 409 surfaces via the existing `error` div — no
+   silent state loss.
+
+## Tests
+
+### Unit — `frontend/src/lib/utils/taggedValues.test.ts`
+
+```
+test('splitTaggedValue: plain value', …)        → { value: '3', notes: '' }
+test('splitTaggedValue: value + #NOTES# block') → { value, notes }
+test('splitTaggedValue: null / "" / "-"')       → { value: '', notes: '' }
+test('joinTaggedValue: empty notes')            → returns just value
+test('joinTaggedValue: multi-line notes')       → 'v#NOTES#l1\nl2'
+test('round-trip: join(split(x)) === x')        → for non-unset x
+test('isUnsetTaggedValue: all four unset forms') → true; '3' / '3#NOTES#…' → false
+```
+
+### E2E — `frontend/tests/e2e/element-metadata-edit.spec.ts`
+
+```
+test('edit metadata round-trip', async ({ page }) => {
+  // fixture: API-create a Set + Element with status = 'Proposed' and one tagged value
+  await page.goto(`/elements/${id}?edit=true`);
+  await page.getByLabel('Status').fill('Validated');
+  await page.getByRole('button', { name: '+ Add Tagged Value' }).click();
+  // fill the new row's three inputs by their aria-labels
+  // (Property / Value / Notes scoped to the last row)
+  await page.getByRole('button', { name: /^Save$/ }).click();
+  await page.waitForResponse(r =>
+    r.url().includes(`/api/elements/${id}`) && r.request().method() === 'PUT'
+  );
+  await page.reload();
+  // status now displays 'Validated'; tagged-values table contains Reviewer / Alice
+});
+```
+
+Plus a follow-up assertion: re-enter edit, click ✕ on the new tagged
+value, save, reload, assert the row is gone.
+
+### Regression
+
+`cd frontend && npm run test` (vitest) + `npx playwright test
+element-metadata-edit element-package-membership` — green before merge.
+
+## Code anchors
+
+- `frontend/src/routes/elements/[id]/+page.svelte`
+  - State near line 66 (next to `editAttributes`).
+  - Init in `enterDetailsEdit` ~284-313.
+  - Save in `saveEntityMetadata` ~315-378, including `element_type` drop.
+  - Display blocks ~866-953.
+- `frontend/src/lib/utils/taggedValues.ts` (new).
+- `frontend/src/lib/utils/taggedValues.test.ts` (new).
+- `frontend/tests/e2e/element-metadata-edit.spec.ts` (new).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.38.0",
+	"version": "6.39.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/utils/taggedValues.ts
+++ b/frontend/src/lib/utils/taggedValues.ts
@@ -1,0 +1,51 @@
+/**
+ * Helpers for the Sparx EA `#NOTES#` tagged-value encoding (ADR-228).
+ *
+ * Sparx EA stores each tagged value's `value` field as a single
+ * string, optionally followed by `#NOTES#` and a prescriptive
+ * description block listing allowed values, the default, and a
+ * human-readable description. Example:
+ *
+ *   "3#NOTES#Values: -,0,1,2,3,4,5\nDefault: -\nDescription: 0 - Does not exist\n1 - Initial …"
+ *
+ * `splitTaggedValue` separates the meaningful value from the notes so
+ * the UI can edit each in its own control. `joinTaggedValue`
+ * reassembles them. `isUnsetTaggedValue` mirrors the backend's
+ * `_extract_tagged_value` (backend/app/diagrams/smart_markdown.py:139)
+ * — `null`, `""`, `"-"`, and `"-#NOTES#…"` are all "unset".
+ */
+
+const NOTES_MARKER = '#NOTES#';
+
+/** Split a Sparx tagged-value `value` string on the `#NOTES#` marker. */
+export function splitTaggedValue(
+	raw: string | null | undefined,
+): { value: string; notes: string } {
+	if (raw == null || raw === '' || raw === '-') {
+		return { value: '', notes: '' };
+	}
+	const idx = raw.indexOf(NOTES_MARKER);
+	if (idx < 0) return { value: raw, notes: '' };
+	return {
+		value: raw.slice(0, idx),
+		notes: raw.slice(idx + NOTES_MARKER.length),
+	};
+}
+
+/** Reassemble a tagged-value string from the editor's split form.
+ *  Empty notes → omit the `#NOTES#` marker entirely. */
+export function joinTaggedValue(value: string, notes: string): string {
+	if (!notes) return value;
+	return `${value}${NOTES_MARKER}${notes}`;
+}
+
+/** Match `_extract_tagged_value` in
+ *  `backend/app/diagrams/smart_markdown.py:139` — treat `null`, `""`,
+ *  `"-"`, and `"-#NOTES#…"` all as unset. */
+export function isUnsetTaggedValue(
+	raw: string | null | undefined,
+): boolean {
+	if (raw == null || raw === '' || raw === '-') return true;
+	const { value } = splitTaggedValue(raw);
+	return value === '' || value === '-';
+}

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { joinTaggedValue, splitTaggedValue } from '$lib/utils/taggedValues';
 	import { openScenia } from '$lib/scenia/config.js';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
@@ -71,6 +72,22 @@
 	interface PackageOption { id: string; name: string }
 	let setPackages = $state<PackageOption[]>([]);
 	let editElementType = $state('');
+	// ADR-228 — `metadata` is now editable. Status + the eleven extended
+	// scalars get plain text inputs in edit mode; tagged_values become
+	// an editable grid with #NOTES# split per row.
+	let editStatus = $state('');
+	let editStereotype = $state('');
+	let editMetaVersion = $state('');
+	let editScope = $state('');
+	let editAbstract = $state('');
+	let editPersistence = $state('');
+	let editAuthor = $state('');
+	let editComplexity = $state('');
+	let editPhase = $state('');
+	let editCreatedDate = $state('');
+	let editModifiedDate = $state('');
+	let editGenType = $state('');
+	let editTaggedValues = $state<{ property: string; value: string; notes: string }[]>([]);
 	// ADR-221 — element → detail diagram drill link. ``detailDiagramName``
 	// is the resolved name shown in read mode; the edit-mode picker
 	// updates ``editDetailDiagramId`` / ``editDetailDiagramName``.
@@ -121,7 +138,38 @@
 		const typeChanged = editElementType !== entity.element_type;
 		const pkgChanged = (editPackageId ?? null) !== ((entity as any).package_id ?? null);
 		const detailDiagramChanged = (editDetailDiagramId ?? null) !== (entity.detail_diagram_id ?? null);
-		detailsDirty = nameChanged || descChanged || tagsChanged || attrsChanged || typeChanged || pkgChanged || detailDiagramChanged;
+		// ADR-228: any edit to status / the eleven extended scalars /
+		// the tagged-values rows flips the dirty flag. Compare the
+		// rebuilt metadata against the entity's current value — same
+		// JSON-equality approach used for attributes above.
+		const origMeta = (entity.metadata ?? {}) as Record<string, unknown>;
+		const editedMeta: Record<string, unknown> = { ...origMeta };
+		const apply = (k: string, v: string) => {
+			if (v.trim()) editedMeta[k] = v;
+			else delete editedMeta[k];
+		};
+		apply('status', editStatus);
+		apply('stereotype', editStereotype);
+		apply('version', editMetaVersion);
+		apply('scope', editScope);
+		apply('abstract', editAbstract);
+		apply('persistence', editPersistence);
+		apply('author', editAuthor);
+		apply('complexity', editComplexity);
+		apply('phase', editPhase);
+		apply('created_date', editCreatedDate);
+		apply('modified_date', editModifiedDate);
+		apply('gen_type', editGenType);
+		const rebuiltTV = editTaggedValues
+			.filter((r) => r.property.trim())
+			.map((r) => ({
+				property: r.property,
+				value: joinTaggedValue(r.value, r.notes) || null,
+			}));
+		if (rebuiltTV.length) editedMeta.tagged_values = rebuiltTV;
+		else delete editedMeta.tagged_values;
+		const metaChanged = JSON.stringify(editedMeta) !== JSON.stringify(origMeta);
+		detailsDirty = nameChanged || descChanged || tagsChanged || attrsChanged || typeChanged || pkgChanged || detailDiagramChanged || metaChanged;
 	});
 
 	async function loadEntity(id: string) {
@@ -294,6 +342,28 @@
 		editPackageId = (entity as any).package_id ?? null;
 		editDetailDiagramId = entity.detail_diagram_id ?? null;
 		editDetailDiagramName = detailDiagramName;
+		// ADR-228: seed metadata edit state from `entity.metadata`. Each
+		// blank string corresponds to "field unset" so the existing
+		// {#if meta?.field} display behaviour is preserved on save.
+		const md = (entity.metadata ?? {}) as Record<string, unknown>;
+		editStatus = (md.status as string | undefined) ?? '';
+		editStereotype = (md.stereotype as string | undefined) ?? '';
+		editMetaVersion = (md.version as string | undefined) ?? '';
+		editScope = (md.scope as string | undefined) ?? '';
+		editAbstract = (md.abstract as string | undefined) ?? '';
+		editPersistence = (md.persistence as string | undefined) ?? '';
+		editAuthor = (md.author as string | undefined) ?? '';
+		editComplexity = (md.complexity as string | undefined) ?? '';
+		editPhase = (md.phase as string | undefined) ?? '';
+		editCreatedDate = (md.created_date as string | undefined) ?? '';
+		editModifiedDate = (md.modified_date as string | undefined) ?? '';
+		editGenType = (md.gen_type as string | undefined) ?? '';
+		const tvs = Array.isArray(md.tagged_values) ? md.tagged_values : [];
+		editTaggedValues = (tvs as Array<{ property?: string; value?: string | null }>)
+			.map((tv) => ({
+				property: tv.property ?? '',
+				...splitTaggedValue(tv.value),
+			}));
 		// Load packages scoped to the element's set so the picker stays
 		// constrained to a consistent group (ADR-184).
 		try {
@@ -332,7 +402,9 @@
 			}
 			const putBody: Record<string, unknown> = {
 				name: sanitizedName,
-				element_type: editElementType || entity.element_type,
+				// v6.39.0 (ADR-228): `element_type` is intentionally omitted —
+				// `ElementUpdate` doesn't accept it (element type is immutable
+				// after creation per ADR-178). Previously included as dead bytes.
 				description: sanitizedDesc,
 				data: updatedData,
 				change_summary: 'Updated element details',
@@ -346,6 +418,38 @@
 			// ADR-221 tri-state — same convention as package_id: always
 			// include the key (set / null) since we seed it on edit entry.
 			putBody.detail_diagram_id = editDetailDiagramId ?? null;
+			// ADR-228: assemble the updated metadata from edit state and
+			// include it in the PUT body. Preserves any keys we didn't
+			// surface in the editor; deletes scalars the user blanked
+			// out; reassembles tagged-value `value` from the split
+			// editor form, dropping blank-property rows.
+			const baseMeta = (entity.metadata ?? {}) as Record<string, unknown>;
+			const updatedMeta: Record<string, unknown> = { ...baseMeta };
+			const setOrDelete = (k: string, v: string) => {
+				if (v.trim()) updatedMeta[k] = v;
+				else delete updatedMeta[k];
+			};
+			setOrDelete('status', editStatus);
+			setOrDelete('stereotype', editStereotype);
+			setOrDelete('version', editMetaVersion);
+			setOrDelete('scope', editScope);
+			setOrDelete('abstract', editAbstract);
+			setOrDelete('persistence', editPersistence);
+			setOrDelete('author', editAuthor);
+			setOrDelete('complexity', editComplexity);
+			setOrDelete('phase', editPhase);
+			setOrDelete('created_date', editCreatedDate);
+			setOrDelete('modified_date', editModifiedDate);
+			setOrDelete('gen_type', editGenType);
+			const rebuiltTV = editTaggedValues
+				.filter((r) => r.property.trim())
+				.map((r) => ({
+					property: r.property,
+					value: joinTaggedValue(r.value, r.notes) || null,
+				}));
+			if (rebuiltTV.length) updatedMeta.tagged_values = rebuiltTV;
+			else delete updatedMeta.tagged_values;
+			putBody.metadata = updatedMeta;
 			await apiFetch(`/api/elements/${entity.id}`, {
 				method: 'PUT',
 				headers: { 'If-Match': String(entity.current_version) },
@@ -863,9 +967,29 @@
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">Modified By</dt>
 							<dd style="color: var(--color-fg)">{modifiedByUsername}</dd>
 
-							{#if (entity.metadata as Record<string, unknown> | null | undefined)?.status}
+							{#if editingDetails || (entity.metadata as Record<string, unknown> | null | undefined)?.status}
 								<dt class="text-sm font-medium" style="color: var(--color-muted)">Status</dt>
-								<dd style="color: var(--color-fg)">{(entity.metadata as Record<string, unknown>).status}</dd>
+								<dd style="color: var(--color-fg)">
+									{#if editingDetails}
+										<input
+											type="text"
+											list="status-suggestions"
+											bind:value={editStatus}
+											aria-label="Status"
+											class="w-full rounded border px-2 py-1 text-sm"
+											style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+										/>
+										<datalist id="status-suggestions">
+											<option value="Approved"></option>
+											<option value="Proposed"></option>
+											<option value="Implemented"></option>
+											<option value="Validated"></option>
+											<option value="Mandatory"></option>
+										</datalist>
+									{:else}
+										{(entity.metadata as Record<string, unknown>).status}
+									{/if}
+								</dd>
 							{/if}
 						</dl>
 					</Accordion.Content>
@@ -882,54 +1006,113 @@
 					<Accordion.Content class="pb-4">
 						{@const meta = entity.metadata as Record<string, unknown> | null | undefined}
 						{@const hasMeta = !!(meta && (meta.stereotype || meta.version || meta.scope || meta.abstract || meta.persistence || meta.author || meta.complexity || meta.phase || meta.created_date || meta.modified_date || meta.gen_type || (Array.isArray(meta.tagged_values) && (meta.tagged_values as unknown[]).length > 0)))}
-						{#if hasMeta}
+						{#if hasMeta || editingDetails}
+							<!-- ADR-228: each row shows in edit mode regardless of
+								 whether the underlying metadata key is set, so the
+								 user can add or clear it. Tailwind classes mirror
+								 the Attributes editor at lines 854-907. -->
+							{#snippet scalarRow(label: string, displayValue: string, ariaLabel: string, get: () => string, set: (v: string) => void)}
+								{#if editingDetails || displayValue}
+									<dt class="text-sm font-medium" style="color: var(--color-muted)">{label}</dt>
+									<dd style="color: var(--color-fg)">
+										{#if editingDetails}
+											<input
+												type="text"
+												value={get()}
+												oninput={(e) => set((e.currentTarget as HTMLInputElement).value)}
+												aria-label={ariaLabel}
+												class="w-full rounded border px-2 py-1 text-sm"
+												style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+											/>
+										{:else}
+											{displayValue}
+										{/if}
+									</dd>
+								{/if}
+							{/snippet}
 							<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
-								{#if meta?.stereotype}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Stereotype</dt>
-									<dd style="color: var(--color-fg)">{meta.stereotype}</dd>
-								{/if}
-								{#if meta?.version}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Metadata Version</dt>
-									<dd style="color: var(--color-fg)">{meta.version}</dd>
-								{/if}
-								{#if meta?.scope}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Scope</dt>
-									<dd style="color: var(--color-fg)">{meta.scope}</dd>
-								{/if}
-								{#if meta?.abstract}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Abstract</dt>
-									<dd style="color: var(--color-fg)">Yes</dd>
-								{/if}
-								{#if meta?.persistence}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Persistence</dt>
-									<dd style="color: var(--color-fg)">{meta.persistence}</dd>
-								{/if}
-								{#if meta?.author}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Author</dt>
-									<dd style="color: var(--color-fg)">{meta.author}</dd>
-								{/if}
-								{#if meta?.complexity}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Complexity</dt>
-									<dd style="color: var(--color-fg)">{meta.complexity}</dd>
-								{/if}
-								{#if meta?.phase}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Phase</dt>
-									<dd style="color: var(--color-fg)">{meta.phase}</dd>
-								{/if}
-								{#if meta?.created_date}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">EA Created Date</dt>
-									<dd style="color: var(--color-fg)">{meta.created_date}</dd>
-								{/if}
-								{#if meta?.modified_date}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">EA Modified Date</dt>
-									<dd style="color: var(--color-fg)">{meta.modified_date}</dd>
-								{/if}
-								{#if meta?.gen_type}
-									<dt class="text-sm font-medium" style="color: var(--color-muted)">Gen Type</dt>
-									<dd style="color: var(--color-fg)">{meta.gen_type}</dd>
-								{/if}
+								{@render scalarRow('Stereotype', (meta?.stereotype as string) ?? '', 'Stereotype', () => editStereotype, (v) => (editStereotype = v))}
+								{@render scalarRow('Metadata Version', (meta?.version as string) ?? '', 'Metadata Version', () => editMetaVersion, (v) => (editMetaVersion = v))}
+								{@render scalarRow('Scope', (meta?.scope as string) ?? '', 'Scope', () => editScope, (v) => (editScope = v))}
+								{@render scalarRow('Abstract', meta?.abstract ? 'Yes' : '', 'Abstract', () => editAbstract, (v) => (editAbstract = v))}
+								{@render scalarRow('Persistence', (meta?.persistence as string) ?? '', 'Persistence', () => editPersistence, (v) => (editPersistence = v))}
+								{@render scalarRow('Author', (meta?.author as string) ?? '', 'Author', () => editAuthor, (v) => (editAuthor = v))}
+								{@render scalarRow('Complexity', (meta?.complexity as string) ?? '', 'Complexity', () => editComplexity, (v) => (editComplexity = v))}
+								{@render scalarRow('Phase', (meta?.phase as string) ?? '', 'Phase', () => editPhase, (v) => (editPhase = v))}
+								{@render scalarRow('EA Created Date', (meta?.created_date as string) ?? '', 'EA Created Date', () => editCreatedDate, (v) => (editCreatedDate = v))}
+								{@render scalarRow('EA Modified Date', (meta?.modified_date as string) ?? '', 'EA Modified Date', () => editModifiedDate, (v) => (editModifiedDate = v))}
+								{@render scalarRow('Gen Type', (meta?.gen_type as string) ?? '', 'Gen Type', () => editGenType, (v) => (editGenType = v))}
 
-								{#if Array.isArray(meta?.tagged_values) && (meta.tagged_values as unknown[]).length > 0}
+								{#if editingDetails}
+									<!-- Edit mode: the full grid of tagged values
+										 including a `+ Add Tagged Value` button so
+										 users can grow / shrink the list. -->
+									<dt class="text-sm font-medium" style="color: var(--color-muted)">Tagged Values</dt>
+									<dd>
+										<table class="w-full text-sm" style="color: var(--color-fg)">
+											<thead>
+												<tr style="border-bottom: 1px solid var(--color-border)">
+													<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Property</th>
+													<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Value</th>
+													<th class="py-1 pr-2 text-left font-medium" style="color: var(--color-muted)">Notes</th>
+													<th class="py-1 w-6"></th>
+												</tr>
+											</thead>
+											<tbody>
+												{#each editTaggedValues as _row, i (i)}
+													<tr style="border-bottom: 1px solid var(--color-border)">
+														<td class="py-1 pr-2">
+															<input
+																type="text"
+																bind:value={editTaggedValues[i].property}
+																aria-label={`Tagged value ${i + 1} property`}
+																class="w-full rounded border px-1 py-0.5 text-sm"
+																style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+															/>
+														</td>
+														<td class="py-1 pr-2">
+															<input
+																type="text"
+																bind:value={editTaggedValues[i].value}
+																aria-label={`Tagged value ${i + 1} value`}
+																class="w-full rounded border px-1 py-0.5 text-sm"
+																style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+															/>
+														</td>
+														<td class="py-1 pr-2">
+															<textarea
+																bind:value={editTaggedValues[i].notes}
+																rows="1"
+																aria-label={`Tagged value ${i + 1} notes`}
+																class="w-full rounded border px-1 py-0.5 text-sm"
+																style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+															></textarea>
+														</td>
+														<td class="py-1">
+															<button
+																type="button"
+																aria-label={`Remove tagged value ${i + 1}`}
+																onclick={() => { editTaggedValues = editTaggedValues.filter((_, j) => j !== i); }}
+																class="rounded px-2 py-0.5 text-sm"
+																style="color: var(--color-muted)"
+															>✕</button>
+														</td>
+													</tr>
+												{/each}
+												<tr>
+													<td colspan="4" class="py-2">
+														<button
+															type="button"
+															onclick={() => { editTaggedValues = [...editTaggedValues, { property: '', value: '', notes: '' }]; }}
+															class="rounded px-2 py-1 text-sm"
+															style="border: 1px solid var(--color-border); color: var(--color-fg)"
+														>+ Add Tagged Value</button>
+													</td>
+												</tr>
+											</tbody>
+										</table>
+									</dd>
+								{:else if Array.isArray(meta?.tagged_values) && (meta.tagged_values as unknown[]).length > 0}
 									<dt class="text-sm font-medium" style="color: var(--color-muted)">Tagged Values</dt>
 									<dd>
 										<table class="w-full text-sm" style="color: var(--color-fg)">

--- a/frontend/tests/e2e/element-metadata-edit.spec.ts
+++ b/frontend/tests/e2e/element-metadata-edit.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * E2E for ADR-228 — element metadata edit UI.
+ *
+ * Verifies that the Status input under Details and the editable
+ * tagged-values grid under Extended round-trip through the API:
+ *   1. Status changes are sent in the PUT body's `metadata` and
+ *      survive a page reload.
+ *   2. A new tagged value added in the editor is persisted, and the
+ *      Notes textarea on a row carrying a `#NOTES#` block reassembles
+ *      via `joinTaggedValue` on save.
+ *   3. Deleting a tagged-value row drops it from `metadata.tagged_values`.
+ *   4. Regression: the PUT body MUST NOT include `element_type`
+ *      (v6.39.0 dead-byte cleanup).
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { createSet, getAuthToken, loginAsAdmin } from './fixtures';
+
+const API_BASE = 'http://localhost:8000';
+
+async function createElement(
+	token: string,
+	body: {
+		name: string;
+		element_type: string;
+		set_id: string;
+		metadata?: Record<string, unknown>;
+	},
+): Promise<{ id: string; current_version: number }> {
+	const res = await fetch(`${API_BASE}/api/elements`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify(body),
+	});
+	if (!res.ok) {
+		throw new Error(`createElement failed: ${res.status} ${await res.text()}`);
+	}
+	return (await res.json()) as { id: string; current_version: number };
+}
+
+test.describe('ADR-228 element metadata edit', () => {
+	test('status + tagged-values round-trip through the UI', async ({ page }) => {
+		const token = await getAuthToken();
+		const set = (await createSet(undefined, token, {
+			name: `Set-meta-${Date.now()}`,
+		})) as { id: string };
+		const el = await createElement(token, {
+			name: 'MetaEditMe',
+			element_type: 'component',
+			set_id: set.id,
+			metadata: {
+				status: 'Proposed',
+				stereotype: 'ArchiMate_Capability',
+				tagged_values: [
+					{
+						property: 'Current Maturity Level',
+						value: '-#NOTES#Values: -,0,1,2,3,4,5\nDefault: -',
+					},
+				],
+			},
+		});
+
+		// Capture every PUT body sent to this element so we can assert
+		// `metadata` is included and `element_type` is not.
+		const putBodies: Array<Record<string, unknown>> = [];
+		page.on('request', (req) => {
+			if (
+				req.method() === 'PUT' &&
+				req.url().includes(`/api/elements/${el.id}`) &&
+				!req.url().includes('/tags')
+			) {
+				try {
+					putBodies.push(JSON.parse(req.postData() ?? '{}'));
+				} catch {
+					/* not JSON — ignore */
+				}
+			}
+		});
+
+		await loginAsAdmin(page);
+		await page.goto(`/elements/${el.id}?edit=true`);
+
+		// Open the Details accordion so the Status input is visible.
+		const detailsTrigger = page.getByRole('button', { name: /^Details/ });
+		if ((await detailsTrigger.getAttribute('data-state')) !== 'open') {
+			await detailsTrigger.click();
+		}
+		await page.getByLabel('Status').fill('Validated');
+
+		// Open the Extended accordion to surface the tagged-values grid.
+		const extendedTrigger = page.getByRole('button', { name: /^Extended/ });
+		if ((await extendedTrigger.getAttribute('data-state')) !== 'open') {
+			await extendedTrigger.click();
+		}
+		// Edit the seeded tagged value's value cell, then add a fresh one.
+		await page.getByLabel('Tagged value 1 value').fill('3');
+		await page.getByRole('button', { name: '+ Add Tagged Value' }).click();
+		await page.getByLabel('Tagged value 2 property').fill('Reviewer');
+		await page.getByLabel('Tagged value 2 value').fill('Alice');
+
+		await page.getByRole('button', { name: /^Save$/i }).first().click();
+		await page.waitForResponse(
+			(r) =>
+				r.url().includes(`/api/elements/${el.id}`) &&
+				!r.url().includes('/tags') &&
+				r.request().method() === 'PUT',
+		);
+
+		// Verify via the backend (decoupled from the UI's read path).
+		const res1 = await fetch(`${API_BASE}/api/elements/${el.id}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const body1 = (await res1.json()) as {
+			metadata: Record<string, unknown>;
+			element_type: string;
+		};
+		expect(body1.metadata.status).toBe('Validated');
+		expect(body1.element_type).toBe('component'); // unchanged
+		const tvs1 = body1.metadata.tagged_values as Array<{
+			property: string;
+			value: string | null;
+		}>;
+		expect(tvs1).toHaveLength(2);
+		// First row: value 3 + the original #NOTES# block reassembled.
+		expect(tvs1[0].property).toBe('Current Maturity Level');
+		expect(tvs1[0].value).toMatch(/^3#NOTES#Values: -,0,1,2,3,4,5/);
+		// Second row: new Reviewer / Alice, no notes.
+		expect(tvs1.find((tv) => tv.property === 'Reviewer')?.value).toBe('Alice');
+
+		// Regression: the captured PUT body must include `metadata` and
+		// must NOT include `element_type` (v6.39.0 cleanup).
+		expect(putBodies.length).toBeGreaterThan(0);
+		const last = putBodies[putBodies.length - 1];
+		expect(last).toHaveProperty('metadata');
+		expect(last).not.toHaveProperty('element_type');
+
+		// Now: reload, re-enter edit, delete the second tagged value,
+		// save, reload, assert it's gone.
+		await page.reload();
+		await page.goto(`/elements/${el.id}?edit=true`);
+		const extendedTrigger2 = page.getByRole('button', { name: /^Extended/ });
+		if ((await extendedTrigger2.getAttribute('data-state')) !== 'open') {
+			await extendedTrigger2.click();
+		}
+		await page
+			.getByRole('button', { name: 'Remove tagged value 2' })
+			.click();
+		await page.getByRole('button', { name: /^Save$/i }).first().click();
+		await page.waitForResponse(
+			(r) =>
+				r.url().includes(`/api/elements/${el.id}`) &&
+				!r.url().includes('/tags') &&
+				r.request().method() === 'PUT',
+		);
+		const res2 = await fetch(`${API_BASE}/api/elements/${el.id}`, {
+			headers: { Authorization: `Bearer ${token}` },
+		});
+		const body2 = (await res2.json()) as { metadata: Record<string, unknown> };
+		const tvs2 = body2.metadata.tagged_values as Array<{ property: string }>;
+		expect(tvs2).toHaveLength(1);
+		expect(tvs2[0].property).toBe('Current Maturity Level');
+	});
+});

--- a/frontend/tests/unit/taggedValues.test.ts
+++ b/frontend/tests/unit/taggedValues.test.ts
@@ -1,0 +1,100 @@
+/**
+ * ADR-228 / SPEC-228-A: Sparx EA `#NOTES#` tagged-value helpers.
+ *
+ * Pure-function tests covering the split / join / unset checks used
+ * by the element metadata editor and (eventually) any other caller
+ * that needs to parse Sparx tagged-value strings on the frontend.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	isUnsetTaggedValue,
+	joinTaggedValue,
+	splitTaggedValue,
+} from '$lib/utils/taggedValues';
+
+describe('splitTaggedValue', () => {
+	it('returns the raw value when no #NOTES# marker is present', () => {
+		expect(splitTaggedValue('3')).toEqual({ value: '3', notes: '' });
+		expect(splitTaggedValue('Approved')).toEqual({ value: 'Approved', notes: '' });
+	});
+
+	it('splits value from notes on the #NOTES# marker', () => {
+		expect(splitTaggedValue('3#NOTES#Values: 1,2,3')).toEqual({
+			value: '3',
+			notes: 'Values: 1,2,3',
+		});
+	});
+
+	it('handles multi-line notes (Sparx convention)', () => {
+		const raw =
+			'-#NOTES#Values: -,0,1,2,3,4,5\nDefault: -\nDescription: 0 - Does not exist';
+		expect(splitTaggedValue(raw)).toEqual({
+			value: '-',
+			notes: 'Values: -,0,1,2,3,4,5\nDefault: -\nDescription: 0 - Does not exist',
+		});
+	});
+
+	it('returns empty value and notes for unset placeholders', () => {
+		expect(splitTaggedValue(null)).toEqual({ value: '', notes: '' });
+		expect(splitTaggedValue(undefined)).toEqual({ value: '', notes: '' });
+		expect(splitTaggedValue('')).toEqual({ value: '', notes: '' });
+		expect(splitTaggedValue('-')).toEqual({ value: '', notes: '' });
+	});
+
+	it('treats a #NOTES# at the very start as empty value + everything as notes', () => {
+		expect(splitTaggedValue('#NOTES#just a description')).toEqual({
+			value: '',
+			notes: 'just a description',
+		});
+	});
+});
+
+describe('joinTaggedValue', () => {
+	it('omits the #NOTES# marker when notes is empty', () => {
+		expect(joinTaggedValue('3', '')).toBe('3');
+		expect(joinTaggedValue('Approved', '')).toBe('Approved');
+	});
+
+	it('joins value and notes with #NOTES#', () => {
+		expect(joinTaggedValue('3', 'Values: 1,2,3')).toBe('3#NOTES#Values: 1,2,3');
+	});
+
+	it('preserves multi-line notes verbatim', () => {
+		const notes = 'Values: -,0,1,2,3,4,5\nDefault: -\nDescription: …';
+		expect(joinTaggedValue('-', notes)).toBe(`-#NOTES#${notes}`);
+	});
+});
+
+describe('round-trip', () => {
+	it('join(split(x)) === x for any non-unset value', () => {
+		const cases = [
+			'3',
+			'3#NOTES#Values: 1,2,3',
+			'Approved',
+			'-#NOTES#Values: -,0,1,2,3\nDefault: -',
+			'#NOTES#description only',
+		];
+		for (const x of cases) {
+			const { value, notes } = splitTaggedValue(x);
+			expect(joinTaggedValue(value, notes)).toBe(x);
+		}
+	});
+});
+
+describe('isUnsetTaggedValue', () => {
+	it.each([null, undefined, '', '-', '-#NOTES#Values: 1,2,3'])(
+		'treats %p as unset',
+		(v) => {
+			expect(isUnsetTaggedValue(v)).toBe(true);
+		},
+	);
+
+	it.each(['3', '3#NOTES#desc', 'Approved', '0', 'false'])(
+		'treats %p as set',
+		(v) => {
+			expect(isUnsetTaggedValue(v)).toBe(false);
+		},
+	);
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.38.0"
+version = "6.39.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.38.0"
+version = "6.39.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes the user-reported gap on the element details page where `metadata.status`, the Extended scalars (stereotype / version / scope / abstract / persistence / author / complexity / phase / EA created+modified dates / gen_type), and `metadata.tagged_values` were display-only despite the backend accepting `metadata` on `ElementUpdate` since v6.36.1.

- **Status**: free-text `<input list="status-suggestions">` + a `<datalist>` of common Sparx values (Approved, Proposed, Implemented, Validated, Mandatory).
- **Extended scalars**: per-field `<input>` in edit mode via a reusable `scalarRow` snippet. Blanking a field deletes it from `metadata` on save (matches the Attributes pattern).
- **Tagged values**: read-only table → editable grid (property + value + notes + delete + add). Sparx `#NOTES#` convention preserved via a new `frontend/src/lib/utils/taggedValues.ts` util.
- **`element_type` PUT-body cleanup**: dropped — `ElementUpdate` doesn't accept it. Dead bytes.

ADR-228 + SPEC-228-A. No backend change. No schema change. Protocol §14 surface parity untouched.

## Test plan

- [x] 19 vitest unit tests for `taggedValues` helpers — green.
- [x] Pre-existing type-checker errors unchanged (same 4 pre-existing "entity possibly null" errors at shifted line numbers; nothing new introduced by this PR).
- [ ] Playwright e2e `element-metadata-edit.spec.ts` covers the round-trip (status edit + tagged-value add/edit/delete + PUT body inspection). Will run in CI.
- [ ] Post-deploy UAT verification on the C&A (alternative name) element — edit status + a tagged value, save, reload, confirm; then revert demo edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)