### PR TITLE
fix(v6.41.4): package page hierarchy drawer on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.4] - 2026-05-31
+
+### Fixed
+
+- **Package page hierarchy drawer on mobile (ADR-229 follow-up).** The
+  package detail page's hierarchy sidebar now gets the same mobile
+  treatment as the view page: it opens as a full-height fixed left overlay
+  drawer (toggle to open, backdrop to close) instead of an inline 280px
+  column. Added the `data-hierarchy-sidebar` hook so the shared overlay CSS
+  applies.
+
 ## [6.41.3] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.3"
+version = "6.41.4"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.3",
+	"version": "6.41.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -15,6 +15,7 @@
 	import type { Bookmark, Diagram, DiagramHierarchyNode } from '$lib/types/api';
 	import { addAiContextItem, removeAiContextItem, getAiContextItems } from '$lib/stores/aiContext.svelte.js';
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
+	import { viewport } from '$lib/stores/viewport.svelte';
 
 	interface Package {
 		id: string;
@@ -566,9 +567,20 @@
 	</div>
 
 	<div class="mt-6 flex gap-4">
-		<!-- Collapsible hierarchy sidebar -->
+		<!-- Collapsible hierarchy sidebar. Inline sticky column on desktop; on
+		     mobile (ADR-229) the [data-hierarchy-sidebar] CSS turns it into a
+		     full-height fixed left overlay drawer, closed via this backdrop. -->
+		{#if sidebarOpen && viewport.isMobile}
+			<button
+				type="button"
+				class="drawer-backdrop"
+				aria-label="Close hierarchy"
+				onclick={toggleSidebar}
+			></button>
+		{/if}
 		{#if sidebarOpen}
 			<aside
+				data-hierarchy-sidebar
 				style="width: 280px; max-height: calc(100vh - 80px); flex-shrink: 0"
 				class="overflow-y-auto rounded border"
 				style:border-color="var(--color-border)"

--- a/frontend/tests/e2e/package-hierarchy.mobile.spec.ts
+++ b/frontend/tests/e2e/package-hierarchy.mobile.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin, createSet, createPackage } from './fixtures';
+
+// ADR-229 follow-up: the package page's hierarchy sidebar gets the same mobile
+// treatment as the view page — a full-height fixed left overlay drawer (the
+// toggle opens it, a backdrop closes it) instead of an inline 280px column.
+
+let packageId = '';
+
+test.beforeAll(async () => {
+	await seedAdmin();
+	const token = await getAuthToken();
+	const set = await createSet(undefined, token, { name: 'Mobile Pkg Hierarchy Set' });
+	const pkg = await createPackage(undefined, token, {
+		name: 'Mobile Hierarchy Package',
+		set_id: set.id as string
+	});
+	packageId = pkg.id as string;
+});
+
+test('package hierarchy toggle opens a full-height overlay drawer on mobile', async ({ page }) => {
+	test.slow();
+	await loginAsAdmin(page);
+	await page.goto(`/packages/${packageId}`);
+	await expect(page.getByRole('button', { name: 'Toggle hierarchy sidebar' }).first()).toBeVisible({
+		timeout: 15_000
+	});
+
+	const aside = page.locator('[data-hierarchy-sidebar]');
+	await page.getByRole('button', { name: 'Toggle hierarchy sidebar' }).first().click();
+	await expect(aside).toBeVisible();
+
+	// Fixed overlay (not the inline sticky column) and fills the viewport.
+	await expect(aside).toHaveCSS('position', 'fixed');
+	const vh = await page.evaluate(() => window.innerHeight);
+	const box = await aside.boundingBox();
+	expect(box!.height).toBeGreaterThan(vh * 0.8);
+
+	// Backdrop closes it (tap the strip right of the ≤320px drawer).
+	await page.getByRole('button', { name: 'Close hierarchy' }).click({ position: { x: 370, y: 400 } });
+	await expect(aside).toBeHidden();
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.3"
+version = "6.41.4"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.3"
+version = "6.41.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Applies the view-page hierarchy-drawer fix to the package detail page: the hierarchy sidebar now opens as a full-height fixed left overlay drawer on mobile (toggle to open, backdrop to close) instead of an inline 280px column. Adds the `data-hierarchy-sidebar` hook so the shared overlay CSS applies, plus a mobile e2e guard. Version 6.41.3 → 6.41.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)