### PR TITLE
fix(v6.41.5): text-view TOC overlay drawer on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.5] - 2026-05-31
+
+### Fixed
+
+- **Text-view Table of Contents on mobile (ADR-229 follow-up).** The TOC
+  on Text (markdown) views was a fixed 300px right column that squeezed the
+  document to a sliver on a phone. On mobile it now opens as a full-height
+  fixed right overlay drawer (`100dvh`) with a tap-to-close backdrop, and
+  jumping to a heading closes it so the reader lands on the content. Desktop
+  keeps the inline column.
+
 ## [6.41.4] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.4"
+version = "6.41.5"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.4",
+	"version": "6.41.5",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/MarkdownToc.svelte
+++ b/frontend/src/lib/components/MarkdownToc.svelte
@@ -8,6 +8,7 @@
 	 * heading element by id (slugged from heading text).
 	 */
 	import type { TocHeading } from './MarkdownView.svelte';
+	import { viewport } from '$lib/stores/viewport.svelte';
 
 	interface Props {
 		headings: TocHeading[];
@@ -20,9 +21,17 @@
 	function jump(id: string) {
 		const el = document.getElementById(id);
 		el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		// On mobile the TOC is a full-screen overlay drawer (ADR-229); close it
+		// after jumping so the reader lands on the content.
+		if (viewport.isMobile) onclose?.();
 	}
 </script>
 
+<!-- Mobile (ADR-229): the TOC becomes a fixed right overlay drawer; this
+     backdrop closes it on tap. On desktop it's an inline column (no backdrop). -->
+{#if viewport.isMobile && onclose}
+	<button type="button" class="md-toc-backdrop" aria-label="Close TOC" onclick={onclose}></button>
+{/if}
 <aside class="md-toc" aria-label="Table of contents">
 	<header class="md-toc__header">
 		<span class="md-toc__title">Contents</span>
@@ -59,6 +68,26 @@
 		padding: 12px;
 		font-size: 12px;
 		overflow-y: auto;
+	}
+
+	/* Mobile (ADR-229): a fixed right overlay drawer instead of a 300px column
+	   that would squeeze the markdown content to nothing on a phone. */
+	.md-toc-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.4);
+		z-index: 49;
+		border: 0;
+	}
+	@media (max-width: 767px) {
+		.md-toc {
+			position: fixed;
+			right: 0; top: 0; bottom: 0;
+			height: 100dvh;
+			width: 85vw; max-width: 320px;
+			border-radius: 0;
+			z-index: 50;
+		}
 	}
 	.md-toc__header {
 		display: flex; justify-content: space-between; align-items: center;

--- a/frontend/tests/e2e/markdown-toc.mobile.spec.ts
+++ b/frontend/tests/e2e/markdown-toc.mobile.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { seedAdmin, getAuthToken, loginAsAdmin, createDiagram } from './fixtures';
+
+// ADR-229 follow-up: the Table of Contents on Text (markdown) views is a
+// 300px right column that would squeeze the content to nothing on a phone.
+// On mobile it should open as a fixed right overlay drawer instead.
+
+const MARKDOWN = `# Document Title
+
+## Section One
+
+Some content here.
+
+## Section Two
+
+More content.
+`;
+
+let diagramId = '';
+
+test.beforeAll(async () => {
+	await seedAdmin();
+	const token = await getAuthToken();
+	const d = await createDiagram(undefined, token, {
+		diagram_type: 'text',
+		notation: 'markdown',
+		name: 'Mobile TOC Doc',
+		data: { content: MARKDOWN }
+	});
+	diagramId = d.id as string;
+});
+
+test('the TOC opens as a full-height right overlay drawer on mobile', async ({ page }) => {
+	test.slow();
+	await loginAsAdmin(page);
+	await page.goto(`/views/${diagramId}`);
+	await expect(page.getByText('Loading diagram...')).toHaveCount(0, { timeout: 20_000 });
+
+	const toc = page.locator('aside.md-toc');
+	await page.getByRole('button', { name: 'Toggle table of contents' }).first().click();
+	await expect(toc).toBeVisible();
+
+	// Fixed overlay (not the inline 300px column) and fills the viewport height.
+	await expect(toc).toHaveCSS('position', 'fixed');
+	const vh = await page.evaluate(() => window.innerHeight);
+	const box = await toc.boundingBox();
+	expect(box!.height).toBeGreaterThan(vh * 0.8);
+
+	// Headings are listed.
+	await expect(toc.getByRole('button', { name: 'Section One' })).toBeVisible();
+
+	// No horizontal overflow while the overlay is open (content not squeezed).
+	const overflow = await page.evaluate(
+		() => document.documentElement.scrollWidth - document.documentElement.clientWidth
+	);
+	expect(overflow).toBeLessThanOrEqual(1);
+
+	// Backdrop closes it — tap the strip left of the right-anchored drawer.
+	await page.locator('.md-toc-backdrop').click({ position: { x: 20, y: 400 } });
+	await expect(toc).toBeHidden();
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.4"
+version = "6.41.5"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.4"
+version = "6.41.5"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Answer to "is the TOC on smart-markdown views mobile-friendly?" — it wasn't: the Table of Contents was a fixed 300px right column that squeezed the document to a sliver on a phone. On mobile it now opens as a full-height (`100dvh`) fixed right overlay drawer with a tap-to-close backdrop, and jumping to a heading closes it. Desktop keeps the inline column (all changes viewport-gated). New `markdown-toc.mobile.spec`. Version 6.41.4 → 6.41.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)