### PR TITLE
fix(v6.39.3): re-ship Status select swap (orphaned from v6.39.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Status dropdown on the element edit page now actually shows the
+  suggestions.** The v6.39.0 / v6.39.1 `<input list>` + `<datalist>`
+  approach was being filtered by Chrome to entries matching the
+  current input text — with the cell already showing the existing
+  status, the only entry shown was the existing value, looking like
+  an empty dropdown. Replaced with a paired `<select>` (quick-pick
+  of common Sparx values) + a text input (custom values), both
+  bound to the same `editStatus` state. The select always lists all
+  five standard values plus any non-standard existing value, so
+  state is preserved without forcing the user to retype.
 - **Aggregation cache now invalidates on element edits** (ADR-227
   follow-up). The v6.38.0 two-layer cache only tracked DIAGRAM
   versions in `AggregationResult.source_versions`. Element edits —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.39.3] - 2026-05-31
+
+### Fixed
+
+- **Status dropdown re-released as v6.39.3.** The Status select-swap
+  fix was committed and pushed to the v6.39.2 PR branch but did not
+  land on `main` when the PR was merged (GitHub merge used the
+  earlier commit at PR-edit time). Re-shipped as v6.39.3 to actually
+  roll the fix out.
+
 ## [6.39.2] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.39.2"
+version = "6.39.3"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.39.2",
+	"version": "6.39.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -971,25 +971,45 @@
 								<dt class="text-sm font-medium" style="color: var(--color-muted)">Status</dt>
 								<dd style="color: var(--color-fg)">
 									{#if editingDetails}
-										<input
-											type="text"
-											list="status-suggestions"
-											bind:value={editStatus}
-											aria-label="Status"
-											class="w-full rounded border px-2 py-1 text-sm"
-											style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
-										/>
-										<datalist id="status-suggestions">
-											<!-- v6.39.1: Chrome/Edge show NOTHING in the datalist
-												 dropdown when an <option> has only a `value` attribute
-												 and no text node. Repeating the value as the label
-												 is the cross-browser pattern. -->
-											<option value="Approved">Approved</option>
-											<option value="Proposed">Proposed</option>
-											<option value="Implemented">Implemented</option>
-											<option value="Validated">Validated</option>
-											<option value="Mandatory">Mandatory</option>
-										</datalist>
+										<!-- v6.39.2: the v6.39.1 `<input list>` + `<datalist>`
+											 approach was filtering the dropdown to entries
+											 matching the current input text. With the cell
+											 already showing "Approved", Chrome only surfaced
+											 the matching entry — looking to the user like an
+											 empty dropdown carrying just the existing value.
+											 Pair a real <select> for quick-pick with a text
+											 input for custom values; both bind the same
+											 `editStatus` state, so changes in either
+											 propagate. -->
+										<div class="flex gap-2">
+											<select
+												bind:value={editStatus}
+												aria-label="Status quick-pick"
+												class="rounded border px-2 py-1 text-sm"
+												style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+											>
+												<option value="">—</option>
+												<option value="Approved">Approved</option>
+												<option value="Proposed">Proposed</option>
+												<option value="Implemented">Implemented</option>
+												<option value="Validated">Validated</option>
+												<option value="Mandatory">Mandatory</option>
+												{#if editStatus && !['', 'Approved', 'Proposed', 'Implemented', 'Validated', 'Mandatory'].includes(editStatus)}
+													<!-- Preserve any non-standard existing value so
+														 the select reflects state correctly without
+														 forcing the user to retype it. -->
+													<option value={editStatus}>{editStatus}</option>
+												{/if}
+											</select>
+											<input
+												type="text"
+												bind:value={editStatus}
+												aria-label="Status"
+												placeholder="or type a custom value"
+												class="flex-1 rounded border px-2 py-1 text-sm"
+												style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+											/>
+										</div>
 									{:else}
 										{(entity.metadata as Record<string, unknown>).status}
 									{/if}

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.39.2"
+version = "6.39.3"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.39.2"
+version = "6.39.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

The Status select-swap fix (`<input list>` + `<datalist>` → `<select>` + `<input>`) was committed and pushed to PR #261 (v6.39.2) but did not land on `main` — the merge used the earlier commit ref. Re-shipping as v6.39.3 so the actual fix rolls out.

Same change as the orphaned commit `31ded67`:
- Paired `<select>` (always shows all five Sparx values) with a text `<input>` (custom values), both bound to `editStatus`.
- Non-standard existing values are injected as a `<select>` option so state survives.

## Test plan

- [ ] After deploy: open an element in edit mode, click the Status dropdown — all five values (Approved / Proposed / Implemented / Validated / Mandatory) should be visible regardless of the current cell value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)