### PR TITLE
fix(v6.41.3): mobile hierarchy drawer fills the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.3] - 2026-05-31
+
+### Fixed
+
+- **Mobile hierarchy drawer height (ADR-229 follow-up).** When opened on
+  mobile the hierarchy overlay shrank to a short box (a fixed flex column
+  with `top`+`bottom` set can shrink-wrap to content rather than fill),
+  leaving the tree area looking empty below the search field. The drawer
+  now takes an explicit `height: 100dvh`, so the tree grows to fill it and
+  scrolls.
+
 ## [6.41.2] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.2"
+version = "6.41.3"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.2",
+	"version": "6.41.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -170,10 +170,13 @@ body.scroll-locked {
 		position: fixed !important;
 		left: 0 !important;
 		top: 0 !important;
-		bottom: 0 !important;
+		/* Explicit height — a fixed flex column with top+bottom can shrink-wrap
+		   to content instead of filling, leaving the tree area looking empty.
+		   100dvh fills the drawer so the tree flex-grows and scrolls. */
+		height: 100dvh !important;
+		max-height: 100dvh !important;
 		width: 85vw !important;
 		max-width: 320px !important;
-		max-height: 100dvh !important;
 		z-index: 50 !important;
 	}
 	.focus-view [data-hierarchy-sidebar],

--- a/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
+++ b/frontend/tests/e2e/canvas-readonly.mobile.spec.ts
@@ -92,7 +92,12 @@ test('the hierarchy toggle opens an overlay drawer on mobile', async ({ page }) 
 	await expect(aside).toBeVisible();
 	// On mobile it's a fixed overlay (not the inline sticky column).
 	await expect(aside).toHaveCSS('position', 'fixed');
-	// The backdrop closes it.
-	await page.getByRole('button', { name: 'Close hierarchy' }).click();
+	// It fills the viewport height (a fixed flex column can otherwise
+	// shrink-wrap to content, leaving the tree area looking empty).
+	const vh = await page.evaluate(() => window.innerHeight);
+	const box = await aside.boundingBox();
+	expect(box!.height).toBeGreaterThan(vh * 0.8);
+	// The backdrop closes it — tap the strip to the right of the ≤320px drawer.
+	await page.getByRole('button', { name: 'Close hierarchy' }).click({ position: { x: 370, y: 400 } });
 	await expect(aside).toBeHidden();
 });

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.2"
+version = "6.41.3"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.2"
+version = "6.41.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Follow-up to v6.41.2. The mobile hierarchy overlay shrank to a short (~336px) box — a fixed flex column with `top`+`bottom` set shrink-wraps to content instead of filling — so the tree looked empty below the search field. Fix: explicit `height: 100dvh` on `[data-hierarchy-sidebar]` at mobile widths so the tree flex-grows and scrolls. Verified the tree renders and fills (8 items on the example view). Version 6.41.2 → 6.41.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)