### PR TITLE
fix(v6.39.2): element-aware cache invalidation + Status dropdown UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.39.2] - 2026-05-31
+
+### Fixed
+
+- **Aggregation cache now invalidates on element edits** (ADR-227
+  follow-up). The v6.38.0 two-layer cache only tracked DIAGRAM
+  versions in `AggregationResult.source_versions`. Element edits —
+  the user-facing case (flipping *C&A (alternative name)* from
+  `Proposed` to `Approved` and finding the GEANZ Dashboard's Status
+  pie unchanged) — don't bump the rollup-source diagram's version,
+  so the revalidator passed and we served stale aggregated output.
+  - The engine now records every distinct element it touched during
+    the walk in `AggregationResult.element_versions: dict[str, int]`
+    via one batched `SELECT id, current_version FROM elements WHERE
+    id IN (…)` after the walk completes. Only runs for
+    element-collecting profiles; other `collect_token_type` profiles
+    skip the extra query.
+  - `engine_cache.revalidate` now also batch-checks element versions
+    against the cached set. Any element edit (status flip, attribute
+    change, name rename) bumps the element's `current_version` and
+    misses the cache on next lookup.
+  - Older cached results have an empty `element_versions` dict and
+    still revalidate via the diagram check; new computes populate
+    the new field, so cache warmth recovers within one cold-path
+    request after the deploy.
+
 ## [6.39.1] - 2026-05-31
 
 ### Fixed

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -710,6 +710,26 @@ async def _run_uncached(
         db, grouped, p.output,
     )
 
+    # ADR-227 fix v6.39.2: record the current_version of every distinct
+    # element touched during the walk so the cache revalidator can
+    # detect element-level edits (status flips, metadata changes,
+    # attribute edits) — the diagram-level `source_versions` doesn't
+    # change when only an element's row bumps. Only run for
+    # element-collecting profiles; other collect_token_types don't read
+    # element rows and don't need the extra query.
+    element_versions: dict[str, int] = {}
+    if p.traversal.inner.collect_token_type == "element":
+        token_ids = sorted({r.token_id for r in accumulator})
+        if token_ids:
+            placeholders = ",".join(["?"] * len(token_ids))
+            cursor = await db.execute(
+                "SELECT id, current_version FROM elements "
+                f"WHERE id IN ({placeholders}) AND is_deleted = 0",  # noqa: S608
+                tuple(token_ids),
+            )
+            rows = await cursor.fetchall()
+            element_versions = {r[0]: r[1] for r in rows}
+
     return AggregationResult(
         markdown=markdown,
         computed_at=datetime.now(tz=UTC).isoformat(),
@@ -718,4 +738,5 @@ async def _run_uncached(
         warnings=warnings,
         group_counts=group_counts,
         profile_updated_at=profile_updated_at,
+        element_versions=element_versions,
     )

--- a/backend/app/aggregation/engine_cache.py
+++ b/backend/app/aggregation/engine_cache.py
@@ -182,14 +182,14 @@ async def revalidate(
     profile_updated_at: str,
 ) -> bool:
     """Return True iff the cached result is still consistent with the
-    live profile `updated_at` and the `current_version` of every
-    diagram in `cached.source_versions`.
+    live profile `updated_at`, the `current_version` of every diagram
+    in `cached.source_versions`, AND (ADR-227 v6.39.2 fix) the
+    `current_version` of every element in `cached.element_versions`.
 
-    Two SQL queries: one for the bound profile (caller already has it
-    in hand and passes `profile_updated_at`), one batched query for
-    all referenced diagrams. The caller is responsible for fetching
-    the profile fresh and supplying its `updated_at`; this function
-    only handles the version comparison.
+    Up to three SQL queries: the caller has already fetched the
+    profile and passes its `updated_at`; this function batches one
+    query for the referenced diagrams and (if the cached result
+    walked any elements) one query for the referenced elements.
     """
     cached_profile_updated_at = cached.profile_updated_at
     if cached_profile_updated_at is None:
@@ -200,21 +200,46 @@ async def revalidate(
     if not cached.source_versions:
         # Nothing to validate against — refuse to trust.
         return False
-    ids = list(cached.source_versions.keys())
-    # Build the IN-list placeholders portably (SQLite + Postgres both
-    # accept `?` via the iris asyncpg adapter).
-    placeholders = ",".join(["?"] * len(ids))
-    sql = (
+
+    # ── Diagram-level revalidation (covers source + outer-step refs) ──
+    diag_ids = list(cached.source_versions.keys())
+    placeholders = ",".join(["?"] * len(diag_ids))
+    cursor = await db.execute(
         "SELECT id, current_version FROM diagrams "
-        f"WHERE id IN ({placeholders}) AND is_deleted = 0"
+        f"WHERE id IN ({placeholders}) AND is_deleted = 0",  # noqa: S608
+        tuple(diag_ids),
     )
-    cursor = await db.execute(sql, tuple(ids))
     rows = await cursor.fetchall()
-    live = {r[0]: r[1] for r in rows}
-    if len(live) != len(ids):
+    live_diagrams = {r[0]: r[1] for r in rows}
+    if len(live_diagrams) != len(diag_ids):
         # Some referenced diagram was soft-deleted.
         return False
     for did, ver in cached.source_versions.items():
-        if live.get(did) != ver:
+        if live_diagrams.get(did) != ver:
             return False
+
+    # ── Element-level revalidation (ADR-227 v6.39.2 fix) ───────────────
+    # The diagram-level check above misses pure element edits — e.g. a
+    # status flip in `metadata.status`. The engine now records every
+    # touched element's current_version in `element_versions`; verify
+    # them all here. Older cached results have an empty dict and skip
+    # straight to "valid" (safe: they were computed before the engine
+    # tracked elements, but the diagram check still gates them).
+    if cached.element_versions:
+        elem_ids = list(cached.element_versions.keys())
+        placeholders = ",".join(["?"] * len(elem_ids))
+        cursor = await db.execute(
+            "SELECT id, current_version FROM elements "
+            f"WHERE id IN ({placeholders}) AND is_deleted = 0",  # noqa: S608
+            tuple(elem_ids),
+        )
+        rows = await cursor.fetchall()
+        live_elements = {r[0]: r[1] for r in rows}
+        if len(live_elements) != len(elem_ids):
+            # Some referenced element was soft-deleted.
+            return False
+        for eid, ver in cached.element_versions.items():
+            if live_elements.get(eid) != ver:
+                return False
+
     return True

--- a/backend/app/aggregation/models.py
+++ b/backend/app/aggregation/models.py
@@ -146,3 +146,10 @@ class AggregationResult(BaseModel):
     # cached values (or callers that hand-construct results) remain
     # parseable.
     profile_updated_at: str | None = None
+    # ADR-227 fix v6.39.2: the engine reads every inner-token element's
+    # `metadata` / `data` / `name` during the walk. The diagram-level
+    # `source_versions` doesn't change when only an element's metadata
+    # flips (e.g. a status edit), so the cache used to serve stale
+    # aggregated output. Track element versions too — checked alongside
+    # `source_versions` on revalidate.
+    element_versions: dict[str, int] = Field(default_factory=dict)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.39.1"
+version = "6.39.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_aggregation/test_engine_cache.py
+++ b/backend/tests/test_aggregation/test_engine_cache.py
@@ -288,6 +288,71 @@ async def test_lru_miss_when_source_version_bumps(
 
 
 @pytest.mark.asyncio
+async def test_lru_miss_when_element_metadata_changes(
+    env: tuple[httpx.AsyncClient, DatabaseManager, dict],
+) -> None:
+    """v6.39.2 fix: flipping a referenced element's `metadata.status`
+    (the user-facing case that exposed the bug — element edit on
+    *C&A (alternative name)* didn't update the Dashboard pie) must
+    invalidate the cache. The diagram-level source_versions doesn't
+    change for an element-only edit, so this used to serve stale."""
+    c, dm, h = env
+    profile_id, source_id = await _setup_status_rollup(c, h, dm)
+
+    with patch.object(
+        _engine, "_run_uncached", wraps=_engine._run_uncached,
+    ) as spy:
+        first = await _engine.run(
+            dm.main_db,
+            profile_id=profile_id, source_diagram_id=source_id,
+        )
+        # The status rollup of 2 Approved + 1 Proposed → group_counts
+        # has those two keys.
+        assert first.group_counts.get("Approved") == 2
+        assert first.group_counts.get("Proposed") == 1
+
+        # Flip the Proposed element's status → Approved via the API.
+        # The element's current_version bumps; the source diagram's
+        # version does NOT.
+        # Find the Proposed element id (the source markdown enumerates
+        # them but doesn't tell us which is which; query via the API).
+        listing = await c.get(
+            "/api/elements",
+            headers=h,
+            params={"page_size": 50},
+        )
+        items = listing.json().get("items") or []
+        prop_el = next(
+            (e for e in items if (e.get("metadata") or {}).get("status") == "Proposed"),
+            None,
+        )
+        assert prop_el is not None, "expected at least one Proposed element"
+        flip_response = await c.put(
+            f"/api/elements/{prop_el['id']}",
+            json={
+                "name": prop_el["name"],
+                "data": prop_el.get("data") or {},
+                "metadata": {**(prop_el.get("metadata") or {}), "status": "Approved"},
+            },
+            headers={**h, "If-Match": str(prop_el["current_version"])},
+        )
+        assert flip_response.status_code == 200, flip_response.text
+
+        # Re-run — Layer 2 lookup should detect the element version
+        # bump and miss the cache.
+        second = await _engine.run(
+            dm.main_db,
+            profile_id=profile_id, source_diagram_id=source_id,
+        )
+
+    # _run_uncached fired twice (initial + post-flip recompute).
+    assert spy.call_count == 2
+    # And the recomputed totals reflect the flip: 3 Approved, 0 Proposed.
+    assert second.group_counts.get("Approved") == 3
+    assert second.group_counts.get("Proposed", 0) == 0
+
+
+@pytest.mark.asyncio
 async def test_lru_miss_when_profile_updates(
     env: tuple[httpx.AsyncClient, DatabaseManager, dict],
 ) -> None:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.39.1",
+	"version": "6.39.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.39.1"
+version = "6.39.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.39.1"
+version = "6.39.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Two related fixes from the same user session, bundled per request:

### 1. Aggregation cache invalidates on element edits (ADR-227 follow-up)

User flipped *C&A (alternative name)* status from `Proposed` to `Approved` and the GEANZ Dashboard's Status pie didn't budge. ADR-227's revalidator tracked DIAGRAM versions only — pure element edits don't bump the rollup-source diagram's `current_version`, so the cache passed validation and served stale aggregated output.

- Engine records every distinct element it touched in `AggregationResult.element_versions` via one batched `SELECT id, current_version FROM elements WHERE id IN (...)` after the walk. Element-collecting profiles only.
- `engine_cache.revalidate` batch-checks element versions on every Layer-2 hit. Any element edit bumps `current_version` → cache miss → recompute.
- Older cached results have an empty `element_versions` dict and still revalidate via the diagram check; new computes populate the new field.

### 2. Status dropdown actually shows suggestions

v6.39.0 used `<input list>` + `<datalist>`. v6.39.1 added explicit option text. Neither helped because Chrome's datalist FILTERS suggestions to entries matching the current input text — with "Approved" already in the cell, the dropdown only surfaced "Approved", looking empty.

Swapped to a paired control:
- A real `<select>` for quick-pick of common Sparx values (Approved / Proposed / Implemented / Validated / Mandatory).
- A text `<input>` for custom values.
- Both bind the same `editStatus`; picking from the select fills the input, typing in the input updates the select.
- Non-standard existing values are injected as a `<select>` option so state survives.

## Test plan

- [x] New `test_lru_miss_when_element_metadata_changes` mirrors the user-facing scenario (flip a Proposed element to Approved, assert cache invalidates, new group_counts reflect the flip).
- [x] Full diagrams + aggregation regression — 100 tests green.
- [ ] Post-deploy: edit a capability's status on UAT, reload the Dashboard, confirm the pie updates without a worker restart. The Status edit dropdown should now list all five suggestions when opened, regardless of current cell value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)