### PR TITLE
fix(v6.41.2): mobile views polish (ADR-229 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.2] - 2026-05-31
+
+### Fixed
+
+- **Mobile views polish (ADR-229 follow-up).** Five fixes from testing the
+  diagram-view page on a phone:
+  - **Breadcrumbs** no longer wrap to several lines — they're a single
+    horizontally-scrollable row (`flex-nowrap overflow-x-auto`) on the view,
+    element and package pages.
+  - **Full-screen (FocusView) button** is shown on mobile again — fullscreen
+    canvas viewing is one of the most useful things to do on a phone.
+  - **View action buttons** (Add to context / Bookmark / Clone / Delete)
+    wrap instead of spilling off the right edge.
+  - **Header sign-out** stays inside the header: the scope breadcrumb
+    (collection / set) is hidden on mobile and the action group is pinned.
+  - **Hierarchy tree toggle** now works on mobile — it opens the tree as a
+    fixed left overlay drawer (with a tap-to-close backdrop) instead of
+    doing nothing; fullscreen stays pure-canvas.
+
 ## [6.41.1] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.1"
+version = "6.41.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.1",
+	"version": "6.41.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -161,6 +161,27 @@ body.scroll-locked {
 	}
 }
 
+/* Diagram-viewer hierarchy sidebar on mobile (ADR-229). On a phone the inline
+   sticky column becomes a fixed left overlay drawer (the toggle button opens
+   it, a backdrop closes it) so the canvas keeps the full width. In fullscreen
+   (FocusView) the diagram is pure canvas — hide the aside and its toggle. */
+@media (max-width: 767px) {
+	[data-hierarchy-sidebar] {
+		position: fixed !important;
+		left: 0 !important;
+		top: 0 !important;
+		bottom: 0 !important;
+		width: 85vw !important;
+		max-width: 320px !important;
+		max-height: 100dvh !important;
+		z-index: 50 !important;
+	}
+	.focus-view [data-hierarchy-sidebar],
+	.focus-view [aria-label='Toggle hierarchy sidebar'] {
+		display: none !important;
+	}
+}
+
 /* Definition grids on detail pages (elements/packages) — term + value in two
    columns on desktop, stacked single column on mobile (ADR-229). Replaces the
    inline `grid-template-columns: auto 1fr` so a media query can override it

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -282,7 +282,7 @@
 		class="flex h-14 items-center justify-between border-b px-4"
 		style="background-color: var(--color-surface); border-color: var(--color-border)"
 	>
-		<div class="flex items-center gap-3">
+		<div class="flex min-w-0 items-center gap-2 sm:gap-3">
 			<button
 				onclick={toggleNav}
 				aria-label={(viewport.isDesktop ? sidebarOpen : drawerOpen) ? 'Close navigation' : 'Open navigation'}
@@ -292,17 +292,19 @@
 				<span aria-hidden="true" class="text-lg">&#9776;</span>
 			</button>
 			<a href="/" class="text-lg font-bold" style="color: var(--color-fg)">Iris</a>
-			{#if activeCollectionId}
+			<!-- Scope breadcrumb hidden on mobile (ADR-229) to keep the header
+			     one line; the right-hand actions must stay inside the header. -->
+			{#if activeCollectionId && !viewport.isMobile}
 				<span style="color: var(--color-fg)">/</span>
-				<a href="/collections" class="text-lg" style="color: var(--color-fg)">{activeCollectionName}</a>
+				<a href="/collections" class="truncate text-lg" style="color: var(--color-fg)">{activeCollectionName}</a>
 			{/if}
-			{#if activeSetId}
+			{#if activeSetId && !viewport.isMobile}
 				<span style="color: var(--color-fg)">/</span>
-				<a href="/sets" class="text-lg" style="color: var(--color-fg)">{activeSetName}</a>
+				<a href="/sets" class="truncate text-lg" style="color: var(--color-fg)">{activeSetName}</a>
 			{/if}
 		</div>
 
-		<div class="flex items-center gap-4">
+		<div class="flex shrink-0 items-center gap-2 sm:gap-4">
 			<a
 				href="/guide"
 				class="header-link rounded px-3 py-1 text-sm transition-colors"

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -528,7 +528,7 @@
 </svelte:head>
 
 <nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-	<ol class="flex flex-wrap items-baseline gap-1">
+	<ol class="flex flex-nowrap items-baseline gap-1 overflow-x-auto whitespace-nowrap">
 		<li><a href="/elements" style="color: var(--color-primary)">Elements</a></li>
 		<li class="flex items-baseline gap-1">
 			<span aria-hidden="true">/</span>

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -495,7 +495,7 @@
 	</div>
 {:else if pkg}
 	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-		<ol class="flex flex-wrap items-baseline gap-1">
+		<ol class="flex flex-nowrap items-baseline gap-1 overflow-x-auto whitespace-nowrap">
 			<li><a href="/" style="color: var(--color-primary)">Packages</a></li>
 			{#if pkg.parent_package_id}
 				<li class="flex items-baseline gap-1">

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2020,7 +2020,7 @@
 		</FocusView>
 	{:else}
 		<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-			<ol class="flex flex-wrap items-baseline gap-1">
+			<ol class="flex flex-nowrap items-baseline gap-1 overflow-x-auto whitespace-nowrap">
 				<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
 				<li aria-hidden="true">/</li>
 				<li aria-current="page">{page.params.id}</li>
@@ -2039,7 +2039,7 @@
 		</FocusView>
 	{:else}
 		<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-			<ol class="flex flex-wrap items-baseline gap-1">
+			<ol class="flex flex-nowrap items-baseline gap-1 overflow-x-auto whitespace-nowrap">
 				<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
 				<li aria-hidden="true">/</li>
 				<li aria-current="page">{page.params.id}</li>
@@ -2077,7 +2077,7 @@
 	{/if}
 	<div style={(windowedBrowseSidebar || windowedCommentsSidebar) && !viewport.isMobile ? 'margin-right: 316px; margin-bottom: -24px; transition: margin-right 0.15s ease;' : 'margin-bottom: -24px; transition: margin-right 0.15s ease;'}>
 	<nav aria-label="Breadcrumb" class="mb-4 text-sm" style="color: var(--color-muted)">
-		<ol class="flex flex-wrap items-baseline gap-1">
+		<ol class="flex flex-nowrap items-baseline gap-1 overflow-x-auto whitespace-nowrap">
 			<li><a href="/views" style="color: var(--color-primary)">Views</a></li>
 			{#each ancestors as ancestor}
 				<li class="flex items-baseline gap-1">
@@ -2091,7 +2091,7 @@
 			</li>
 		</ol>
 	</nav>
-	<div class="flex items-center justify-between">
+	<div class="flex flex-wrap items-center justify-between gap-2">
 		<div>
 			<div class="flex flex-wrap items-center gap-3">
 				<h1 class="text-2xl font-bold" style="color: var(--color-fg)">{diagram.name}</h1>
@@ -2110,7 +2110,7 @@
 				{/if}
 			</p>
 		</div>
-		<div class="flex gap-2">
+		<div class="flex flex-wrap gap-2">
 			{#if isInContext}
 				<button
 					onclick={() => removeAiContextItem(diagram.id)}
@@ -2156,9 +2156,19 @@
 	</div>
 
 	<div class="mt-6 flex gap-4">
-	<!-- Collapsible hierarchy sidebar — hidden on mobile (ADR-229) so the canvas
-	     takes the full width; the diagram is pan/zoom view-first on a phone. -->
-	{#if sidebarOpen && !viewport.isMobile}
+	<!-- Collapsible hierarchy sidebar. On desktop it's an inline sticky column;
+	     on mobile (ADR-229) CSS turns [data-hierarchy-sidebar] into a fixed
+	     left overlay so the canvas stays full-width and the toggle still works.
+	     The backdrop below closes the overlay on tap. -->
+	{#if sidebarOpen && viewport.isMobile}
+		<button
+			type="button"
+			class="drawer-backdrop"
+			aria-label="Close hierarchy"
+			onclick={toggleSidebar}
+		></button>
+	{/if}
+	{#if sidebarOpen}
 		<aside
 			data-hierarchy-sidebar
 			style="width: 280px; max-height: calc(100vh - 216px); flex-shrink: 0; border-radius: 6px; overflow: hidden; display: flex; flex-direction: column; position: sticky; top: 16px; align-self: flex-start"
@@ -2667,7 +2677,6 @@
 						<button
 							onclick={() => (focusMode = true)}
 							class="rounded px-3 py-1.5 text-sm"
-							class:hidden={viewport.isMobile}
 							style="border: 1px solid var(--color-border); color: var(--color-fg)"
 							aria-label="Full screen"
 							title="Full screen"
@@ -2972,7 +2981,6 @@
 						<button
 							onclick={() => (focusMode = true)}
 							class="rounded px-3 py-1.5 text-sm"
-							class:hidden={viewport.isMobile}
 							style="border: 1px solid var(--color-border); color: var(--color-fg)"
 							aria-label="Full screen"
 							title="Full screen"

--- a/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
+++ b/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
@@ -57,19 +57,42 @@ test('canvas layout authoring is locked on mobile but panning works', async ({ p
 	const before = await viewportEl.evaluate((el) => getComputedStyle(el).transform);
 	const box = await page.locator('.svelte-flow__pane').boundingBox();
 	if (box) {
-		const cx = box.x + box.width / 2;
-		const cy = box.y + box.height / 2;
-		await page.mouse.move(cx, cy);
+		// Start in the top-right of the pane — empty canvas, clear of the
+		// fitView-centred node (centre), the mode badges (top-left) and xyflow's
+		// zoom Controls (bottom-left) — so the gesture pans the viewport.
+		const sx = box.x + box.width - 28;
+		const sy = box.y + 28;
+		await page.mouse.move(sx, sy);
 		await page.mouse.down();
-		await page.mouse.move(cx - 100, cy - 60, { steps: 8 });
+		await page.mouse.move(sx - 140, sy + 110, { steps: 10 });
 		await page.mouse.up();
 	}
 	const after = await viewportEl.evaluate((el) => getComputedStyle(el).transform);
 	expect(after).not.toBe(before);
 });
 
-test('the full-screen (FocusView) trigger is hidden on mobile', async ({ page }) => {
+test('the full-screen (FocusView) trigger is available on mobile', async ({ page }) => {
+	test.slow();
 	await loginAsAdmin(page);
 	await page.goto(`/views/${diagramId}`);
-	await expect(page.getByRole('button', { name: 'Full screen' })).toHaveCount(0);
+	await expect(page.getByText('Loading diagram...')).toHaveCount(0, { timeout: 20_000 });
+	// Restored on mobile (ADR-229 follow-up) — fullscreen canvas viewing.
+	await expect(page.getByRole('button', { name: 'Full screen' })).toBeVisible();
+});
+
+test('the hierarchy toggle opens an overlay drawer on mobile', async ({ page }) => {
+	test.slow();
+	await loginAsAdmin(page);
+	await page.goto(`/views/${diagramId}`);
+	await expect(page.getByText('Loading diagram...')).toHaveCount(0, { timeout: 20_000 });
+
+	const aside = page.locator('[data-hierarchy-sidebar]');
+	// Toggle the hierarchy on.
+	await page.getByRole('button', { name: 'Toggle hierarchy sidebar' }).first().click();
+	await expect(aside).toBeVisible();
+	// On mobile it's a fixed overlay (not the inline sticky column).
+	await expect(aside).toHaveCSS('position', 'fixed');
+	// The backdrop closes it.
+	await page.getByRole('button', { name: 'Close hierarchy' }).click();
+	await expect(aside).toBeHidden();
 });

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.1"
+version = "6.41.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.1"
+version = "6.41.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Five mobile fixes from testing the diagram-view page (`/views/<id>`) on a phone:

1. **Breadcrumbs** wrapped to ~4 lines → now a single horizontally-scrollable row (`flex-nowrap overflow-x-auto whitespace-nowrap`) on view / element / package pages.
2. **Full-screen (FocusView) button** was hidden on mobile in v6.41.0 → restored (fullscreen canvas viewing is one of the most useful things on a phone).
3. **View action buttons** (Add to context / Bookmark / Clone / Delete) spilled off the right edge → the header row and button group now wrap.
4. **Header sign-out** was pushed outside the header → the scope breadcrumb (collection / set) is hidden on mobile, the left group is `min-w-0`, and the action group is `shrink-0`, so it stays inside the header.
5. **Hierarchy tree toggle** did nothing on mobile (the aside was hidden but the button stayed) → it now opens the tree as a fixed left overlay drawer with a tap-to-close backdrop (`[data-hierarchy-sidebar]` CSS); fullscreen stays pure-canvas.

Version bump 6.41.1 → 6.41.2 (frontend/backend/mcp/iris-client).

## Testing

- `npm run test:mobile`: 15 pass (incl. updated `canvas-readonly` — fullscreen now visible + new hierarchy-overlay test).
- Desktop shell guard (`appshell-desktop.spec.ts`) passes.
- Will re-verify against the live example view after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)