### PR TITLE
fix(v6.41.1): mobile dashboard card overflow (ADR-229 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.1] - 2026-05-31
+
+### Fixed
+
+- **Mobile dashboard overflow (ADR-229 follow-up).** The dashboard
+  count-cards (Collections / Sets / Views / Elements) were forced into
+  four columns at every width, so on a phone each card was too narrow for
+  its label and the row pushed a few pixels of horizontal overflow. The
+  grid is now `grid-cols-2 md:grid-cols-4` — two columns on mobile, four
+  on desktop. Caught by driving the live production site at a 393px
+  viewport (the empty test backend didn't render enough to surface it).
+
 ## [6.41.0] - 2026-05-31
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.0"
+version = "6.41.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.0",
+	"version": "6.41.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -540,7 +540,7 @@
 	<!-- v5.4.0 (#12): Collections + Sets cards get a muted-grey background
 		 (`dashboard-card--ambient`) so they read as "scope filters" distinct
 		 from the working-content cards (Views, Elements). -->
-	<div class="mt-6 grid grid-cols-4 gap-4" style="max-width: 1000px">
+	<div class="mt-6 grid grid-cols-2 gap-4 md:grid-cols-4" style="max-width: 1000px">
 		<div
 			class="dashboard-card--ambient rounded border p-4 text-center"
 			style="border-color: var(--color-border); color: var(--color-fg); background: var(--color-surface)"

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.0"
+version = "6.41.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.0"
+version = "6.41.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Follow-up to the v6.41.0 mobile-responsive rollout (ADR-229). Driving the **live production** site at a 393px viewport surfaced a ~7px horizontal overflow on the dashboard: the count-cards (Collections / Sets / Views / Elements) were `grid-cols-4` at every width, so each card was too narrow for its label and the row pushed past the viewport. The empty test backend didn't render enough to trip the local no-overflow check.

Fix: `grid-cols-2 md:grid-cols-4` — two columns on mobile, four on desktop.

Version bump 6.41.0 → 6.41.1 (frontend/backend/mcp/iris-client).

## Testing

- Local `npm run test:mobile` no-overflow suite green.
- Will re-verify against live prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)