### PR TITLE
fix(v6.41.6): clean TOC heading text + working jump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.41.6] - 2026-05-31
+
+### Fixed
+
+- **Text-view TOC heading text + jump (ADR-137 follow-up).** TOC entries
+  showed raw inline-markdown syntax for headings that contain links —
+  e.g. `Security (CSE) · [13](iris://diagram/…)` instead of `Security
+  (CSE) · 13`. Heading text is now flattened to plain text (links/images
+  keep their label/alt; emphasis, code and strikethrough markers are
+  dropped). Separately, rendered headings had no `id`, so clicking a TOC
+  entry did nothing; rendered headings now get slug ids that match the TOC
+  entries (shared slugger), so TOC jumps scroll to the heading.
+
 ## [6.41.5] - 2026-05-31
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.5"
+version = "6.41.6"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.5",
+	"version": "6.41.6",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/markdownHelpers.ts
+++ b/frontend/src/lib/components/markdownHelpers.ts
@@ -60,23 +60,47 @@ export function urlIsAllowed(href: string): boolean {
 	}
 }
 
+/** A fresh slugger with its own dedup counter. Shared by extractHeadings and
+ *  renderMarkdown — walked in the same (document) order — so the TOC entry ids
+ *  match the ids assigned to the rendered heading elements, and TOC jumps land. */
+export function makeSlugger(): (s: string) => string {
+	const counts = new Map<string, number>();
+	return (s: string) => {
+		const base = s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'h';
+		const n = (counts.get(base) ?? 0) + 1;
+		counts.set(base, n);
+		return n === 1 ? base : `${base}-${n}`;
+	};
+}
+
+/** Flatten inline markdown to plain text for TOC display: links/images keep
+ *  their label/alt; emphasis, inline code, and strikethrough markers are
+ *  dropped. So a heading authored as `Security (CSE) · [13](iris://diagram/…)`
+ *  reads `Security (CSE) · 13` in the TOC instead of leaking the raw link
+ *  syntax (ADR-137 follow-up). */
+export function stripInlineMarkdown(s: string): string {
+	return s
+		.replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1') // images → alt text
+		.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // links → label
+		.replace(/`([^`]+)`/g, '$1') // inline code
+		.replace(/(\*\*|__)(.*?)\1/g, '$2') // bold
+		.replace(/(\*|_)(.*?)\1/g, '$2') // italic
+		.replace(/~~(.*?)~~/g, '$2') // strikethrough
+		.trim();
+}
+
 export function extractHeadings(source: string): TocHeading[] {
 	const out: TocHeading[] = [];
 	const lines = source.split(/\r?\n/);
 	let inFence = false;
-	const slugCounts = new Map<string, number>();
-	const slug = (s: string) => {
-		const base = s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'h';
-		const n = (slugCounts.get(base) ?? 0) + 1;
-		slugCounts.set(base, n);
-		return n === 1 ? base : `${base}-${n}`;
-	};
+	const slug = makeSlugger();
 	for (const line of lines) {
 		if (/^```/.test(line.trim())) { inFence = !inFence; continue; }
 		if (inFence) continue;
 		const m = /^(#{1,6})\s+(.+?)\s*#*\s*$/.exec(line);
 		if (!m) continue;
-		out.push({ id: slug(m[2].trim()), level: m[1].length, text: m[2].trim() });
+		const text = stripInlineMarkdown(m[2].trim());
+		out.push({ id: slug(text), level: m[1].length, text });
 	}
 	return out;
 }
@@ -157,6 +181,14 @@ export function renderMarkdown(source: string, textDiagramIds?: Set<string>): Re
 		if (irisLink.kind === 'diagram' && textDiagramIds?.has(irisLink.id)) {
 			a.classList.add('md-iris-link--text');
 		}
+	}
+
+	// ADR-137 follow-up: give rendered headings slug ids so the TOC's
+	// getElementById jump targets exist. Same slugger as extractHeadings,
+	// walked in document order, so ids line up with the TOC entries.
+	const slugHeading = makeSlugger();
+	for (const h of tpl.content.querySelectorAll('h1, h2, h3, h4, h5, h6')) {
+		if (!h.id) h.id = slugHeading(h.textContent ?? '');
 	}
 
 	return { html: tpl.innerHTML, links };

--- a/frontend/tests/unit/markdownView.test.ts
+++ b/frontend/tests/unit/markdownView.test.ts
@@ -125,6 +125,35 @@ describe('extractHeadings', () => {
 	it('returns an empty list when there are no headings', () => {
 		expect(extractHeadings('Just paragraphs.')).toEqual([]);
 	});
+
+	it('flattens inline markdown (links/emphasis/code) in heading text', () => {
+		const source = [
+			'## Security (CSE) · [13](iris://diagram/ef1eafcd-e608)',
+			'',
+			'### **Bold** and `code` and _em_',
+		].join('\n');
+		const headings = extractHeadings(source);
+		expect(headings[0].text).toBe('Security (CSE) · 13');
+		expect(headings[0].id).toBe('security-cse-13');
+		expect(headings[1].text).toBe('Bold and code and em');
+	});
+});
+
+describe('renderMarkdown — heading ids match the TOC (ADR-137 follow-up)', () => {
+	it('assigns slug ids to rendered headings that match extractHeadings', () => {
+		const source = [
+			'# Top',
+			'',
+			'## Security (CSE) · [13](iris://diagram/ef1eafcd-e608)',
+		].join('\n');
+		const { html } = renderMarkdown(source);
+		const tpl = document.createElement('template');
+		tpl.innerHTML = html;
+		const ids = Array.from(tpl.content.querySelectorAll('h1, h2, h3, h4, h5, h6')).map((h) => h.id);
+		const tocIds = extractHeadings(source).map((h) => h.id);
+		expect(ids).toEqual(tocIds);
+		expect(ids).toContain('security-cse-13');
+	});
 });
 
 describe('parseIrisHref + urlIsAllowed', () => {

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.5"
+version = "6.41.6"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.5"
+version = "6.41.6"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
The Text-view TOC leaked raw inline-markdown for headings containing links — `Security (CSE) · [13](iris://diagram/…)` instead of `Security (CSE) · 13`. Heading text is now flattened to plain text (links/images keep label/alt; emphasis/code/strikethrough markers dropped). While investigating I found rendered headings had no `id`, so TOC clicks did nothing — `renderMarkdown` now assigns slug ids (shared `makeSlugger()` matching `extractHeadings`) so jumps actually scroll. Unit tests cover both. Version 6.41.5 → 6.41.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)