### PR TITLE
fix(v6.39.1): Status datalist suggestions visible in Chrome/Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.39.1] - 2026-05-31
+
+### Fixed
+
+- **Status datalist suggestions now visible** on the element edit
+  page. Chrome / Edge render an empty dropdown when a `<datalist>`
+  `<option>` carries only a `value` attribute and no text node — the
+  spec-valid `<option value="Approved"></option>` form looks like
+  nothing's there. Repeated the value as the option's text content
+  (`<option value="Approved">Approved</option>`) so the suggestions
+  show across browsers.
+
 ## [6.39.0] - 2026-05-31
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.39.0"
+version = "6.39.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.39.0",
+	"version": "6.39.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -980,11 +980,15 @@
 											style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 										/>
 										<datalist id="status-suggestions">
-											<option value="Approved"></option>
-											<option value="Proposed"></option>
-											<option value="Implemented"></option>
-											<option value="Validated"></option>
-											<option value="Mandatory"></option>
+											<!-- v6.39.1: Chrome/Edge show NOTHING in the datalist
+												 dropdown when an <option> has only a `value` attribute
+												 and no text node. Repeating the value as the label
+												 is the cross-browser pattern. -->
+											<option value="Approved">Approved</option>
+											<option value="Proposed">Proposed</option>
+											<option value="Implemented">Implemented</option>
+											<option value="Validated">Validated</option>
+											<option value="Mandatory">Mandatory</option>
 										</datalist>
 									{:else}
 										{(entity.metadata as Record<string, unknown>).status}

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.39.0"
+version = "6.39.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.39.0"
+version = "6.39.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

v6.39.0 shipped the Status edit input with empty `<option>` elements (`<option value="Approved"></option>`). That's spec-valid but Chrome and Edge render an empty dropdown — the user sees the input accept their typed value but no suggestion list (Firefox is fine).

Fix: repeat the value as the option's text content (`<option value="Approved">Approved</option>`) so the dropdown shows the suggestions across browsers.

## Test plan

- [ ] Open an element on UAT in edit mode, focus the Status input, confirm the dropdown lists Approved / Proposed / Implemented / Validated / Mandatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)