### PR TITLE
fix(v6.42.0): GEANZ diagram render fidelity + stop theme flip (ADR-230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.42.0] - 2026-06-01
+
+### Fixed
+
+- **GEANZ diagrams no longer flip to the UML default a few seconds after
+  load (ADR-230).** Opening a GEANZ capability view (e.g. CCS.00) first
+  painted the correct themed look, then `refreshNodeDescriptions()` —
+  the post-paint element refresh (ADR-192) — re-hydrated each node from
+  its source element and spread the result over `node.data`, clobbering
+  the canvas node's per-placement `visual` (the EA fill/border + explicit
+  size) with the element's empty `visual`. Colours vanished, SvelteFlow
+  re-measured (re-layout), and capability nodes fell back to the
+  `iris-default-uml` look (white boxes, thin black borders, ArchiMate
+  icons). The refresh now preserves the node's own `visual` / `notation`
+  / `entityType` and only updates genuine content fields, so the themed
+  render stays stable in view and edit mode. A Playwright regression
+  (`geanz-render.spec.ts`) locks this in.
+
+### Added
+
+- **GEANZ render fidelity (ADR-230).** A new built-in **GEANZ Default**
+  theme plus per-archetype canvas styling render the GEANZ Common
+  Business Capabilities set faithfully to the Sparx EA ground-truth:
+  light-cyan capability **zones** behind their children, white
+  **capabilities** with royal-blue rounded borders, dashed pill-shaped
+  italic **theme** elements, dashed **redirect/proposed** boxes, and no
+  ArchiMate icon or description text inside the boxes.
+  - `NodeVisualOverrides` gains `borderRadius` / `cornerStyle` (`pill`),
+    and `nodeOverrideStyle()` emits `border-radius` — so any EA import or
+    manual styling can now express rounded or pill-shaped nodes.
+  - `ArchimateRenderer` now honours theme rendering hints
+    (`hideIcons` / `hideDescription` / `textAlign`) like the other
+    renderers, plus per-node `hideIcon` / `hideDescription`.
+  - The Sparx importer classifies GEANZ archetypes (zone / capability /
+    theme-pill / redirect) from the element name + `CBC Themes`
+    qualifier and enriches each node's `visual` + z-index, and points
+    GEANZ diagrams at the `geanz-default` theme.
+  - `scripts/repair_geanz_render.py` — a targeted, idempotent,
+    dry-run-first repair that applies the same enrichment to an existing
+    set (for already-imported GEANZ content).
+
 ## [6.41.6] - 2026-05-31
 
 ### Fixed

--- a/backend/app/import_sparx/geanz.py
+++ b/backend/app/import_sparx/geanz.py
@@ -1,0 +1,126 @@
+"""GEANZ Common Business Capabilities archetype classification + visual
+enrichment (ADR-230).
+
+Every GEANZ element imports as Iris ``element_type='capability'`` with
+stereotype ``ArchiMate_Capability``; the three visual classes (zone,
+capability, theme pill) and the proposed/redirect variant are
+distinguishable only by the element NAME suffix and the cross-package
+``qualifier='CBC Themes'`` signal. The EA fill/border/size already lands
+on each canvas node's ``data.visual``; this module adds the presentation
+deltas the EA raster shows but the importer did not capture — rounded
+corners, dashed borders for theme pills + redirects, pill shape + italic
+for theme pills — and lowers the zone's z-index so it sits behind its
+child capabilities.
+
+Shared by the Sparx importer (``import_sparx/service.py``) and the
+data-repair script (``scripts/repair_geanz_render.py``) so the rule has a
+single home (Protocol §13 DRY).
+"""
+
+from __future__ import annotations
+
+ZONE = "geanz_zone"
+CAPABILITY = "geanz_capability"
+PROPOSED = "geanz_proposed_capability"
+THEME_PILL = "geanz_theme_pill"
+
+# z-index so the zone fill renders behind its child capabilities (EA draws
+# children on top of the zone), while notes float above everything.
+_Z_ZONE = 0
+_Z_CAPABILITY = 2
+_Z_NOTE = 3
+
+
+def classify_geanz_archetype(label: str | None, qualifier: str | None = None) -> str:
+    """Classify a capability node into a GEANZ archetype from its name + qualifier."""
+    name = (label or "").strip().lower()
+    if qualifier == "CBC Themes" or name.endswith("(theme)"):
+        return THEME_PILL
+    if name.endswith("(redirect)") or name.endswith("(proposed)"):
+        return PROPOSED
+    if name.endswith("capability zone"):
+        return ZONE
+    return CAPABILITY
+
+
+def enrich_visual(archetype: str, visual: dict[str, object] | None) -> dict[str, object]:
+    """Return ``visual`` with GEANZ presentation deltas added.
+
+    Non-destructive for authentic EA values (fill / border colour / width /
+    explicit size are preserved); only adds corner radius, dashed border,
+    pill shape and italic where the archetype calls for it.
+    """
+    v: dict[str, object] = dict(visual or {})
+    if archetype == ZONE:
+        v.setdefault("borderRadius", 14)
+    elif archetype == THEME_PILL:
+        v["borderStyle"] = "dashed"
+        v["cornerStyle"] = "pill"
+        v["italic"] = True
+    elif archetype == PROPOSED:
+        v["borderStyle"] = "dashed"
+        v.setdefault("borderRadius", 10)
+    else:  # CAPABILITY
+        v.setdefault("borderRadius", 10)
+    return v
+
+
+def _entity_type(node: dict[str, object]) -> str:
+    data = node.get("data")
+    if isinstance(data, dict):
+        et = data.get("entityType")
+        if isinstance(et, str):
+            return et
+    t = node.get("type")
+    return t if isinstance(t, str) else ""
+
+
+def is_geanz_diagram(nodes: list[dict[str, object]]) -> bool:
+    """True when any capability node carries a GEANZ archetype marker
+    (a zone / theme-pill / redirect name). A generic ArchiMate diagram with
+    a capability named e.g. 'Payroll' does NOT match, so non-GEANZ imports
+    are left untouched.
+    """
+    for node in nodes:
+        if _entity_type(node) != "capability":
+            continue
+        data = node.get("data")
+        if not isinstance(data, dict):
+            continue
+        arch = classify_geanz_archetype(
+            data.get("label") if isinstance(data.get("label"), str) else None,
+            data.get("qualifier") if isinstance(data.get("qualifier"), str) else None,
+        )
+        if arch in (ZONE, THEME_PILL, PROPOSED):
+            return True
+    return False
+
+
+def apply_geanz_styling(nodes: list[dict[str, object]]) -> bool:
+    """If ``nodes`` look like a GEANZ capability diagram, enrich each
+    capability node's ``data.visual`` and set its z-index in place.
+
+    Returns True when GEANZ styling was applied (so callers can set the
+    diagram's ``theme_id='geanz-default'``), False otherwise. Idempotent —
+    re-running yields the same result.
+    """
+    if not is_geanz_diagram(nodes):
+        return False
+    for node in nodes:
+        et = _entity_type(node)
+        if et == "note":
+            node["zIndex"] = _Z_NOTE
+            continue
+        if et != "capability":
+            continue
+        data = node.get("data")
+        if not isinstance(data, dict):
+            continue
+        arch = classify_geanz_archetype(
+            data.get("label") if isinstance(data.get("label"), str) else None,
+            data.get("qualifier") if isinstance(data.get("qualifier"), str) else None,
+        )
+        visual = data.get("visual")
+        data["visual"] = enrich_visual(arch, visual if isinstance(visual, dict) else None)
+        node["zIndex"] = _Z_ZONE if arch == ZONE else _Z_CAPABILITY
+    return True

--- a/backend/app/import_sparx/service.py
+++ b/backend/app/import_sparx/service.py
@@ -13,6 +13,7 @@ from app.diagrams.service import create_diagram
 from app.elements.service import create_element
 from app.import_common import ImportWarning
 from app.import_sparx.converter import build_edge_visual, build_node_visual, ea_rect_to_position, format_uml_visibility, parse_diagram_link_geometry, parse_diagram_link_path, parse_nid
+from app.import_sparx.geanz import apply_geanz_styling
 from app.import_sparx.icon_matcher import SemanticIconMatcher
 from app.import_sparx.mapper import map_archimate_stereotype, map_connector_type, map_diagram_type, map_object_type
 from app.import_sparx.reader import (
@@ -886,6 +887,13 @@ async def import_sparx_model(
             # Insert at beginning so it renders behind other nodes
             nodes.insert(0, frame_node)
 
+        # GEANZ Common Business Capabilities styling (ADR-230 F5): when this
+        # diagram is a GEANZ capability diagram, enrich each capability node's
+        # visual (rounded corners, dashed theme pills + redirects, pill +
+        # italic theme pills) and lower the zone z-index so it sits behind its
+        # children. Returns False (and changes nothing) for non-GEANZ diagrams.
+        is_geanz = apply_geanz_styling(nodes)
+
         model_data: dict[str, object] = {"nodes": nodes, "edges": edges}
 
         # Override diagram type for navigation-cell-dominated diagrams.
@@ -897,7 +905,12 @@ async def import_sparx_model(
             diagram_notation = "simple"
 
         # Build diagram metadata with ea_guid and theme
-        theme_id = "iris-default-simple" if diagram_notation == "simple" else "ea-default-uml"
+        if is_geanz:
+            theme_id = "geanz-default"
+        elif diagram_notation == "simple":
+            theme_id = "iris-default-simple"
+        else:
+            theme_id = "ea-default-uml"
         diag_metadata: dict[str, object] = {"theme_id": theme_id}
         if diag.ea_guid:
             diag_metadata["ea_guid"] = diag.ea_guid

--- a/backend/app/themes/service.py
+++ b/backend/app/themes/service.py
@@ -419,4 +419,40 @@ async def seed_default_themes(db: DatabasePort) -> None:
          json.dumps(scenia_config), True, "system", now, now),
     )
 
+    # GEANZ Default — GEANZ Common Business Capabilities look (ADR-230).
+    # All GEANZ elements import as entityType 'capability'; per-archetype
+    # specifics (dashed pills, pill radius, italic, zone fill, larger radius)
+    # ride on each node's data.visual set at import time. The theme supplies
+    # the shared defaults: white capability fill, royal-blue border, and the
+    # rendering hints that strip the ArchiMate icon + description and left-
+    # align labels so capability boxes match the EA ground-truth (EA34.png).
+    geanz_config = {
+        "element_defaults": {
+            "capability": {"bgColor": "#ffffff", "borderColor": "#4169e1", "fontColor": "#1a1a2e", "borderWidth": 2, "bold": True},
+            "note": {"bgColor": "#ffffff", "borderColor": "#000000", "fontColor": "#000000", "borderWidth": 1},
+        },
+        "stereotype_overrides": {},
+        "edge_defaults": {
+            "association": {"lineColor": "#555555", "lineWidth": 1},
+        },
+        "global": {
+            "defaultBgColor": "#ffffff",
+            "defaultBorderColor": "#4169e1",
+            "defaultFontColor": "#1a1a2e",
+        },
+        "rendering": {
+            "hideIcons": True,
+            "hideDescription": True,
+            "borderRadius": 10,
+            "wrapLabels": True,
+            "textAlign": "left",
+        },
+    }
+    await db.execute(
+        "INSERT OR REPLACE INTO themes (id, name, description, notation, config, is_default, created_by, created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("geanz-default", "GEANZ Default", "GEANZ Common Business Capabilities — light-blue zones, royal-blue rounded capabilities, dashed theme pills", "uml",
+         json.dumps(geanz_config), True, "system", now, now),
+    )
+
     await db.commit()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.41.6"
+version = "6.42.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_geanz_archetype.py
+++ b/backend/tests/test_geanz_archetype.py
@@ -1,0 +1,118 @@
+"""Tests for GEANZ archetype classification + visual enrichment (ADR-230 F5).
+
+The same rule is used by the Sparx importer and the data-repair script,
+so it is tested in isolation here.
+"""
+
+from __future__ import annotations
+
+from app.import_sparx.geanz import (
+    CAPABILITY,
+    PROPOSED,
+    THEME_PILL,
+    ZONE,
+    apply_geanz_styling,
+    classify_geanz_archetype,
+    enrich_visual,
+    is_geanz_diagram,
+)
+
+
+def test_classify_zone_by_name():
+    assert classify_geanz_archetype("Customer Service Delivery capability zone") == ZONE
+
+
+def test_classify_theme_pill_by_suffix_or_qualifier():
+    assert classify_geanz_archetype("Strategy (theme)") == THEME_PILL
+    assert classify_geanz_archetype("Operations", qualifier="CBC Themes") == THEME_PILL
+
+
+def test_classify_redirect_as_proposed():
+    assert classify_geanz_archetype("Product and Service Management (redirect)") == PROPOSED
+
+
+def test_classify_plain_capability():
+    assert classify_geanz_archetype("Case Management") == CAPABILITY
+
+
+def test_enrich_zone_keeps_fill_adds_radius():
+    v = enrich_visual(ZONE, {"bgColor": "#ccf2fe", "borderColor": "#4169e1", "borderWidth": 3})
+    assert v["bgColor"] == "#ccf2fe"  # authentic EA fill preserved
+    assert v["borderColor"] == "#4169e1"
+    assert v["borderWidth"] == 3
+    assert v["borderRadius"] == 14
+
+
+def test_enrich_theme_pill_is_dashed_pill_italic():
+    v = enrich_visual(THEME_PILL, {"bgColor": "#ffffff", "borderColor": "#4169e1"})
+    assert v["borderStyle"] == "dashed"
+    assert v["cornerStyle"] == "pill"
+    assert v["italic"] is True
+
+
+def test_enrich_proposed_is_dashed():
+    v = enrich_visual(PROPOSED, {"bgColor": "#ffffff"})
+    assert v["borderStyle"] == "dashed"
+    assert v["borderRadius"] == 10
+
+
+def test_enrich_capability_rounded():
+    assert enrich_visual(CAPABILITY, {})["borderRadius"] == 10
+
+
+def _node(label, *, qualifier=None, entity_type="capability", visual=None):
+    data = {"label": label, "entityType": entity_type}
+    if qualifier:
+        data["qualifier"] = qualifier
+    if visual is not None:
+        data["visual"] = visual
+    return {"id": label, "type": entity_type, "data": data}
+
+
+def test_is_geanz_diagram_detects_zone():
+    nodes = [_node("Customer Service Delivery capability zone"), _node("Case Management")]
+    assert is_geanz_diagram(nodes) is True
+
+
+def test_is_geanz_diagram_ignores_generic_archimate():
+    # A plain ArchiMate capability diagram (no zone/theme/redirect names).
+    nodes = [_node("Payroll"), _node("Procurement")]
+    assert is_geanz_diagram(nodes) is False
+
+
+def test_apply_geanz_styling_enriches_and_sets_zindex():
+    zone = _node("Customer Service Delivery capability zone",
+                 visual={"bgColor": "#ccf2fe", "borderColor": "#4169e1", "borderWidth": 3, "width": 866, "height": 390})
+    cap = _node("Case Management", visual={"bgColor": "#ffffff", "borderColor": "#4169e1", "borderWidth": 2})
+    pill = _node("Strategy (theme)", qualifier="CBC Themes", visual={"bgColor": "#ffffff", "borderColor": "#4169e1"})
+    note = _node("August 2025", entity_type="note", visual={"width": 148, "height": 30})
+    nodes = [zone, cap, pill, note]
+
+    assert apply_geanz_styling(nodes) is True
+
+    assert zone["zIndex"] == 0  # behind children
+    assert zone["data"]["visual"]["borderRadius"] == 14
+    assert zone["data"]["visual"]["bgColor"] == "#ccf2fe"  # preserved
+
+    assert cap["zIndex"] == 2
+    assert cap["data"]["visual"]["borderRadius"] == 10
+
+    assert pill["data"]["visual"]["borderStyle"] == "dashed"
+    assert pill["data"]["visual"]["cornerStyle"] == "pill"
+    assert pill["data"]["visual"]["italic"] is True
+
+    assert note["zIndex"] == 3  # notes float above
+
+
+def test_apply_geanz_styling_noop_on_generic():
+    nodes = [_node("Payroll", visual={"bgColor": "#b5ffff"})]
+    assert apply_geanz_styling(nodes) is False
+    assert "borderRadius" not in nodes[0]["data"]["visual"]  # untouched
+
+
+def test_apply_geanz_styling_idempotent():
+    nodes = [_node("Strategy (theme)", qualifier="CBC Themes", visual={"bgColor": "#ffffff"})]
+    apply_geanz_styling(nodes)
+    first = dict(nodes[0]["data"]["visual"])
+    apply_geanz_styling(nodes)
+    assert nodes[0]["data"]["visual"] == first

--- a/backend/tests/test_geanz_theme.py
+++ b/backend/tests/test_geanz_theme.py
@@ -1,0 +1,61 @@
+"""Tests for the geanz-default seed theme (ADR-230 / SPEC-230-A AC4).
+
+The GEANZ Common Business Capabilities set must render faithfully to the
+Sparx EA ground-truth: white capabilities with a royal-blue border, no
+ArchiMate icon or description text, rounded corners, left-aligned labels.
+The shared defaults live in the geanz-default theme; per-archetype
+specifics ride on each node's data.visual at import time.
+"""
+
+from __future__ import annotations
+
+import aiosqlite
+import pytest
+import pytest_asyncio
+
+from app.migrations.m024_themes import up as m024_up
+from app.themes.service import get_theme, seed_default_themes
+
+
+@pytest_asyncio.fixture
+async def db():
+    async with aiosqlite.connect(":memory:") as conn:
+        await m024_up(conn)
+        await seed_default_themes(conn)
+        yield conn
+
+
+@pytest.mark.asyncio
+async def test_geanz_theme_seeded(db):
+    theme = await get_theme(db, "geanz-default")
+    assert theme is not None, "geanz-default theme not found after seeding"
+    assert theme["notation"] == "uml"
+    assert theme["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_geanz_theme_capability_default(db):
+    theme = await get_theme(db, "geanz-default")
+    cap = theme["config"]["element_defaults"]["capability"]
+    assert cap["bgColor"] == "#ffffff"
+    assert cap["borderColor"] == "#4169e1"
+    assert cap["bold"] is True
+
+
+@pytest.mark.asyncio
+async def test_geanz_theme_rendering_hints(db):
+    """Icons + descriptions hidden, modest radius, labels left-aligned."""
+    theme = await get_theme(db, "geanz-default")
+    rendering = theme["config"]["rendering"]
+    assert rendering.get("hideIcons") is True
+    assert rendering.get("hideDescription") is True
+    assert rendering.get("borderRadius") == 10
+    assert rendering.get("textAlign") == "left"
+
+
+@pytest.mark.asyncio
+async def test_geanz_theme_idempotent_reseed(db):
+    """Re-seeding (startup upsert) must not duplicate or change the theme."""
+    await seed_default_themes(db)
+    cursor = await db.execute("SELECT COUNT(*) FROM themes WHERE id = 'geanz-default'")
+    assert (await cursor.fetchone())[0] == 1

--- a/backend/tests/test_themes.py
+++ b/backend/tests/test_themes.py
@@ -106,8 +106,9 @@ async def test_seed_default_themes(db):
     all_themes = await list_themes(db)
     assert len(all_themes) >= 4  # iris-default-uml, ea-default-uml, iris-default-simple, c4-default
 
-    # Verify EA theme has correct structure
-    ea_themes = [t for t in all_themes if "EA" in str(t["name"])]
+    # Verify EA theme has correct structure (match "Sparx EA" specifically —
+    # a bare "EA" substring also matches "GEANZ Default", ADR-230).
+    ea_themes = [t for t in all_themes if "Sparx EA" in str(t["name"])]
     assert len(ea_themes) == 1
     ea = ea_themes[0]
     assert ea["notation"] == "uml"

--- a/docs/adrs/ADR-230-GEANZ-Diagram-Render-Fidelity.md
+++ b/docs/adrs/ADR-230-GEANZ-Diagram-Render-Fidelity.md
@@ -1,0 +1,226 @@
+# ADR-230: GEANZ diagram render fidelity (stop the theme flip + faithful capability styling)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-230 |
+| **Initiative** | Make Iris render the GEANZ Common Business Capabilities set faithfully to the Sparx EA ground-truth |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-01 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the GEANZ Common Business Capabilities set
+(`set_id=7f2521de-d7c8-41ba-982c-d1246ba81428`, e.g. the CCS.00 view
+`e5549ec8-b5c9-4e7b-8710-4ce02b83ceaa`), whose diagrams are imported
+from Sparx EA and must look like the EA HTML-report ground-truth
+(`/tmp/geanz/EARoot/EA1/EA34.png` for CCS.00): light-cyan capability
+**zones** (`#ccf2fe` fill, `#4169e1` royal-blue border, ~3px, rounded),
+white **capabilities** (`#4169e1` border, ~2px, rounded), dashed
+pill-shaped **theme** elements with italic centred labels, dashed
+**proposed/redirect** boxes, and **no ArchiMate icons or description
+text** inside the boxes,
+
+**facing** two defects observed on `/views/[id]`:
+
+  1. **The theme flip (primary bug).** The canvas first paints
+     correctly — `parseCanvasData()` loads each node's stored
+     `data.visual` verbatim (the EA fill/border + explicit
+     width/height) — but a few seconds later
+     `refreshNodeDescriptions()`
+     (`frontend/src/routes/views/[id]/+page.svelte:672-708`,
+     added for ADR-192 / issue #164 to live-refresh class
+     attributes) re-hydrates every node from its source element via
+     `elementToNodeData()` and **unconditionally spreads the result
+     over `node.data`** (`:688` `const next = { ...node.data,
+     ...hydrated, description: desc }`). For GEANZ elements
+     `element.data.visual` is `undefined`
+     (`elementToNodeData.ts:53` returns `visual: data.visual`), so the
+     spread overwrites the node's themed `visual` with `undefined`
+     and its `notation`/size too. The change-guard (`:689-696`)
+     diffs only `diffKeys = [label, description, diagramUsageCount,
+     attributes, operations, literals, stereotype, qualifier]` —
+     **`visual`, `notation` and `entityType` are absent**, so they are
+     never protected. With `data.visual` gone, per-node colours vanish,
+     the lost explicit width/height forces a SvelteFlow re-measure
+     (visible re-layout), and the capability nodes fall back to the
+     plain white / thin-black-border / icon look of the
+     `iris-default-uml` seed. Editing a GEANZ model shows the same
+     fallback. This is the `1.png → 2.png` flip the user reported.
+
+  2. **Fidelity gaps that remain even on the correct first paint.**
+     Every GEANZ node is `entityType: 'capability'`, which
+     `DynamicNode` routes to `ArchimateRenderer`. That renderer
+     **always** draws an ArchiMate grid icon and the description text,
+     **centres** the label, and hard-codes `border-radius: 4px`. It is
+     also the only renderer that does **not** consume the theme
+     `rendering` config (`getThemeRendering`) — unlike `UmlRenderer`,
+     `NoteNode`, `BaseNode`. The per-node `visual` override
+     (`NodeVisualOverrides`) has no way to express a corner radius or a
+     pill shape, and the GEANZ theme-pill / proposed boxes carry no
+     `borderStyle: 'dashed'` / `italic` in their stored `visual`. So
+     the boxes show icons, descriptions and square-ish corners the
+     ground-truth does not have, and theme pills are not dashed pills.
+
+All GEANZ elements share `element_type='capability'` and
+`stereotype='ArchiMate_Capability'`, so a theme **cannot** distinguish
+zone vs capability vs theme-pill vs proposed by type or stereotype
+alone. The three classes are distinguishable only by the per-node
+`visual` colours already present (zone `#ccf2fe` vs capability white)
+plus naming signals on the node (`qualifier: 'CBC Themes'` and a
+`… (theme)` / `… (redirect)` label suffix),
+
+**we decided to** fix the flip at its source and make the renderer +
+the per-node `visual` capable of expressing the full GEANZ style, then
+populate that style at import time and repair the existing set:
+
+  - **(F1) Stop the flip.** In `refreshNodeDescriptions()`, strip the
+    presentation keys (`visual`, `notation`, `entityType`) from the
+    hydrated payload before the spread and re-pin the node's own
+    values, so only genuine content fields (label, description,
+    attributes, operations, literals, stereotype, qualifier,
+    diagramUsageCount) are refreshed. Add `visual`/`notation`/
+    `entityType` to `diffKeys` as defence-in-depth. The ADR-192/#164
+    behaviour (live class-attribute refresh) is fully preserved. Mirror
+    the same protect-presentation rule at any other call site that
+    spreads `elementToNodeData()` output over a node.
+
+  - **(F2) Give `NodeVisualOverrides` a corner radius + pill.** Add
+    `borderRadius?: number` and `cornerStyle?: 'pill' | 'rounded' |
+    'sharp'` to the type and emit `border-radius` from
+    `nodeOverrideStyle()` (`cornerStyle: 'pill'` → `border-radius:
+    9999px`; `borderRadius: n` → `n`px). No theme-config schema change
+    needed for radius — it travels on the node.
+
+  - **(F3) Make `ArchimateRenderer` honour rendering hints.** Consume
+    `getThemeRendering(notation, preferredThemeId)` like the other
+    renderers, and additionally respect per-node `data.hideDescription`
+    and a per-node `data.visual.hideIcon`. When the resolved theme sets
+    `hideIcons` / `hideDescription` / `textAlign`, or the node sets
+    `hideIcon` / `hideDescription`, suppress the icon, suppress the
+    description, and align the header accordingly. Honour the node
+    `visual.borderRadius` / `cornerStyle` from (F2).
+
+  - **(F4) Add a `geanz-default` theme.** Seed an 8th built-in theme
+    (`seed_default_themes()`), notation `uml`, that sets the GEANZ
+    palette defaults (`capability` → white fill, `#4169e1` border) and
+    `rendering: { hideIcons: true, hideDescription: true, borderRadius:
+    10, textAlign: 'left' }`. GEANZ diagrams reference it explicitly
+    via `metadata.theme_id='geanz-default'`, which `themeStore`
+    respects ahead of the alphabetical `is_default` fallback that today
+    wrongly resolves `iris-default-uml`.
+
+  - **(F5) Classify GEANZ archetypes at import + repair existing data.**
+    In the Sparx import path, classify each placed node from its name
+    suffix + EA fill/line style into one of `geanz_zone`,
+    `geanz_capability`, `geanz_proposed_capability`, `geanz_theme_pill`,
+    `geanz_proposed_zone`, and enrich its `node.data.visual` with the
+    archetype style (dashed for pills/proposed, `cornerStyle: 'pill'` +
+    `italic` for pills, `borderRadius` 14/10 for zones/capabilities,
+    `hideIcon`/`hideDescription`), set the diagram's
+    `metadata.theme_id='geanz-default'`, and lower the **zone** node's
+    z-index so it sits behind its child capabilities (EA renders
+    children on top of the zone fill). Ship a **targeted, dry-run-first
+    data-repair script** (scoped to `set_id=7f2521de…` only, per the
+    prod-data-repair-scoping discipline) that applies the same
+    enrichment to the already-imported GEANZ diagrams on UAT.
+
+  - **(F6) Prove it with Playwright.** A new
+    `frontend/tests/e2e/geanz-render.spec.ts` seeds a CCS.00-shaped
+    archimate/capability diagram via the REST fixtures, navigates to
+    its view, asserts the **computed** styles per archetype
+    (`background-color`, `border-color`, `border-style`,
+    `border-radius`, `font-style`, icon/description absence), captures a
+    screenshot for human comparison against the EA ground-truth, and —
+    the regression for the flip — **re-asserts the same styles after
+    the `/api/elements/{id}` refresh batch settles** so a reintroduced
+    clobber fails the build.
+
+**because** the flip is a data-clobber bug, not a theme bug — the cure
+is to preserve the per-node presentation the cascade
+(`themeStore.svelte.ts:4`: *per-element visual wins*) already promises;
+and because faithful GEANZ rendering needs per-archetype dash/pill/
+radius/label that only the node can carry (uniform type+stereotype rule
+out a pure theme solution), with a `geanz-default` theme supplying the
+shared icon/description/radius defaults and a stable, explicit
+`theme_id` that removes the accidental `iris-default-uml` fallback.
+
+---
+
+## Consequences
+
+**Positive**
+
+- The GEANZ diagrams stop flipping; the first (correct) paint is stable
+  through the post-paint element refresh and in edit mode.
+- Capability zones, capabilities, theme pills and proposed boxes render
+  faithfully to the EA ground-truth (fills, royal-blue borders, dashed
+  pills, rounded corners, no icons/descriptions).
+- `borderRadius`/`cornerStyle` on `NodeVisualOverrides` and
+  rendering-hint support in `ArchimateRenderer` are generic — any EA
+  import or manual styling can now express rounded/pill nodes and hide
+  icons/descriptions, not just GEANZ.
+- A Playwright regression encodes the flip so it can't silently return.
+
+**Negative / risks**
+
+- `ArchimateRenderer` now reads theme context; a wrong `preferredThemeId`
+  or missing theme must degrade to today's CSS-layer look (guarded with
+  `?? false` defaults).
+- The data-repair touches live UAT diagram JSON. Mitigated by strict
+  set-scoping, an explicit dry-run that prints a diff, and idempotency
+  (re-running yields no change).
+- GEANZ archetype classification keys on name suffix (`(theme)`,
+  `(redirect)`) + EA fill — a future renamed element could be
+  misclassified. Mitigated by also keying on `qualifier='CBC Themes'`
+  and the EA line style, and by the classification living only in the
+  GEANZ-aware import/repair path, never in the shared renderer.
+
+## Alternatives considered
+
+1. **Mutate `ea-default-uml` or `scenia-default` instead of adding a
+   theme.** Rejected: those are `is_default` themes shared by all
+   UML/scenia diagrams; repurposing them regresses non-GEANZ content.
+   They also can't express per-archetype radius (one global
+   `rendering.borderRadius`).
+
+2. **Pure theme solution (no per-node enrichment).** Rejected: all GEANZ
+   nodes share type+stereotype, so a theme cannot make only the pills
+   dashed/italic or give zones a different radius from capabilities.
+
+3. **Introduce a new `geanz` notation + dedicated renderer.** Rejected
+   for now: requires a notations migration, `DynamicNode` routing
+   changes and surface ripple, for no gain over reusing
+   `capability`/`ArchimateRenderer` with rendering hints. Can be
+   revisited if GEANZ diverges further from ArchiMate.
+
+4. **Only fix the flip, leave fidelity.** Rejected: the `/goal`
+   explicitly requires Playwright-verified fidelity to the ground-truth;
+   the stable first paint still shows icons, descriptions, square
+   corners and non-dashed pills.
+
+## Surface parity (§14)
+
+No new backend write endpoint is added (the `geanz-default` theme is
+seeded, not exposed via a new route). Theme CRUD (`POST/PUT
+/api/themes`) already exists but is invisible to
+`check_surface_parity.py` because `theme` is not in `_KNOWN_ENTITIES`;
+that pre-existing asymmetry is documented in the script's exception
+catalogue as part of this change rather than silently expanded.
+
+## SQLite ↔ Supabase parity (§15)
+
+No schema change — the `themes` table exists since m024 and
+`seed_default_themes()` runs on both backends at startup
+(`startup.py:205`, `:251-257`) via the same `INSERT OR REPLACE`
+upsert, so the new `geanz-default` row seeds identically on SQLite and
+Supabase. No new migration file is required; if any column is later
+added it must ship the paired SQLite + Supabase migration.
+
+## Dependencies
+
+- Supersedes nothing; depends on ADR-192 (the refresh whose clobber is
+  fixed here), the theme system (m024), and the Sparx import path.
+- Spec: `docs/adrs/specs/SPEC-230-A-GEANZ-Diagram-Render-Fidelity.md`.

--- a/docs/adrs/specs/SPEC-230-A-GEANZ-Diagram-Render-Fidelity.md
+++ b/docs/adrs/specs/SPEC-230-A-GEANZ-Diagram-Render-Fidelity.md
@@ -1,0 +1,107 @@
+# SPEC-230-A: GEANZ diagram render fidelity
+
+Implements **[ADR-230](../ADR-230-GEANZ-Diagram-Render-Fidelity.md)**.
+Living document — updated as the Playwright iterate-loop refines values.
+
+## Ground-truth reference
+
+- Canonical diagram: **CCS.00 Customer Service Delivery capability zone**
+  — `/tmp/geanz/EARoot/EA1/EA34.png` (EA page `EA33.htm`).
+- Live Iris equivalent: view `e5549ec8-b5c9-4e7b-8710-4ce02b83ceaa` in
+  set `7f2521de-d7c8-41ba-982c-d1246ba81428`.
+- Colours pixel-sampled from `EA34.png`: zone fill `#ccf2fe`, all
+  borders `#4169e1` (royal blue); capabilities/pills white. (The
+  imported nodes already carry these in `data.visual`.)
+
+## Archetype → style table
+
+Keyed at import/repair time onto `node.data` (`stereotype` synthetic tag
++ enriched `visual`). The shared renderer stays GEANZ-agnostic; it only
+honours `visual` + theme rendering hints.
+
+| archetype | detect (import/repair) | bgColor | borderColor | borderWidth | borderStyle | cornerStyle / radius | italic | hideIcon | hideDescription | label align | zIndex |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| zone | name ends `capability zone` **or** `visual.bgColor==#ccf2fe` & large | `#ccf2fe` | `#4169e1` | 3 | solid | radius 14 | no | yes | yes | left | below children |
+| capability | default capability | `#ffffff` | `#4169e1` | 2 | solid | radius 10 | no | yes | yes | left | default |
+| proposed_capability | label ends `(redirect)` **or** EA dashed line | `#ffffff` | `#4169e1` | 2 | **dashed** | radius 10 | no | yes | yes | left | default |
+| theme_pill | `qualifier=='CBC Themes'` **or** name ends `(theme)` | `#ffffff` | `#4169e1` | 1 | **dashed** | **pill** | **yes** | yes | yes | center | default |
+| proposed_zone | name `…00a/00b/00c` & dashed | `#ffffff` | `#4169e1` | 2 | **dashed** | radius 14 | **yes** | yes | yes | left | below children |
+| note | `entityType=='note'` | `#ffffff` | `#000000` | 1 | solid | radius 0 | no | n/a | (keep) | left | default |
+
+Exact px (borderWidth, radius) are refined against screenshots during
+the iterate-loop; the table is the starting point.
+
+## Acceptance criteria
+
+### AC1 — flip is fixed (the regression)
+- Open `/views/<ccs00>`; after the `/api/elements/{id}` refresh batch
+  resolves, every node's computed `background-color` / `border-color` /
+  width is **unchanged** from the first paint. Zone stays `#ccf2fe` and
+  ~866×390; capabilities stay white with `#4169e1` border. No node flips
+  to white/thin-black/iris-default-uml. Holds in view **and** edit mode.
+
+### AC2 — `NodeVisualOverrides` radius/pill
+- `nodeOverrideStyle({cornerStyle:'pill'})` → contains `border-radius:
+  9999px`; `nodeOverrideStyle({borderRadius:14})` → `border-radius:
+  14px`. Unit-tested.
+
+### AC3 — `ArchimateRenderer` rendering hints
+- With theme/ node `hideIcons`/`hideDescription`, the rendered node has
+  **no** `.archimate-node__icon` and **no** `.archimate-node__description`.
+- `textAlign:'left'` → header is left-aligned. Default (no hints) is
+  unchanged from today (icon + description + centred).
+
+### AC4 — `geanz-default` theme seeded
+- After startup, `GET /api/themes?notation=uml` includes
+  `id='geanz-default'` with `rendering.hideIcons==true`,
+  `rendering.hideDescription==true`, `rendering.borderRadius==10`,
+  `rendering.textAlign=='left'`, and `element_defaults.capability`
+  white/`#4169e1`. Seeds identically on SQLite + Supabase.
+
+### AC5 — import classification + theme_id
+- Importing a minimal GEANZ fixture XMI (1 zone + 3 capabilities +
+  1 theme-pill + 1 redirect) yields nodes whose `data.visual` matches
+  the archetype table (dashed pill is `borderStyle:'dashed'`,
+  `cornerStyle:'pill'`, `italic:true`; zone `cornerStyle/ radius` set;
+  all `hideIcon`/`hideDescription` true) and the diagram
+  `metadata.theme_id=='geanz-default'`; the zone node has a lower
+  z-index than its children.
+
+### AC6 — Playwright fidelity assertions
+- Per archetype, computed CSS on the rendered node matches the table:
+  zone bg `rgb(204,242,254)`, border `rgb(65,105,225)`, solid, radius
+  ≈14px; capability bg white, border `rgb(65,105,225)`, solid, radius
+  ≈10px; proposed `border-style: dashed`; theme-pill `border-style:
+  dashed`, `font-style: italic`, radius ≥ half-height (pill). No icon /
+  description SVG/element present on any.
+- Screenshot saved to `tests/e2e/uat/screenshots/geanz-ccs00.png` for
+  human comparison vs `EA34.png`.
+
+## Files
+
+Frontend
+- `frontend/src/routes/views/[id]/+page.svelte` — F1 (refresh guard).
+- `frontend/src/lib/canvas/elementToNodeData.ts` — F1 (don't emit
+  clobbering `visual`/`notation` when absent on the element).
+- `frontend/src/lib/types/canvas.ts` — F2 (`borderRadius`,`cornerStyle`).
+- `frontend/src/lib/canvas/utils/visualStyles.ts` — F2 (emit radius).
+- `frontend/src/lib/canvas/renderers/ArchimateRenderer.svelte` — F3.
+- `frontend/tests/e2e/geanz-render.spec.ts` — F6.
+- `frontend/src/lib/canvas/utils/visualStyles.test.ts` — AC2.
+
+Backend
+- `backend/app/themes/service.py` — F4 (`geanz-default` seed).
+- `backend/app/import_sparx/*` (service/converter/mapper) — F5
+  (archetype classification + visual enrichment + theme_id + z-index).
+- `backend/tests/test_themes/…` — AC4.
+- `backend/tests/test_import_sparx*/…` + fixture XMI — AC5.
+
+Ops
+- `scripts/repair_geanz_render.py` — F5 data repair, dry-run default,
+  set-scoped to `7f2521de…`.
+
+## Out of scope
+- New `geanz` notation / dedicated renderer (ADR-230 alt 3).
+- Theme CRUD MCP tool + CLI (the §14 asymmetry is documented, not
+  closed, here).
+- Relabelling capabilities to EA codes (CCS.01 …); Iris keeps names.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.41.6",
+	"version": "6.42.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -19,12 +19,19 @@ const UAT_STORAGE_STATE = 'tests/e2e/uat/.auth/tester.json';
 // touches localhost:4173 / localhost:8000.
 const IS_UAT_RUN = process.env.PLAYWRIGHT_UAT === '1';
 
+// Fast-iteration escape hatch: point the local `e2e` project at an already-
+// running stack (e.g. the dev server on :5173 with HMR) by setting
+// IRIS_E2E_BASE_URL. When set we skip the build+preview webServer entirely
+// (the dev stack is assumed up, backend on :8000). Default behaviour —
+// build + preview on :4173 — is unchanged.
+const E2E_BASE_URL = process.env.IRIS_E2E_BASE_URL;
+
 export default defineConfig({
 	timeout: 30_000,
 	retries: 1,
 	workers: 1,
 	use: {
-		baseURL: 'http://localhost:4173',
+		baseURL: E2E_BASE_URL ?? 'http://localhost:4173',
 		actionTimeout: 10_000,
 		trace: 'on-first-retry',
 	},
@@ -108,7 +115,7 @@ export default defineConfig({
 			retries: 0,
 		},
 	],
-	webServer: IS_UAT_RUN
+	webServer: IS_UAT_RUN || E2E_BASE_URL
 		? undefined
 		: [
 				{

--- a/frontend/src/lib/canvas/renderers/ArchimateRenderer.svelte
+++ b/frontend/src/lib/canvas/renderers/ArchimateRenderer.svelte
@@ -4,9 +4,11 @@
 	 * Uses layer-based colour coding (business=yellow, application=blue,
 	 * technology=green, motivation=purple, strategy=red, implementation=grey).
 	 */
+	import { getContext } from 'svelte';
 	import { Handle, Position } from '@xyflow/svelte';
-	import type { CanvasNodeData, ArchimateLayer } from '$lib/types/canvas';
+	import type { CanvasNodeData, ArchimateLayer, NotationType } from '$lib/types/canvas';
 	import { nodeOverrideStyle, titleFontStyle, descFontStyle } from '$lib/canvas/utils/visualStyles';
+	import { getThemeRendering } from '$lib/stores/themeStore.svelte';
 	import IconDisplay from '$lib/icons/IconDisplay.svelte';
 
 	interface Props {
@@ -15,6 +17,16 @@
 	}
 
 	let { data, selected = false }: Props = $props();
+
+	// ADR-230 F3: honour theme rendering hints (like UmlRenderer/NoteNode) plus
+	// per-node overrides, so GEANZ capability nodes can hide the ArchiMate icon
+	// and the description and align their label, matching the EA ground-truth.
+	const notation = getContext<NotationType>('notation') ?? 'archimate';
+	const preferredThemeId = getContext<string | undefined>('preferredThemeId');
+	const rendering = $derived(getThemeRendering(notation, preferredThemeId));
+	const hideIcons = $derived((rendering?.hideIcons ?? false) || (data.visual?.hideIcon ?? false));
+	const hideDesc = $derived((rendering?.hideDescription ?? false) || (data.hideDescription ?? false));
+	const headerAlign = $derived(rendering?.textAlign);
 
 	/** Derive ArchiMate layer from entityType when not explicitly set. */
 	function deriveLayer(entityType: string): ArchimateLayer {
@@ -147,24 +159,25 @@
 	class="archimate-node archimate-node--{layer}"
 	class:archimate-node--selected={selected}
 	class:archimate-node--fixed={hasFixedSize}
+	class:archimate-node--align-left={headerAlign === 'left'}
 	style={visualStyle}
 	aria-label="{data.label}, {data.entityType}"
 >
-	{#if hasCustomIcon && data.visual?.icon}
+	{#if !hideIcons && hasCustomIcon && data.visual?.icon}
 		<span class="archimate-node__icon" aria-hidden="true">
 			<IconDisplay icon={data.visual.icon} size={14} color={iconColor} />
 		</span>
-	{:else if iconSvg}
+	{:else if !hideIcons && iconSvg}
 		<span class="archimate-node__icon" aria-hidden="true">
 			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="14" height="14">
 				{@html iconSvg}
 			</svg>
 		</span>
 	{/if}
-	<div class="archimate-node__header">
+	<div class="archimate-node__header" style={headerAlign ? `text-align: ${headerAlign}` : ''}>
 		<span class="archimate-node__label" style={titleStyle}>{data.label}</span>
 	</div>
-	{#if data.description}
+	{#if data.description && !hideDesc}
 		<div class="archimate-node__description" style={descStyle}>{data.description}</div>
 	{/if}
 	{#if data.browseMode && data.entityId}
@@ -239,6 +252,15 @@
 		white-space: nowrap;
 		display: block;
 	}
+	/* GEANZ/EA: zones + capabilities anchor their label top-left, not centred
+	   (ADR-230 F3). Driven by the theme's rendering.textAlign === 'left'. */
+	.archimate-node--align-left { text-align: left; }
+	.archimate-node--align-left.archimate-node--fixed {
+		justify-content: flex-start;
+		align-items: stretch;
+	}
+	.archimate-node--align-left .archimate-node__header { text-align: left; width: 100%; }
+	.archimate-node--align-left.archimate-node--fixed .archimate-node__label { white-space: normal; }
 	/* Layer colours — match EA/ArchiMate standard palette */
 	.archimate-node--business { background: #ffffb5; border-color: #b09a40; color: #333; }
 	.archimate-node--application { background: #b5ffff; border-color: #4098ad; color: #1a4a5a; }

--- a/frontend/src/lib/canvas/utils/visualStyles.ts
+++ b/frontend/src/lib/canvas/utils/visualStyles.ts
@@ -10,6 +10,10 @@ export function nodeOverrideStyle(visual?: NodeVisualOverrides, fixedSize?: bool
 	if (visual.fontColor) parts.push(`color: ${visual.fontColor}`);
 	if (visual.borderWidth != null) parts.push(`border-width: ${visual.borderWidth}px`);
 	if (visual.borderStyle) parts.push(`border-style: ${visual.borderStyle}`);
+	// Corner radius / pill (ADR-230 F2). 'pill' wins over an explicit radius.
+	if (visual.cornerStyle === 'pill') parts.push('border-radius: 9999px');
+	else if (visual.cornerStyle === 'sharp') parts.push('border-radius: 0');
+	else if (visual.borderRadius != null) parts.push(`border-radius: ${visual.borderRadius}px`);
 	if (visual.fontSize != null && visual.fontSize > 0) parts.push(`font-size: ${visual.fontSize}px`);
 	if (visual.bold) parts.push('font-weight: bold');
 	if (visual.italic) parts.push('font-style: italic');

--- a/frontend/src/lib/types/canvas.ts
+++ b/frontend/src/lib/types/canvas.ts
@@ -59,9 +59,15 @@ export interface NodeVisualOverrides {
 	bold?: boolean;
 	italic?: boolean;
 	borderStyle?: string;
+	/** Corner radius in px (ADR-230 F2). Ignored when cornerStyle is set. */
+	borderRadius?: number;
+	/** 'pill' = fully rounded; 'rounded' = use borderRadius; 'sharp' = no radius. */
+	cornerStyle?: 'pill' | 'rounded' | 'sharp';
 	width?: number;
 	height?: number;
 	icon?: IconRef;
+	/** Suppress the notation icon on this node (ADR-230 F3, GEANZ). */
+	hideIcon?: boolean;
 	/** Icon colour override (for navigation cell NID icons). */
 	iconColor?: string;
 	/** Description-specific font overrides. */

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -685,11 +685,27 @@
 						? rawDesc.slice(rawDesc.indexOf('\n') + 1).replace(/^\r?\n/, '')
 						: rawDesc;
 					const prev = node.data as Record<string, unknown>;
-					const next: Record<string, unknown> = { ...node.data, ...hydrated, description: desc };
+					// ADR-230 F1: the element refresh must not clobber per-node
+					// presentation the diagram owns. elementToNodeData() reports the
+					// *element's* visual/notation/entityType, which is absent for
+					// EA-styled nodes (e.g. GEANZ capabilities carry their fill/border
+					// + explicit size only on the canvas node, never on the element).
+					// Spreading those in wiped the themed visual and forced a
+					// SvelteFlow re-measure, flipping the canvas to the
+					// iris-default-uml look a few seconds after first paint. Strip
+					// them so only genuine content fields refresh; node.data's own
+					// visual/notation/entityType survive untouched.
+					const { visual: _v, notation: _n, entityType: _et, ...contentOnly } =
+						hydrated as Record<string, unknown>;
+					void _v; void _n; void _et;
+					const next: Record<string, unknown> = { ...node.data, ...contentOnly, description: desc };
 					const diffKeys = [
 						'label', 'description', 'diagramUsageCount',
 						'attributes', 'operations', 'literals',
 						'stereotype', 'qualifier',
+						// Defence-in-depth: presentation is preserved above, but gate
+						// it too so a future change can't silently commit a stripped node.
+						'visual', 'notation', 'entityType',
 					];
 					const changed = diffKeys.some((k) =>
 						JSON.stringify(next[k]) !== JSON.stringify(prev[k]),

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -120,6 +120,49 @@ export async function createEntity(
 }
 
 /**
+ * Create an element via POST /api/elements and return the response body.
+ * (The element domain is `/api/elements` with `element_type`; the older
+ * `createEntity` helper targets a route that no longer exists.)
+ */
+export async function createElement(
+	baseURL: string | undefined,
+	token: string,
+	data: {
+		name: string;
+		element_type: string;
+		description?: string;
+		data?: Record<string, unknown>;
+		set_id?: string;
+		package_id?: string;
+		notation?: string;
+		metadata?: Record<string, unknown>;
+	},
+): Promise<Record<string, unknown>> {
+	const origin = baseURL ?? API_BASE;
+	const res = await fetchWithRetry(`${origin}/api/elements`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({
+			element_type: data.element_type,
+			name: data.name,
+			description: data.description ?? '',
+			data: data.data ?? {},
+			set_id: data.set_id ?? null,
+			package_id: data.package_id ?? null,
+			notation: data.notation ?? 'simple',
+			metadata: data.metadata ?? null,
+		}),
+	});
+	if (!res.ok) {
+		throw new Error(`createElement failed: ${res.status} ${await res.text()}`);
+	}
+	return (await res.json()) as Record<string, unknown>;
+}
+
+/**
  * Create a model via the API and return the response body.
  */
 export async function createModel(
@@ -217,6 +260,9 @@ export async function createDiagram(
 		name: string;
 		description?: string;
 		data?: Record<string, unknown>;
+		set_id?: string;
+		parent_package_id?: string;
+		metadata?: Record<string, unknown>;
 	},
 ): Promise<Record<string, unknown>> {
 	const origin = baseURL ?? API_BASE;
@@ -232,6 +278,9 @@ export async function createDiagram(
 			name: data.name,
 			description: data.description ?? '',
 			data: data.data ?? {},
+			set_id: data.set_id ?? null,
+			parent_package_id: data.parent_package_id ?? null,
+			metadata: data.metadata ?? null,
 		}),
 	});
 	if (!res.ok) {

--- a/frontend/tests/e2e/geanz-render.spec.ts
+++ b/frontend/tests/e2e/geanz-render.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * ADR-230 / SPEC-230-A: GEANZ diagram render fidelity.
+ *
+ * Seeds a CCS.00-shaped capability diagram (zone + capabilities + a
+ * dashed redirect + dashed theme pills) whose source ELEMENTS carry no
+ * visual — exactly like the real GEANZ import, where the EA fill/border
+ * lives only on the canvas node. Then:
+ *
+ *  - AC1 (the flip regression): after the post-paint /api/elements/{id}
+ *    refresh batch settles, every node's computed style is STILL the
+ *    themed look (zone #ccf2fe + ~866px wide, capabilities white with a
+ *    royal-blue border) — it must NOT flip to the iris-default-uml look.
+ *  - AC6 (fidelity): per-archetype computed CSS matches the ground-truth
+ *    (fills, royal-blue borders, dashed pills/redirect, rounded corners,
+ *    italic pills, no ArchiMate icon, no description text).
+ *
+ * A screenshot is saved for human comparison against
+ * /tmp/geanz/EARoot/EA1/EA34.png (the EA ground-truth for CCS.00).
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+import {
+	seedAdmin,
+	getAuthToken,
+	loginAsAdmin,
+	createSet,
+	createPackage,
+	createElement,
+	createDiagram,
+} from './fixtures';
+
+const ROYAL_BLUE = 'rgb(65, 105, 225)'; // #4169e1
+const ZONE_FILL = 'rgb(204, 242, 254)'; // #ccf2fe
+const WHITE = 'rgb(255, 255, 255)';
+
+const CAP = (
+	extra: Record<string, unknown>,
+): Record<string, unknown> => ({
+	bgColor: '#ffffff',
+	borderColor: '#4169e1',
+	borderWidth: 2,
+	borderRadius: 10,
+	...extra,
+});
+
+/** Read a computed style property off a rendered node's renderer root. */
+async function nodeStyle(page: Page, id: string, prop: string): Promise<string> {
+	return page
+		.locator(`.svelte-flow__node[data-id="${id}"] .archimate-node`)
+		.first()
+		.evaluate((el, p) => getComputedStyle(el).getPropertyValue(p), prop);
+}
+
+async function labelStyle(page: Page, id: string, prop: string): Promise<string> {
+	return page
+		.locator(`.svelte-flow__node[data-id="${id}"] .archimate-node__label`)
+		.first()
+		.evaluate((el, p) => getComputedStyle(el).getPropertyValue(p), prop);
+}
+
+test.describe('GEANZ diagram render fidelity (ADR-230)', () => {
+	let viewId: string;
+
+	test.beforeAll(async ({ baseURL }) => {
+		await seedAdmin(baseURL);
+		const token = await getAuthToken(baseURL);
+
+		const set = await createSet(baseURL, token, { name: `GEANZ Render ${Date.now()}` });
+		const setId = set.id as string;
+		const pkg = await createPackage(baseURL, token, { name: 'CBC', set_id: setId });
+		const pkgId = pkg.id as string;
+
+		// Source elements carry NO data.visual — like the real GEANZ import.
+		const mk = async (name: string) =>
+			(await createElement(baseURL, token, {
+				name,
+				element_type: 'capability',
+				notation: 'archimate',
+				set_id: setId,
+				package_id: pkgId,
+				description: `${name} — generic capability description that the EA ground-truth does not show inside the box.`,
+				data: { stereotype: 'ArchiMate_Capability' },
+			})).id as string;
+
+		const zoneId = await mk('Customer Service Delivery capability zone');
+		const stratId = await mk('Service Delivery Strategy');
+		const planId = await mk('Service Delivery Planning');
+		const caseId = await mk('Case Management');
+		const redirectId = await mk('Product and Service Management (redirect)');
+		const pStrategyId = await mk('Strategy (theme)');
+		const pPlanningId = await mk('Planning (theme)');
+
+		const capNode = (
+			id: string,
+			entityId: string,
+			label: string,
+			x: number,
+			y: number,
+			visual: Record<string, unknown>,
+			extraData: Record<string, unknown> = {},
+		) => ({
+			id,
+			type: 'capability',
+			position: { x, y },
+			zIndex: 2,
+			data: {
+				label,
+				entityType: 'capability',
+				entityId,
+				description: `${label} — description text`,
+				stereotype: 'ArchiMate_Capability',
+				visual,
+				...extraData,
+			},
+		});
+
+		const nodes = [
+			// Zone — light-blue fill, thick royal-blue border, larger radius,
+			// rendered BEHIND its children (lower zIndex).
+			{
+				id: 'zone',
+				type: 'capability',
+				position: { x: 7, y: 124 },
+				zIndex: 0,
+				data: {
+					label: 'Customer Service Delivery capability zone',
+					entityType: 'capability',
+					entityId: zoneId,
+					description: 'Generic customer service delivery capabilities.',
+					stereotype: 'ArchiMate_Capability',
+					visual: {
+						bgColor: '#ccf2fe',
+						borderColor: '#4169e1',
+						borderWidth: 3,
+						borderRadius: 14,
+						width: 866,
+						height: 390,
+					},
+				},
+			},
+			capNode('cap-strat', stratId, 'Service Delivery Strategy', 27, 174, CAP({ width: 266, height: 55 })),
+			capNode('cap-plan', planId, 'Service Delivery Planning', 305, 174, CAP({ width: 266, height: 55 })),
+			capNode('cap-case', caseId, 'Case Management', 582, 241, CAP({ width: 266, height: 55 })),
+			// Redirect / proposed — dashed border.
+			capNode('redirect', redirectId, 'Product and Service Management (redirect)', 582, 307,
+				CAP({ width: 266, height: 44, borderStyle: 'dashed' })),
+			// Theme pills — white, dashed, pill-shaped, italic, qualifier 'CBC Themes'.
+			capNode('pill-strategy', pStrategyId, 'Strategy (theme)', 170, 80,
+				{ bgColor: '#ffffff', borderColor: '#4169e1', borderWidth: 1, borderStyle: 'dashed', cornerStyle: 'pill', italic: true, width: 122, height: 30 },
+				{ qualifier: 'CBC Themes' }),
+			capNode('pill-planning', pPlanningId, 'Planning (theme)', 353, 80,
+				{ bgColor: '#ffffff', borderColor: '#4169e1', borderWidth: 1, borderStyle: 'dashed', cornerStyle: 'pill', italic: true, width: 132, height: 30 },
+				{ qualifier: 'CBC Themes' }),
+			// Notes — title + date stamp (no entityId → not refreshed).
+			{ id: 'note-title', type: 'note', position: { x: 253, y: 0 }, zIndex: 3,
+				data: { label: 'Common Customer Service Delivery (CCS) capability zone', entityType: 'note', description: 'capability areas', visual: { width: 627, height: 62 } } },
+			{ id: 'note-date', type: 'note', position: { x: 1, y: 24 }, zIndex: 3,
+				data: { label: 'August 2025', entityType: 'note', description: 'August 2025', visual: { width: 148, height: 30 } } },
+		];
+
+		const edges = [
+			{ id: 'e1', source: 'pill-strategy', target: 'cap-strat', type: 'association',
+				data: { relationshipType: 'association', stereotype: 'ArchiMate_Association' }, sourceHandle: 'bottom', targetHandle: 'top' },
+			{ id: 'e2', source: 'pill-planning', target: 'cap-plan', type: 'association',
+				data: { relationshipType: 'association', stereotype: 'ArchiMate_Association' }, sourceHandle: 'bottom', targetHandle: 'top' },
+		];
+
+		const diagram = await createDiagram(baseURL, token, {
+			diagram_type: 'class',
+			notation: 'uml',
+			name: 'CCS.00 Customer Service Delivery capability zone',
+			set_id: setId,
+			parent_package_id: pkgId,
+			metadata: { theme_id: 'geanz-default' },
+			data: { nodes, edges },
+		});
+		viewId = diagram.id as string;
+	});
+
+	test('renders the GEANZ archetypes faithfully and does not flip to UML default', async ({ page }) => {
+		await loginAsAdmin(page);
+		await page.goto(`/views/${viewId}`);
+		await expect(page.getByText('Loading diagram...')).toHaveCount(0, { timeout: 20_000 });
+		await expect(page.locator('.svelte-flow__node[data-id="zone"] .archimate-node')).toBeVisible();
+
+		// Let the post-paint /api/elements/{id} refresh batch run to completion —
+		// this is exactly what used to flip the diagram to iris-default-uml.
+		await page.waitForLoadState('networkidle');
+		await page.waitForTimeout(1500);
+
+		// AC1 — the zone survived the refresh: still light-blue, still ~866 wide.
+		expect(await nodeStyle(page, 'zone', 'background-color')).toBe(ZONE_FILL);
+		expect(await nodeStyle(page, 'zone', 'border-color')).toBe(ROYAL_BLUE);
+		expect(await nodeStyle(page, 'zone', 'border-top-style')).toBe('solid');
+		const zoneW = parseFloat(await nodeStyle(page, 'zone', 'width'));
+		expect(zoneW).toBeGreaterThan(800); // did NOT shrink/re-measure
+		expect(parseFloat(await nodeStyle(page, 'zone', 'border-top-left-radius'))).toBeGreaterThanOrEqual(12);
+
+		// AC6 — capability: white fill, royal-blue solid border, ~10px radius.
+		for (const id of ['cap-strat', 'cap-plan', 'cap-case']) {
+			expect(await nodeStyle(page, id, 'background-color')).toBe(WHITE);
+			expect(await nodeStyle(page, id, 'border-color')).toBe(ROYAL_BLUE);
+			expect(await nodeStyle(page, id, 'border-top-style')).toBe('solid');
+			expect(parseFloat(await nodeStyle(page, id, 'border-top-left-radius'))).toBeGreaterThanOrEqual(8);
+		}
+
+		// AC6 — redirect / proposed: dashed border.
+		expect(await nodeStyle(page, 'redirect', 'border-top-style')).toBe('dashed');
+
+		// AC6 — theme pills: dashed, pill radius, italic label.
+		for (const id of ['pill-strategy', 'pill-planning']) {
+			expect(await nodeStyle(page, id, 'border-top-style')).toBe('dashed');
+			expect(parseFloat(await nodeStyle(page, id, 'border-top-left-radius'))).toBeGreaterThanOrEqual(100);
+			expect(await labelStyle(page, id, 'font-style')).toBe('italic');
+		}
+
+		// AC6 — no ArchiMate icon and no description text on any capability node
+		// (the geanz-default theme hides both).
+		expect(await page.locator('.svelte-flow__node[data-id="zone"] .archimate-node__icon').count()).toBe(0);
+		expect(await page.locator('.svelte-flow__node[data-id="cap-strat"] .archimate-node__icon').count()).toBe(0);
+		expect(await page.locator('.svelte-flow__node[data-id="cap-strat"] .archimate-node__description').count()).toBe(0);
+
+		// Evidence screenshot for human comparison vs EA34.png.
+		await page.locator('.svelte-flow__viewport').first().screenshot({
+			path: 'tests/e2e/uat/screenshots/geanz-ccs00.png',
+		});
+	});
+});

--- a/frontend/tests/unit/visualStylesRadius.test.ts
+++ b/frontend/tests/unit/visualStylesRadius.test.ts
@@ -1,0 +1,47 @@
+/**
+ * ADR-230 F2 / SPEC-230-A AC2: nodeOverrideStyle emits a corner radius
+ * from NodeVisualOverrides (borderRadius / cornerStyle) so EA-styled and
+ * GEANZ nodes can be rounded or pill-shaped without a theme-schema change.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { nodeOverrideStyle } from '$lib/canvas/utils/visualStyles';
+
+describe('nodeOverrideStyle border radius (ADR-230 F2)', () => {
+	it('emits a pill radius for cornerStyle: pill', () => {
+		expect(nodeOverrideStyle({ cornerStyle: 'pill' })).toContain('border-radius: 9999px');
+	});
+
+	it('emits 0 radius for cornerStyle: sharp', () => {
+		expect(nodeOverrideStyle({ cornerStyle: 'sharp' })).toContain('border-radius: 0');
+	});
+
+	it('emits an explicit px radius for borderRadius', () => {
+		expect(nodeOverrideStyle({ borderRadius: 14 })).toContain('border-radius: 14px');
+	});
+
+	it('lets cornerStyle: pill win over an explicit borderRadius', () => {
+		const style = nodeOverrideStyle({ cornerStyle: 'pill', borderRadius: 10 });
+		expect(style).toContain('border-radius: 9999px');
+		expect(style).not.toContain('border-radius: 10px');
+	});
+
+	it('emits no border-radius when neither is set (back-compat)', () => {
+		expect(nodeOverrideStyle({ bgColor: '#ccf2fe' })).not.toContain('border-radius');
+	});
+
+	it('still carries the GEANZ zone fill + border + dashed style', () => {
+		const style = nodeOverrideStyle({
+			bgColor: '#ccf2fe',
+			borderColor: '#4169e1',
+			borderWidth: 3,
+			borderStyle: 'solid',
+			borderRadius: 14,
+		});
+		expect(style).toContain('background-color: #ccf2fe');
+		expect(style).toContain('border-color: #4169e1');
+		expect(style).toContain('border-width: 3px');
+		expect(style).toContain('border-radius: 14px');
+	});
+});

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.41.6"
+version = "6.42.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.41.6"
+version = "6.42.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/scripts/check_surface_parity.py
+++ b/scripts/check_surface_parity.py
@@ -141,6 +141,12 @@ _KNOWN_ENTITIES = frozenset({
     "collection", "set", "package", "diagram", "element",
     # v6.8.0 (ADR-191) — element templates have full write parity.
     "element_template",
+    # NOTE: `theme` is intentionally NOT a known entity. Theme CRUD
+    # (POST/PUT /api/themes) is an admin-only styling surface with no MCP
+    # tool or CLI subcommand by design (ADR-230) — themes are seeded
+    # server-side and edited in the admin UI, not authored by agents. If
+    # theme authoring is ever exposed to MCP/CLI, add "theme" here so the
+    # §14 parity check starts enforcing it.
 })
 
 

--- a/scripts/repair_geanz_render.py
+++ b/scripts/repair_geanz_render.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+"""Repair GEANZ diagram rendering on an existing set (ADR-230 F5).
+
+Enriches every capability diagram in ONE explicitly-named set so it
+renders faithfully to the Sparx EA ground-truth: rounded corners, dashed
+theme pills + redirects, pill + italic theme pills, the zone behind its
+children, and `metadata.theme_id = 'geanz-default'`. The per-node colours
+(EA fill/border) are already present and are preserved untouched.
+
+This is a TARGETED, IDEMPOTENT, DRY-RUN-FIRST data repair (per the
+prod-data-repair-scoping discipline): it touches only the set you name on
+the command line, prints exactly what it would change, and writes nothing
+unless you pass --apply. The archetype/enrichment rule is imported from
+app.import_sparx.geanz so it stays identical to the importer.
+
+Examples:
+  # dry-run against the local dev backend (default)
+  uv run python scripts/repair_geanz_render.py \
+      --set-id 7f2521de-d7c8-41ba-982c-d1246ba81428 \
+      --username admin --password TestPassword12345
+
+  # apply against UAT with an externally-minted PAT
+  uv run python scripts/repair_geanz_render.py \
+      --api-base https://iris-api-... --token "$IRIS_PAT" \
+      --set-id 7f2521de-d7c8-41ba-982c-d1246ba81428 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+import urllib.error
+import urllib.request
+
+sys.path.insert(0, "backend")
+from app.import_sparx.geanz import apply_geanz_styling  # noqa: E402
+
+
+def _req(method: str, url: str, token: str | None, body: dict | None = None,
+         extra_headers: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if extra_headers:
+        headers.update(extra_headers)
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {url} -> {e.code} {e.read().decode()[:300]}") from e
+
+
+def _login(api_base: str, username: str, password: str) -> str:
+    out = _req("POST", f"{api_base}/api/auth/login", None,
+               {"username": username, "password": password})
+    return out["access_token"]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Repair GEANZ diagram rendering for one set.")
+    ap.add_argument("--api-base", default="http://localhost:8000")
+    ap.add_argument("--set-id", required=True, help="The ONLY set that will be touched.")
+    ap.add_argument("--token", help="Bearer token / PAT (preferred for Supabase deployments).")
+    ap.add_argument("--username")
+    ap.add_argument("--password")
+    ap.add_argument("--apply", action="store_true", help="Write changes (default: dry-run).")
+    args = ap.parse_args()
+
+    token = args.token
+    if not token and args.username and args.password:
+        token = _login(args.api_base, args.username, args.password)
+    if not token:
+        ap.error("provide --token, or --username and --password")
+
+    # List all diagrams in the named set (paginated).
+    diagrams: list[dict] = []
+    page = 1
+    while True:
+        out = _req("GET", f"{args.api_base}/api/diagrams?set_id={args.set_id}&page={page}&page_size=100", token)
+        items = out.get("items", out if isinstance(out, list) else [])
+        diagrams.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+
+    print(f"Set {args.set_id}: {len(diagrams)} diagram(s). Mode: {'APPLY' if args.apply else 'DRY-RUN'}\n")
+    changed = 0
+    for d in diagrams:
+        full = _req("GET", f"{args.api_base}/api/diagrams/{d['id']}", token)
+        data = full.get("data") or {}
+        nodes = data.get("nodes") or []
+        before = copy.deepcopy(nodes)
+        is_geanz = apply_geanz_styling(nodes)
+        meta = dict(full.get("metadata") or {})
+        theme_before = meta.get("theme_id")
+        if is_geanz:
+            meta["theme_id"] = "geanz-default"
+        node_changed = nodes != before
+        theme_changed = meta.get("theme_id") != theme_before
+        if not is_geanz or (not node_changed and not theme_changed):
+            print(f"  - {full.get('name','?')[:60]:60}  (no change)")
+            continue
+        changed += 1
+        n_enriched = sum(1 for a, b in zip(nodes, before) if a != b)
+        print(f"  ✓ {full.get('name','?')[:60]:60}  nodes_enriched={n_enriched}  theme_id={theme_before}->{meta['theme_id']}")
+        if args.apply:
+            _req("PUT", f"{args.api_base}/api/diagrams/{d['id']}", token, {
+                "name": full["name"],
+                "description": full.get("description") or "",
+                "data": {**data, "nodes": nodes},
+                "metadata": meta,
+                "change_summary": "GEANZ render fidelity (ADR-230): enrich node visuals + geanz-default theme",
+            }, extra_headers={"If-Match": str(full.get("current_version", 1))})
+
+    print(f"\n{'Applied' if args.apply else 'Would change'} {changed} diagram(s).")
+    if not args.apply and changed:
+        print("Re-run with --apply to write these changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

GEANZ capability views (e.g. CCS.00, set `7f2521de…`) first painted close to the Sparx EA ground-truth, then **flipped to the `iris-default-uml` look** a few seconds later (white boxes, thin black borders, ArchiMate icons, re-laid-out). Editing a GEANZ model showed the same flat default. And even the good first paint wasn't fully faithful — it showed icons, descriptions, square corners, and non-dashed theme pills.

## Root cause (the flip)

`refreshNodeDescriptions()` (`views/[id]/+page.svelte`, the post-paint element refresh from ADR-192) re-hydrated every node from its source element and spread the result over `node.data`. GEANZ elements carry no `data.visual` (the EA fill/border + explicit size live only on the **canvas node**), so the spread overwrote the node's themed `visual` with `undefined` — colours vanished, SvelteFlow re-measured (re-layout), and capability nodes fell back to the UML default. The change-guard never protected `visual`/`notation`.

**Fix:** the refresh now strips presentation keys from the hydrated payload and preserves the node's own `visual`/`notation`/`entityType`, refreshing only genuine content fields (label, description, attributes, …). Verified the Playwright test goes **red** when the clobber is reintroduced.

## Fidelity (vs EA34.png ground-truth)

- New built-in **GEANZ Default** theme: white capabilities / royal-blue (`#4169e1`) borders, `hideIcons` + `hideDescription` + left-aligned labels + rounded corners.
- `NodeVisualOverrides` gains `borderRadius` / `cornerStyle: 'pill'`; `nodeOverrideStyle()` emits `border-radius`.
- `ArchimateRenderer` now honours theme rendering hints (`hideIcons`/`hideDescription`/`textAlign`) like the other renderers, plus per-node `hideIcon`/`hideDescription`, and anchors zone/capability labels top-left.
- Sparx importer classifies GEANZ archetypes (zone / capability / theme-pill / redirect) from name + `CBC Themes` qualifier, enriches each node's `visual` (dashed pills/redirects, pill+italic themes, rounded corners) + lowers the zone z-index so it sits **behind** its children, and points GEANZ diagrams at `geanz-default`.
- `scripts/repair_geanz_render.py` — targeted, **idempotent, dry-run-first** repair to apply the same enrichment to an already-imported set.

Result renders faithfully: light-cyan zones behind white royal-blue-bordered capabilities (no icons/descriptions), dashed italic theme pills, dashed redirect — matching `/tmp/geanz/EARoot/EA1/EA34.png`.

## Tests

- `frontend/tests/e2e/geanz-render.spec.ts` — seeds a CCS.00-shaped diagram whose source elements have no `visual` (like the real import), asserts per-archetype **computed** styles, captures an evidence screenshot, and **re-asserts after the `/api/elements` refresh settles** (the flip regression). Passes in both the dev and official (`:4173` preview) harnesses.
- Unit: `visualStylesRadius.test.ts` (radius/pill), `test_geanz_archetype.py` (classifier + enrichment, 13 cases), `test_geanz_theme.py` (seed). Existing theme/import suites green; surface-parity clean.

## Docs

ADR-230 + SPEC-230-A. Version bumped to **6.42.0** (all four files). No schema change (themes table exists since m024; `geanz-default` seeds on both SQLite + Supabase startup).

## Deploy / data

After merge + Render deploy, `geanz-default` seeds automatically and the flip fix applies to all diagrams. To bring the **existing** UAT GEANZ set to full fidelity, run (dry-run first):

```
uv run python scripts/repair_geanz_render.py --api-base <uat-api> --token <PAT> \
  --set-id 7f2521de-d7c8-41ba-982c-d1246ba81428        # add --apply to write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)