### PR TITLE
feat(v6.41.0): mobile-responsive UI (ADR-229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,25 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Mobile-responsive foundations (ADR-229 / SPEC-229-A, Phase 0 of the
-  mobile rollout).** Iris now has the primitives to adapt its UI when a
-  mobile screen is detected, ahead of adapting each surface in following
-  phases:
-  - **Viewport store** — `frontend/src/lib/stores/viewport.svelte.ts`
-    exposes reactive `isMobile` / `isTablet` / `isDesktop` flags built on
+- **Mobile-responsive UI (ADR-229 / SPEC-229-A).** Iris now detects a
+  mobile screen and adapts its surfaces — browse everything and make light
+  edits on a phone; heavy diagram-canvas authoring stays desktop-only.
+  Responsive adaptation in one codebase (no separate mobile route tree);
+  breakpoints mirror Tailwind v4 defaults (`< 768px` mobile, `768–1023px`
+  tablet, `≥ 1024px` desktop).
+  - **Foundations** — `frontend/src/lib/stores/viewport.svelte.ts` exposes
+    reactive `isMobile` / `isTablet` / `isDesktop` flags built on
     `matchMedia`, generalising the one-off responsive check that lived
-    inline on the dashboard. Breakpoints mirror Tailwind v4 defaults
-    (`< 768px` mobile, `768–1023px` tablet, `≥ 1024px` desktop). SSR-safe:
-    defaults to desktop during prerender and reconciles on mount. Wired
-    once from the root layout.
-  - **Responsive CSS tokens** in `app.css` — `--page-pad` (tighter gutters
-    on mobile), `.drawer-backdrop`, and `body.scroll-locked` for the
-    upcoming nav drawer and bottom sheets. Existing WCAG utilities are
-    reused, not duplicated.
-  - **Mobile test surface** — a Playwright `mobile` project (Pixel 5
-    device) running `*.mobile.spec.ts`, kept disjoint from the desktop
-    `e2e` suite; `npm run test:mobile`. Unit tests cover the store's
-    breakpoint boundaries, SSR default, reactivity, and listener cleanup.
+    inline on the dashboard. SSR-safe: defaults to desktop during prerender
+    and reconciles eagerly in the browser. Wired once from the root layout.
+    New `app.css` tokens (`--page-pad`, `.drawer-backdrop`,
+    `body.scroll-locked`, `.mobile-nav-drawer`) reuse the existing WCAG
+    utilities. A Playwright `mobile` project (Pixel 5) runs `*.mobile.spec.ts`,
+    disjoint from the desktop `e2e` suite (`npm run test:mobile`).
+  - **App shell + navigation** — on mobile the persistent sidebar becomes a
+    hamburger-triggered overlay drawer (bits-ui `Dialog`: focus trap,
+    scroll-lock, Escape, focus-restore), auto-closing on navigation and when
+    the viewport grows to desktop. Desktop keeps the persistent collapsible
+    sidebar unchanged. The nav markup is shared via a single snippet.
 
 ## [6.40.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.0] - 2026-05-31
+
+### Added
+
+- **Mobile-responsive foundations (ADR-229 / SPEC-229-A, Phase 0 of the
+  mobile rollout).** Iris now has the primitives to adapt its UI when a
+  mobile screen is detected, ahead of adapting each surface in following
+  phases:
+  - **Viewport store** — `frontend/src/lib/stores/viewport.svelte.ts`
+    exposes reactive `isMobile` / `isTablet` / `isDesktop` flags built on
+    `matchMedia`, generalising the one-off responsive check that lived
+    inline on the dashboard. Breakpoints mirror Tailwind v4 defaults
+    (`< 768px` mobile, `768–1023px` tablet, `≥ 1024px` desktop). SSR-safe:
+    defaults to desktop during prerender and reconciles on mount. Wired
+    once from the root layout.
+  - **Responsive CSS tokens** in `app.css` — `--page-pad` (tighter gutters
+    on mobile), `.drawer-backdrop`, and `body.scroll-locked` for the
+    upcoming nav drawer and bottom sheets. Existing WCAG utilities are
+    reused, not duplicated.
+  - **Mobile test surface** — a Playwright `mobile` project (Pixel 5
+    device) running `*.mobile.spec.ts`, kept disjoint from the desktop
+    `e2e` suite; `npm run test:mobile`. Unit tests cover the store's
+    breakpoint boundaries, SSR default, reactivity, and listener cleanup.
+
 ## [6.40.0] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scroll-lock, Escape, focus-restore), auto-closing on navigation and when
     the viewport grows to desktop. Desktop keeps the persistent collapsible
     sidebar unchanged. The nav markup is shared via a single snippet.
+  - **Lists + detail pages** — responsive page gutters (`p-4 md:p-6`),
+    wrapping toolbars/headers, horizontally-scrollable section tab bars, and
+    the two-column `auto 1fr` definition grids on element/package detail pages
+    collapse to a single column on mobile (new `.detail-grid` helper). Wide
+    metadata/relationship tables scroll within their section instead of
+    forcing page-wide horizontal overflow.
 
 ## [6.40.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     collapse to a single column on mobile (new `.detail-grid` helper). Wide
     metadata/relationship tables scroll within their section instead of
     forcing page-wide horizontal overflow.
+  - **Diagram viewer** — on mobile the canvas takes the full width (the
+    hierarchy sidebar is hidden) and stays pan/pinch-zoom viewable, but layout
+    authoring (node drag, edge draw) is disabled via a new `interactiveLayout`
+    prop on `UnifiedCanvas`, with a "view only — edit layout on a larger
+    screen" hint. The full-screen (FocusView) trigger is hidden and the
+    section tab bar scrolls. Light edits (rename, properties, comments) remain.
 
 ## [6.40.0] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     prop on `UnifiedCanvas`, with a "view only — edit layout on a larger
     screen" hint. The full-screen (FocusView) trigger is hidden and the
     section tab bar scrolls. Light edits (rename, properties, comments) remain.
+  - **Iris AI chat** — uses `100dvh` so the mobile browser chrome/keyboard
+    can't clip the composer; the 3-column config row collapses to a single
+    column (`grid-cols-1 md:grid-cols-3`) and drops its fixed 800px cap on
+    mobile; the diagram-picker dropdown is constrained to the viewport width.
 
 ## [6.40.0] - 2026-05-31
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.40.0"
+version = "6.41.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/adrs/ADR-229-Mobile-Responsive-Adaptation.md
+++ b/docs/adrs/ADR-229-Mobile-Responsive-Adaptation.md
@@ -1,0 +1,125 @@
+# ADR-229: Mobile-responsive adaptation (detect small screens, adapt the existing UI)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-229 |
+| **Initiative** | Make Iris usable on a phone — view everything, make light edits |
+| **Proposed By** | Engineering |
+| **Date** | 2026-05-31 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the Iris frontend being desktop-first — the only
+responsive code is a single inline `matchMedia('(min-width: 1024px)')`
+on the dashboard (`frontend/src/routes/+page.svelte:231-238`); the app
+shell carries a fixed 224px sidebar that overlaps content rather than
+collapsing (`frontend/src/lib/components/AppShell.svelte`), the diagram
+viewer renders a three-pane layout (280px hierarchy aside + canvas +
+316px fixed right panels with a `margin-right:316px` page shift) in
+`frontend/src/routes/views/[id]/+page.svelte`, and the detail / list /
+AI-chat pages assume desktop width,
+
+**facing** that a user on a phone gets a sidebar consuming ~40% of the
+viewport, a canvas squeezed to an unusable width, right-side panels that
+clip content, and horizontal overflow on several pages — while the
+backend, MCP, and CLI surfaces are all reachable from mobile clients and
+the actual blocker is purely the web UI's layout,
+
+**we decided to** detect a mobile screen and **adapt the existing
+components responsively in one codebase** (no separate mobile route
+tree), targeting **view + light-edit** capability on mobile:
+
+  - **Breakpoints** mirror Tailwind v4 defaults: `< 768px` = mobile,
+    `768–1023px` = tablet, `≥ 1024px` = desktop (the existing dashboard
+    boundary). A new reactive store
+    `frontend/src/lib/stores/viewport.svelte.ts` generalises the inline
+    matchMedia pattern into shared `isMobile / isTablet / isDesktop`
+    getters, wired once from the root layout's `$effect`. SSR-safe:
+    defaults to desktop when there is no `window` (adapter-static
+    prerender), reconciles on mount.
+  - **Mechanism rule** — use Tailwind responsive classes (`md:`, `lg:`)
+    for pure CSS layout (stacking, visibility, padding); use the JS
+    `viewport` store only when a component *prop or behaviour* must
+    change reactively (canvas drag flags, drawer-vs-inline nav,
+    bottom-sheet panels, body scroll-lock).
+  - **App shell + nav** — the hamburger (already present) opens the nav
+    as an overlay **drawer** on mobile (bits-ui `Dialog`, already a
+    dependency), persistent inline on desktop (unchanged).
+  - **Diagram canvas** stays pan / pinch-zoom **viewable** on mobile but
+    layout authoring (node drag, edge draw) is disabled — a new
+    `interactiveLayout` prop on `UnifiedCanvas.svelte` gates the existing
+    edit-branch `nodesDraggable` / `nodesConnectable` flags, reusing the
+    component's existing `browseMode` semantics rather than a parallel
+    path. A "use desktop to edit layout" hint reuses `.canvas-mode-badge`.
+    Light edits (rename, properties/text fields, comments) remain
+    available.
+  - **Lists / detail / AI chat** stack to single column, tab bars scroll
+    horizontally, panels become bottom sheets on mobile.
+
+  Delivered as **one ADR + one spec** (this ADR / SPEC-229-A) then a
+  **phased rollout** — Phase 0 foundations (store, CSS tokens, Playwright
+  mobile project, ADR/spec), Phase 1 app shell, Phase 2 lists/detail,
+  Phase 3 diagram viewer, Phase 4 AI chat — each its own feature branch /
+  PR / changelog entry / version bump.
+
+**to achieve** a phone-usable Iris where every surface can be browsed and
+lightly edited, without forking the UI into a parallel mobile codebase or
+regressing the desktop experience.
+
+**accepting** that:
+- Heavy canvas authoring (drag-layout, drawing edges) is intentionally
+  desktop-only on mobile. Touch-gesture authoring is out of scope (would
+  reopen as a future ADR if demanded).
+- The SSR default renders the desktop tree for one frame before
+  `initViewport()` reconciles on a real phone — an acceptable, brief flash
+  for the common (desktop) case, and avoids a mobile-tree flash for the
+  majority.
+- Tablets (768–1023px) get the mobile adaptations for now; a dedicated
+  tablet layout is not in this initiative.
+- The diagram viewer page is large (~3000 lines) with three structural
+  copies (windowed / inline / FocusView); we gate each branch with the
+  store rather than rewriting, accepting some conditional duplication.
+
+## Rejected alternatives
+
+- **Separate `/m` mobile route tree / dedicated mobile components** —
+  maximum control over mobile UX but duplicates layout logic and doubles
+  maintenance for every future feature. Responsive adaptation keeps one
+  source of truth.
+- **CSS-only (no JS store)** — can't express prop-level behaviour changes
+  (disabling SvelteFlow node drag, swapping inline nav for a focus-trapped
+  drawer). A small reactive store is the minimum needed; everything else
+  stays CSS.
+- **Hand-rolled drawer / bottom sheet** — bits-ui `Dialog` (already a
+  dependency, Accordion already in use) gives focus trap, scroll-lock,
+  Escape, `aria-modal`, and focus restoration for free. Don't reinvent.
+- **Full mobile parity including touch canvas authoring** — large effort
+  reworking xyflow interaction; not justified for the view + light-edit
+  target.
+
+## Dependencies
+
+- Pattern source: the dashboard's inline matchMedia
+  (`frontend/src/routes/+page.svelte:231-238`) — generalised by the new
+  store; the dashboard migrates onto it as a fast-follow (same 1024px
+  boundary, zero behaviour change).
+- bits-ui 2.16 `Dialog` for the nav drawer and mobile bottom sheets.
+- `UnifiedCanvas.svelte` existing `browseMode` branch (already sets
+  `nodesDraggable/Connectable=false`) — reused via the new
+  `interactiveLayout` prop.
+- Existing WCAG CSS in `app.css` (24px touch targets, focus-visible,
+  reduced-motion, 320px reflow) — built on, not duplicated.
+
+## Consequences
+
+- Spec: SPEC-229-A.
+- Frontend-only. No backend change, no DB migration, no MCP / CLI surface
+  change (Protocol §14 unaffected). Version numbers still bump in lockstep
+  (frontend/backend/mcp/iris-client) per project discipline.
+- New `frontend/src/lib/stores/viewport.svelte.ts` becomes the
+  authoritative responsive-breakpoint primitive for the frontend.
+- New Playwright `mobile` project (Pixel 5) and `*.mobile.spec.ts`
+  convention establish the mobile test surface.

--- a/docs/adrs/specs/SPEC-229-A-Mobile-Responsive-Adaptation.md
+++ b/docs/adrs/specs/SPEC-229-A-Mobile-Responsive-Adaptation.md
@@ -1,0 +1,135 @@
+# SPEC-229-A: Mobile-responsive adaptation
+
+Implements **[ADR-229](../ADR-229-Mobile-Responsive-Adaptation.md)**.
+
+Living spec — evolves across the phased rollout. Phase 0 (foundations) is
+implemented; later phases are specified here and filled in as they ship.
+
+## Breakpoints
+
+Mirror Tailwind v4 defaults:
+
+| Band | Range | `viewport` flag |
+|------|-------|-----------------|
+| Mobile | `< 768px` | `isMobile` |
+| Tablet | `768–1023px` | `isTablet` |
+| Desktop | `≥ 1024px` | `isDesktop` |
+
+Exactly one flag is true at any time. Desktop `≥ 1024px` matches the
+pre-existing dashboard `matchMedia('(min-width: 1024px)')` boundary, so the
+dashboard can migrate onto the store with no behaviour change.
+
+## Mechanism rule
+
+- **Tailwind responsive classes** (`md:`, `lg:`) for pure CSS layout —
+  stacking columns, visibility, padding, gaps. No JS, SSR-safe, no flash.
+- **The `viewport` JS store** only when a component *prop or behaviour* must
+  change reactively: SvelteFlow `nodesDraggable`/`nodesConnectable`,
+  drawer-vs-inline nav, bottom-sheet-vs-fixed panels, body scroll-lock.
+
+## Phase 0 — Foundations (implemented)
+
+### Viewport store
+
+`frontend/src/lib/stores/viewport.svelte.ts` (new):
+
+```ts
+const MOBILE_MAX = 767;  // < 768px  → mobile
+const DESKTOP_MIN = 1024; // ≥ 1024px → desktop; 768–1023px is tablet
+
+// SSR/prerender default: render the desktop tree, reconcile on mount.
+let isMobileState = $state(false);
+let isDesktopState = $state(true);
+
+// Call once from the root layout $effect; returns the matchMedia cleanup.
+// No-ops + returns undefined when window.matchMedia is unavailable.
+export function initViewport(): (() => void) | undefined { /* … */ }
+
+export const viewport = {
+  get isMobile()  { return isMobileState; },
+  get isTablet()  { return !isMobileState && !isDesktopState; },
+  get isDesktop() { return isDesktopState; },
+};
+```
+
+Wired in `frontend/src/routes/+layout.svelte` via `$effect(() => initViewport())`.
+
+Consume anywhere: `import { viewport } from '$lib/stores/viewport.svelte';`
+then `{#if viewport.isMobile}…{/if}` (reactive through the getters).
+
+### CSS tokens — `frontend/src/app.css`
+
+- `--page-pad`: `1.5rem` desktop, `1rem` at `≤ 767px` (pages opt in).
+- `.drawer-backdrop`: fixed full-bleed dim layer (`z-index: 45`) behind a
+  drawer / bottom sheet.
+- `body.scroll-locked { overflow: hidden }`: background scroll-lock while a
+  drawer / sheet is open.
+
+Existing WCAG utilities (24px touch targets, focus-visible, reduced-motion,
+320px reflow) are reused, not duplicated. The mobile "use desktop to edit
+layout" hint reuses `.canvas-mode-badge`.
+
+### Test surface
+
+- Playwright `mobile` project in `frontend/playwright.config.ts`:
+  `{ ...devices['Pixel 5'] }`, `testMatch: /\.mobile\.spec\.ts$/`, same
+  `localhost:4173` webServer. The `e2e` project gains
+  `testIgnore: '**/*.mobile.spec.ts'` so the suites are disjoint. Run via
+  `npm run test:mobile`.
+- Unit: `frontend/tests/unit/viewport.test.ts` — boundary assertions at
+  767/768/1023/1024, SSR default (matchMedia absent → desktop, no-op,
+  cleanup undefined), reactivity on resize, listener cleanup.
+
+## Phase 1 — App shell + nav drawer
+
+`frontend/src/lib/components/AppShell.svelte`. Extract the nav list into a
+`{#snippet}`. Desktop: existing inline `<nav class="w-56 …">` unchanged.
+Mobile/tablet: render the same snippet inside a bits-ui `Dialog` left drawer
+(`fixed left-0 top-0 h-full w-72` + `.drawer-backdrop`). Default closed on
+mobile; hamburger toggles; auto-close on `afterNavigate` and on crossing to
+desktop. Toggle `body.scroll-locked` via `$effect`. Header links wrap/shrink;
+sign-out username `hidden sm:inline`.
+
+Tests: `nav-drawer.mobile.spec.ts` — open/close via hamburger, Escape,
+backdrop, nav-link; scroll-lock applied; focus returns to hamburger on close.
+
+## Phase 2 — Lists + detail pages
+
+`collections/+page.svelte`, `sets/+page.svelte`, `elements/+page.svelte`,
+`elements/[id]/+page.svelte`, `packages/[id]/+page.svelte`. Page padding
+`p-4 md:p-6`; toolbars `flex flex-wrap gap-2 md:gap-4`; tab bars wrapped in
+`overflow-x-auto`; detail accordion grids `auto 1fr` → single column on mobile
+(move inline `style=` to a class + `@media (max-width:767px)`); inputs
+`w-full`; tables wrapped in `overflow-x-auto`. Reuse bits-ui `Accordion`.
+
+Tests: `detail-stack.mobile.spec.ts`, `no-overflow.mobile.spec.ts`.
+
+## Phase 3 — Diagram viewer
+
+`frontend/src/routes/views/[id]/+page.svelte` + `UnifiedCanvas.svelte`. Gate
+each of the three structural copies with `viewport.isMobile`. Hierarchy aside
+→ bits-ui drawer; right panels → bottom sheets (drop the `margin-right:316px`
+shift on mobile). Add `interactiveLayout = true` prop to `UnifiedCanvas`
+`Props`; edit branch becomes `nodesDraggable={interactiveLayout}` /
+`nodesConnectable={interactiveLayout && !connectMode}`; page passes
+`interactiveLayout={!viewport.isMobile}`. Pan/pinch-zoom stay enabled. Show
+the `.canvas-mode-badge` "Use desktop to edit layout" hint; hide
+layout-authoring toolbar buttons on mobile (keep rename/property/comment).
+Hide the FocusView trigger on mobile.
+
+Tests: `canvas-readonly.mobile.spec.ts` — node drag leaves position unchanged,
+connect handles inert, pane pan changes the transform, hint visible.
+
+## Phase 4 — Iris AI chat
+
+`frontend/src/routes/ask/+page.svelte`. Root height `100dvh` minus header so
+the mobile URL bar / keyboard don't clip the composer. Config grid `1fr 1fr
+1fr` → `grid-cols-1 md:grid-cols-3`; drop the `max-width:800px` cap on mobile
+(`w-full md:max-w-[800px]`). Diagrams dropdown `min-width: min(320px,
+calc(100vw - 32px))`. Composer full-width, sticky bottom; message list scrolls.
+
+## Release
+
+Each phase: feature branch → PR → `CHANGELOG.md` entry → version bump in
+lockstep (frontend/package.json, backend/mcp/iris-client pyproject.toml; CLI
+independent) → GitHub release. Phase 0 ships as v6.41.0.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.40.0",
+	"version": "6.41.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
@@ -12,6 +12,7 @@
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"test:unit": "vitest run",
 		"test:e2e": "playwright test --project=e2e",
+		"test:mobile": "playwright test --project=mobile",
 		"test:uat": "PLAYWRIGHT_UAT=1 playwright test --project=uat",
 		"test:bdd": "npx bddgen && playwright test --project=bdd",
 		"test:all-e2e": "npx bddgen && playwright test",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from '@playwright/test';
+import { defineConfig, devices } from '@playwright/test';
 import { defineBddConfig } from 'playwright-bdd';
 
 const bddTestDir = defineBddConfig({
@@ -32,8 +32,20 @@ export default defineConfig({
 		{
 			name: 'e2e',
 			testDir: 'tests/e2e',
-			testIgnore: ['**/uat/**'],
+			// Mobile specs run in the dedicated `mobile` project (Pixel 5 device);
+			// keep them out of the desktop suite so the two stay disjoint.
+			testIgnore: ['**/uat/**', '**/*.mobile.spec.ts'],
 			use: { browserName: 'chromium' },
+		},
+		{
+			// v6.41.0 (ADR-229): mobile-responsive verification. Pixel 5 device
+			// descriptor (393×851, touch, mobile UA). Shares the same
+			// localhost:4173 webServer as `e2e`; runs on demand via
+			// `npm run test:mobile`. Specs are named *.mobile.spec.ts.
+			name: 'mobile',
+			testDir: 'tests/e2e',
+			testMatch: /\.mobile\.spec\.ts$/,
+			use: { ...devices['Pixel 5'] },
 		},
 		{
 			name: 'bdd',

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -133,6 +133,34 @@ body.scroll-locked {
 	overflow: hidden;
 }
 
+/* Mobile nav drawer (ADR-229). bits-ui Dialog.Content renders in a body-level
+   portal, so this must be global (component-scoped styles wouldn't reach it). */
+.mobile-nav-drawer {
+	position: fixed;
+	left: 0;
+	top: 0;
+	height: 100%;
+	width: 18rem;
+	max-width: 85vw;
+	z-index: 46; /* above .drawer-backdrop (45) */
+	overflow-y: auto;
+	border-right: 1px solid var(--color-border);
+	box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
+}
+
+.mobile-nav-drawer[data-state='open'] {
+	animation: drawer-slide-in 0.2s ease-out;
+}
+
+@keyframes drawer-slide-in {
+	from {
+		transform: translateX(-100%);
+	}
+	to {
+		transform: translateX(0);
+	}
+}
+
 /* Screen-reader only utility */
 .sr-only {
 	position: absolute;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -107,6 +107,32 @@ a {
 	}
 }
 
+/* ── Responsive tokens (ADR-229 / SPEC-229-A) ──
+   Shared primitives for the mobile-responsive rollout. Breakpoints mirror
+   Tailwind v4 defaults (md = 768px). Pages opt into --page-pad; drawers
+   (bits-ui Dialog) reuse .drawer-backdrop and body.scroll-locked. */
+:root {
+	--page-pad: 1.5rem; /* desktop default (matches p-6) */
+}
+@media (max-width: 767px) {
+	:root {
+		--page-pad: 1rem; /* tighter gutters on mobile (matches p-4) */
+	}
+}
+
+/* Dimmed backdrop behind a mobile drawer / bottom sheet */
+.drawer-backdrop {
+	position: fixed;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.4);
+	z-index: 45;
+}
+
+/* Lock background scrolling while a drawer / bottom sheet is open */
+body.scroll-locked {
+	overflow: hidden;
+}
+
 /* Screen-reader only utility */
 .sr-only {
 	position: absolute;

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -161,6 +161,19 @@ body.scroll-locked {
 	}
 }
 
+/* Definition grids on detail pages (elements/packages) — term + value in two
+   columns on desktop, stacked single column on mobile (ADR-229). Replaces the
+   inline `grid-template-columns: auto 1fr` so a media query can override it
+   (inline styles can't be). Pair with Tailwind `grid gap-3`. */
+.detail-grid {
+	grid-template-columns: auto 1fr;
+}
+@media (max-width: 767px) {
+	.detail-grid {
+		grid-template-columns: 1fr;
+	}
+}
+
 /* Screen-reader only utility */
 .sr-only {
 	position: absolute;

--- a/frontend/src/lib/canvas/UnifiedCanvas.svelte
+++ b/frontend/src/lib/canvas/UnifiedCanvas.svelte
@@ -52,6 +52,10 @@
 		/** v5.2.0 (issue #37): forwarded to BpmnRenderer via setContext so the
 		 *  ContextPad inside a selected BPMN node can call back to the page. */
 		oncontextpadaction?: (action: string, nodeId: string) => void;
+		/** v6.41.0 (ADR-229): when false, layout authoring (node drag + edge
+		 *  draw) is disabled while pan/zoom stay enabled — used on mobile, where
+		 *  the canvas is view-only. Pass `!viewport.isMobile`. Defaults true. */
+		interactiveLayout?: boolean;
 	}
 
 	let {
@@ -76,6 +80,7 @@
 		onbeforeconnect,
 		ondropentity,
 		oncontextpadaction,
+		interactiveLayout = true,
 	}: Props = $props();
 
 	// Set notation context for DynamicNode/DynamicEdge to read
@@ -355,8 +360,8 @@
 			onconnect={handleSvelteFlowConnect}
 			proOptions={{ hideAttribution: true }}
 			defaultEdgeOptions={{ type: defaultEdgeType }}
-			nodesDraggable={true}
-			nodesConnectable={!connectMode}
+			nodesDraggable={interactiveLayout}
+			nodesConnectable={interactiveLayout && !connectMode}
 			elementsSelectable={true}
 		>
 			<Controls showLock={false} {fitViewOptions} />
@@ -390,6 +395,14 @@
 	{#if connectMode}
 		<div class="canvas-connect-indicator" aria-live="assertive">
 			Connect mode — select target node or press Escape
+		</div>
+	{/if}
+
+	<!-- ADR-229: on mobile the canvas is pan/zoom view-only; layout authoring
+	     (drag + edge draw) is disabled. Surface why. -->
+	{#if !browseMode && !interactiveLayout}
+		<div class="canvas-mode-badge" data-testid="layout-locked-hint">
+			View only — edit layout on a larger screen
 		</div>
 	{/if}
 

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -363,7 +363,7 @@
 		{/if}
 
 		<!-- Main content landmark -->
-		<main id="main-content" class="flex flex-1 flex-col p-6" tabindex="-1">
+		<main id="main-content" class="flex min-w-0 flex-1 flex-col p-4 md:p-6" tabindex="-1">
 			{@render children()}
 		</main>
 	</div>

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -1,17 +1,45 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
+	import { goto, afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 	import { isAuthenticated, isAnonymous, getCurrentUser, clearAuth } from '$lib/stores/auth.svelte.js';
 	import { getActiveSetId, getActiveSetName } from '$lib/stores/activeSet.svelte.js';
 	import { getActiveCollectionId, getActiveCollectionName } from '$lib/stores/activeCollection.svelte.js';
 	import { getAiContextCount } from '$lib/stores/aiContext.svelte.js';
 	import { startProviderPolling, stopProviderPolling } from '$lib/stores/aiProviders.svelte.js';
+	import { viewport } from '$lib/stores/viewport.svelte';
 	import { apiFetch } from '$lib/utils/api';
 	import SystemBanner from '$lib/components/SystemBanner.svelte';
+	import { Dialog } from 'bits-ui';
 
 	let { children } = $props();
 
+	// Desktop: the sidebar is a persistent, collapsible column (default open).
+	// Mobile/tablet (ADR-229): the same nav becomes an overlay drawer whose
+	// open state is `drawerOpen` (default closed). The hamburger toggles
+	// whichever applies to the current viewport.
 	let sidebarOpen = $state(true);
+	let drawerOpen = $state(false);
+
+	function toggleNav() {
+		if (viewport.isDesktop) {
+			sidebarOpen = !sidebarOpen;
+		} else {
+			drawerOpen = !drawerOpen;
+		}
+	}
+
+	// Close the mobile drawer after navigating to a new route.
+	afterNavigate(() => {
+		drawerOpen = false;
+	});
+
+	// If the viewport grows to desktop while the drawer is open, close it —
+	// the persistent sidebar takes over and a lingering modal would trap focus.
+	$effect(() => {
+		if (viewport.isDesktop && drawerOpen) {
+			drawerOpen = false;
+		}
+	});
 	let aiContextCount = $derived(getAiContextCount());
 	let recycleBinCount = $state(0);
 	let bookmarkCount = $state(0);
@@ -159,6 +187,88 @@
 	</svg>
 {/snippet}
 
+<!-- Nav body — rendered inline in the desktop sidebar and inside the mobile
+     drawer (ADR-229). Single source of truth for the menu markup. -->
+{#snippet navInner()}
+	<ul class="space-y-1">
+		{#each navItems as item}
+			{#if item.icon === 'bookmarks' && sceniaEnabled}
+				<li>
+					<a
+						href="/roadmap"
+						class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
+						style="color: var(--color-fg){page.url.pathname.startsWith('/roadmap') || page.url.pathname.startsWith('/scenia') ? '; background-color: var(--color-bg)' : ''}"
+						aria-current={page.url.pathname.startsWith('/roadmap') || page.url.pathname.startsWith('/scenia') ? 'page' : undefined}
+						title="Roadmap (G)"
+					>
+						{@render navIcon('roadmap')}
+						Roadmap
+					</a>
+				</li>
+				<li aria-hidden="true" class="my-3 border-t" style="border-color: var(--color-border)"></li>
+			{/if}
+			<li>
+				<a
+					href={item.href}
+					class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
+					style="color: var(--color-fg){(item.href === '/' ? page.url.pathname === '/' : page.url.pathname.startsWith(item.href)) ? '; background-color: var(--color-bg)' : ''}"
+					aria-current={(item.href === '/' ? page.url.pathname === '/' : page.url.pathname.startsWith(item.href)) ? 'page' : undefined}
+					title="{item.label} ({item.shortcut})"
+				>
+					{#if item.icon === 'ai'}
+						<span class="ai-icon-highlight">{@render navIcon(item.icon)}</span>
+					{:else}
+						{@render navIcon(item.icon)}
+					{/if}
+					{item.label}
+					{#if item.icon === 'ai' && aiContextCount > 0}
+						<span
+							class="ai-context-indicator"
+							aria-label="{aiContextCount} item{aiContextCount === 1 ? '' : 's'} in AI context"
+						></span>
+					{/if}
+					{#if item.icon === 'bookmarks' && bookmarkCount > 0}
+						<span
+							class="recycle-bin-indicator"
+							aria-label="{bookmarkCount} bookmark{bookmarkCount === 1 ? '' : 's'}"
+						></span>
+					{/if}
+					{#if item.icon === 'recycle-bin' && recycleBinCount > 0}
+						<span
+							class="recycle-bin-indicator"
+							aria-label="{recycleBinCount} item{recycleBinCount === 1 ? '' : 's'} in recycle bin"
+						></span>
+					{/if}
+				</a>
+			</li>
+		{/each}
+	</ul>
+
+	{#if getCurrentUser()?.role === 'admin'}
+		<div class="mt-4 border-t pt-4" style="border-color: var(--color-border)">
+			<h2 class="mb-2 px-3 text-xs font-semibold uppercase" style="color: var(--color-muted)">
+				Admin
+			</h2>
+			<ul class="space-y-1">
+				{#each adminItems as item}
+					<li>
+						<a
+							href={item.href}
+							class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
+							style="color: var(--color-fg){page.url.pathname.startsWith(item.href) ? '; background-color: var(--color-bg)' : ''}"
+							aria-current={page.url.pathname.startsWith(item.href) ? 'page' : undefined}
+							title="{item.label} ({item.shortcut})"
+						>
+							{@render navIcon(item.icon)}
+							{item.label}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+{/snippet}
+
 <div class="flex min-h-screen flex-col">
 	<!-- Skip link per WCAG 2.4.1 -->
 	<a href="#main-content" class="skip-link">Skip to main content</a>
@@ -174,8 +284,9 @@
 	>
 		<div class="flex items-center gap-3">
 			<button
-				onclick={() => (sidebarOpen = !sidebarOpen)}
-				aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+				onclick={toggleNav}
+				aria-label={(viewport.isDesktop ? sidebarOpen : drawerOpen) ? 'Close navigation' : 'Open navigation'}
+				aria-expanded={viewport.isDesktop ? sidebarOpen : drawerOpen}
 				class="rounded p-1"
 			>
 				<span aria-hidden="true" class="text-lg">&#9776;</span>
@@ -205,7 +316,7 @@
 					class="header-link rounded px-3 py-1 text-sm transition-colors"
 					style="color: var(--color-danger)"
 				>
-					Sign out ({getCurrentUser()?.username})
+					Sign out <span class="hidden sm:inline">({getCurrentUser()?.username})</span>
 				</button>
 			{:else}
 				<a
@@ -220,91 +331,35 @@
 	</header>
 
 	<div class="flex flex-1">
-		<!-- Sidebar / Navigation landmark -->
-		{#if sidebarOpen}
+		<!-- Desktop sidebar (≥1024px): persistent, collapsible column. -->
+		{#if viewport.isDesktop && sidebarOpen}
 			<nav
 				aria-label="Main navigation"
 				class="w-56 border-r p-4"
 				style="background-color: var(--color-surface); border-color: var(--color-border)"
 			>
-				<ul class="space-y-1">
-					{#each navItems as item}
-						{#if item.icon === 'bookmarks' && sceniaEnabled}
-							<li>
-								<a
-									href="/roadmap"
-									class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
-									style="color: var(--color-fg){page.url.pathname.startsWith('/roadmap') || page.url.pathname.startsWith('/scenia') ? '; background-color: var(--color-bg)' : ''}"
-									aria-current={page.url.pathname.startsWith('/roadmap') || page.url.pathname.startsWith('/scenia') ? 'page' : undefined}
-									title="Roadmap (G)"
-								>
-									{@render navIcon('roadmap')}
-									Roadmap
-								</a>
-							</li>
-							<li aria-hidden="true" class="my-3 border-t" style="border-color: var(--color-border)"></li>
-						{/if}
-						<li>
-							<a
-								href={item.href}
-								class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
-								style="color: var(--color-fg){(item.href === '/' ? page.url.pathname === '/' : page.url.pathname.startsWith(item.href)) ? '; background-color: var(--color-bg)' : ''}"
-								aria-current={(item.href === '/' ? page.url.pathname === '/' : page.url.pathname.startsWith(item.href)) ? 'page' : undefined}
-								title="{item.label} ({item.shortcut})"
-							>
-								{#if item.icon === 'ai'}
-									<span class="ai-icon-highlight">{@render navIcon(item.icon)}</span>
-								{:else}
-									{@render navIcon(item.icon)}
-								{/if}
-								{item.label}
-								{#if item.icon === 'ai' && aiContextCount > 0}
-									<span
-										class="ai-context-indicator"
-										aria-label="{aiContextCount} item{aiContextCount === 1 ? '' : 's'} in AI context"
-									></span>
-								{/if}
-								{#if item.icon === 'bookmarks' && bookmarkCount > 0}
-									<span
-										class="recycle-bin-indicator"
-										aria-label="{bookmarkCount} bookmark{bookmarkCount === 1 ? '' : 's'}"
-									></span>
-								{/if}
-								{#if item.icon === 'recycle-bin' && recycleBinCount > 0}
-									<span
-										class="recycle-bin-indicator"
-										aria-label="{recycleBinCount} item{recycleBinCount === 1 ? '' : 's'} in recycle bin"
-									></span>
-								{/if}
-							</a>
-						</li>
-					{/each}
-				</ul>
-
-				{#if getCurrentUser()?.role === 'admin'}
-					<div class="mt-4 border-t pt-4" style="border-color: var(--color-border)">
-						<h2 class="mb-2 px-3 text-xs font-semibold uppercase" style="color: var(--color-muted)">
-							Admin
-						</h2>
-						<ul class="space-y-1">
-							{#each adminItems as item}
-								<li>
-									<a
-										href={item.href}
-										class="sidebar-link flex items-center gap-2.5 rounded px-3 py-2 text-sm transition-colors"
-										style="color: var(--color-fg){page.url.pathname.startsWith(item.href) ? '; background-color: var(--color-bg)' : ''}"
-										aria-current={page.url.pathname.startsWith(item.href) ? 'page' : undefined}
-										title="{item.label} ({item.shortcut})"
-									>
-										{@render navIcon(item.icon)}
-										{item.label}
-									</a>
-								</li>
-							{/each}
-						</ul>
-					</div>
-				{/if}
+				{@render navInner()}
 			</nav>
+		{/if}
+
+		<!-- Mobile/tablet drawer (<1024px): same nav as an overlay. bits-ui
+		     Dialog provides the focus trap, scroll-lock, Escape, aria-modal,
+		     and focus-restore-to-trigger (ADR-229). -->
+		{#if !viewport.isDesktop}
+			<Dialog.Root bind:open={drawerOpen}>
+				<Dialog.Portal>
+					<Dialog.Overlay class="drawer-backdrop" />
+					<Dialog.Content
+						class="mobile-nav-drawer"
+						style="background-color: var(--color-surface); border-color: var(--color-border)"
+					>
+						<Dialog.Title class="sr-only">Main navigation</Dialog.Title>
+						<nav aria-label="Main navigation" class="p-4">
+							{@render navInner()}
+						</nav>
+					</Dialog.Content>
+				</Dialog.Portal>
+			</Dialog.Root>
 		{/if}
 
 		<!-- Main content landmark -->

--- a/frontend/src/lib/stores/viewport.svelte.ts
+++ b/frontend/src/lib/stores/viewport.svelte.ts
@@ -1,0 +1,68 @@
+// Reactive viewport breakpoint store (ADR-229 / SPEC-229-A).
+//
+// Generalises the one-off `matchMedia('(min-width: 1024px)')` pattern that
+// previously lived inline in routes/+page.svelte's dashboard. A single set of
+// listeners is shared across every consumer via module-level $state, so reading
+// `viewport.isMobile` in any component is reactive without that component
+// owning its own listener.
+//
+// Mechanism guidance (SPEC-229-A): prefer Tailwind responsive classes
+// (`md:`, `lg:`) for pure CSS layout. Reach for this store only when a
+// component *prop or behaviour* must change reactively — e.g. passing
+// `nodesDraggable` into SvelteFlow, choosing drawer-vs-inline nav, or toggling
+// body scroll-lock.
+
+// Breakpoints align with Tailwind v4 defaults: md = 768px, lg = 1024px.
+const MOBILE_MAX = 767; // < 768px  → mobile
+const DESKTOP_MIN = 1024; // ≥ 1024px → desktop; the 768–1023px band is tablet.
+
+// SSR / prerender default: adapter-static prerenders without a window, so we
+// render the desktop tree (the historical default) and reconcile on mount.
+let isMobileState = $state(false);
+let isDesktopState = $state(true);
+
+/**
+ * Wire up the matchMedia listeners. Call once from the root layout's $effect
+ * (which only runs in the browser) and return value is the cleanup function.
+ * No-ops and returns undefined when there is no usable `window.matchMedia`
+ * (SSR/prerender, or a test environment that hasn't stubbed it).
+ */
+export function initViewport(): (() => void) | undefined {
+	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+		return undefined;
+	}
+
+	const mqMobile = window.matchMedia(`(max-width: ${MOBILE_MAX}px)`);
+	const mqDesktop = window.matchMedia(`(min-width: ${DESKTOP_MIN}px)`);
+
+	const sync = () => {
+		isMobileState = mqMobile.matches;
+		isDesktopState = mqDesktop.matches;
+	};
+	sync();
+
+	mqMobile.addEventListener('change', sync);
+	mqDesktop.addEventListener('change', sync);
+
+	return () => {
+		mqMobile.removeEventListener('change', sync);
+		mqDesktop.removeEventListener('change', sync);
+	};
+}
+
+/**
+ * Reactive viewport flags. Exactly one of isMobile / isTablet / isDesktop is
+ * true at any time. Consume via the getters so reads track the underlying
+ * $state (e.g. `{#if viewport.isMobile}`).
+ */
+export const viewport = {
+	get isMobile() {
+		return isMobileState;
+	},
+	get isTablet() {
+		return !isMobileState && !isDesktopState;
+	},
+	get isDesktop() {
+		return isDesktopState;
+	}
+};

--- a/frontend/src/lib/stores/viewport.svelte.ts
+++ b/frontend/src/lib/stores/viewport.svelte.ts
@@ -16,10 +16,27 @@
 const MOBILE_MAX = 767; // < 768px  → mobile
 const DESKTOP_MIN = 1024; // ≥ 1024px → desktop; the 768–1023px band is tablet.
 
-// SSR / prerender default: adapter-static prerenders without a window, so we
-// render the desktop tree (the historical default) and reconcile on mount.
-let isMobileState = $state(false);
-let isDesktopState = $state(true);
+function canMatch(): boolean {
+	return typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+}
+
+// Read the current breakpoint straight from matchMedia. Used both for the
+// eager initial value (below) and on every change event.
+function readMobile(): boolean {
+	return canMatch() ? window.matchMedia(`(max-width: ${MOBILE_MAX}px)`).matches : false;
+}
+function readDesktop(): boolean {
+	// SSR / prerender (no window): default to desktop — adapter-static
+	// prerenders the desktop tree, then the browser reconciles eagerly below.
+	return canMatch() ? window.matchMedia(`(min-width: ${DESKTOP_MIN}px)`).matches : true;
+}
+
+// Eager initial values: in the browser the module loads during hydration when
+// `window` is available, so consumers (and toggle handlers that branch on
+// `isDesktop`) see the correct breakpoint on the very first render — no flash,
+// no race. Falls back to the desktop default during SSR.
+let isMobileState = $state(readMobile());
+let isDesktopState = $state(readDesktop());
 
 /**
  * Wire up the matchMedia listeners. Call once from the root layout's $effect
@@ -28,7 +45,7 @@ let isDesktopState = $state(true);
  * (SSR/prerender, or a test environment that hasn't stubbed it).
  */
 export function initViewport(): (() => void) | undefined {
-	if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+	if (!canMatch()) {
 		return undefined;
 	}
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -5,9 +5,14 @@
 	import AppShell from '$lib/components/AppShell.svelte';
 	import SessionTimeoutWarning from '$lib/components/SessionTimeoutWarning.svelte';
 	import { isAuthenticated } from '$lib/stores/auth.svelte.js';
+	import { initViewport } from '$lib/stores/viewport.svelte';
 	import { ModeWatcher } from 'mode-watcher';
 
 	let { children } = $props();
+
+	// Wire up the shared viewport breakpoint store once for the whole app
+	// (ADR-229). Runs browser-only; returns the matchMedia cleanup.
+	$effect(() => initViewport());
 
 	// /login renders without the AppShell (clean full-page login form).
 	// Every other route renders inside the AppShell — anonymous visitors

--- a/frontend/src/routes/ask/+page.svelte
+++ b/frontend/src/routes/ask/+page.svelte
@@ -226,7 +226,7 @@
 	<title>Iris AI</title>
 </svelte:head>
 
-<div class="flex flex-col" style="height: calc(100vh - 56px - 48px); overflow: hidden">
+<div class="flex flex-col" style="height: calc(100dvh - 56px - 48px); overflow: hidden">
 	<div class="flex-none">
 		<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Iris AI</h1>
 		<p class="mt-1 text-sm" style="color: var(--color-muted)">
@@ -261,7 +261,7 @@
 		{#if loading}
 			<p class="mt-4 text-sm" style="color: var(--color-muted)">Loading...</p>
 		{:else}
-			<div class="mt-4 grid items-end gap-4" style="max-width: 800px; grid-template-columns: 1fr 1fr 1fr">
+			<div class="mt-4 grid grid-cols-1 items-end gap-4 md:max-w-[800px] md:grid-cols-3">
 				<div style="min-width: 0">
 					{#if collections.length > 0}
 						<label for="ask-collection" class="mb-1 block text-sm font-medium" style="color: var(--color-fg)">Collection</label>
@@ -311,7 +311,7 @@
 						></div>
 						<div
 							class="rounded border shadow-lg"
-							style="position: absolute; top: 100%; left: 0; z-index: 10; margin-top: 4px; min-width: 320px; max-height: 400px; background: var(--color-surface); border-color: var(--color-border); overflow: hidden; display: flex; flex-direction: column"
+							style="position: absolute; top: 100%; left: 0; z-index: 10; margin-top: 4px; min-width: min(320px, calc(100vw - 32px)); max-width: calc(100vw - 32px); max-height: 400px; background: var(--color-surface); border-color: var(--color-border); overflow: hidden; display: flex; flex-direction: column"
 						>
 							<div class="flex items-center gap-2 border-b px-3 py-2" style="border-color: var(--color-border)">
 								<button type="button" onclick={selectAllDiagrams} class="text-xs" style="color: var(--color-primary)">Select all</button>

--- a/frontend/src/routes/collections/+page.svelte
+++ b/frontend/src/routes/collections/+page.svelte
@@ -101,7 +101,7 @@
 	<title>Collections — Iris</title>
 </svelte:head>
 
-<div class="flex items-center justify-between">
+<div class="flex flex-wrap items-center justify-between gap-2">
 	<div>
 		<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Collections</h1>
 		<p class="mt-1 text-sm" style="color: var(--color-muted)">Group and organise related Sets into Collections.</p>
@@ -134,7 +134,7 @@
 		</button>
 	</div>
 </div>
-<div class="mt-3 flex items-center gap-4">
+<div class="mt-3 flex flex-wrap items-center gap-2 sm:gap-4">
 	<input
 		type="search"
 		bind:value={searchQuery}

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -383,7 +383,7 @@
 	<title>Elements — Iris</title>
 </svelte:head>
 
-<div class="flex items-center justify-between">
+<div class="flex flex-wrap items-center justify-between gap-2">
 	<div>
 		<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Elements</h1>
 		<p class="mt-1 text-sm" style="color: var(--color-muted)">Browse and manage architectural elements.</p>

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -544,7 +544,7 @@
 		{error}
 	</div>
 {:else if entity}
-	<div class="flex items-center justify-between">
+	<div class="flex flex-wrap items-center justify-between gap-2">
 		<div>
 			<div class="flex flex-wrap items-center gap-3">
 				<h1 class="text-2xl font-bold" style="color: var(--color-fg)">{entity.name}</h1>
@@ -604,7 +604,7 @@
 	<!-- Tab navigation. ADR-208 (v6.16.0): Relationships first; the
 		 old "Used In Diagrams" tab is folded into Relationships as a
 		 section, alongside the new Package membership section. -->
-	<div class="mt-6 flex gap-1 border-b" style="border-color: var(--color-border)" role="tablist" aria-label="Element sections">
+	<div class="mt-6 flex gap-1 overflow-x-auto border-b" style="border-color: var(--color-border)" role="tablist" aria-label="Element sections">
 		<button
 			role="tab"
 			aria-selected={activeTab === 'relationships'}
@@ -686,8 +686,8 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
-						<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+					<Accordion.Content class="pb-4 overflow-x-auto">
+						<dl class="detail-grid grid gap-3">
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">Name</dt>
 							<dd>
 								{#if editingDetails}
@@ -867,7 +867,7 @@
 								<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 							</Accordion.Trigger>
 						</Accordion.Header>
-						<Accordion.Content class="pb-4">
+						<Accordion.Content class="pb-4 overflow-x-auto">
 							{#if editingDetails}
 								<table class="w-full text-sm" style="color: var(--color-fg)">
 									<thead>
@@ -947,8 +947,8 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
-						<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+					<Accordion.Content class="pb-4 overflow-x-auto">
+						<dl class="detail-grid grid gap-3">
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">ID</dt>
 							<dd class="text-sm" style="color: var(--color-fg)">{entity.id}</dd>
 
@@ -1027,7 +1027,7 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
+					<Accordion.Content class="pb-4 overflow-x-auto">
 						{@const meta = entity.metadata as Record<string, unknown> | null | undefined}
 						{@const hasMeta = !!(meta && (meta.stereotype || meta.version || meta.scope || meta.abstract || meta.persistence || meta.author || meta.complexity || meta.phase || meta.created_date || meta.modified_date || meta.gen_type || (Array.isArray(meta.tagged_values) && (meta.tagged_values as unknown[]).length > 0)))}
 						{#if hasMeta || editingDetails}
@@ -1054,7 +1054,7 @@
 									</dd>
 								{/if}
 							{/snippet}
-							<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+							<dl class="detail-grid grid gap-3">
 								{@render scalarRow('Stereotype', (meta?.stereotype as string) ?? '', 'Stereotype', () => editStereotype, (v) => (editStereotype = v))}
 								{@render scalarRow('Metadata Version', (meta?.version as string) ?? '', 'Metadata Version', () => editMetaVersion, (v) => (editMetaVersion = v))}
 								{@render scalarRow('Scope', (meta?.scope as string) ?? '', 'Scope', () => editScope, (v) => (editScope = v))}
@@ -1232,6 +1232,7 @@
 				{:else if relationships.length === 0}
 					<p style="color: var(--color-muted)">No relationships yet. Relationships are created automatically when elements are connected by edges in a view canvas.</p>
 				{:else}
+					<div class="overflow-x-auto">
 					<table class="w-full text-sm">
 						<thead>
 							<tr style="border-bottom: 1px solid var(--color-border)">
@@ -1260,6 +1261,7 @@
 							{/each}
 						</tbody>
 					</table>
+					</div>
 				{/if}
 			</section>
 		{:else if activeTab === 'versions'}

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -509,7 +509,7 @@
 			</li>
 		</ol>
 	</nav>
-	<div class="flex items-center justify-between">
+	<div class="flex flex-wrap items-center justify-between gap-2">
 		<div>
 			<div class="flex flex-wrap items-center gap-3">
 				<h1 class="text-2xl font-bold" style="color: var(--color-fg)">{pkg.name}</h1>
@@ -630,7 +630,7 @@
 		<!-- Main content -->
 		<div class="min-w-0 flex-1">
 		<!-- Tab navigation with hierarchy toggle -->
-		<div class="flex items-center gap-1 border-b" style="border-color: var(--color-border)">
+		<div class="flex items-center gap-1 overflow-x-auto border-b" style="border-color: var(--color-border)">
 			<button onclick={toggleSidebar} aria-label="Toggle hierarchy sidebar" aria-pressed={sidebarOpen} class="rounded p-1">
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="20" height="20"
 					style="color: {sidebarOpen ? 'var(--color-primary)' : 'var(--color-muted)'}">
@@ -711,8 +711,8 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
-						<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+					<Accordion.Content class="pb-4 overflow-x-auto">
+						<dl class="detail-grid grid gap-3">
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">Name</dt>
 							<dd>
 								{#if editingDetails}
@@ -790,8 +790,8 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
-						<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+					<Accordion.Content class="pb-4 overflow-x-auto">
+						<dl class="detail-grid grid gap-3">
 							<dt class="text-sm font-medium" style="color: var(--color-muted)">ID</dt>
 							<dd class="text-sm" style="color: var(--color-fg)">{pkg.id}</dd>
 
@@ -823,11 +823,11 @@
 							<span class="transition-transform duration-200 group-data-[state=open]:rotate-90" style="color: var(--color-muted); font-size: 0.75rem" aria-hidden="true">&#9654;</span>
 						</Accordion.Trigger>
 					</Accordion.Header>
-					<Accordion.Content class="pb-4">
+					<Accordion.Content class="pb-4 overflow-x-auto">
 						{@const meta = pkg.metadata as Record<string, unknown> | null | undefined}
 						{@const hasMeta = !!(meta && (meta.ea_guid || meta.stereotype || meta.version || meta.scope || meta.author || meta.complexity || meta.phase || meta.created_date || meta.modified_date || meta.gen_type || (Array.isArray(meta.tagged_values) && (meta.tagged_values as unknown[]).length > 0)))}
 						{#if hasMeta}
-							<dl class="grid gap-3" style="grid-template-columns: auto 1fr">
+							<dl class="detail-grid grid gap-3">
 								{#if meta?.ea_guid}
 									<dt class="text-sm font-medium" style="color: var(--color-muted)">EA GUID</dt>
 									<dd class="text-sm font-mono" style="color: var(--color-fg)">{meta.ea_guid}</dd>

--- a/frontend/src/routes/sets/+page.svelte
+++ b/frontend/src/routes/sets/+page.svelte
@@ -117,7 +117,7 @@
 	<title>Sets — Iris</title>
 </svelte:head>
 
-<div class="flex items-center justify-between">
+<div class="flex flex-wrap items-center justify-between gap-2">
 	<div>
 		<h1 class="text-2xl font-bold" style="color: var(--color-fg)">
 			Sets
@@ -161,7 +161,7 @@
 		</button>
 	</div>
 </div>
-<div class="mt-3 flex items-center gap-4">
+<div class="mt-3 flex flex-wrap items-center gap-2 sm:gap-4">
 	<input
 		type="search"
 		bind:value={searchQuery}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -10,6 +10,7 @@
 	import type { Diagram, DiagramVersion, Bookmark } from '$lib/types/api';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
+	import { viewport } from '$lib/stores/viewport.svelte';
 	import UnifiedCanvas from '$lib/canvas/UnifiedCanvas.svelte';
 	import BpmnAuthoringShell from '$lib/canvas/bpmn/BpmnAuthoringShell.svelte';
 	import SequenceDiagram from '$lib/canvas/sequence/SequenceDiagram.svelte';
@@ -2074,7 +2075,7 @@
 			/>
 		</div>
 	{/if}
-	<div style={(windowedBrowseSidebar || windowedCommentsSidebar) ? 'margin-right: 316px; margin-bottom: -24px; transition: margin-right 0.15s ease;' : 'margin-bottom: -24px; transition: margin-right 0.15s ease;'}>
+	<div style={(windowedBrowseSidebar || windowedCommentsSidebar) && !viewport.isMobile ? 'margin-right: 316px; margin-bottom: -24px; transition: margin-right 0.15s ease;' : 'margin-bottom: -24px; transition: margin-right 0.15s ease;'}>
 	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
 		<ol class="flex flex-wrap items-baseline gap-1">
 			<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
@@ -2155,8 +2156,9 @@
 	</div>
 
 	<div class="mt-6 flex gap-4">
-	<!-- Collapsible hierarchy sidebar -->
-	{#if sidebarOpen}
+	<!-- Collapsible hierarchy sidebar — hidden on mobile (ADR-229) so the canvas
+	     takes the full width; the diagram is pan/zoom view-first on a phone. -->
+	{#if sidebarOpen && !viewport.isMobile}
 		<aside
 			data-hierarchy-sidebar
 			style="width: 280px; max-height: calc(100vh - 216px); flex-shrink: 0; border-radius: 6px; overflow: hidden; display: flex; flex-direction: column; position: sticky; top: 16px; align-self: flex-start"
@@ -2226,7 +2228,7 @@
 				<path d="M176,152h32a16,16,0,0,0,16-16V104a16,16,0,0,0-16-16H176a16,16,0,0,0-16,16v8H88V80h8a16,16,0,0,0,16-16V32A16,16,0,0,0,96,16H64A16,16,0,0,0,48,32V64A16,16,0,0,0,64,80h8V192a24,24,0,0,0,24,24h64v8a16,16,0,0,0,16,16h32a16,16,0,0,0,16-16V192a16,16,0,0,0-16-16H176a16,16,0,0,0-16,16v8H96a8,8,0,0,1-8-8V128h72v8A16,16,0,0,0,176,152ZM64,32H96V64H64ZM176,192h32v32H176Zm0-88h32v32H176Z"/>
 			</svg>
 		</button>
-		<div class="flex gap-1" role="tablist" aria-label="Diagram sections">
+		<div class="flex gap-1 overflow-x-auto" role="tablist" aria-label="Diagram sections">
 			<!-- v5.4.0 (#10): Canvas first — the working content tab leads.
 			     ADR-204 (v6.14.0): Details moved between Relationships and
 			     Version History. -->
@@ -2665,6 +2667,7 @@
 						<button
 							onclick={() => (focusMode = true)}
 							class="rounded px-3 py-1.5 text-sm"
+							class:hidden={viewport.isMobile}
 							style="border: 1px solid var(--color-border); color: var(--color-fg)"
 							aria-label="Full screen"
 							title="Full screen"
@@ -2969,6 +2972,7 @@
 						<button
 							onclick={() => (focusMode = true)}
 							class="rounded px-3 py-1.5 text-sm"
+							class:hidden={viewport.isMobile}
 							style="border: 1px solid var(--color-border); color: var(--color-fg)"
 							aria-label="Full screen"
 							title="Full screen"
@@ -3081,6 +3085,7 @@
 											onnodedragstart={handleNodeDragStart}
 											ontogglemode={handleToggleToBrowseMode}
 											panX={selectedEditNodeId && selectedNodeVisual ? -308 : 0}
+											interactiveLayout={!viewport.isMobile}
 										/>
 									</div>
 									{#if selectedEditNodeId && selectedNodeVisual}
@@ -3155,6 +3160,7 @@
 								onnodedragstart={handleNodeDragStart}
 								ontogglemode={handleToggleToBrowseMode}
 								panX={selectedEditNodeId && selectedNodeVisual ? -308 : 0}
+								interactiveLayout={!viewport.isMobile}
 							/>
 						</div>
 						{#if selectedEditNodeId && selectedNodeVisual}

--- a/frontend/tests/e2e/appshell-desktop.spec.ts
+++ b/frontend/tests/e2e/appshell-desktop.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+// Desktop regression guard for the mobile-responsive AppShell change (ADR-229).
+// Runs under the default `e2e` project (1280px viewport). On desktop the
+// persistent inline sidebar must still render (NOT the mobile drawer), so the
+// drawer work can't have regressed the desktop shell. Anonymous-safe (ADR-123)
+// so it doesn't depend on seedAdmin/login.
+
+test('desktop renders the persistent inline sidebar, not the drawer', async ({ page }) => {
+	await page.goto('/');
+
+	// The inline sidebar is a `navigation` landmark and is visible by default.
+	const nav = page.getByRole('navigation', { name: 'Main navigation' });
+	await expect(nav).toBeVisible();
+	await expect(nav.getByRole('link', { name: 'Collections', exact: true })).toBeVisible();
+	await expect(nav.getByRole('link', { name: 'Elements', exact: true })).toBeVisible();
+
+	// It is NOT the mobile Dialog drawer.
+	await expect(page.getByRole('dialog', { name: 'Main navigation' })).toHaveCount(0);
+
+	// The hamburger collapses the persistent sidebar (original desktop behaviour).
+	await page.getByRole('button', { name: 'Close navigation' }).click();
+	await expect(nav).toHaveCount(0);
+	await page.getByRole('button', { name: 'Open navigation' }).click();
+	await expect(page.getByRole('navigation', { name: 'Main navigation' })).toBeVisible();
+});

--- a/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
+++ b/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin, createDiagram } from './fixtures';
+
+// Phase 3 of the mobile-responsive rollout (ADR-229 / SPEC-229-A).
+// On mobile the diagram canvas is pan/zoom view-only: layout authoring (node
+// drag, edge draw) is disabled even in edit mode, but panning still works.
+
+const API_BASE = 'http://localhost:8000';
+
+let diagramId = '';
+
+test.beforeAll(async () => {
+	await seedAdmin();
+	const token = await getAuthToken();
+
+	const elRes = await fetch(`${API_BASE}/api/elements`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+		body: JSON.stringify({ element_type: 'class', name: 'Mobile Canvas Node', data: {} })
+	});
+	if (!elRes.ok) throw new Error(`create element failed: ${elRes.status} ${await elRes.text()}`);
+	const entityId = (await elRes.json()).id as string;
+
+	const diagram = await createDiagram(undefined, token, {
+		diagram_type: 'class',
+		notation: 'uml',
+		name: 'Mobile Canvas Probe',
+		description: 'Drag-disabled on mobile.',
+		data: { nodes: [{ id: 'n0', position: { x: 120, y: 120 }, data: { entityId } }], edges: [] }
+	});
+	diagramId = diagram.id as string;
+});
+
+test('canvas layout authoring is locked on mobile but panning works', async ({ page }) => {
+	test.slow(); // login + diagram load; absorb rate-limit back-off under full-suite load
+	await loginAsAdmin(page);
+	await page.goto(`/views/${diagramId}`);
+
+	// Wait for the diagram to finish loading before reaching for the toolbar.
+	await expect(page.getByText('Loading diagram...')).toHaveCount(0, { timeout: 20_000 });
+
+	// Enter edit mode — on a phone this is where the lock matters most.
+	await page.getByRole('button', { name: 'Edit Canvas' }).click();
+
+	// The view-only hint proves interactiveLayout resolved to false on mobile.
+	await expect(page.getByTestId('layout-locked-hint')).toBeVisible({ timeout: 15_000 });
+
+	// The node renders but is NOT draggable: SvelteFlow only adds the
+	// `draggable` class to nodes when nodesDraggable is true.
+	const node = page.locator('.svelte-flow__node').first();
+	await expect(node).toBeVisible();
+	await expect(node).not.toHaveClass(/\bdraggable\b/);
+
+	// Panning still works (touch-first viewing): dragging the pane translates
+	// the SvelteFlow viewport transform.
+	const viewportEl = page.locator('.svelte-flow__viewport');
+	const before = await viewportEl.evaluate((el) => getComputedStyle(el).transform);
+	const box = await page.locator('.svelte-flow__pane').boundingBox();
+	if (box) {
+		const cx = box.x + box.width / 2;
+		const cy = box.y + box.height / 2;
+		await page.mouse.move(cx, cy);
+		await page.mouse.down();
+		await page.mouse.move(cx - 100, cy - 60, { steps: 8 });
+		await page.mouse.up();
+	}
+	const after = await viewportEl.evaluate((el) => getComputedStyle(el).transform);
+	expect(after).not.toBe(before);
+});
+
+test('the full-screen (FocusView) trigger is hidden on mobile', async ({ page }) => {
+	await loginAsAdmin(page);
+	await page.goto(`/views/${diagramId}`);
+	await expect(page.getByRole('button', { name: 'Full screen' })).toHaveCount(0);
+});

--- a/frontend/tests/e2e/detail-stack.mobile.spec.ts
+++ b/frontend/tests/e2e/detail-stack.mobile.spec.ts
@@ -23,6 +23,7 @@ test.beforeAll(async () => {
 });
 
 test('detail definition grid collapses to a single column on mobile', async ({ page }) => {
+	test.slow(); // login + page load; absorb rate-limit back-off under full-suite load
 	await loginAsAdmin(page);
 	await page.goto(`/elements/${elementId}`);
 	await page.getByRole('tab', { name: 'Details' }).click();
@@ -37,6 +38,7 @@ test('detail definition grid collapses to a single column on mobile', async ({ p
 });
 
 test('section tab bar is horizontally scrollable, not clipped', async ({ page }) => {
+	test.slow(); // login + page load; absorb rate-limit back-off under full-suite load
 	await loginAsAdmin(page);
 	await page.goto(`/elements/${elementId}`);
 

--- a/frontend/tests/e2e/detail-stack.mobile.spec.ts
+++ b/frontend/tests/e2e/detail-stack.mobile.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin } from './fixtures';
+
+// Phase 2 of the mobile-responsive rollout (ADR-229 / SPEC-229-A).
+// On mobile the two-column `auto 1fr` definition grids on detail pages collapse
+// to a single column (.detail-grid + the <768px media query), and the section
+// tab bar scrolls horizontally rather than clipping.
+
+const API_BASE = 'http://localhost:8000';
+
+let elementId = '';
+
+test.beforeAll(async () => {
+	await seedAdmin();
+	const token = await getAuthToken();
+	const res = await fetch(`${API_BASE}/api/elements`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+		body: JSON.stringify({ element_type: 'class', name: 'Mobile Detail Stack Element', data: {} })
+	});
+	if (!res.ok) throw new Error(`create element failed: ${res.status} ${await res.text()}`);
+	elementId = (await res.json()).id as string;
+});
+
+test('detail definition grid collapses to a single column on mobile', async ({ page }) => {
+	await loginAsAdmin(page);
+	await page.goto(`/elements/${elementId}`);
+	await page.getByRole('tab', { name: 'Details' }).click();
+
+	const grid = page.locator('.detail-grid').first();
+	await expect(grid).toBeVisible();
+
+	// A single grid column resolves to one track (e.g. "393px"); a two-column
+	// grid resolves to two space-separated tracks. Assert exactly one track.
+	const columns = await grid.evaluate((el) => getComputedStyle(el).gridTemplateColumns);
+	expect(columns.trim().split(/\s+/)).toHaveLength(1);
+});
+
+test('section tab bar is horizontally scrollable, not clipped', async ({ page }) => {
+	await loginAsAdmin(page);
+	await page.goto(`/elements/${elementId}`);
+
+	const tablist = page.getByRole('tablist', { name: 'Element sections' });
+	await expect(tablist).toBeVisible();
+	// overflow-x-auto keeps every tab reachable even when they exceed the width.
+	const overflowX = await tablist.evaluate((el) => getComputedStyle(el).overflowX);
+	expect(overflowX).toBe('auto');
+});

--- a/frontend/tests/e2e/nav-drawer.mobile.spec.ts
+++ b/frontend/tests/e2e/nav-drawer.mobile.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+// Phase 1 of the mobile-responsive rollout (ADR-229 / SPEC-229-A).
+// Runs under the `mobile` Playwright project (Pixel 5, 393px wide). The app
+// shell renders for anonymous visitors (ADR-123), so these need no seeding.
+//
+// On mobile the persistent desktop sidebar (a `nav` landmark) is replaced by a
+// bits-ui Dialog drawer (role `dialog`, labelled "Main navigation"). Assertions
+// target the dialog so they can't collide with same-named dashboard content.
+
+test.beforeEach(async ({ page }) => {
+	await page.goto('/');
+	// Wait for the viewport store to reconcile to mobile after mount — the
+	// hamburger advertises "Open navigation" while the drawer is closed.
+	await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible();
+});
+
+test('desktop sidebar nav is not rendered on a mobile viewport', async ({ page }) => {
+	// Neither the desktop sidebar nor the (closed) drawer expose a nav landmark.
+	await expect(page.getByRole('navigation', { name: 'Main navigation' })).toHaveCount(0);
+	await expect(page.getByRole('dialog', { name: 'Main navigation' })).toHaveCount(0);
+});
+
+test('hamburger opens the drawer and reveals the nav', async ({ page }) => {
+	await page.getByRole('button', { name: 'Open navigation' }).click();
+
+	const drawer = page.getByRole('dialog', { name: 'Main navigation' });
+	await expect(drawer).toBeVisible();
+	await expect(drawer.getByRole('link', { name: 'Collections', exact: true })).toBeVisible();
+	await expect(drawer.getByRole('link', { name: 'Elements', exact: true })).toBeVisible();
+	// Background scroll is locked while the drawer is open (bits-ui sets this).
+	await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+});
+
+test('Escape closes the drawer and restores focus to the hamburger', async ({ page }) => {
+	const hamburger = page.getByRole('button', { name: 'Open navigation' });
+	await hamburger.click();
+	const drawer = page.getByRole('dialog', { name: 'Main navigation' });
+	await expect(drawer).toBeVisible();
+
+	await page.keyboard.press('Escape');
+	await expect(drawer).toHaveCount(0);
+	await expect(hamburger).toBeFocused();
+});
+
+test('clicking the backdrop closes the drawer', async ({ page }) => {
+	await page.getByRole('button', { name: 'Open navigation' }).click();
+	const drawer = page.getByRole('dialog', { name: 'Main navigation' });
+	await expect(drawer).toBeVisible();
+
+	// Click the overlay clear of the 18rem (≈288px) drawer. Position is relative
+	// to the full-bleed overlay's top-left, so x≈370 is past the drawer's edge.
+	const overlay = page.locator('.drawer-backdrop');
+	await expect(overlay).toBeVisible();
+	await overlay.click({ position: { x: 370, y: 400 } });
+	await expect(drawer).toHaveCount(0);
+});
+
+test('selecting a nav link navigates and auto-closes the drawer', async ({ page }) => {
+	await page.getByRole('button', { name: 'Open navigation' }).click();
+	const drawer = page.getByRole('dialog', { name: 'Main navigation' });
+	await drawer.getByRole('link', { name: 'Collections', exact: true }).click();
+
+	await page.waitForURL('**/collections');
+	// afterNavigate closes the drawer.
+	await expect(page.getByRole('dialog', { name: 'Main navigation' })).toHaveCount(0);
+	await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible();
+});

--- a/frontend/tests/e2e/no-overflow.mobile.spec.ts
+++ b/frontend/tests/e2e/no-overflow.mobile.spec.ts
@@ -18,7 +18,7 @@ async function expectNoHorizontalOverflow(page: Page) {
 
 test.describe('no horizontal overflow on mobile', () => {
 	// Anonymous-reachable browse surfaces (ADR-123) — no seeding needed.
-	for (const path of ['/', '/collections', '/sets', '/elements']) {
+	for (const path of ['/', '/collections', '/sets', '/elements', '/ask']) {
 		test(`browse page ${path} does not overflow`, async ({ page }) => {
 			await page.goto(path);
 			await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible();

--- a/frontend/tests/e2e/no-overflow.mobile.spec.ts
+++ b/frontend/tests/e2e/no-overflow.mobile.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin } from './fixtures';
+
+// Phase 2 of the mobile-responsive rollout (ADR-229 / SPEC-229-A).
+// No page should scroll horizontally at the Pixel 5 viewport (393px). A
+// horizontal overflow on mobile is the classic symptom of a fixed-width or
+// non-wrapping desktop layout leaking through.
+
+const API_BASE = 'http://localhost:8000';
+
+async function expectNoHorizontalOverflow(page: Page) {
+	const overflow = await page.evaluate(
+		() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+	);
+	// Allow 1px for sub-pixel rounding.
+	expect(overflow, 'horizontal overflow (scrollWidth − clientWidth)').toBeLessThanOrEqual(1);
+}
+
+test.describe('no horizontal overflow on mobile', () => {
+	// Anonymous-reachable browse surfaces (ADR-123) — no seeding needed.
+	for (const path of ['/', '/collections', '/sets', '/elements']) {
+		test(`browse page ${path} does not overflow`, async ({ page }) => {
+			await page.goto(path);
+			await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible();
+			await expectNoHorizontalOverflow(page);
+		});
+	}
+
+	// A populated element-detail page exercises the detail grids and the wide
+	// metadata/relationship tables, which are the real overflow risks.
+	test('populated element-detail page does not overflow', async ({ page }) => {
+		await seedAdmin();
+		const token = await getAuthToken();
+		const res = await fetch(`${API_BASE}/api/elements`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+			body: JSON.stringify({
+				element_type: 'class',
+				name: 'Mobile Overflow Probe Element',
+				data: {
+					attributes: [
+						{ name: 'identifier', type: 'string', scope: 'Public', notes: 'primary key for the record' },
+						{ name: 'createdAtTimestamp', type: 'datetime', scope: 'Private', notes: 'set on insert' },
+						{ name: 'longDescriptiveFieldName', type: 'text', scope: 'Protected', notes: 'free text notes column' }
+					]
+				}
+			})
+		});
+		if (!res.ok) throw new Error(`create element failed: ${res.status} ${await res.text()}`);
+		const elementId = (await res.json()).id as string;
+
+		await loginAsAdmin(page);
+		await page.goto(`/elements/${elementId}`);
+		await page.getByRole('tab', { name: 'Details' }).click();
+		await expect(page.locator('.detail-grid').first()).toBeVisible();
+		await expectNoHorizontalOverflow(page);
+	});
+});

--- a/frontend/tests/e2e/no-overflow.mobile.spec.ts
+++ b/frontend/tests/e2e/no-overflow.mobile.spec.ts
@@ -29,6 +29,7 @@ test.describe('no horizontal overflow on mobile', () => {
 	// A populated element-detail page exercises the detail grids and the wide
 	// metadata/relationship tables, which are the real overflow risks.
 	test('populated element-detail page does not overflow', async ({ page }) => {
+		test.slow(); // seeds + logs in; absorb API rate-limit back-off under full-suite load
 		await seedAdmin();
 		const token = await getAuthToken();
 		const res = await fetch(`${API_BASE}/api/elements`, {

--- a/frontend/tests/unit/viewport.test.ts
+++ b/frontend/tests/unit/viewport.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { initViewport, viewport } from '$lib/stores/viewport.svelte';
+
+// Installs a fake window.matchMedia driven by a single controllable width.
+// matches is computed live from the query so the same change handler covers
+// both the (max-width: 767px) and (min-width: 1024px) queries the store opens.
+function mockMatchMedia(initialWidth: number) {
+	let width = initialWidth;
+	// One registration per addEventListener call across every MediaQueryList —
+	// real MQLs track listeners independently, so two queries = two listeners
+	// even when the same callback is registered on both.
+	const registrations: Array<() => void> = [];
+
+	const matchesFor = (query: string) => {
+		const min = query.match(/min-width:\s*(\d+)/);
+		const max = query.match(/max-width:\s*(\d+)/);
+		if (min) return width >= Number(min[1]);
+		if (max) return width <= Number(max[1]);
+		return false;
+	};
+
+	window.matchMedia = ((query: string) => ({
+		media: query,
+		get matches() {
+			return matchesFor(query);
+		},
+		addEventListener: (_type: string, cb: () => void) => registrations.push(cb),
+		removeEventListener: (_type: string, cb: () => void) => {
+			const i = registrations.indexOf(cb);
+			if (i !== -1) registrations.splice(i, 1);
+		}
+	})) as unknown as typeof window.matchMedia;
+
+	return {
+		resize(next: number) {
+			width = next;
+			[...registrations].forEach((cb) => cb());
+		},
+		listenerCount: () => registrations.length
+	};
+}
+
+afterEach(() => {
+	// @ts-expect-error — restore so a stray reference can't leak between tests
+	delete window.matchMedia;
+});
+
+describe('viewport store', () => {
+	it('reports mobile below 768px', () => {
+		mockMatchMedia(360);
+		const cleanup = initViewport();
+		expect(viewport.isMobile).toBe(true);
+		expect(viewport.isTablet).toBe(false);
+		expect(viewport.isDesktop).toBe(false);
+		cleanup?.();
+	});
+
+	it('treats the 768–1023px band as tablet', () => {
+		const mm = mockMatchMedia(768);
+		const cleanup = initViewport();
+		expect(viewport.isTablet).toBe(true);
+		expect(viewport.isMobile).toBe(false);
+		expect(viewport.isDesktop).toBe(false);
+
+		mm.resize(1023);
+		expect(viewport.isTablet).toBe(true);
+		cleanup?.();
+	});
+
+	it('reports desktop at 1024px and up', () => {
+		mockMatchMedia(1440);
+		const cleanup = initViewport();
+		expect(viewport.isDesktop).toBe(true);
+		expect(viewport.isMobile).toBe(false);
+		expect(viewport.isTablet).toBe(false);
+		cleanup?.();
+	});
+
+	it('honours the exact 767/768/1023/1024 boundaries', () => {
+		const mm = mockMatchMedia(767);
+		const cleanup = initViewport();
+		expect(viewport.isMobile).toBe(true); // 767 → mobile
+
+		mm.resize(768);
+		expect(viewport.isTablet).toBe(true); // 768 → tablet
+
+		mm.resize(1023);
+		expect(viewport.isTablet).toBe(true); // 1023 → tablet
+
+		mm.resize(1024);
+		expect(viewport.isDesktop).toBe(true); // 1024 → desktop
+		cleanup?.();
+	});
+
+	it('reacts to viewport changes after init', () => {
+		const mm = mockMatchMedia(1440);
+		const cleanup = initViewport();
+		expect(viewport.isDesktop).toBe(true);
+
+		mm.resize(360);
+		expect(viewport.isMobile).toBe(true);
+		expect(viewport.isDesktop).toBe(false);
+		cleanup?.();
+	});
+
+	it('defaults to desktop and no-ops when matchMedia is unavailable (SSR)', async () => {
+		// A pristine module instance — module-level $state from prior tests must
+		// not leak in, since the point is the untouched SSR default.
+		vi.resetModules();
+		const fresh = await import('$lib/stores/viewport.svelte');
+		// No mockMatchMedia installed → matchMedia is undefined this test.
+		const cleanup = fresh.initViewport();
+		expect(cleanup).toBeUndefined();
+		expect(fresh.viewport.isDesktop).toBe(true);
+		expect(fresh.viewport.isMobile).toBe(false);
+		expect(fresh.viewport.isTablet).toBe(false);
+	});
+
+	it('cleanup removes both listeners', () => {
+		const mm = mockMatchMedia(360);
+		const cleanup = initViewport();
+		expect(mm.listenerCount()).toBe(2);
+		cleanup?.();
+		expect(mm.listenerCount()).toBe(0);
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.40.0"
+version = "6.41.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.40.0"
+version = "6.41.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Makes the Iris frontend mobile-responsive (ADR-229 / SPEC-229-A). Detects a mobile screen and adapts every surface so users can **browse everything and make light edits** on a phone; heavy diagram-canvas authoring stays desktop-only. Responsive adaptation in one codebase (no separate mobile route tree). Breakpoints mirror Tailwind v4 defaults: `<768px` mobile, `768–1023px` tablet, `≥1024px` desktop.

Delivered as phased commits, all shipping together as **v6.41.0**:

- **Phase 0 — Foundations:** `viewport.svelte.ts` reactive `isMobile/isTablet/isDesktop` store (matchMedia, SSR-safe, eager init), `app.css` tokens (`--page-pad`, `.drawer-backdrop`, `.mobile-nav-drawer`, `.detail-grid`, `body.scroll-locked`), Playwright `mobile` project (Pixel 5, `*.mobile.spec.ts`), ADR-229 + SPEC-229-A. Unit tests for the store.
- **Phase 1 — App shell + nav:** mobile hamburger opens a bits-ui `Dialog` drawer (focus trap, scroll-lock, Escape, focus-restore), auto-closing on nav and on growth to desktop; desktop sidebar unchanged.
- **Phase 2 — Lists + detail:** responsive gutters, wrapping toolbars, scrollable section tab bars, single-column detail grids, tables scroll within their section.
- **Phase 3 — Diagram viewer:** full-width canvas on mobile (hierarchy hidden), pan/zoom view-only with layout authoring disabled via `UnifiedCanvas` `interactiveLayout` prop + "view only" hint, FocusView trigger hidden, side panels don't squish the canvas.
- **Phase 4 — Iris AI chat:** `100dvh`, single-column config row, viewport-constrained dropdown.

Version bumped 6.40.0 → 6.41.0 (frontend/backend/mcp/iris-client). Frontend-only; no backend/MCP/CLI surface change (Protocol §14 unaffected).

## Testing

- **Unit:** `viewport.test.ts` (7) pass; full suite unchanged (4 pre-existing failures in untouched files).
- **Mobile e2e (`npm run test:mobile`, Pixel 5):** 14 pass — nav drawer (open/close/Escape/backdrop/focus-restore), no-overflow at 393px across browse + populated detail + `/ask`, detail-grid single-column, canvas layout-locked + pan-works + FocusView hidden.
- **Desktop regression:** new `appshell-desktop.spec.ts` confirms the persistent inline sidebar (not the drawer) still renders and the hamburger collapses/expands it. The broader desktop e2e failures are pre-existing/environmental (`/api/models` `/api/entities` 404, `seedAdmin` 429 — verified identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)