### PR TITLE
feat(v6.40.0): form-based aggregation profile editor (SPEC-212-f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.40.0] - 2026-05-31
+
+### Added
+
+- **Form-based aggregation profile editor (SPEC-212-f).** A non-
+  technical user can now create or modify an aggregation profile
+  end-to-end without seeing JSON. Four UX additions land together:
+  - **Output fields** are lifted from the JSON textarea into form
+    widgets — `aggregation_fn` (Sum/Count radio), `group_by` text
+    input with helper menu, `sort_groups` / `sort_items_within_group`
+    selects, `show_per_source_breakdown` checkbox + `breakdown_format`
+    input, and the existing `include_provenance` checkbox.
+  - **`line_format` chip composer** with clickable placeholder chips
+    (`{element.name}`, `{element.id}`, `{sum_value}`, `{bucket}`,
+    `{bucket_spaced}`) that insert at the cursor. When the editor
+    runs against a known source diagram, a debounced live-preview
+    pane shows the first 5 rendered lines via the inline-draft run
+    path.
+  - **Traversal wizard** — a two-step builder for `traversal.outer`
+    (optional, with multiplier sub-form) and `traversal.inner`. The
+    value / bucket attribute-path inputs offer a drill-down picker
+    that reuses the existing `/api/elements/{id}/data-tree` endpoint;
+    falls back to a plain text input when no example element is
+    available (globals authoring path).
+  - **Template gallery** replaces the blank-form default on "New
+    profile". Card grid with the five seeded global profiles plus a
+    Blank card; selecting a card pre-populates the form (no JSON
+    visible).
+  The JSON textarea is retained as an opt-in "Advanced (JSON)"
+  disclosure for power users and for fields the form doesn't surface
+  yet. When Advanced is open, JSON is authoritative on save.
+- **Inline `profile_data` on `POST /api/aggregation/run`** — the
+  endpoint now accepts an optional inline profile draft alongside
+  the existing `profile_id` lookup. Exactly-one-of is enforced. The
+  inline path bypasses the ADR-227 two-layer cache and feeds the
+  draft straight through `_run_uncached`. Mirrored on the MCP
+  `aggregate` tool (new optional `profile_data` arg) and the
+  `iris aggregate` CLI (new `--profile-data <path|->` flag) per the
+  Protocol §14 surface-parity invariant.
+
+### Changed
+
+- `AggregationProfileEditor.svelte` orchestrates four new child
+  components — `LineFormatComposer.svelte`, `TraversalBuilder.svelte`,
+  `AttributePathPicker.svelte`, `AggregationTemplateGallery.svelte`
+  — plus a new `aggregationProfileHelpers.ts` module of pure
+  read/patch/assemble functions shared across the children (DRY §13).
+- `AggregationRunRequest.profile_id` is now optional (paired with
+  `profile_data`). The route handler enforces exactly-one-of and
+  returns a clear `400` on misuse.
+
 ## [6.39.3] - 2026-05-31
 
 ### Fixed

--- a/backend/app/aggregation/engine.py
+++ b/backend/app/aggregation/engine.py
@@ -602,20 +602,34 @@ async def _format_output(
 async def run(
     db: DatabasePort,
     *,
-    profile_id: str,
+    profile_id: str | None = None,
+    profile_data: ProfileData | None = None,
     source_diagram_id: str,
 ) -> AggregationResult:
-    """Apply ``profile_id`` to ``source_diagram_id``. See SPEC-212-b.
+    """Apply a profile to ``source_diagram_id``. See SPEC-212-b.
 
-    ADR-227 (v6.38.0): two-layer cache wrapper. Layer 1 is per-request
-    memoisation via a ContextVar — within one HTTP request, repeated
-    `(profile_id, source_diagram_id)` calls (the common case for a
-    smart-markdown body with multiple `{{aggregation:<view>:…}}` tokens)
-    share a single result. Layer 2 is a process-wide LRU keyed by the
-    same pair, revalidated against profile `updated_at` plus the
-    `current_version` of every diagram in the cached
-    `AggregationResult.source_versions`.
+    Exactly one of ``profile_id`` (saved profile lookup) or
+    ``profile_data`` (inline draft, e.g. the form-editor live preview
+    per SPEC-212-f) must be provided. Inline drafts bypass both cache
+    layers — they're ephemeral and there's no stable key to revalidate
+    against. Saved-profile calls use the ADR-227 two-layer cache: a
+    ContextVar-scoped per-request memo plus a process-wide LRU keyed
+    by ``(profile_id, source_diagram_id)`` and revalidated against the
+    profile's ``updated_at`` and every cached diagram's
+    ``current_version``.
     """
+    if profile_data is not None:
+        # Inline draft — skip both caches; the caller is iterating on
+        # a profile that isn't saved anywhere so there's no stable key.
+        return await _run_uncached(
+            db,
+            profile_id=None,
+            profile_data=profile_data,
+            source_diagram_id=source_diagram_id,
+        )
+    if profile_id is None:
+        raise AggregationProfileNotFound("")
+
     # Layer 1 — per-request memo.
     req_key = ("agg", profile_id, source_diagram_id)
     hit = engine_cache.lookup_request(req_key)
@@ -656,16 +670,27 @@ async def run(
 async def _run_uncached(
     db: DatabasePort,
     *,
-    profile_id: str,
+    profile_id: str | None,
+    profile_data: ProfileData | None = None,
     source_diagram_id: str,
 ) -> AggregationResult:
     """Engine cold path — the original `run` body. Always runs end-to-end;
-    callers are responsible for any caching."""
-    profile_row = await get_aggregation_profile(db, profile_id)
-    if profile_row is None:
-        raise AggregationProfileNotFound(profile_id)
-    p = ProfileData(**profile_row["profile_data"])
-    profile_updated_at = str(profile_row.get("updated_at") or "")
+    callers are responsible for any caching.
+
+    Pass ``profile_data`` for an inline draft (the form-editor live
+    preview path); otherwise ``profile_id`` is loaded from the DB.
+    """
+    if profile_data is not None:
+        p = profile_data
+        profile_updated_at = ""
+    else:
+        if profile_id is None:
+            raise AggregationProfileNotFound("")
+        profile_row = await get_aggregation_profile(db, profile_id)
+        if profile_row is None:
+            raise AggregationProfileNotFound(profile_id)
+        p = ProfileData(**profile_row["profile_data"])
+        profile_updated_at = str(profile_row.get("updated_at") or "")
 
     # Sanity: source must exist.
     src_name, src_version = await _diagram_meta(db, source_diagram_id)

--- a/backend/app/aggregation/models.py
+++ b/backend/app/aggregation/models.py
@@ -126,7 +126,17 @@ class AggregationProfileListResponse(BaseModel):
 
 
 class AggregationRunRequest(BaseModel):
-    profile_id: str = Field(min_length=1)
+    """Run a profile against a source diagram.
+
+    Exactly one of ``profile_id`` (saved profile lookup) or
+    ``profile_data`` (inline draft, used by the form-editor live
+    preview per SPEC-212-f) must be set. The route handler enforces
+    the exclusivity — keeping the rule there lets the response shape
+    a 400 with a clear message instead of a generic 422.
+    """
+
+    profile_id: str | None = Field(default=None, min_length=1)
+    profile_data: ProfileData | None = None
     source_diagram_id: str = Field(min_length=1)
 
 

--- a/backend/app/aggregation/routes.py
+++ b/backend/app/aggregation/routes.py
@@ -167,12 +167,28 @@ async def run_aggregation(
     _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
 ) -> AggregationResult:
     """Apply a profile to a source smart-markdown diagram. Returns the
-    computed markdown and observed source versions."""
+    computed markdown and observed source versions.
+
+    Accepts either ``profile_id`` (saved profile) or ``profile_data``
+    (inline draft for the form-editor live preview — SPEC-212-f).
+    Exactly one must be provided.
+    """
+    if body.profile_id and body.profile_data is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide exactly one of profile_id or profile_data",
+        )
+    if not body.profile_id and body.profile_data is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide one of profile_id or profile_data",
+        )
     db = request.app.state.db_manager.main_db
     try:
         return await _engine.run(
             db,
             profile_id=body.profile_id,
+            profile_data=body.profile_data,
             source_diagram_id=body.source_diagram_id,
         )
     except AggregationProfileNotFound:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.39.3"
+version = "6.40.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_aggregation/test_inline_profile_run.py
+++ b/backend/tests/test_aggregation/test_inline_profile_run.py
@@ -1,0 +1,286 @@
+"""POST /api/aggregation/run with an inline profile_data draft (SPEC-212-f).
+
+Enables the form-editor's live-preview pane to render a draft profile
+that hasn't been saved yet. Mirrors the on-disk profile-id path through
+the same engine — no duplication.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True, cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1, argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def env(
+    app_config: AppConfig,
+) -> AsyncIterator[tuple[httpx.AsyncClient, dict]]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        await c.post(
+            "/api/auth/setup",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        resp = await c.post(
+            "/api/auth/login",
+            json={"username": "admin", "password": "AdminPass123!"},
+        )
+        h = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        yield c, h
+    await db_manager.close()
+
+
+_ATTR_BLUEPRINT = {
+    "attributes": [
+        {"name": "Quantity", "type": "", "scope": "Public",
+         "notes": "", "lower_bound": "", "upper_bound": ""},
+        {"name": "Unit", "type": "g", "scope": "Public",
+         "notes": "", "lower_bound": "", "upper_bound": ""},
+    ],
+}
+
+
+_INLINE_PROFILE = {
+    "traversal": {
+        "inner": {
+            "collect_token_type": "element",
+            "value_attribute_path": "attributes/Quantity/type",
+            "bucket_attribute_path": "attributes/Unit/type",
+            "skip_blank_values": True,
+        },
+    },
+    "output": {
+        "group_by": "element.name",
+        "sort_groups": "alpha",
+        "sort_items_within_group": "alpha",
+        "aggregation_fn": "sum",
+        "line_format": "- {element.name}: {sum_value}{bucket_spaced}",
+        "show_per_source_breakdown": False,
+        "breakdown_format": "",
+    },
+}
+
+
+async def _seed_source(
+    c: httpx.AsyncClient, h: dict,
+) -> tuple[str, str]:
+    """Create a set + Pork element + smart-markdown diagram referencing
+    it twice (so the engine has something to aggregate). Returns
+    (set_id, diagram_id)."""
+    r = await c.post("/api/sets", json={"name": "S"}, headers=h)
+    set_id = r.json()["id"]
+    r = await c.post(
+        "/api/elements",
+        json={
+            "name": "Pork mince", "element_type": "class",
+            "set_id": set_id, "data": _ATTR_BLUEPRINT,
+        },
+        headers=h,
+    )
+    pork_id = r.json()["id"]
+    source = (
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=500}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}\n"
+        f"- {{{{element:{pork_id}:attr:attributes/Quantity/type=300}}}} "
+        f"{{{{element:{pork_id}:attr:attributes/Unit/type}}}}"
+    )
+    r = await c.post(
+        "/api/diagrams",
+        json={
+            "name": "Src", "set_id": set_id,
+            "diagram_type": "smart_markdown", "notation": "markdown",
+            "data": {"markdown_source": source},
+        },
+        headers=h,
+    )
+    return set_id, r.json()["id"]
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Happy path
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_with_inline_profile_data_renders(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """profile_data only — engine runs against the inline draft."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/run",
+        json={
+            "profile_data": _INLINE_PROFILE,
+            "source_diagram_id": diag_id,
+        },
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # 500 + 300 = 800 g
+    assert "Pork mince: 800 g" in body["markdown"]
+    assert body["row_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_run_inline_profile_does_not_persist(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """An inline draft is ephemeral — no profile is created on disk."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    # Snapshot the profile list before the inline run (the m077 seed
+    # ships globals, so we compare deltas — not absolute counts).
+    r = await c.get("/api/aggregation/profiles", headers=h)
+    before = r.json()["total"]
+    await c.post(
+        "/api/aggregation/run",
+        json={
+            "profile_data": _INLINE_PROFILE,
+            "source_diagram_id": diag_id,
+        },
+        headers=h,
+    )
+    r = await c.get("/api/aggregation/profiles", headers=h)
+    assert r.status_code == 200
+    assert r.json()["total"] == before
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Validation guards
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_both_profile_id_and_profile_data(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """Exactly-one-of contract — passing both is a client error."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/run",
+        json={
+            "profile_id": "any-string",
+            "profile_data": _INLINE_PROFILE,
+            "source_diagram_id": diag_id,
+        },
+        headers=h,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_neither_profile_id_nor_profile_data(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """Exactly-one-of contract — passing neither is a client error."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/run",
+        json={"source_diagram_id": diag_id},
+        headers=h,
+    )
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_malformed_inline_profile_data(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """Pydantic catches a profile_data that doesn't match ProfileData."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/run",
+        json={
+            # Missing required `traversal.inner` and `output`.
+            "profile_data": {"traversal": {}},
+            "source_diagram_id": diag_id,
+        },
+        headers=h,
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_run_inline_profile_source_not_found(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """The source-diagram 404 path still fires for inline drafts."""
+    c, h = env
+    await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/run",
+        json={
+            "profile_data": _INLINE_PROFILE,
+            "source_diagram_id": "non-existent-diagram-id",
+        },
+        headers=h,
+    )
+    assert r.status_code == 404, r.text
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Existing profile_id path remains unchanged
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_run_with_profile_id_still_works(
+    env: tuple[httpx.AsyncClient, dict],
+) -> None:
+    """Backwards compatibility — the on-disk profile_id path is intact."""
+    c, h = env
+    _, diag_id = await _seed_source(c, h)
+    r = await c.post(
+        "/api/aggregation/profiles",
+        json={
+            "name": "Saved profile",
+            "is_global": True,
+            "profile_data": _INLINE_PROFILE,
+        },
+        headers=h,
+    )
+    assert r.status_code == 201, r.text
+    profile_id = r.json()["id"]
+    r = await c.post(
+        "/api/aggregation/run",
+        json={
+            "profile_id": profile_id,
+            "source_diagram_id": diag_id,
+        },
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    assert "Pork mince: 800 g" in r.json()["markdown"]

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -1475,21 +1475,47 @@ def delete_aggregation_profile_cmd(profile_id: str = typer.Argument(...)) -> Non
 
 @app.command("aggregate")
 def aggregate_cmd(
-    profile: str = typer.Option(
-        ..., "--profile",
-        help="Profile id (UUID).",
-    ),
     source: str = typer.Option(
         ..., "--source",
         help="Source smart_markdown diagram id (UUID).",
+    ),
+    profile: str | None = typer.Option(
+        None, "--profile",
+        help="Saved profile id (UUID). Mutually exclusive with --profile-data.",
+    ),
+    profile_data: str | None = typer.Option(
+        None, "--profile-data",
+        help=(
+            "Inline profile draft as a JSON file path, or `-` to read "
+            "from stdin (SPEC-212-f). Mutually exclusive with --profile."
+        ),
     ),
 ) -> None:
     """Run an aggregation profile against a source diagram (ADR-212).
 
     Returns the computed markdown plus metadata. Equivalent to
-    `POST /api/aggregation/run`.
+    `POST /api/aggregation/run`. Pass either --profile (saved) or
+    --profile-data (inline draft, SPEC-212-f) but not both.
     """
-    body = {"profile_id": profile, "source_diagram_id": source}
+    if (profile is None) == (profile_data is None):
+        msg = (
+            "Provide exactly one of --profile or --profile-data."
+        )
+        raise typer.BadParameter(msg)
+
+    body: dict[str, Any] = {"source_diagram_id": source}
+    if profile is not None:
+        body["profile_id"] = profile
+    if profile_data is not None:
+        # Inline draft — accept a file path or `-` for stdin.
+        raw = sys.stdin.read() if profile_data == "-" else Path(
+            profile_data,
+        ).read_text(encoding="utf-8")
+        try:
+            body["profile_data"] = json_lib.loads(raw)
+        except json_lib.JSONDecodeError as exc:
+            msg = f"--profile-data is not valid JSON: {exc}"
+            raise typer.BadParameter(msg) from exc
 
     async def _do() -> Any:
         async with _client() as c:

--- a/docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md
+++ b/docs/adrs/specs/SPEC-212-b-Aggregation-Engine.md
@@ -217,3 +217,9 @@ For the shopping-list demo (~30 recipes × ~10 ingredients), full computation is
 - Dangling outer token (deleted diagram) → warning, no contribution.
 
 `backend/tests/test_aggregation/test_seeded_profiles_smoke.py` — for each of the five seeded profiles, build a minimal fixture and assert the engine runs without raising. Asserts the seeded JSON validates against the schema. Does NOT assert specific output (output-format details are per-profile).
+
+## 12. Inline `profile_data` path (SPEC-212-f)
+
+`engine.run()` accepts an optional `profile_data: ProfileData | None` kwarg in addition to `profile_id`. When `profile_data` is supplied, the engine bypasses the ADR-227 two-layer cache (no stable key to revalidate against) and feeds the supplied `ProfileData` straight into the cold path — exactly the same internal walk/group/format pipeline as the persisted-profile case, no logic duplication. Used by the form-editor's live-preview pane (`LineFormatComposer.svelte`) and by callers that want a one-off run without persisting a profile. Exactly one of `profile_id` or `profile_data` must be set; the REST/MCP/CLI surfaces enforce this on their side and the engine treats the un-supplied case as `AggregationProfileNotFound`.
+
+`backend/tests/test_aggregation/test_inline_profile_run.py` — covers the inline path end-to-end via `POST /api/aggregation/run`.

--- a/docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md
+++ b/docs/adrs/specs/SPEC-212-c-Aggregation-Surfaces.md
@@ -74,3 +74,23 @@ iris aggregate                    --profile <id-or-name> --source <diagram-id>
 `mcp/tests/test_aggregation.py` — every MCP tool name resolves and forwards correctly.
 
 `cli/tests/test_aggregation.py` — every CLI subcommand round-trips against a fixture API.
+
+## 6. Inline `profile_data` on `/run` (SPEC-212-f)
+
+`POST /api/aggregation/run` accepts an optional `profile_data: ProfileData` in the request body for the form-editor's live-preview pane:
+
+```json
+{
+  "profile_data": {"traversal": {...}, "output": {...}},
+  "source_diagram_id": "<uuid>"
+}
+```
+
+Exactly one of `profile_id` or `profile_data` must be supplied — providing both is `400`, providing neither is `400`. Malformed inline `profile_data` is `422` (Pydantic). The inline path bypasses the ADR-227 cache.
+
+Mirrored on the parity surfaces:
+
+- **MCP** `aggregate` tool: `profile_id` is now optional, new optional `profile_data: object` arg with the same exactly-one-of semantics.
+- **CLI** `iris aggregate`: `--profile-data <path|->` flag accepts a JSON file path or `-` for stdin. Mutually exclusive with `--profile`.
+
+`scripts/check_surface_parity.py` is unaffected — only the write set is checked, and `aggregate` was already a read-shaped POST on the existing exception list.

--- a/docs/adrs/specs/SPEC-212-f-Aggregation-Profile-Form-Editor.md
+++ b/docs/adrs/specs/SPEC-212-f-Aggregation-Profile-Form-Editor.md
@@ -1,0 +1,144 @@
+# SPEC-212-f: Aggregation profile form-editor (JSON-free authoring)
+
+Implements: extension of [ADR-212](../ADR-212-Aggregation-Profiles-And-Engine.md). Builds on [SPEC-212-d](./SPEC-212-d-Aggregation-Profile-Editor.md) (v1 JSON-textarea editor) and [SPEC-212-e](./SPEC-212-e-Aggregation-Profile-Editor-Polish.md) (clone-from-existing). Addresses the "future v6.26+" list in SPEC-212-d §7: form-based fields, attribute-path autocomplete, and inline preview.
+
+## 1. Goal
+
+A non-technical user can create or modify an aggregation profile end-to-end **without seeing JSON**. The JSON textarea remains as an opt-in "Advanced" escape hatch for power users and for fields the form doesn't surface yet.
+
+## 2. Four UX additions
+
+The work is grouped as four orthogonal additions, all landing together:
+
+| # | Addition | Component |
+|---|---|---|
+| A | Lift flat output fields to form widgets | `AggregationProfileEditor.svelte` (in place) |
+| B | `line_format` chip composer with live preview | `LineFormatComposer.svelte` (new child) |
+| C | Traversal wizard with attribute-path picker | `TraversalBuilder.svelte` + `AttributePathPicker.svelte` (new children) |
+| E | Template gallery on "New profile" | `AggregationTemplateGallery.svelte` (new child) |
+
+The four child components compose. The editor owns the draft state; children are pure presentation bound via Svelte 5 `$bindable` props.
+
+## 3. Backend surface — inline `profile_data` on `/run`
+
+The live-preview pane (Option B) needs to run an unsaved draft. Extend `AggregationRunRequest`:
+
+```python
+class AggregationRunRequest(BaseModel):
+    profile_id: str | None = Field(default=None, min_length=1)
+    profile_data: ProfileData | None = None
+    source_diagram_id: str = Field(min_length=1)
+```
+
+Exactly-one-of (`profile_id` XOR `profile_data`) is enforced in the route handler, returning a `400` with a clear message. The engine's `run()` gains an optional `profile_data` kwarg; when provided it bypasses both ADR-227 cache layers (no stable key to revalidate against) and feeds the inline `ProfileData` straight into `_run_uncached`.
+
+Mirrored in:
+
+- MCP `aggregate` tool — `profile_id` becomes optional, `profile_data: object` added.
+- CLI `iris aggregate` — `--profile-data <path|-> ` accepts a file path or stdin.
+
+Surface parity (Protocol §14) stays clean — `scripts/check_surface_parity.py` passes unchanged.
+
+## 4. Helpers — single source of truth for form ↔ JSON
+
+`frontend/src/lib/components/aggregationProfileHelpers.ts` exposes pure functions that all four child components share (DRY §13):
+
+- `readOutputFields(profileData) → OutputFields` / `patchOutputFields(profileData, fields)` — Option A round-trip.
+- `readTraversalFields(profileData) → TraversalFields` / `patchTraversalFields(profileData, fields)` — Option C round-trip.
+- `assembleProfileData(output, traversal)` — assembles a full `profile_data` for save / preview.
+- `buildDraftFromTemplate(seed)` / `buildBlankDraft()` — Option E seed → form-fields hydration.
+- `insertAtCursor(text, cursor, insertion)` — Option B chip insertion.
+- Enum constants (`TOKEN_TYPES`, `SORT_MODES`, `AGGREGATION_FNS`) and `LINE_FORMAT_PLACEHOLDERS` — mirror backend Pydantic literals. Tests guard drift.
+
+The Pydantic backend remains the validation source of truth; the frontend constants only populate dropdowns. A new value added backend-side requires a one-line addition here (and the round-trip test will fail loudly if patterns diverge).
+
+## 5. Option A — lifted output fields
+
+`AggregationProfileEditor.svelte` renders an "Output" section above the JSON textarea with:
+
+- `aggregation_fn` — select (Sum / Count)
+- `group_by` — text input + helper showing common path shapes
+- `sort_groups`, `sort_items_within_group` — selects
+- `show_per_source_breakdown` — checkbox; reveals `breakdown_format` input
+- `include_provenance` — checkbox (existing, kept in place)
+
+Empty `group_by` normalises to `null` so the engine treats it as ungrouped. The form patches its values into a draft `profile_data` object that mirrors what would be POSTed.
+
+## 6. Option B — `line_format` chip composer + live preview
+
+`LineFormatComposer.svelte`:
+
+- Single-line text input + a row of clickable placeholder chips: `{element.name}`, `{element.id}`, `{sum_value}`, `{bucket}`, `{bucket_spaced}`. Clicking a chip inserts it at the input's cursor (`insertAtCursor` helper).
+- Live-preview pane: when `sourceDiagramId` is supplied, debounce-call (400 ms) `POST /api/aggregation/run` with the inline `profile_data` and show the first 5 rendered lines. Validation failures and source-not-found are rendered as inline error chips, not blocking.
+- When no source is supplied (globals authoring), the preview pane is replaced by a one-line "Live preview requires a source diagram" notice.
+
+The placeholder catalogue lives in `aggregationProfileHelpers.LINE_FORMAT_PLACEHOLDERS` so docs and composer never drift.
+
+## 7. Option C — traversal wizard + path picker
+
+`TraversalBuilder.svelte` renders two `<details open>` sections:
+
+- **Source container (optional)**: "These items live inside a parent container" checkbox; when on, shows the outer token-type select and (optional) multiplier sub-form (numerator override path + divisor path + default multiplier).
+- **Inner items**: token-type select + value path picker + bucket path picker + `skip_blank_values` checkbox.
+
+`AttributePathPicker.svelte` is a new lightweight picker that:
+
+- Hits `/api/elements/{id}/data-tree` (the same endpoint `SmartMarkdownSlashPicker` uses; that endpoint is the **single source of truth** for the data-tree shape — both consumers depend on it, no logic duplication).
+- Drills via the `dict.keys` / `list_of_named.names` / `list.length` descriptor returned by the endpoint.
+- Emits a path string only (e.g. `attributes/Quantity/type`) — not the full `{{element:UUID:attr:…}}` smart-markdown token the slash picker produces.
+- Falls back to a plain text input when no `exampleElementId` is supplied (globals authoring path).
+
+**Out of scope here**: refactoring `SmartMarkdownSlashPicker` itself to consume `AttributePathPicker` internally. The slash picker is deeply intertwined with browse-mode and stamps; that refactor is a separate, higher-risk change. The two pickers share the backend endpoint, which is what DRY actually requires — the *logic* (walking the data tree) lives in one place (the server), with two UI consumers tuned for different jobs.
+
+## 8. Option E — template gallery
+
+`AggregationTemplateGallery.svelte` replaces the blank-form default when a user clicks "New profile":
+
+- Card grid (`auto-fill` / `minmax(220px, 1fr)`, mirroring `EntityImagesEditor`'s grid pattern — DRY §13).
+- "Blank" card first; then one card per seeded global profile (Shopping list, Sprint points rollup, Time tracker rollup, Expense report, Reading log rollup — from `m077_seed_global_aggregation_profiles.py`).
+- Each card shows: name, description, and a truncated `line_format` preview.
+- Selecting a card pre-populates Option A's form fields and Option C's wizard via `buildDraftFromTemplate`. The user only sees JSON if they open Advanced.
+
+The legacy "+ Clone from existing" button remains alongside the gallery as a secondary action — it still surfaces in-scope user profiles + globals in a flat list for users who want to clone something they've previously customised.
+
+## 9. Save semantics
+
+- Default path (Advanced closed): form fields are authoritative. Save serialises `assembleProfileData(draftOutput, draftTraversal)` and posts it.
+- Advanced open: JSON textarea is authoritative. Save runs `JSON.parse(draftJson)` and posts that. JSON syntax errors keep the editor open with an inline message.
+- The Advanced disclosure opening also syncs the JSON from the current form state (so the user sees the JSON the form would have produced, with their edits as the starting point).
+
+## 10. Genericness invariant (ADR-214)
+
+All new copy + placeholder text passes `scripts/check_aggregation_genericness.py`. The aggregation feature stays domain-neutral end-to-end — placeholders show structural examples (`attributes/<Name>/type`, `data.<field>`), never food/sprint/expense terminology.
+
+## 11. Tests
+
+- `frontend/tests/unit/aggregationProfileHelpers.test.ts` — 29 tests covering read/patch round-trips, default fallbacks, empty-string normalisation, blank-draft validity, template-clone draft construction, chip-insert cursor math, and inline-run body shape. Pure-function tests per repo convention (no component renders).
+- `frontend/tests/unit/aggregationProfileEditor.test.ts` — existing 13 tests intact (request body shapes, list filter logic, clone draft construction).
+- `backend/tests/test_aggregation/test_inline_profile_run.py` — 7 tests covering happy path, ephemerality (no row created), 400 on both/neither, 422 on malformed inline `profile_data`, 404 on missing source, and backwards-compat for the saved-`profile_id` path.
+
+## 12. Files touched
+
+| Path | Change |
+|---|---|
+| `backend/app/aggregation/models.py` | `AggregationRunRequest` accepts optional `profile_data` |
+| `backend/app/aggregation/routes.py` | Route handler enforces exactly-one-of + forwards `profile_data` |
+| `backend/app/aggregation/engine.py` | `run()` accepts optional `profile_data`; inline path bypasses cache |
+| `mcp/src/iris_mcp/tools.py` | `aggregate` tool gets optional `profile_data` arg |
+| `cli/src/iris_cli/main.py` | `iris aggregate --profile-data <path|->` flag |
+| `frontend/src/lib/components/aggregationProfileHelpers.ts` (new) | Shared pure helpers |
+| `frontend/src/lib/components/AggregationProfileEditor.svelte` | Orchestrator — composes the four children |
+| `frontend/src/lib/components/LineFormatComposer.svelte` (new) | Option B |
+| `frontend/src/lib/components/TraversalBuilder.svelte` (new) | Option C |
+| `frontend/src/lib/components/AttributePathPicker.svelte` (new) | Option C — path picker |
+| `frontend/src/lib/components/AggregationTemplateGallery.svelte` (new) | Option E |
+| `frontend/tests/unit/aggregationProfileHelpers.test.ts` (new) | Helpers tests |
+| `backend/tests/test_aggregation/test_inline_profile_run.py` (new) | Inline-run tests |
+| `docs/adrs/specs/SPEC-212-b-*.md` | Note inline engine path |
+| `docs/adrs/specs/SPEC-212-c-*.md` | Note new run-endpoint field + parity mirrors |
+
+## 13. Follow-ups (not in this spec)
+
+- Refactor `SmartMarkdownSlashPicker` to consume `AttributePathPicker` internally (would eliminate two slightly-different drill UIs, but is high-risk without a dedicated test pass).
+- Schema-driven form rendering (Option D from the planning conversation): derive the form from `ProfileData.model_json_schema()` exported via a new `/api/aggregation/profile-schema` endpoint. Becomes attractive once the custom widgets here are stable.
+- Joint "create profile + paired element template" wizard tying ADR-211 into the gallery cards.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.39.3",
+	"version": "6.40.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/AggregationProfileEditor.svelte
+++ b/frontend/src/lib/components/AggregationProfileEditor.svelte
@@ -1,19 +1,32 @@
 <script lang="ts">
 	/**
 	 * SPEC-212-d: aggregation-profile editor (v6.25.0).
+	 * SPEC-212-e (v6.29.0): clone-from-existing picker.
+	 * SPEC-212-f: form-based authoring — output fields lifted out of
+	 *   JSON (Option A), `line_format` chip composer with live preview
+	 *   (Option B), traversal wizard with attribute-path picker
+	 *   (Option C), and a template gallery on "New profile" (Option E).
+	 *   The JSON textarea is retained as an "Advanced (JSON)" escape
+	 *   hatch — round-tripping through JSON.parse / JSON.stringify so
+	 *   power users keep their direct path.
 	 *
-	 * Reusable component for creating, editing, and deleting
-	 * aggregation profiles (ADR-212). Used in two parents:
+	 * Used in two parents:
 	 *   - /admin/aggregation-profiles for global profiles.
 	 *   - /sets/{id} for set-scoped profiles.
-	 *
-	 * v1 surface: list + create + delete + edit (JSON textarea with
-	 * parse-validate on save). Form-based tabs editor with autocomplete
-	 * is a future follow-up — the seeded profiles are good clone
-	 * templates.
 	 */
 
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import {
+		readOutputFields, patchOutputFields,
+		readTraversalFields, patchTraversalFields,
+		assembleProfileData,
+		buildDraftFromTemplate, buildBlankDraft,
+		AGGREGATION_FNS, SORT_MODES,
+		type OutputFields, type TraversalFields,
+	} from './aggregationProfileHelpers';
+	import AggregationTemplateGallery from './AggregationTemplateGallery.svelte';
+	import LineFormatComposer from './LineFormatComposer.svelte';
+	import TraversalBuilder from './TraversalBuilder.svelte';
 
 	interface Props {
 		/** When set, only this set's profiles + globals are shown.
@@ -22,6 +35,10 @@
 		/** When true, the editor manages globals only — Create produces
 		 * is_global=true profiles. */
 		globalsMode?: boolean;
+		/** Source smart-markdown diagram id used by the live-preview pane
+		 *  in the LineFormatComposer. Caller typically passes the page's
+		 *  primary aggregation source; leave null to hide preview. */
+		previewSourceDiagramId?: string | null;
 	}
 
 	interface AggregationProfile {
@@ -46,60 +63,45 @@
 		page_size: number;
 	}
 
-	let { setId = null, globalsMode = false }: Props = $props();
+	let {
+		setId = null,
+		globalsMode = false,
+		previewSourceDiagramId = null,
+	}: Props = $props();
 
 	let profiles = $state<AggregationProfile[]>([]);
 	let loading = $state(true);
 	let listError = $state<string | null>(null);
 
 	// Editor state — when editingId is non-null we're editing a row;
-	// when creating is true we're creating a new one (blank or cloned).
+	// when creating is true we're creating a new one (blank or template).
 	let editingId = $state<string | null>(null);
 	let creating = $state(false);
+	let gallery = $state(false);
 	let draftName = $state('');
 	let draftDescription = $state('');
 	let draftJson = $state('');
 	let draftIsDefault = $state(false);
-	// SPEC-217-a (v6.31.0) — surface the `output.include_provenance` flag as
-	// a discrete checkbox so a non-technical user can flip it without editing
-	// the JSON. The rest of the profile_data still lives in the textarea below;
-	// this checkbox patches the parsed JSON on save.
-	let draftIncludeProvenance = $state(false);
+	let draftOutput = $state<OutputFields>(readOutputFields(null));
+	let draftTraversal = $state<TraversalFields>(readTraversalFields(null));
+	let showAdvanced = $state(false);
 	let draftError = $state<string | null>(null);
 	let saving = $state(false);
 
-	function readIncludeProvenance(profileData: Record<string, unknown>): boolean {
-		const output = profileData?.output as Record<string, unknown> | undefined;
-		return output?.include_provenance === true;
-	}
-
-	// SPEC-212-e (v6.29.0): Clone-from-existing picker state.
+	// SPEC-212-e (v6.29.0): clone-from-existing picker (kept as a
+	// secondary action alongside the gallery so set-scoped users can
+	// still clone an in-scope custom profile).
 	let cloning = $state(false);
 	let cloneCandidates = $state<AggregationProfile[]>([]);
 
-	const DEFAULT_PROFILE_JSON = JSON.stringify({
-		traversal: {
-			inner: {
-				collect_token_type: 'element',
-				value_attribute_path: 'attributes/Quantity/type',
-				bucket_attribute_path: null,
-				skip_blank_values: true,
-			},
-		},
-		output: {
-			group_by: 'element.package_name',
-			sort_groups: 'alpha',
-			sort_items_within_group: 'alpha',
-			aggregation_fn: 'sum',
-			line_format: '- {element.name}: {sum_value}{bucket_spaced}',
-			show_per_source_breakdown: false,
-			breakdown_format: ' ({sources_joined})',
-			include_provenance: false,
-		},
-	}, null, 2);
+	// Seeded global profiles for the Option E gallery. Loaded once when
+	// the gallery opens — the set is small (5 today) so a single fetch
+	// is fine.
+	let seededGlobals = $state<AggregationProfile[]>([]);
 
 	$effect(() => {
-		// Re-fetch when scope changes.
+		void setId;
+		void globalsMode;
 		void load();
 	});
 
@@ -118,7 +120,6 @@
 				`/api/aggregation/profiles?${params}`,
 			);
 			profiles = (data.items ?? []).filter((p) => {
-				// In set mode, exclude globals; in globals mode, exclude set-scoped.
 				if (globalsMode) return p.is_global;
 				if (setId) return !p.is_global && p.set_id === setId;
 				return true;
@@ -129,28 +130,63 @@
 		loading = false;
 	}
 
-	function startCreate() {
-		creating = true;
+	// Form ↔ JSON sync: when form fields change (the default path), the
+	// JSON textarea is regenerated. When the user opens Advanced and
+	// edits JSON directly, we parse it on save and let JSON win.
+	function syncJsonFromForm() {
+		const pd = assembleProfileData(draftOutput, draftTraversal);
+		draftJson = JSON.stringify(pd, null, 2);
+	}
+
+	async function startGallery() {
+		gallery = true;
+		creating = false;
 		editingId = null;
 		cloning = false;
-		draftName = '';
-		draftDescription = '';
-		draftJson = DEFAULT_PROFILE_JSON;
-		draftIsDefault = false;
-		draftIncludeProvenance = false;
+		// Fetch globals to populate the gallery if we haven't already.
+		if (seededGlobals.length === 0) {
+			try {
+				const params = new URLSearchParams();
+				params.set('include_global', 'true');
+				const data = await apiFetch<ListResponse>(
+					`/api/aggregation/profiles?${params}`,
+				);
+				seededGlobals = (data.items ?? []).filter((p) => p.is_global);
+			} catch {
+				seededGlobals = [];
+			}
+		}
+	}
+
+	function pickFromGallery(template: { id: string; name: string; description: string | null; profile_data: Record<string, unknown> } | null) {
+		gallery = false;
+		creating = true;
+		editingId = null;
+		const draft = template ? buildDraftFromTemplate(template) : buildBlankDraft();
+		// For a template clone we want a fresh name (the helper suffixes
+		// " (copy)"); for blank we leave it empty so the field highlights.
+		draftName = template ? draft.name : '';
+		draftDescription = draft.description;
+		draftJson = draft.json;
+		draftIsDefault = draft.isDefault;
+		draftOutput = draft.output;
+		draftTraversal = draft.traversal;
+		showAdvanced = false;
 		draftError = null;
 	}
 
-	// SPEC-212-e: open the clone-source picker. Candidates are the
-	// in-scope profiles already loaded in `profiles`, plus globals when
-	// we're in set-mode (so the user can clone from a seeded global
-	// into a set-scoped copy).
+	function cancelGallery() {
+		gallery = false;
+	}
+
+	// SPEC-212-e: open the clone-source picker. Candidates are in-scope
+	// profiles plus globals when we're in set-mode (so a user can clone
+	// from a seeded global into a set-scoped copy).
 	async function startClone() {
 		cloning = true;
 		creating = false;
 		editingId = null;
-		// In set mode, also fetch globals so the user can clone from
-		// a seeded global into a new set-scoped profile.
+		gallery = false;
 		if (setId) {
 			try {
 				const params = new URLSearchParams();
@@ -174,55 +210,72 @@
 	}
 
 	function commitClone(source: AggregationProfile) {
+		const draft = buildDraftFromTemplate({
+			id: source.id, name: source.name,
+			description: source.description,
+			profile_data: source.profile_data,
+		});
 		creating = true;
 		editingId = null;
 		cloning = false;
 		cloneCandidates = [];
-		draftName = `${source.name} (copy)`;
-		draftDescription = source.description ?? '';
-		draftJson = JSON.stringify(source.profile_data, null, 2);
-		draftIsDefault = false;  // copies don't inherit default-for-set
-		draftIncludeProvenance = readIncludeProvenance(source.profile_data);
+		draftName = draft.name;
+		draftDescription = draft.description;
+		draftJson = draft.json;
+		draftIsDefault = draft.isDefault;
+		draftOutput = draft.output;
+		draftTraversal = draft.traversal;
+		showAdvanced = false;
 		draftError = null;
 	}
 
 	function startEdit(p: AggregationProfile) {
 		editingId = p.id;
 		creating = false;
+		gallery = false;
+		cloning = false;
 		draftName = p.name;
 		draftDescription = p.description ?? '';
 		draftJson = JSON.stringify(p.profile_data, null, 2);
 		draftIsDefault = p.is_default_for_set;
-		draftIncludeProvenance = readIncludeProvenance(p.profile_data);
+		draftOutput = readOutputFields(p.profile_data);
+		draftTraversal = readTraversalFields(p.profile_data);
+		showAdvanced = false;
 		draftError = null;
 	}
 
 	function cancelEdit() {
 		creating = false;
 		editingId = null;
+		gallery = false;
+		cloning = false;
 		draftError = null;
 	}
 
 	async function save() {
 		if (saving) return;
 		draftError = null;
-		let parsed: Record<string, unknown>;
-		try {
-			parsed = JSON.parse(draftJson);
-		} catch (e) {
-			draftError = `Invalid JSON: ${(e as Error).message}`;
-			return;
-		}
 		if (!draftName.trim()) {
 			draftError = 'Name is required';
 			return;
 		}
-		// SPEC-217-a: merge the include-provenance checkbox into output.include_provenance.
-		// We ensure the output object exists so a malformed profile_data doesn't
-		// silently drop the flag on save.
-		const outputObj = (parsed.output as Record<string, unknown> | undefined) ?? {};
-		outputObj.include_provenance = draftIncludeProvenance;
-		parsed.output = outputObj;
+		// Two sources of truth for profile_data:
+		//   - Form fields (default) — assemble from draftOutput + draftTraversal.
+		//   - Advanced JSON — user may have edited the textarea directly.
+		// When Advanced is open we trust the JSON (the user opted in);
+		// otherwise we trust the form. JSON-syntax errors keep the
+		// editor open with an inline error.
+		let parsed: Record<string, unknown>;
+		if (showAdvanced) {
+			try {
+				parsed = JSON.parse(draftJson);
+			} catch (e) {
+				draftError = `Invalid JSON: ${(e as Error).message}`;
+				return;
+			}
+		} else {
+			parsed = assembleProfileData(draftOutput, draftTraversal);
+		}
 		saving = true;
 		try {
 			if (creating) {
@@ -274,6 +327,20 @@
 			listError = e instanceof ApiError ? e.message : 'Failed to delete profile';
 		}
 	}
+
+	function toggleAdvanced() {
+		// Entering advanced mode → serialise current form state into JSON
+		// so the textarea matches what would be saved.
+		if (!showAdvanced) {
+			syncJsonFromForm();
+		}
+		showAdvanced = !showAdvanced;
+	}
+
+	// Live profile_data for the LineFormatComposer preview pane.
+	const livePreviewProfile = $derived(
+		assembleProfileData(draftOutput, draftTraversal),
+	);
 </script>
 
 <section class="agg-profile-editor">
@@ -281,12 +348,12 @@
 		<h2 class="text-base font-semibold" style="color: var(--color-fg)">
 			{globalsMode ? 'Global aggregation profiles' : 'Aggregation profiles for this set'}
 		</h2>
-		{#if !creating && !editingId && !cloning}
+		{#if !creating && !editingId && !cloning && !gallery}
 			<div class="flex gap-2">
 				<button onclick={startClone} class="rounded px-3 py-1 text-sm" style="border: 1px solid var(--color-border); color: var(--color-fg)">
 					+ Clone from existing
 				</button>
-				<button onclick={startCreate} class="rounded px-3 py-1 text-sm text-white" style="background: var(--color-primary)">
+				<button onclick={startGallery} class="rounded px-3 py-1 text-sm text-white" style="background: var(--color-primary)">
 					+ New profile
 				</button>
 			</div>
@@ -295,11 +362,21 @@
 	<p class="mt-1 text-xs" style="color: var(--color-muted)">
 		Aggregation profiles describe how to roll up data across a group
 		of documents — deduplicated lists with summed quantities, points
-		totals, time-tracking rollups, and so on. Pick a seeded profile
-		as a starting point with <strong>Clone from existing</strong> and
-		duplicate-and-edit it for your use case, or start blank with
-		<strong>New profile</strong>.
+		totals, time-tracking rollups, and so on. Start with
+		<strong>New profile</strong> to pick a template, or
+		<strong>Clone from existing</strong> to duplicate one you've already
+		customised.
 	</p>
+
+	{#if gallery}
+		<div class="mt-3">
+			<AggregationTemplateGallery
+				seededProfiles={seededGlobals}
+				onpick={pickFromGallery}
+				oncancel={cancelGallery}
+			/>
+		</div>
+	{/if}
 
 	{#if cloning}
 		<div class="mt-3 rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
@@ -357,27 +434,136 @@
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 				/>
 			</label>
+
+			<!-- Option A: lifted output fields -->
+			<h3 class="mt-4 text-sm font-semibold" style="color: var(--color-fg)">Output</h3>
+			<div class="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
+				<label class="block text-sm font-medium" style="color: var(--color-fg)">
+					Aggregation
+					<select
+						bind:value={draftOutput.aggregation_fn}
+						class="mt-1 w-full rounded border px-3 py-2 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					>
+						{#each AGGREGATION_FNS as fn (fn)}
+							<option value={fn}>{fn}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="block text-sm font-medium" style="color: var(--color-fg)">
+					Group by
+					<input
+						type="text"
+						bind:value={draftOutput.group_by}
+						placeholder="element.package_name"
+						class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					/>
+					<span class="mt-1 block text-xs" style="color: var(--color-muted)">
+						<code>element.name</code>, <code>element.package_name</code>, <code>element.attributes.&lt;Name&gt;/type</code>, or leave blank for ungrouped.
+					</span>
+				</label>
+				<label class="block text-sm font-medium" style="color: var(--color-fg)">
+					Sort groups
+					<select
+						bind:value={draftOutput.sort_groups}
+						class="mt-1 w-full rounded border px-3 py-2 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					>
+						{#each SORT_MODES as m (m)}
+							<option value={m}>{m}</option>
+						{/each}
+					</select>
+				</label>
+				<label class="block text-sm font-medium" style="color: var(--color-fg)">
+					Sort items within group
+					<select
+						bind:value={draftOutput.sort_items_within_group}
+						class="mt-1 w-full rounded border px-3 py-2 text-sm"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					>
+						{#each SORT_MODES as m (m)}
+							<option value={m}>{m}</option>
+						{/each}
+					</select>
+				</label>
+			</div>
+
+			<!-- Option B: line_format chip composer + preview -->
+			<div class="mt-3">
+				<LineFormatComposer
+					bind:value={draftOutput.line_format}
+					profileData={livePreviewProfile}
+					sourceDiagramId={previewSourceDiagramId}
+				/>
+			</div>
+
 			<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
-				<input type="checkbox" bind:checked={draftIncludeProvenance} class="mt-1" />
+				<input type="checkbox" bind:checked={draftOutput.show_per_source_breakdown} class="mt-1" />
+				<span>
+					<span class="font-medium">Show per-source breakdown</span>
+					<span class="block text-xs" style="color: var(--color-muted)">
+						Append a parenthetical showing how each contributing source
+						added up.
+					</span>
+				</span>
+			</label>
+			{#if draftOutput.show_per_source_breakdown}
+				<label class="mt-2 block text-sm font-medium" style="color: var(--color-fg)">
+					Breakdown format
+					<input
+						type="text"
+						bind:value={draftOutput.breakdown_format}
+						placeholder={' ({sources_joined})'}
+						class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					/>
+				</label>
+			{/if}
+			<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
+				<input type="checkbox" bind:checked={draftOutput.include_provenance} class="mt-1" />
 				<span>
 					<span class="font-medium">Include provenance comments</span>
 					<span class="block text-xs" style="color: var(--color-muted)">
 						When on, each aggregated line is rendered with a trailing HTML
 						comment carrying the source element id, e.g. <code>&lt;!-- iris:element=… --&gt;</code>.
 						Required by downstream orchestrators that need to map output
-						lines back to elements (e.g. the woolies-shopper skill). ADR-217.
+						lines back to elements (ADR-217).
 					</span>
 				</span>
 			</label>
-			<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
-				profile_data (JSON)
-				<textarea
-					bind:value={draftJson}
-					rows="18"
-					class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
-					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
-				></textarea>
-			</label>
+
+			<!-- Option C: traversal wizard -->
+			<h3 class="mt-4 text-sm font-semibold" style="color: var(--color-fg)">Traversal</h3>
+			<div class="mt-2">
+				<TraversalBuilder bind:fields={draftTraversal} />
+			</div>
+
+			<!-- Advanced (JSON) escape hatch -->
+			<details class="mt-4 rounded border p-2" style="border-color: var(--color-border); background: var(--color-bg)">
+				<summary
+					class="cursor-pointer text-sm font-medium"
+					style="color: var(--color-fg)"
+					onclick={toggleAdvanced}
+				>
+					Advanced (JSON)
+				</summary>
+				<label class="mt-2 block text-sm font-medium" style="color: var(--color-fg)">
+					profile_data (JSON)
+					<textarea
+						bind:value={draftJson}
+						rows="14"
+						class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+					></textarea>
+					<span class="mt-1 block text-xs" style="color: var(--color-muted)">
+						When this section is open, the JSON is authoritative on save —
+						the form fields above are ignored. Use this for fields the
+						form doesn't surface yet.
+					</span>
+				</label>
+			</details>
+
 			{#if !globalsMode && setId}
 				<label class="mt-3 flex items-center gap-2 text-sm" style="color: var(--color-fg)">
 					<input type="checkbox" bind:checked={draftIsDefault} />

--- a/frontend/src/lib/components/AggregationTemplateGallery.svelte
+++ b/frontend/src/lib/components/AggregationTemplateGallery.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	/**
+	 * SPEC-212-f: card-grid template gallery (Option E).
+	 *
+	 * Shown when the user clicks "New profile". Surfaces seeded global
+	 * profiles (Shopping list, Sprint points, Time tracker, Expense
+	 * report, Reading log per m077) as cards plus a "Blank" card.
+	 * Selecting a card hands the chosen profile (or null for blank)
+	 * back to the parent for form pre-population.
+	 *
+	 * Grid CSS mirrors EntityImagesEditor's pattern (DRY §13) — same
+	 * `auto-fill` / `minmax` shape, just tuned for card width.
+	 */
+
+	interface SeededProfile {
+		id: string;
+		name: string;
+		description: string | null;
+		profile_data: Record<string, unknown>;
+	}
+
+	interface Props {
+		seededProfiles: SeededProfile[];
+		onpick: (profile: SeededProfile | null) => void;
+		oncancel: () => void;
+	}
+
+	let { seededProfiles, onpick, oncancel }: Props = $props();
+
+	function previewLineFormat(p: SeededProfile): string {
+		const output = p.profile_data?.output as Record<string, unknown> | undefined;
+		const fmt = output?.line_format;
+		return typeof fmt === 'string' ? fmt : '';
+	}
+</script>
+
+<div class="agg-gallery rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
+	<div class="flex items-center justify-between">
+		<p class="text-sm font-medium" style="color: var(--color-fg)">
+			Pick a template to start from
+		</p>
+		<button
+			onclick={oncancel}
+			class="text-xs"
+			style="color: var(--color-muted)"
+		>
+			Cancel
+		</button>
+	</div>
+	<p class="mt-1 text-xs" style="color: var(--color-muted)">
+		These ship with Iris — each one is a complete, working profile you
+		can edit. Pick the closest match and tweak; pick Blank to build
+		from scratch.
+	</p>
+
+	<div class="agg-gallery__grid mt-3">
+		<button
+			onclick={() => onpick(null)}
+			class="agg-gallery__card text-left"
+			style="border: 1px solid var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+		>
+			<p class="font-medium">Blank</p>
+			<p class="mt-1 text-xs" style="color: var(--color-muted)">
+				Start with sensible defaults — element-collecting, sum-by-package.
+			</p>
+		</button>
+
+		{#each seededProfiles as p (p.id)}
+			<button
+				onclick={() => onpick(p)}
+				class="agg-gallery__card text-left"
+				style="border: 1px solid var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			>
+				<p class="font-medium">{p.name}</p>
+				{#if p.description}
+					<p class="mt-1 text-xs" style="color: var(--color-muted)">{p.description}</p>
+				{/if}
+				{#if previewLineFormat(p)}
+					<p class="mt-2 truncate font-mono text-xs" style="color: var(--color-muted)" title={previewLineFormat(p)}>
+						{previewLineFormat(p)}
+					</p>
+				{/if}
+			</button>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.agg-gallery__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+		gap: 0.75rem;
+	}
+	.agg-gallery__card {
+		border-radius: 0.375rem;
+		padding: 0.75rem;
+		cursor: pointer;
+		transition: transform 0.05s;
+	}
+	.agg-gallery__card:hover {
+		transform: translateY(-1px);
+	}
+</style>

--- a/frontend/src/lib/components/AttributePathPicker.svelte
+++ b/frontend/src/lib/components/AttributePathPicker.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+	/**
+	 * SPEC-212-f: drill-down picker for attribute paths (Option C).
+	 *
+	 * Reuses the existing /api/elements/{id}/data-tree endpoint (the same
+	 * one SmartMarkdownSlashPicker uses) — the data-tree shape is the
+	 * single source of truth (DRY §13). Emits a path-string like
+	 * `attributes/Quantity/type`. The user picks an example element from
+	 * the seeded set; the path generalises to any element matching the
+	 * same template.
+	 *
+	 * Falls back to a plain text input when no example element is
+	 * available (e.g. globals-mode authoring).
+	 */
+
+	import { apiFetch, ApiError } from '$lib/utils/api';
+
+	type TreeKind = 'dict' | 'list_of_named' | 'list' | 'primitive' | 'empty';
+	interface TreeDescriptor {
+		kind: TreeKind;
+		keys?: string[];
+		names?: string[];
+		length?: number;
+		value?: string;
+	}
+
+	interface Props {
+		value: string;
+		exampleElementId: string | null;
+		label?: string;
+		placeholder?: string;
+	}
+
+	let {
+		value = $bindable(''),
+		exampleElementId,
+		label = 'Attribute path',
+		placeholder = 'e.g. attributes/Quantity/type',
+	}: Props = $props();
+
+	let drillOpen = $state(false);
+	let drillPath = $state<string[]>([]);
+	let drillNode = $state<TreeDescriptor | null>(null);
+	let drillError = $state<string | null>(null);
+	let drillLoading = $state(false);
+
+	async function openDrill() {
+		if (!exampleElementId) return;
+		drillOpen = true;
+		drillPath = [];
+		drillError = null;
+		await loadNode();
+	}
+
+	function cancelDrill() {
+		drillOpen = false;
+		drillError = null;
+	}
+
+	async function loadNode() {
+		if (!exampleElementId) return;
+		drillLoading = true;
+		drillError = null;
+		try {
+			const pathParam = drillPath.join('/');
+			const url = pathParam
+				? `/api/elements/${exampleElementId}/data-tree?path=${encodeURIComponent(pathParam)}`
+				: `/api/elements/${exampleElementId}/data-tree`;
+			drillNode = await apiFetch<TreeDescriptor>(url);
+		} catch (e) {
+			drillNode = null;
+			drillError = e instanceof ApiError ? e.message : 'Failed to load data tree';
+		}
+		drillLoading = false;
+	}
+
+	async function drillInto(segment: string) {
+		drillPath = [...drillPath, segment];
+		await loadNode();
+	}
+
+	async function drillUp() {
+		drillPath = drillPath.slice(0, -1);
+		await loadNode();
+	}
+
+	function selectCurrent() {
+		value = drillPath.join('/');
+		drillOpen = false;
+	}
+
+	function items(): string[] {
+		if (!drillNode) return [];
+		if (drillNode.kind === 'dict') return drillNode.keys ?? [];
+		if (drillNode.kind === 'list_of_named') return drillNode.names ?? [];
+		if (drillNode.kind === 'list') return Array.from({ length: drillNode.length ?? 0 }, (_, i) => String(i));
+		return [];
+	}
+</script>
+
+<div class="attr-path-picker">
+	<label class="block text-sm font-medium" style="color: var(--color-fg)">
+		{label}
+		<div class="mt-1 flex gap-2">
+			<input
+				type="text"
+				bind:value
+				{placeholder}
+				class="flex-1 rounded border px-3 py-2 font-mono text-xs"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			/>
+			{#if exampleElementId}
+				<button
+					type="button"
+					onclick={openDrill}
+					class="rounded px-3 py-1 text-xs"
+					style="border: 1px solid var(--color-border); color: var(--color-fg); background: var(--color-bg)"
+				>
+					Pick…
+				</button>
+			{/if}
+		</div>
+	</label>
+
+	{#if !exampleElementId}
+		<p class="mt-1 text-xs" style="color: var(--color-muted)">
+			Type the path manually, e.g. <code>attributes/Quantity/type</code>.
+		</p>
+	{/if}
+
+	{#if drillOpen}
+		<div class="mt-2 rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
+			<div class="flex items-center justify-between">
+				<p class="text-xs font-medium" style="color: var(--color-fg)">
+					{drillPath.length === 0 ? 'Pick a field' : drillPath.join(' / ')}
+				</p>
+				<button
+					type="button"
+					onclick={cancelDrill}
+					class="text-xs"
+					style="color: var(--color-muted)"
+				>
+					Close
+				</button>
+			</div>
+			{#if drillError}
+				<p class="mt-2 text-xs" style="color: var(--color-danger)">{drillError}</p>
+			{/if}
+			{#if drillLoading}
+				<p class="mt-2 text-xs" style="color: var(--color-muted)">Loading…</p>
+			{:else if drillNode}
+				{#if drillNode.kind === 'primitive'}
+					<p class="mt-2 text-xs" style="color: var(--color-muted)">
+						Value: <code>{drillNode.value}</code>
+					</p>
+					<button
+						type="button"
+						onclick={selectCurrent}
+						class="mt-2 rounded px-2 py-1 text-xs text-white"
+						style="background: var(--color-primary)"
+					>
+						Use this path
+					</button>
+				{:else if drillNode.kind === 'empty'}
+					<p class="mt-2 text-xs" style="color: var(--color-muted)">No data here.</p>
+				{:else}
+					<div class="mt-2 flex flex-wrap gap-1">
+						{#if drillPath.length > 0}
+							<button
+								type="button"
+								onclick={drillUp}
+								class="rounded px-2 py-1 text-xs"
+								style="border: 1px solid var(--color-border); color: var(--color-fg); background: var(--color-bg)"
+							>
+								↑ up
+							</button>
+						{/if}
+						{#each items() as item (item)}
+							<button
+								type="button"
+								onclick={() => drillInto(item)}
+								class="rounded px-2 py-1 text-xs"
+								style="border: 1px solid var(--color-border); color: var(--color-fg); background: var(--color-bg)"
+							>
+								{item}
+							</button>
+						{/each}
+					</div>
+					{#if drillPath.length > 0}
+						<button
+							type="button"
+							onclick={selectCurrent}
+							class="mt-2 rounded px-2 py-1 text-xs text-white"
+							style="background: var(--color-primary)"
+						>
+							Use {drillPath.join('/')}
+						</button>
+					{/if}
+				{/if}
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/LineFormatComposer.svelte
+++ b/frontend/src/lib/components/LineFormatComposer.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	/**
+	 * SPEC-212-f: line_format chip composer with live preview (Option B).
+	 *
+	 * Click a chip → that placeholder is inserted at the input's cursor.
+	 * When `sourceDiagramId` is set, debounce-call POST /api/aggregation/run
+	 * with the inline profile draft to show 3-5 rendered preview lines.
+	 */
+
+	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { LINE_FORMAT_PLACEHOLDERS } from './aggregationProfileHelpers';
+	import { insertAtCursor } from './aggregationProfileHelpers';
+
+	interface Props {
+		value: string;
+		profileData: Record<string, unknown>;
+		sourceDiagramId: string | null;
+	}
+
+	let { value = $bindable(''), profileData, sourceDiagramId }: Props = $props();
+
+	let inputEl: HTMLInputElement | null = $state(null);
+	let preview = $state<string | null>(null);
+	let previewError = $state<string | null>(null);
+	let previewLoading = $state(false);
+	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	function insertChip(placeholder: string) {
+		const el = inputEl;
+		if (!el) {
+			value = value + placeholder;
+			return;
+		}
+		const cursor = el.selectionStart ?? value.length;
+		const { text, cursor: newCursor } = insertAtCursor(value, cursor, placeholder);
+		value = text;
+		// Restore focus + cursor after Svelte re-renders.
+		queueMicrotask(() => {
+			el.focus();
+			el.setSelectionRange(newCursor, newCursor);
+		});
+	}
+
+	async function runPreview() {
+		if (!sourceDiagramId) {
+			preview = null;
+			previewError = null;
+			return;
+		}
+		previewLoading = true;
+		previewError = null;
+		try {
+			const result = await apiFetch<{ markdown: string; row_count: number }>(
+				'/api/aggregation/run',
+				{
+					method: 'POST',
+					body: JSON.stringify({
+						profile_data: profileData,
+						source_diagram_id: sourceDiagramId,
+					}),
+				},
+			);
+			// Show first 5 non-empty lines as a preview.
+			const lines = (result.markdown ?? '').split('\n').filter((l) => l.trim() !== '');
+			preview = lines.slice(0, 5).join('\n');
+			if (lines.length === 0) {
+				preview = '(no rows matched the current profile)';
+			}
+		} catch (e) {
+			preview = null;
+			previewError = e instanceof ApiError ? e.message : 'Preview failed';
+		}
+		previewLoading = false;
+	}
+
+	$effect(() => {
+		// Watch profileData + sourceDiagramId; debounce 400ms.
+		// Touch the inputs Svelte should track:
+		void value;
+		void profileData;
+		void sourceDiagramId;
+		if (debounceTimer) clearTimeout(debounceTimer);
+		if (!sourceDiagramId) {
+			preview = null;
+			previewError = null;
+			return;
+		}
+		debounceTimer = setTimeout(() => {
+			void runPreview();
+		}, 400);
+	});
+</script>
+
+<div class="line-format-composer">
+	<label class="block text-sm font-medium" style="color: var(--color-fg)">
+		Line format
+		<input
+			type="text"
+			bind:value
+			bind:this={inputEl}
+			class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+			style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+		/>
+	</label>
+	<div class="mt-2 flex flex-wrap gap-1">
+		{#each LINE_FORMAT_PLACEHOLDERS as p (p.key)}
+			<button
+				type="button"
+				onclick={() => insertChip(p.label)}
+				title={p.hint}
+				class="rounded px-2 py-1 text-xs"
+				style="border: 1px solid var(--color-border); background: var(--color-bg); color: var(--color-fg); font-family: monospace"
+			>
+				{p.label}
+			</button>
+		{/each}
+	</div>
+	<p class="mt-1 text-xs" style="color: var(--color-muted)">
+		Click a placeholder to insert it at the cursor.
+	</p>
+
+	{#if sourceDiagramId}
+		<div class="mt-3 rounded border p-2" style="border-color: var(--color-border); background: var(--color-bg)">
+			<p class="text-xs font-medium" style="color: var(--color-muted)">Live preview</p>
+			{#if previewLoading}
+				<p class="mt-1 text-xs" style="color: var(--color-muted)">Rendering…</p>
+			{:else if previewError}
+				<p class="mt-1 text-xs" style="color: var(--color-danger)">{previewError}</p>
+			{:else if preview}
+				<pre class="mt-1 whitespace-pre-wrap text-xs" style="color: var(--color-fg); font-family: monospace">{preview}</pre>
+			{:else}
+				<p class="mt-1 text-xs" style="color: var(--color-muted)">(no preview yet)</p>
+			{/if}
+		</div>
+	{:else}
+		<p class="mt-2 text-xs" style="color: var(--color-muted)">
+			Live preview requires a source diagram. Open the editor from a set page that has a smart-markdown diagram, or set the preview source after creating the profile.
+		</p>
+	{/if}
+</div>

--- a/frontend/src/lib/components/TraversalBuilder.svelte
+++ b/frontend/src/lib/components/TraversalBuilder.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	/**
+	 * SPEC-212-f: form-based traversal builder (Option C).
+	 *
+	 * Two-step wizard for the `traversal` half of a profile:
+	 *   Step 1 — optional outer source (with optional multiplier).
+	 *   Step 2 — inner items (value path + bucket path + skip-blank).
+	 *
+	 * Replaces the JSON-only authoring path for traversal. The
+	 * attribute-path inputs autocomplete via AttributePathPicker when an
+	 * example element is available; otherwise they fall back to a plain
+	 * text field (e.g. globals-mode authoring).
+	 */
+
+	import AttributePathPicker from './AttributePathPicker.svelte';
+	import { TOKEN_TYPES, type TraversalFields } from './aggregationProfileHelpers';
+
+	interface Props {
+		fields: TraversalFields;
+		/** Pre-selected example element id used to seed AttributePathPicker
+		 *  drill-mode. Null in globals authoring → text-only input. */
+		exampleElementId?: string | null;
+	}
+
+	let { fields = $bindable(), exampleElementId = null }: Props = $props();
+</script>
+
+<div class="traversal-builder">
+	<details open class="rounded border p-3" style="border-color: var(--color-border); background: var(--color-bg)">
+		<summary class="cursor-pointer text-sm font-medium" style="color: var(--color-fg)">
+			Source container (optional)
+		</summary>
+		<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
+			<input type="checkbox" bind:checked={fields.has_outer} class="mt-1" />
+			<span>
+				<span class="font-medium">These items live inside a parent container</span>
+				<span class="block text-xs" style="color: var(--color-muted)">
+					Turn this on when the source diagram references other
+					diagrams whose contents should be summed together. Leave
+					off for a one-level walk.
+				</span>
+			</span>
+		</label>
+		{#if fields.has_outer}
+			<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
+				Container token type
+				<select
+					bind:value={fields.outer_token_type}
+					class="mt-1 w-full rounded border px-3 py-2 text-sm"
+					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+				>
+					{#each TOKEN_TYPES as t (t)}
+						<option value={t}>{t}</option>
+					{/each}
+				</select>
+			</label>
+			<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
+				<input type="checkbox" bind:checked={fields.has_multiplier} class="mt-1" />
+				<span>
+					<span class="font-medium">Scale items by a per-container multiplier</span>
+					<span class="block text-xs" style="color: var(--color-muted)">
+						Numerator is a per-use override on the container; divisor
+						is read from the container's diagram data.
+					</span>
+				</span>
+			</label>
+			{#if fields.has_multiplier}
+				<div class="mt-2 rounded border p-3" style="border-color: var(--color-border); background: var(--color-surface)">
+					<label class="block text-sm font-medium" style="color: var(--color-fg)">
+						Numerator attribute (override on the container token)
+						<input
+							type="text"
+							bind:value={fields.multiplier.from_attribute_override}
+							placeholder="attributes/<Name>/type"
+							class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+							style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+						/>
+					</label>
+					<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
+						Divisor (path on the container's diagram data)
+						<input
+							type="text"
+							bind:value={fields.multiplier.divisor_from_diagram_data}
+							placeholder="data.<field>"
+							class="mt-1 w-full rounded border px-3 py-2 font-mono text-xs"
+							style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+						/>
+					</label>
+					<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
+						Default multiplier (when no override is set)
+						<input
+							type="number"
+							step="0.01"
+							bind:value={fields.multiplier.default_multiplier}
+							class="mt-1 w-full rounded border px-3 py-2 text-sm"
+							style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+						/>
+					</label>
+				</div>
+			{/if}
+		{/if}
+	</details>
+
+	<details open class="mt-3 rounded border p-3" style="border-color: var(--color-border); background: var(--color-bg)">
+		<summary class="cursor-pointer text-sm font-medium" style="color: var(--color-fg)">
+			Inner items
+		</summary>
+		<label class="mt-3 block text-sm font-medium" style="color: var(--color-fg)">
+			Inner token type
+			<select
+				bind:value={fields.inner_token_type}
+				class="mt-1 w-full rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
+			>
+				{#each TOKEN_TYPES as t (t)}
+					<option value={t}>{t}</option>
+				{/each}
+			</select>
+		</label>
+		<div class="mt-3">
+			<AttributePathPicker
+				bind:value={fields.inner_value_path}
+				{exampleElementId}
+				label="Value attribute path"
+				placeholder="e.g. attributes/Quantity/type"
+			/>
+		</div>
+		<div class="mt-3">
+			<AttributePathPicker
+				bind:value={fields.inner_bucket_path}
+				{exampleElementId}
+				label="Bucket attribute path (optional)"
+				placeholder="e.g. attributes/Unit/type"
+			/>
+		</div>
+		<label class="mt-3 flex items-start gap-2 text-sm" style="color: var(--color-fg)">
+			<input type="checkbox" bind:checked={fields.skip_blank_values} class="mt-1" />
+			<span>
+				<span class="font-medium">Skip blank values</span>
+				<span class="block text-xs" style="color: var(--color-muted)">
+					When on, tokens without a value contribute nothing to the
+					total. When off, blanks count as zero.
+				</span>
+			</span>
+		</label>
+	</details>
+</div>

--- a/frontend/src/lib/components/aggregationProfileHelpers.ts
+++ b/frontend/src/lib/components/aggregationProfileHelpers.ts
@@ -1,0 +1,286 @@
+/**
+ * SPEC-212-f: helpers for the form-based aggregation profile editor.
+ *
+ * Pure functions that lift fields out of (and patch them back into)
+ * the ProfileData JSON shape. Co-located with AggregationProfileEditor.svelte
+ * + LineFormatComposer + TraversalBuilder + AggregationTemplateGallery so
+ * a single round-trip representation is shared across all three (DRY §13).
+ *
+ * Enum literals (TokenType, SortMode, AggregationFn) intentionally mirror
+ * the backend Pydantic definitions in backend/app/aggregation/models.py.
+ * The backend validates on save — the frontend uses these only to
+ * populate dropdowns. If a new value is added backend-side, add it here
+ * (and the tests will catch any drift between the two).
+ */
+
+export type TokenType = 'element' | 'diagram' | 'package' | 'set' | 'collection';
+export type SortMode = 'alpha' | 'none';
+export type AggregationFn = 'sum' | 'count';
+
+export const TOKEN_TYPES: readonly TokenType[] = [
+	'element', 'diagram', 'package', 'set', 'collection',
+] as const;
+export const SORT_MODES: readonly SortMode[] = ['alpha', 'none'] as const;
+export const AGGREGATION_FNS: readonly AggregationFn[] = ['sum', 'count'] as const;
+
+/** All `{placeholder}` tokens the engine substitutes in `line_format`
+ *  (see backend/app/aggregation/engine.py `_render_line`). The composer
+ *  surfaces these as clickable chips. */
+export const LINE_FORMAT_PLACEHOLDERS = [
+	{ key: 'element.name', label: '{element.name}', hint: 'The element\'s display name' },
+	{ key: 'element.id', label: '{element.id}', hint: 'The element\'s UUID (link target)' },
+	{ key: 'sum_value', label: '{sum_value}', hint: 'Aggregated value (sum or count)' },
+	{ key: 'bucket', label: '{bucket}', hint: 'Bucket value (e.g. units), unspaced' },
+	{ key: 'bucket_spaced', label: '{bucket_spaced}', hint: 'Bucket with a leading space when set' },
+] as const;
+
+export const BREAKDOWN_PLACEHOLDERS = [
+	{ key: 'sources_joined', label: '{sources_joined}', hint: 'Per-source values joined by commas' },
+] as const;
+
+/** Fields lifted from `output.*` into form widgets. */
+export interface OutputFields {
+	aggregation_fn: AggregationFn;
+	group_by: string;
+	sort_groups: SortMode;
+	sort_items_within_group: SortMode;
+	line_format: string;
+	show_per_source_breakdown: boolean;
+	breakdown_format: string;
+	include_provenance: boolean;
+}
+
+const DEFAULT_OUTPUT: OutputFields = {
+	aggregation_fn: 'sum',
+	group_by: '',
+	sort_groups: 'alpha',
+	sort_items_within_group: 'alpha',
+	line_format: '- {element.name}: {sum_value}{bucket_spaced}',
+	show_per_source_breakdown: false,
+	breakdown_format: ' ({sources_joined})',
+	include_provenance: false,
+};
+
+function getObj(parent: Record<string, unknown>, key: string): Record<string, unknown> {
+	const v = parent[key];
+	return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+}
+
+function pickStr(obj: Record<string, unknown>, key: string, fallback: string): string {
+	const v = obj[key];
+	return typeof v === 'string' ? v : fallback;
+}
+
+function pickEnum<T extends string>(obj: Record<string, unknown>, key: string, allowed: readonly T[], fallback: T): T {
+	const v = obj[key];
+	return typeof v === 'string' && (allowed as readonly string[]).includes(v) ? (v as T) : fallback;
+}
+
+function pickBool(obj: Record<string, unknown>, key: string, fallback: boolean): boolean {
+	const v = obj[key];
+	return typeof v === 'boolean' ? v : fallback;
+}
+
+/** Read every output field from a profile_data object, falling back to
+ *  per-field defaults that match backend OutputConfig defaults. */
+export function readOutputFields(profileData: Record<string, unknown> | null | undefined): OutputFields {
+	const output = profileData ? getObj(profileData, 'output') : {};
+	return {
+		aggregation_fn: pickEnum(output, 'aggregation_fn', AGGREGATION_FNS, DEFAULT_OUTPUT.aggregation_fn),
+		group_by: pickStr(output, 'group_by', DEFAULT_OUTPUT.group_by),
+		sort_groups: pickEnum(output, 'sort_groups', SORT_MODES, DEFAULT_OUTPUT.sort_groups),
+		sort_items_within_group: pickEnum(output, 'sort_items_within_group', SORT_MODES, DEFAULT_OUTPUT.sort_items_within_group),
+		line_format: pickStr(output, 'line_format', DEFAULT_OUTPUT.line_format),
+		show_per_source_breakdown: pickBool(output, 'show_per_source_breakdown', DEFAULT_OUTPUT.show_per_source_breakdown),
+		breakdown_format: pickStr(output, 'breakdown_format', DEFAULT_OUTPUT.breakdown_format),
+		include_provenance: pickBool(output, 'include_provenance', DEFAULT_OUTPUT.include_provenance),
+	};
+}
+
+/** Merge form-field values back into a profile_data object, returning
+ *  a NEW object (does not mutate the input). `group_by` empty-string
+ *  is normalised to `null` so the engine treats it as ungrouped. */
+export function patchOutputFields(
+	profileData: Record<string, unknown> | null | undefined,
+	fields: OutputFields,
+): Record<string, unknown> {
+	const base: Record<string, unknown> = profileData ? { ...profileData } : {};
+	const output = profileData ? getObj(profileData, 'output') : {};
+	base.output = {
+		...output,
+		aggregation_fn: fields.aggregation_fn,
+		group_by: fields.group_by.trim() === '' ? null : fields.group_by.trim(),
+		sort_groups: fields.sort_groups,
+		sort_items_within_group: fields.sort_items_within_group,
+		line_format: fields.line_format,
+		show_per_source_breakdown: fields.show_per_source_breakdown,
+		breakdown_format: fields.breakdown_format,
+		include_provenance: fields.include_provenance,
+	};
+	return base;
+}
+
+/** Fields lifted from `traversal.*` into the wizard. */
+export interface MultiplierFields {
+	from_attribute_override: string;
+	divisor_from_diagram_data: string;
+	default_multiplier: number;
+}
+
+export interface TraversalFields {
+	has_outer: boolean;
+	outer_token_type: TokenType;
+	has_multiplier: boolean;
+	multiplier: MultiplierFields;
+	inner_token_type: TokenType;
+	inner_value_path: string;
+	inner_bucket_path: string;
+	skip_blank_values: boolean;
+}
+
+const DEFAULT_TRAVERSAL: TraversalFields = {
+	has_outer: false,
+	outer_token_type: 'diagram',
+	has_multiplier: false,
+	multiplier: {
+		from_attribute_override: '',
+		divisor_from_diagram_data: '',
+		default_multiplier: 1,
+	},
+	inner_token_type: 'element',
+	inner_value_path: '',
+	inner_bucket_path: '',
+	skip_blank_values: true,
+};
+
+export function readTraversalFields(profileData: Record<string, unknown> | null | undefined): TraversalFields {
+	const traversal = profileData ? getObj(profileData, 'traversal') : {};
+	const outerRaw = traversal['outer'];
+	const hasOuter = outerRaw !== null && outerRaw !== undefined && typeof outerRaw === 'object';
+	const outer = hasOuter ? (outerRaw as Record<string, unknown>) : {};
+	const multiplierRaw = outer['multiplier'];
+	const hasMultiplier = multiplierRaw !== null && multiplierRaw !== undefined && typeof multiplierRaw === 'object';
+	const multiplier = hasMultiplier ? (multiplierRaw as Record<string, unknown>) : {};
+	const inner = getObj(traversal, 'inner');
+	return {
+		has_outer: hasOuter,
+		outer_token_type: pickEnum(outer, 'collect_token_type', TOKEN_TYPES, DEFAULT_TRAVERSAL.outer_token_type),
+		has_multiplier: hasMultiplier,
+		multiplier: {
+			from_attribute_override: pickStr(multiplier, 'from_attribute_override', ''),
+			divisor_from_diagram_data: pickStr(multiplier, 'divisor_from_diagram_data', ''),
+			default_multiplier: typeof multiplier['default_multiplier'] === 'number'
+				? (multiplier['default_multiplier'] as number)
+				: DEFAULT_TRAVERSAL.multiplier.default_multiplier,
+		},
+		inner_token_type: pickEnum(inner, 'collect_token_type', TOKEN_TYPES, DEFAULT_TRAVERSAL.inner_token_type),
+		inner_value_path: pickStr(inner, 'value_attribute_path', ''),
+		inner_bucket_path: pickStr(inner, 'bucket_attribute_path', ''),
+		skip_blank_values: pickBool(inner, 'skip_blank_values', DEFAULT_TRAVERSAL.skip_blank_values),
+	};
+}
+
+export function patchTraversalFields(
+	profileData: Record<string, unknown> | null | undefined,
+	fields: TraversalFields,
+): Record<string, unknown> {
+	const base: Record<string, unknown> = profileData ? { ...profileData } : {};
+	const inner: Record<string, unknown> = {
+		collect_token_type: fields.inner_token_type,
+		value_attribute_path: fields.inner_value_path.trim() === '' ? null : fields.inner_value_path.trim(),
+		bucket_attribute_path: fields.inner_bucket_path.trim() === '' ? null : fields.inner_bucket_path.trim(),
+		skip_blank_values: fields.skip_blank_values,
+	};
+	const traversal: Record<string, unknown> = { inner };
+	if (fields.has_outer) {
+		const outer: Record<string, unknown> = {
+			collect_token_type: fields.outer_token_type,
+		};
+		if (fields.has_multiplier) {
+			outer.multiplier = {
+				from_attribute_override: fields.multiplier.from_attribute_override.trim() === ''
+					? null
+					: fields.multiplier.from_attribute_override.trim(),
+				divisor_from_diagram_data: fields.multiplier.divisor_from_diagram_data.trim() === ''
+					? null
+					: fields.multiplier.divisor_from_diagram_data.trim(),
+				default_multiplier: fields.multiplier.default_multiplier,
+			};
+		} else {
+			outer.multiplier = null;
+		}
+		traversal.outer = outer;
+	}
+	base.traversal = traversal;
+	return base;
+}
+
+/** Insert a placeholder at a cursor position in a text field. Returns
+ *  the new text and the new cursor position (after the inserted token). */
+export function insertAtCursor(
+	text: string,
+	cursor: number,
+	insertion: string,
+): { text: string; cursor: number } {
+	const safe = Math.max(0, Math.min(cursor, text.length));
+	const next = text.slice(0, safe) + insertion + text.slice(safe);
+	return { text: next, cursor: safe + insertion.length };
+}
+
+/** Build a draft from a seeded template profile (Option E gallery path).
+ *  The seeded profile_data populates form fields; the user only sees JSON
+ *  if they click "Advanced". */
+export interface SeededProfile {
+	id: string;
+	name: string;
+	description: string | null;
+	profile_data: Record<string, unknown>;
+}
+
+export interface FormDraft {
+	name: string;
+	description: string;
+	json: string;
+	isDefault: boolean;
+	output: OutputFields;
+	traversal: TraversalFields;
+}
+
+export function buildDraftFromTemplate(source: SeededProfile): FormDraft {
+	return {
+		name: `${source.name} (copy)`,
+		description: source.description ?? '',
+		json: JSON.stringify(source.profile_data, null, 2),
+		isDefault: false,
+		output: readOutputFields(source.profile_data),
+		traversal: readTraversalFields(source.profile_data),
+	};
+}
+
+/** Build a blank draft (Option E "Blank" card). Defaults match the backend
+ *  Pydantic defaults so a save with no edits produces a valid profile. */
+export function buildBlankDraft(): FormDraft {
+	const traversal: TraversalFields = {
+		...DEFAULT_TRAVERSAL,
+		multiplier: { ...DEFAULT_TRAVERSAL.multiplier },
+	};
+	const output: OutputFields = { ...DEFAULT_OUTPUT };
+	const profileData = patchOutputFields(patchTraversalFields({}, traversal), output);
+	return {
+		name: '',
+		description: '',
+		json: JSON.stringify(profileData, null, 2),
+		isDefault: false,
+		output,
+		traversal,
+	};
+}
+
+/** Reassemble a full profile_data object from form-field state. Used at
+ *  save time to merge the form back into JSON the backend will accept. */
+export function assembleProfileData(
+	output: OutputFields,
+	traversal: TraversalFields,
+): Record<string, unknown> {
+	return patchOutputFields(patchTraversalFields({}, traversal), output);
+}

--- a/frontend/tests/unit/aggregationProfileHelpers.test.ts
+++ b/frontend/tests/unit/aggregationProfileHelpers.test.ts
@@ -1,0 +1,349 @@
+/**
+ * SPEC-212-f: tests for the form-editor helpers.
+ *
+ * Pure-function tests per repo convention (data-shape + round-trip),
+ * not full component renders.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	readOutputFields,
+	patchOutputFields,
+	readTraversalFields,
+	patchTraversalFields,
+	insertAtCursor,
+	buildDraftFromTemplate,
+	buildBlankDraft,
+	assembleProfileData,
+	type OutputFields,
+	type TraversalFields,
+} from '../../src/lib/components/aggregationProfileHelpers';
+
+const FULL_PROFILE = {
+	traversal: {
+		outer: {
+			collect_token_type: 'diagram',
+			multiplier: {
+				from_attribute_override: 'attributes/Diners/type',
+				divisor_from_diagram_data: 'data.servings',
+				default_multiplier: 1,
+			},
+		},
+		inner: {
+			collect_token_type: 'element',
+			value_attribute_path: 'attributes/Quantity/type',
+			bucket_attribute_path: 'attributes/Unit/type',
+			skip_blank_values: true,
+		},
+	},
+	output: {
+		group_by: 'element.package_name',
+		sort_groups: 'alpha',
+		sort_items_within_group: 'alpha',
+		aggregation_fn: 'sum',
+		line_format: '- {element.name}: {sum_value}{bucket_spaced}',
+		show_per_source_breakdown: true,
+		breakdown_format: ' ({sources_joined})',
+		include_provenance: false,
+	},
+};
+
+describe('readOutputFields', () => {
+	it('reads every output field from a complete profile', () => {
+		const f = readOutputFields(FULL_PROFILE);
+		expect(f.aggregation_fn).toBe('sum');
+		expect(f.group_by).toBe('element.package_name');
+		expect(f.sort_groups).toBe('alpha');
+		expect(f.sort_items_within_group).toBe('alpha');
+		expect(f.line_format).toBe('- {element.name}: {sum_value}{bucket_spaced}');
+		expect(f.show_per_source_breakdown).toBe(true);
+		expect(f.breakdown_format).toBe(' ({sources_joined})');
+		expect(f.include_provenance).toBe(false);
+	});
+
+	it('fills in defaults for missing fields', () => {
+		const f = readOutputFields({ output: {} });
+		expect(f.aggregation_fn).toBe('sum');
+		expect(f.sort_groups).toBe('alpha');
+		expect(f.line_format).toContain('{element.name}');
+		expect(f.show_per_source_breakdown).toBe(false);
+	});
+
+	it('handles null/undefined profile_data gracefully', () => {
+		const f = readOutputFields(null);
+		expect(f.aggregation_fn).toBe('sum');
+		expect(f.group_by).toBe('');
+	});
+
+	it('rejects unknown enum values and falls back to default', () => {
+		const f = readOutputFields({ output: { aggregation_fn: 'median', sort_groups: 'random' } });
+		expect(f.aggregation_fn).toBe('sum');
+		expect(f.sort_groups).toBe('alpha');
+	});
+});
+
+describe('patchOutputFields', () => {
+	it('returns a new object — does NOT mutate input', () => {
+		const original = { output: { aggregation_fn: 'sum' } } as Record<string, unknown>;
+		const fields: OutputFields = readOutputFields(original);
+		const out = patchOutputFields(original, fields);
+		expect(out).not.toBe(original);
+		expect((original.output as Record<string, unknown>).line_format).toBeUndefined();
+	});
+
+	it('round-trip: read → patch produces an equivalent output block', () => {
+		const fields = readOutputFields(FULL_PROFILE);
+		const patched = patchOutputFields(FULL_PROFILE, fields);
+		const output = patched.output as Record<string, unknown>;
+		expect(output.aggregation_fn).toBe('sum');
+		expect(output.group_by).toBe('element.package_name');
+		expect(output.include_provenance).toBe(false);
+	});
+
+	it('empty group_by normalises to null (engine treats as ungrouped)', () => {
+		const fields = readOutputFields(FULL_PROFILE);
+		fields.group_by = '   ';
+		const patched = patchOutputFields(FULL_PROFILE, fields);
+		expect((patched.output as Record<string, unknown>).group_by).toBeNull();
+	});
+
+	it('preserves unrelated keys on the output block (provenance + custom)', () => {
+		const original = { output: { custom_future_field: 'keep me', aggregation_fn: 'sum' } } as Record<string, unknown>;
+		const fields = readOutputFields(original);
+		const patched = patchOutputFields(original, fields);
+		expect((patched.output as Record<string, unknown>).custom_future_field).toBe('keep me');
+	});
+});
+
+describe('readTraversalFields', () => {
+	it('reads outer + inner from a two-level profile', () => {
+		const f = readTraversalFields(FULL_PROFILE);
+		expect(f.has_outer).toBe(true);
+		expect(f.outer_token_type).toBe('diagram');
+		expect(f.has_multiplier).toBe(true);
+		expect(f.multiplier.from_attribute_override).toBe('attributes/Diners/type');
+		expect(f.multiplier.divisor_from_diagram_data).toBe('data.servings');
+		expect(f.multiplier.default_multiplier).toBe(1);
+		expect(f.inner_token_type).toBe('element');
+		expect(f.inner_value_path).toBe('attributes/Quantity/type');
+		expect(f.inner_bucket_path).toBe('attributes/Unit/type');
+		expect(f.skip_blank_values).toBe(true);
+	});
+
+	it('inner-only profile has has_outer=false', () => {
+		const innerOnly = {
+			traversal: {
+				inner: { collect_token_type: 'element', value_attribute_path: 'attributes/Quantity/type', skip_blank_values: true },
+			},
+			output: {},
+		};
+		const f = readTraversalFields(innerOnly);
+		expect(f.has_outer).toBe(false);
+		expect(f.has_multiplier).toBe(false);
+	});
+
+	it('outer without multiplier reads has_multiplier=false', () => {
+		const noMul = {
+			traversal: {
+				outer: { collect_token_type: 'diagram' },
+				inner: { collect_token_type: 'element', skip_blank_values: true },
+			},
+		};
+		const f = readTraversalFields(noMul);
+		expect(f.has_outer).toBe(true);
+		expect(f.has_multiplier).toBe(false);
+	});
+});
+
+describe('patchTraversalFields', () => {
+	it('round-trip preserves inner-only structure', () => {
+		const fields: TraversalFields = {
+			has_outer: false,
+			outer_token_type: 'diagram',
+			has_multiplier: false,
+			multiplier: { from_attribute_override: '', divisor_from_diagram_data: '', default_multiplier: 1 },
+			inner_token_type: 'element',
+			inner_value_path: 'attributes/Quantity/type',
+			inner_bucket_path: 'attributes/Unit/type',
+			skip_blank_values: true,
+		};
+		const out = patchTraversalFields({}, fields);
+		const t = out.traversal as Record<string, unknown>;
+		expect(t.outer).toBeUndefined();
+		expect((t.inner as Record<string, unknown>).value_attribute_path).toBe('attributes/Quantity/type');
+		expect((t.inner as Record<string, unknown>).bucket_attribute_path).toBe('attributes/Unit/type');
+	});
+
+	it('round-trip preserves outer+multiplier structure', () => {
+		const fields = readTraversalFields(FULL_PROFILE);
+		const out = patchTraversalFields(FULL_PROFILE, fields);
+		const t = out.traversal as Record<string, unknown>;
+		const outer = t.outer as Record<string, unknown>;
+		const mul = outer.multiplier as Record<string, unknown>;
+		expect(outer.collect_token_type).toBe('diagram');
+		expect(mul.from_attribute_override).toBe('attributes/Diners/type');
+		expect(mul.divisor_from_diagram_data).toBe('data.servings');
+		expect(mul.default_multiplier).toBe(1);
+	});
+
+	it('empty value/bucket paths normalise to null', () => {
+		const fields = readTraversalFields(FULL_PROFILE);
+		fields.inner_value_path = '';
+		fields.inner_bucket_path = '   ';
+		const out = patchTraversalFields(FULL_PROFILE, fields);
+		const inner = (out.traversal as Record<string, unknown>).inner as Record<string, unknown>;
+		expect(inner.value_attribute_path).toBeNull();
+		expect(inner.bucket_attribute_path).toBeNull();
+	});
+
+	it('toggling has_outer=false drops the outer block entirely', () => {
+		const fields = readTraversalFields(FULL_PROFILE);
+		fields.has_outer = false;
+		const out = patchTraversalFields(FULL_PROFILE, fields);
+		expect((out.traversal as Record<string, unknown>).outer).toBeUndefined();
+	});
+
+	it('toggling has_multiplier=false nulls the multiplier (engine treats as 1.0)', () => {
+		const fields = readTraversalFields(FULL_PROFILE);
+		fields.has_multiplier = false;
+		const out = patchTraversalFields(FULL_PROFILE, fields);
+		const outer = (out.traversal as Record<string, unknown>).outer as Record<string, unknown>;
+		expect(outer.multiplier).toBeNull();
+	});
+});
+
+describe('insertAtCursor', () => {
+	it('inserts at the given position and returns the new cursor', () => {
+		const { text, cursor } = insertAtCursor('hello world', 5, ' beautiful');
+		expect(text).toBe('hello beautiful world');
+		expect(cursor).toBe(15);
+	});
+
+	it('clamps a negative cursor to 0 (insert at start)', () => {
+		const { text, cursor } = insertAtCursor('abc', -3, 'X');
+		expect(text).toBe('Xabc');
+		expect(cursor).toBe(1);
+	});
+
+	it('clamps an over-length cursor to end (insert at end)', () => {
+		const { text, cursor } = insertAtCursor('abc', 99, 'Z');
+		expect(text).toBe('abcZ');
+		expect(cursor).toBe(4);
+	});
+
+	it('inserts a {placeholder} chip into a line_format draft', () => {
+		const start = '- ';
+		const { text } = insertAtCursor(start, 2, '{element.name}: {sum_value}');
+		expect(text).toBe('- {element.name}: {sum_value}');
+	});
+});
+
+describe('buildDraftFromTemplate', () => {
+	const SEED = {
+		id: 'seed',
+		name: 'Shopping list',
+		description: 'Sum quantities by element, grouped by package.',
+		profile_data: FULL_PROFILE,
+	};
+
+	it('name carries " (copy)" suffix', () => {
+		const d = buildDraftFromTemplate(SEED);
+		expect(d.name).toBe('Shopping list (copy)');
+	});
+
+	it('description copied verbatim', () => {
+		const d = buildDraftFromTemplate(SEED);
+		expect(d.description).toBe('Sum quantities by element, grouped by package.');
+	});
+
+	it('isDefault always false on clone', () => {
+		const d = buildDraftFromTemplate(SEED);
+		expect(d.isDefault).toBe(false);
+	});
+
+	it('output and traversal pre-populated from the seed', () => {
+		const d = buildDraftFromTemplate(SEED);
+		expect(d.output.group_by).toBe('element.package_name');
+		expect(d.traversal.has_outer).toBe(true);
+		expect(d.traversal.multiplier.from_attribute_override).toBe('attributes/Diners/type');
+	});
+
+	it('json mirrors the original profile_data (escape hatch intact)', () => {
+		const d = buildDraftFromTemplate(SEED);
+		expect(JSON.parse(d.json)).toEqual(FULL_PROFILE);
+	});
+});
+
+describe('buildBlankDraft', () => {
+	it('produces a profile_data that already passes Pydantic shape (traversal + output)', () => {
+		const d = buildBlankDraft();
+		const parsed = JSON.parse(d.json);
+		expect(parsed.traversal).toBeDefined();
+		expect(parsed.traversal.inner).toBeDefined();
+		expect(parsed.traversal.inner.collect_token_type).toBe('element');
+		expect(parsed.output).toBeDefined();
+		expect(parsed.output.aggregation_fn).toBe('sum');
+	});
+
+	it('has no outer (inner-only by default)', () => {
+		const d = buildBlankDraft();
+		expect(d.traversal.has_outer).toBe(false);
+		expect(JSON.parse(d.json).traversal.outer).toBeUndefined();
+	});
+});
+
+describe('assembleProfileData', () => {
+	it('combines form-field state into a complete profile_data for save', () => {
+		const traversal: TraversalFields = {
+			has_outer: false, outer_token_type: 'diagram', has_multiplier: false,
+			multiplier: { from_attribute_override: '', divisor_from_diagram_data: '', default_multiplier: 1 },
+			inner_token_type: 'element',
+			inner_value_path: 'attributes/Quantity/type',
+			inner_bucket_path: '',
+			skip_blank_values: true,
+		};
+		const output: OutputFields = {
+			aggregation_fn: 'sum', group_by: 'element.name',
+			sort_groups: 'alpha', sort_items_within_group: 'alpha',
+			line_format: '- {element.name}: {sum_value}',
+			show_per_source_breakdown: false, breakdown_format: '',
+			include_provenance: false,
+		};
+		const pd = assembleProfileData(output, traversal);
+		expect((pd.traversal as Record<string, unknown>).inner).toBeDefined();
+		expect((pd.output as Record<string, unknown>).group_by).toBe('element.name');
+		expect((pd.output as Record<string, unknown>).line_format).toBe('- {element.name}: {sum_value}');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Live preview request body shape (SPEC-212-f)
+// ─────────────────────────────────────────────────────────────────────
+
+describe('inline run request body', () => {
+	it('POST /api/aggregation/run with profile_data inline omits profile_id', () => {
+		// The composer's live-preview hits the run endpoint with profile_data
+		// inline — the backend tests guarantee the server-side semantics; this
+		// just guards the request body shape the frontend will send.
+		const traversal: TraversalFields = {
+			has_outer: false, outer_token_type: 'diagram', has_multiplier: false,
+			multiplier: { from_attribute_override: '', divisor_from_diagram_data: '', default_multiplier: 1 },
+			inner_token_type: 'element', inner_value_path: 'attributes/Quantity/type',
+			inner_bucket_path: '', skip_blank_values: true,
+		};
+		const output: OutputFields = {
+			aggregation_fn: 'sum', group_by: 'element.name',
+			sort_groups: 'alpha', sort_items_within_group: 'alpha',
+			line_format: '- {element.name}: {sum_value}',
+			show_per_source_breakdown: false, breakdown_format: '',
+			include_provenance: false,
+		};
+		const body = {
+			profile_data: assembleProfileData(output, traversal),
+			source_diagram_id: 'some-uuid',
+		};
+		expect((body as Record<string, unknown>).profile_id).toBeUndefined();
+		expect(body.profile_data).toBeDefined();
+		expect(body.source_diagram_id).toBe('some-uuid');
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.39.3"
+version = "6.40.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.39.3"
+version = "6.40.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -682,9 +682,16 @@ async def _aggregate(c: IrisClient, args: dict[str, Any]) -> str:
     to a downstream consumer.
     """
     body: dict[str, Any] = {
-        "profile_id": args["profile_id"],
         "source_diagram_id": args["source_diagram_id"],
     }
+    # Exactly-one-of: ``profile_id`` references a saved profile;
+    # ``profile_data`` is an inline draft (SPEC-212-f live preview).
+    # The REST endpoint enforces the mutual-exclusion; we pass through
+    # whichever the caller supplied.
+    if "profile_id" in args and args["profile_id"] is not None:
+        body["profile_id"] = args["profile_id"]
+    if "profile_data" in args and args["profile_data"] is not None:
+        body["profile_data"] = args["profile_data"]
     try:
         resp = await c._request(
             "POST", "/api/aggregation/run", json=body,
@@ -2187,8 +2194,25 @@ TOOLS: list[Tool] = [
         input_schema=_schema({
             "profile_id": _str_arg(
                 "profile_id",
-                "The aggregation profile to apply. Look up names via "
-                "`list_aggregation_profiles`.",
+                "The saved aggregation profile to apply. Look up names "
+                "via `list_aggregation_profiles`. Provide either this "
+                "OR `profile_data` (not both).",
+                required=False,
+            ),
+            "profile_data": (
+                {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "description": (
+                        "Inline profile draft (SPEC-212-f). Same shape "
+                        "as `create_aggregation_profile.profile_data` "
+                        "— must contain `traversal` and `output`. Use "
+                        "this for live-preview / one-off runs without "
+                        "persisting the profile. Provide either this "
+                        "OR `profile_id` (not both)."
+                    ),
+                },
+                False,
             ),
             "source_diagram_id": _str_arg(
                 "source_diagram_id",


### PR DESCRIPTION
## Summary

- **JSON-free aggregation profile authoring.** Lifts output fields into form widgets, adds a chip composer + live preview for `line_format`, a traversal wizard with attribute-path drill picker, and a template gallery on "New profile". JSON textarea stays as an opt-in Advanced disclosure.
- **Inline `profile_data` on `POST /api/aggregation/run`** for the live-preview path. Mirrored on the MCP `aggregate` tool and `iris aggregate` CLI per Protocol §14 surface parity.
- Spec: [SPEC-212-f](docs/adrs/specs/SPEC-212-f-Aggregation-Profile-Form-Editor.md). Engine + surfaces specs (b, c) updated for the new inline path.

## What changed

- **Backend** (3 files + 1 new test file): `AggregationRunRequest` accepts optional `profile_data`; route enforces exactly-one-of; engine's `run()` takes optional `profile_data` kwarg and bypasses the ADR-227 cache for inline drafts. 7 new tests covering happy path, ephemerality, both/neither guards, malformed body, and saved-profile back-compat.
- **MCP + CLI**: `aggregate` tool and `iris aggregate` subcommand mirror the inline path (`--profile-data <path|->` for stdin/file). `scripts/check_surface_parity.py` stays clean.
- **Frontend** (6 new components + 1 helpers module): pure helpers shared across children (DRY §13); editor composes `AggregationTemplateGallery`, `LineFormatComposer`, `TraversalBuilder`, `AttributePathPicker`. 29 new helper tests + 13 existing editor tests intact.
- **Docs**: SPEC-212-f new; SPEC-212-b (engine) and SPEC-212-c (surfaces) updated.
- **Genericness**: all new copy passes ADR-214 invariant; placeholders are structural (`attributes/<Name>/type`, `data.<field>`) not domain-specific.
- **CHANGELOG + version bumps** (frontend + backend + mcp + iris-client all → 6.40.0).

## Test plan

- [x] `pytest backend/tests/test_aggregation` → 36 passed
- [x] `pytest backend/tests/test_aggregation/test_inline_profile_run.py` → 7 passed (new)
- [x] `vitest tests/unit/aggregationProfile*` → 42 passed (13 existing + 29 new)
- [x] `python scripts/check_surface_parity.py` → ✅ Parity clean
- [x] `python scripts/check_aggregation_genericness.py` (via test_genericness_invariant) → passes
- [x] Live smoke test against `POST /api/aggregation/run`: all three guard paths (both / neither / inline-only) return the expected response.
- [ ] Manual UAT on Render: open admin → aggregation profiles → New → gallery → pick Shopping list → save → reload → form re-hydrates correctly.
- [ ] Manual UAT: from set page (preview source available), verify live preview renders 3-5 lines as you edit `line_format`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)