### PR TITLE
feat(v6.43.0): element → element containment (ADR-231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.43.0] - 2026-06-01
+
+### Added
+
+- **Element → element containment (ADR-231).** Elements can now own child
+  elements, forming a navigable hierarchy — a new optional
+  `parent_element_id` axis alongside package membership (ADR-184) and the
+  detail-diagram drill (ADR-221). This lets Sparx EA `nestedClassifier`
+  models import with their full depth: the GEANZ Common Business
+  Capabilities set (capability *zone* → capability → sub-capability, 3
+  levels) previously flattened to two packages because the importer read
+  each element's `<model package>` but dropped its `<model owner>`. The
+  XMI importer now reads `owner`, links child → parent in an idempotent
+  post-process pass, and the diagram-hierarchy tree nests the elements
+  under their parent element (or package), reusing the existing tree
+  component. The element page shows a "Parent element" link and a "Child
+  elements" list.
+  - Backend: nullable `elements.parent_element_id` (paired SQLite m081 +
+    Supabase m087 migrations); service validation (parent exists, same-set
+    only, no cycles, no self-parent → 422); tri-state on create/update;
+    `GET /api/elements/{id}/children` and `/ancestors`.
+  - Surface parity: `parent_element_id` is set via the existing
+    create/update verbs on backend, MCP and CLI (`--parent-element-id`) —
+    no new write verb, ADR-178 untouched.
+  - Manual drag-to-reparent is deferred to a later phase.
+
 ## [6.42.0] - 2026-06-01
 
 ### Fixed

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -907,10 +907,12 @@ async def get_diagram_hierarchy(
     params: list[object] = []
     pkg_set_filter = ""
     diag_set_filter = ""
+    elem_set_filter = ""
     if set_id is not None:
         pkg_set_filter = "AND p.set_id = ? "
         diag_set_filter = "AND d.set_id = ? "
-        params = [set_id, set_id]
+        elem_set_filter = "AND e.set_id = ? "
+        params = [set_id, set_id, set_id]
 
     # ADR-202: resolve sort preference for this scope. Sets without a
     # set_id (root_id-only or full-repo queries) fall back to 'manual'.
@@ -951,6 +953,23 @@ async def get_diagram_hierarchy(
         "  JOIN diagram_versions dv ON d.id = dv.diagram_id "
         "       AND d.current_version = dv.version "
         f"  WHERE d.is_deleted = 0 {diag_set_filter}"
+        # ADR-231: nested elements as tree nodes. Only elements INVOLVED in
+        # containment (have a parent element, or are themselves a parent) are
+        # included — so a flat element pool with no containment adds nothing
+        # and existing hierarchies are unchanged. The parent key is the parent
+        # element if set, else the package (the §E2 precedence rule).
+        "  UNION ALL "
+        "  SELECT e.id, ev.name, 'element' AS node_type, "
+        "         COALESCE(e.parent_element_id, e.package_id) AS parent_package_id, "
+        "         NULL AS diagram_type, NULL AS data, NULL AS notation, "
+        "         NULL AS sequence_order, e.created_at "
+        "  FROM elements e "
+        "  JOIN element_versions ev ON e.id = ev.element_id "
+        "       AND e.current_version = ev.version "
+        f"  WHERE e.is_deleted = 0 {elem_set_filter}"
+        "       AND (e.parent_element_id IS NOT NULL "
+        "            OR e.id IN (SELECT parent_element_id FROM elements "
+        "                        WHERE parent_element_id IS NOT NULL AND is_deleted = 0)) "
         ") t "
         f"ORDER BY {order_by}"  # noqa: S608 - order_by is from _HIERARCHY_ORDER_BY whitelist
     )

--- a/backend/app/elements/models.py
+++ b/backend/app/elements/models.py
@@ -28,6 +28,7 @@ class ElementCreate(BaseModel):
     set_id: str | None = None
     package_id: str | None = None
     detail_diagram_id: str | None = None
+    parent_element_id: str | None = None
     metadata: dict[str, object] | None = None
     notation: str = "simple"
     template_id: str | None = None
@@ -36,10 +37,10 @@ class ElementCreate(BaseModel):
 class ElementUpdate(BaseModel):
     """Request body for updating an element.
 
-    ``package_id`` and ``detail_diagram_id`` are tri-state: omit the key
-    to leave the column untouched, pass ``null`` (JSON) to clear, or pass
-    a string to set. The router translates these three states into a
-    kwarg passed to the service layer.
+    ``package_id``, ``detail_diagram_id`` and ``parent_element_id`` are
+    tri-state: omit the key to leave the column untouched, pass ``null``
+    (JSON) to clear, or pass a string to set. The router translates these
+    three states into a kwarg passed to the service layer.
     """
 
     name: str = Field(min_length=1, max_length=255)
@@ -49,6 +50,7 @@ class ElementUpdate(BaseModel):
     metadata: dict[str, object] | None = None
     package_id: Any = _UNSET
     detail_diagram_id: Any = _UNSET
+    parent_element_id: Any = _UNSET
 
 
 class ElementRollback(BaseModel):
@@ -79,6 +81,8 @@ class ElementResponse(BaseModel):
     package_id: str | None = None
     package_name: str | None = None
     detail_diagram_id: str | None = None
+    parent_element_id: str | None = None
+    parent_element_name: str | None = None
     metadata: dict[str, object] | None = None
     notation: str = "simple"
 

--- a/backend/app/elements/router.py
+++ b/backend/app/elements/router.py
@@ -25,9 +25,12 @@ from app.element_templates.service import (
 from app.elements.service import (
     ElementDetailDiagramError,
     ElementPackageInvariantError,
+    ElementParentInvariantError,
     cascade_delete_element,
     create_element,
     get_element,
+    get_element_ancestors,
+    get_element_children,
     get_element_version,
     get_element_versions,
     list_elements,
@@ -90,10 +93,12 @@ async def create(
             set_id=fields.get("set_id"),
             package_id=fields.get("package_id"),
             detail_diagram_id=fields.get("detail_diagram_id"),
+            parent_element_id=fields.get("parent_element_id"),
             metadata=fields.get("metadata"),
             notation=fields.get("notation") or "simple",
         )
-    except (ElementPackageInvariantError, ElementDetailDiagramError) as exc:
+    except (ElementPackageInvariantError, ElementDetailDiagramError,
+            ElementParentInvariantError) as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
 
     # Apply template-supplied tags (if any) to the element_tags table.
@@ -328,6 +333,48 @@ async def get_package_memberships(
     return [PackageMembership(id=str(package_id), name=str(package_name))]
 
 
+class ElementTreeNode(BaseModel):
+    """A child or ancestor element in the containment tree (ADR-231)."""
+
+    id: str
+    name: str
+    element_type: str
+
+
+@router.get("/{element_id}/children", response_model=list[ElementTreeNode])
+async def get_children(
+    element_id: str,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> list[ElementTreeNode]:
+    """Direct child elements of this element (ADR-231 containment).
+
+    404 if the element is missing or soft-deleted.
+    """
+    db = request.app.state.db_manager.main_db
+    if await get_element(db, element_id) is None:
+        raise HTTPException(status_code=404, detail="Element not found")
+    rows = await get_element_children(db, element_id)
+    return [ElementTreeNode(**r) for r in rows]
+
+
+@router.get("/{element_id}/ancestors", response_model=list[ElementTreeNode])
+async def get_ancestors(
+    element_id: str,
+    request: Request,
+    _current_user: dict[str, Any] | None = Depends(get_optional_user),  # noqa: B008
+) -> list[ElementTreeNode]:
+    """Containment breadcrumb (root-first), excluding this element (ADR-231).
+
+    404 if the element is missing or soft-deleted.
+    """
+    db = request.app.state.db_manager.main_db
+    if await get_element(db, element_id) is None:
+        raise HTTPException(status_code=404, detail="Element not found")
+    rows = await get_element_ancestors(db, element_id)
+    return [ElementTreeNode(**r) for r in rows]
+
+
 @router.get("/{element_id}/data-tree")
 async def get_data_tree(
     element_id: str,
@@ -398,9 +445,12 @@ async def update(
         update_kwargs["package_id"] = body.package_id
     if body.detail_diagram_id is not _ELEMENT_UPDATE_UNSET:
         update_kwargs["detail_diagram_id"] = body.detail_diagram_id
+    if body.parent_element_id is not _ELEMENT_UPDATE_UNSET:
+        update_kwargs["parent_element_id"] = body.parent_element_id
     try:
         result = await update_element(db, element_id, **update_kwargs)
-    except (ElementPackageInvariantError, ElementDetailDiagramError) as exc:
+    except (ElementPackageInvariantError, ElementDetailDiagramError,
+            ElementParentInvariantError) as exc:
         raise HTTPException(status_code=422, detail=str(exc))  # noqa: B904
     if result is None:
         raise HTTPException(status_code=409, detail="Version conflict")

--- a/backend/app/elements/service.py
+++ b/backend/app/elements/service.py
@@ -34,6 +34,14 @@ class ElementDetailDiagramError(ValueError):
     """
 
 
+class ElementParentInvariantError(ValueError):
+    """Raised when an element's parent_element_id is invalid — missing,
+    soft-deleted, cross-set, a containment cycle, or self-parent (ADR-231).
+
+    The router translates this into HTTP 422 with the message intact.
+    """
+
+
 async def _validate_detail_diagram_exists(
     db: DatabasePort,
     detail_diagram_id: str | None,
@@ -92,6 +100,68 @@ async def _validate_element_package_set_consistency(
         raise ElementPackageInvariantError(msg)
 
 
+async def _validate_parent_element(
+    db: DatabasePort,
+    *,
+    parent_element_id: str | None,
+    set_id: str | None,
+    element_id: str | None = None,
+) -> None:
+    """Ensure ``parent_element_id`` is a live element in the same set, and
+    (on update) that linking it forms no cycle or self-parent (ADR-231).
+
+    ``None`` (clear / unset) is always valid. Element containment is
+    single-set — unlike the cross-set ADR-221 detail link.
+    """
+    if parent_element_id is None:
+        return
+    if element_id is not None and parent_element_id == element_id:
+        msg = "An element cannot be its own parent"
+        raise ElementParentInvariantError(msg)
+    cursor = await db.execute(
+        "SELECT set_id FROM elements WHERE id = ? AND is_deleted = 0",
+        (parent_element_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        msg = f"Parent element {parent_element_id} not found"
+        raise ElementParentInvariantError(msg)
+    parent_set_id = row[0]
+    if set_id is not None and parent_set_id is not None and parent_set_id != set_id:
+        msg = (
+            f"Element belongs to set {set_id} but parent element "
+            f"{parent_element_id} belongs to set {parent_set_id}"
+        )
+        raise ElementParentInvariantError(msg)
+    if element_id is not None:
+        await _validate_no_element_cycle(db, element_id, parent_element_id)
+
+
+async def _validate_no_element_cycle(
+    db: DatabasePort,
+    element_id: str,
+    proposed_parent_id: str,
+) -> None:
+    """Walk up the proposed parent's ancestry; reject if it reaches
+    ``element_id`` (a cycle). Mirrors ``packages.service.validate_no_cycle``.
+    """
+    seen: set[str] = set()
+    current: str | None = proposed_parent_id
+    while current is not None:
+        if current == element_id:
+            msg = "Cannot set parent: would create a containment cycle"
+            raise ElementParentInvariantError(msg)
+        if current in seen:
+            break  # pre-existing cycle elsewhere — bail rather than loop
+        seen.add(current)
+        cursor = await db.execute(
+            "SELECT parent_element_id FROM elements WHERE id = ? AND is_deleted = 0",
+            (current,),
+        )
+        r = await cursor.fetchone()
+        current = r[0] if r else None
+
+
 async def create_element(
     db: DatabasePort,
     *,
@@ -103,6 +173,7 @@ async def create_element(
     set_id: str | None = None,
     package_id: str | None = None,
     detail_diagram_id: str | None = None,
+    parent_element_id: str | None = None,
     metadata: dict[str, object] | None = None,
     change_summary: str | None = None,
     notation: str = "simple",
@@ -118,14 +189,18 @@ async def create_element(
         db, set_id=effective_set_id, package_id=package_id,
     )
     await _validate_detail_diagram_exists(db, detail_diagram_id)
+    # No cycle check at create — a brand-new id can't be an ancestor (ADR-231).
+    await _validate_parent_element(
+        db, parent_element_id=parent_element_id, set_id=effective_set_id,
+    )
 
     await db.execute(
         "INSERT INTO elements (id, element_type, current_version, "
         "created_at, created_by, updated_at, set_id, package_id, "
-        "detail_diagram_id, notation) "
-        "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?)",
+        "detail_diagram_id, parent_element_id, notation) "
+        "VALUES (?, ?, 1, ?, ?, ?, ?, ?, ?, ?, ?)",
         (element_id, element_type, now, created_by, now,
-         effective_set_id, package_id, detail_diagram_id, notation),
+         effective_set_id, package_id, detail_diagram_id, parent_element_id, notation),
     )
     await db.execute(
         "INSERT INTO element_versions (element_id, version, name, description, "
@@ -154,6 +229,7 @@ async def create_element(
         "set_id": effective_set_id,
         "package_id": package_id,
         "detail_diagram_id": detail_diagram_id,
+        "parent_element_id": parent_element_id,
         "metadata": metadata,
         "notation": notation,
     }
@@ -169,11 +245,15 @@ async def get_element(
         "ev.name, ev.description, ev.data, "
         "e.created_at, e.created_by, e.updated_at, e.is_deleted, "
         "u.username, e.set_id, s.name, ev.metadata, e.notation, "
-        "e.package_id, e.detail_diagram_id, "
+        "e.package_id, e.detail_diagram_id, e.parent_element_id, "
         "(SELECT pv.name FROM packages p "
         "  JOIN package_versions pv ON p.id = pv.package_id "
         "    AND p.current_version = pv.version "
-        "  WHERE p.id = e.package_id) AS package_name "
+        "  WHERE p.id = e.package_id) AS package_name, "
+        "(SELECT pev.name FROM elements pe "
+        "  JOIN element_versions pev ON pe.id = pev.element_id "
+        "    AND pe.current_version = pev.version "
+        "  WHERE pe.id = e.parent_element_id) AS parent_element_name "
         "FROM elements e "
         "JOIN element_versions ev ON e.id = ev.element_id "
         "AND e.current_version = ev.version "
@@ -204,7 +284,9 @@ async def get_element(
         "notation": row[14] or "simple",
         "package_id": row[15],
         "detail_diagram_id": row[16],
-        "package_name": row[17],
+        "parent_element_id": row[17],
+        "package_name": row[18],
+        "parent_element_name": row[19],
     }
 
     # Enrich with tags
@@ -306,11 +388,15 @@ async def list_elements(
         "ev.name, ev.description, ev.data, "
         "e.created_at, e.created_by, e.updated_at, e.is_deleted, "
         "e.set_id, s.name, ev.metadata, e.notation, "
-        "e.package_id, e.detail_diagram_id, "
+        "e.package_id, e.detail_diagram_id, e.parent_element_id, "
         "(SELECT pv.name FROM packages p "
         "  JOIN package_versions pv ON p.id = pv.package_id "
         "    AND p.current_version = pv.version "
-        "  WHERE p.id = e.package_id) AS package_name "
+        "  WHERE p.id = e.package_id) AS package_name, "
+        "(SELECT pev.name FROM elements pe "
+        "  JOIN element_versions pev ON pe.id = pev.element_id "
+        "    AND pe.current_version = pev.version "
+        "  WHERE pe.id = e.parent_element_id) AS parent_element_name "
         "FROM elements e "
         "JOIN element_versions ev ON e.id = ev.element_id "
         "AND e.current_version = ev.version "
@@ -339,7 +425,9 @@ async def list_elements(
             "notation": r[13] or "simple",
             "package_id": r[14],
             "detail_diagram_id": r[15],
-            "package_name": r[16],
+            "parent_element_id": r[16],
+            "package_name": r[17],
+            "parent_element_name": r[18],
         }
         for r in rows
     ]
@@ -378,8 +466,60 @@ async def list_elements(
     return items, total
 
 
+async def get_element_children(
+    db: DatabasePort,
+    element_id: str,
+) -> list[dict[str, object]]:
+    """Direct child elements (ADR-231), name + type, alphabetical."""
+    cursor = await db.execute(
+        "SELECT e.id, ev.name, e.element_type FROM elements e "
+        "JOIN element_versions ev ON e.id = ev.element_id "
+        "  AND e.current_version = ev.version "
+        "WHERE e.parent_element_id = ? AND e.is_deleted = 0 "
+        "ORDER BY ev.name",
+        (element_id,),
+    )
+    return [
+        {"id": r[0], "name": r[1], "element_type": r[2]}
+        for r in await cursor.fetchall()
+    ]
+
+
+async def get_element_ancestors(
+    db: DatabasePort,
+    element_id: str,
+) -> list[dict[str, object]]:
+    """Containment breadcrumb, root-first (ADR-231). Excludes the element
+    itself; cycle-guarded."""
+    chain: list[dict[str, object]] = []
+    seen: set[str] = set()
+    cursor = await db.execute(
+        "SELECT parent_element_id FROM elements WHERE id = ? AND is_deleted = 0",
+        (element_id,),
+    )
+    head = await cursor.fetchone()
+    current = head[0] if head else None
+    while current is not None and current not in seen:
+        seen.add(current)
+        c = await db.execute(
+            "SELECT e.id, ev.name, e.element_type, e.parent_element_id FROM elements e "
+            "JOIN element_versions ev ON e.id = ev.element_id "
+            "  AND e.current_version = ev.version "
+            "WHERE e.id = ? AND e.is_deleted = 0",
+            (current,),
+        )
+        row = await c.fetchone()
+        if row is None:
+            break
+        chain.append({"id": row[0], "name": row[1], "element_type": row[2]})
+        current = row[3]
+    chain.reverse()
+    return chain
+
+
 _UNSET_PACKAGE_ID: Any = object()
 _UNSET_DETAIL_DIAGRAM_ID: Any = object()
+_UNSET_PARENT_ELEMENT_ID: Any = object()
 
 
 async def update_element(
@@ -395,6 +535,7 @@ async def update_element(
     metadata: dict[str, object] | None = None,
     package_id: Any = _UNSET_PACKAGE_ID,
     detail_diagram_id: Any = _UNSET_DETAIL_DIAGRAM_ID,
+    parent_element_id: Any = _UNSET_PARENT_ELEMENT_ID,
 ) -> dict[str, object] | None:
     """Update an element with optimistic concurrency. Returns None on conflict.
 
@@ -424,6 +565,11 @@ async def update_element(
         )
     if detail_diagram_id is not _UNSET_DETAIL_DIAGRAM_ID:
         await _validate_detail_diagram_exists(db, detail_diagram_id)
+    if parent_element_id is not _UNSET_PARENT_ELEMENT_ID:
+        await _validate_parent_element(
+            db, parent_element_id=parent_element_id,
+            set_id=current_set_id, element_id=element_id,
+        )
 
     new_version = current_version + 1
     now = datetime.now(tz=UTC).isoformat()
@@ -441,6 +587,9 @@ async def update_element(
     if detail_diagram_id is not _UNSET_DETAIL_DIAGRAM_ID:
         set_clauses.append("detail_diagram_id = ?")
         set_params.append(detail_diagram_id)
+    if parent_element_id is not _UNSET_PARENT_ELEMENT_ID:
+        set_clauses.append("parent_element_id = ?")
+        set_params.append(parent_element_id)
     set_params.append(element_id)
     await db.execute(
         f"UPDATE elements SET {', '.join(set_clauses)} WHERE id = ?",  # noqa: S608

--- a/backend/app/import_sparx/reader.py
+++ b/backend/app/import_sparx/reader.py
@@ -43,6 +43,10 @@ class QeaElement:
     Alias: str | None = None
     PDATA1: str | None = None
     StyleEx: str | None = None
+    # EA object-id of the parent element (nestedClassifier owner), ADR-231.
+    # None for top-level / package-owned elements. Resolved to an Iris
+    # parent_element_id in a post-process pass by the orchestrator.
+    Parent_Object_ID: int | None = None
 
 
 @dataclass

--- a/backend/app/import_sparx/service.py
+++ b/backend/app/import_sparx/service.py
@@ -1026,4 +1026,24 @@ async def import_sparx_model(
     if linked_detail:
         await db.commit()
 
+    # 8. Post-process: populate elements.parent_element_id from nestedClassifier
+    # containment (ADR-231). elem.Parent_Object_ID is the EA object-id of the
+    # parent ELEMENT; now that every element has an Iris UUID, link child →
+    # parent. Idempotent and runs over ALL elements (incl. ones skipped on a
+    # re-import), so re-importing an existing set back-fills the links.
+    linked_parent = False
+    for elem in elements:
+        if not elem.Parent_Object_ID:
+            continue
+        child_iris = element_map.get(elem.Object_ID)
+        parent_iris = element_map.get(elem.Parent_Object_ID)
+        if child_iris and parent_iris and child_iris != parent_iris:
+            await db.execute(
+                "UPDATE elements SET parent_element_id = ? WHERE id = ?",
+                (parent_iris, child_iris),
+            )
+            linked_parent = True
+    if linked_parent:
+        await db.commit()
+
     return summary

--- a/backend/app/import_sparx_xml/reader.py
+++ b/backend/app/import_sparx_xml/reader.py
@@ -221,6 +221,15 @@ def parse_sparx_xmi(path: str) -> SparxXmiModel:
         obj_id = guid_to_int.get(idref, -1) if idref else -1
         parent_pkg_guid = m.get("package") if m is not None else None
         pkg_id = guid_to_int.get(parent_pkg_guid, 0) if parent_pkg_guid else 0
+        # nestedClassifier containment (ADR-231): <model owner="..."> points
+        # at the parent ELEMENT when it differs from the containing package
+        # GUID (same disambiguation the diagram loop uses for ADR-221).
+        owner_guid = m.get("owner") if m is not None else None
+        parent_obj_id = (
+            guid_to_int.get(owner_guid)
+            if owner_guid and owner_guid != parent_pkg_guid
+            else None
+        )
         name = _attr(el, "name")
         s_type = props.get("sType") if props is not None else None
         documentation = props.get("documentation") if props is not None else None
@@ -268,6 +277,7 @@ def parse_sparx_xmi(path: str) -> SparxXmiModel:
                 Bordercolor=appearance.get("BorderColor"),
                 BorderWidth=appearance.get("BorderWidth"),
                 Alias=props.get("alias") if props is not None else None,
+                Parent_Object_ID=parent_obj_id,
             )
         )
         _collect_attributes(el, obj_id, model)

--- a/backend/app/migrations/m081_element_parent_element.py
+++ b/backend/app/migrations/m081_element_parent_element.py
@@ -1,0 +1,35 @@
+"""Migration 081: Element → parent element containment (ADR-231).
+
+Adds nullable self-referencing ``parent_element_id`` column to ``elements``
+plus an index. No back-fill — every existing element keeps
+``parent_element_id = NULL``. This is the element-containment axis (an element
+owns child elements), so Sparx EA ``nestedClassifier`` trees (e.g. the GEANZ
+capability zone → capability → sub-capability hierarchy) import with depth.
+Orthogonal to ``package_id`` (ADR-184) and ``detail_diagram_id`` (ADR-221);
+carried on the element row, not versioned.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m081_element_parent_element"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    cursor = await db.execute("PRAGMA table_info(elements)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "parent_element_id" not in cols:
+        await db.execute(
+            "ALTER TABLE elements ADD COLUMN parent_element_id TEXT "
+            "REFERENCES elements(id)"
+        )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_elements_parent_element "
+        "ON elements(parent_element_id)"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m087_element_parent_element.sql
+++ b/backend/app/migrations/supabase/m087_element_parent_element.sql
@@ -1,0 +1,16 @@
+-- Migration 087: Element → parent element containment (ADR-231).
+--
+-- Adds nullable self-referencing ``parent_element_id`` column to
+-- ``elements`` plus an index. The element-containment axis: an element owns
+-- child elements, so Sparx EA nestedClassifier trees (GEANZ capability zone
+-- → capability → sub-capability) import with depth. Orthogonal to
+-- ``package_id`` (ADR-184) and ``detail_diagram_id`` (ADR-221).
+-- Mirrors SQLite m081.
+--
+-- Idempotent.
+
+ALTER TABLE public.elements
+    ADD COLUMN IF NOT EXISTS parent_element_id TEXT REFERENCES public.elements(id);
+
+CREATE INDEX IF NOT EXISTS idx_elements_parent_element
+    ON public.elements(parent_element_id);

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -85,6 +85,7 @@ from app.migrations.m077_seed_global_aggregation_profiles import up as m077_up
 from app.migrations.m078_aggregation_list_diagram_type import up as m078_up
 from app.migrations.m079_rename_quantified_item_to_ingredient import up as m079_up
 from app.migrations.m080_element_detail_diagram import up as m080_up
+from app.migrations.m081_element_parent_element import up as m081_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -196,6 +197,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m078_up(main)  # issue #211, v6.21.0: register aggregation_list diagram type (ADR-213)
     await m079_up(main)  # issue #211, v6.29.0: rename seeded "Quantified item" → "Ingredient"
     await m080_up(main)  # issue #242, v6.33.0: elements.detail_diagram_id drill link (ADR-221)
+    await m081_up(main)  # v6.43.0: elements.parent_element_id containment axis (ADR-231)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.42.0"
+version = "6.43.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_elements/test_parent_element.py
+++ b/backend/tests/test_elements/test_parent_element.py
@@ -1,0 +1,189 @@
+"""Integration tests for element → element containment (ADR-231).
+
+Covers:
+- creating/updating an element with ``parent_element_id`` (tri-state);
+- validation: parent exists (422), same-set only (422), no cycles (422),
+  no self-parent (422);
+- ``get``/``list`` expose ``parent_element_id`` + ``parent_element_name``;
+- ``GET /api/elements/{id}/children`` and ``/ancestors``.
+
+Real FastAPI app + temp SQLite database (no mocks — protocol 9). TDD.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post("/api/auth/setup", json={"username": "admin", "password": "AdminPass123!"})
+    resp = await client.post("/api/auth/login", json={"username": "admin", "password": "AdminPass123!"})
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _set(client: httpx.AsyncClient, headers: dict, name: str = "S") -> str:
+    resp = await client.post("/api/sets", json={"name": name}, headers=headers)
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _elem(
+    client: httpx.AsyncClient,
+    headers: dict,
+    *,
+    name: str = "E",
+    set_id: str | None = None,
+    parent_element_id: str | None = None,
+) -> dict:
+    body: dict[str, object] = {"element_type": "capability", "name": name, "data": {}}
+    if set_id is not None:
+        body["set_id"] = set_id
+    if parent_element_id is not None:
+        body["parent_element_id"] = parent_element_id
+    resp = await client.post("/api/elements", json=body, headers=headers)
+    return {"status": resp.status_code, "body": resp.json()}
+
+
+async def _update_parent(client, headers, eid, ver, parent):  # noqa: ANN001
+    return await client.put(
+        f"/api/elements/{eid}",
+        json={"name": "E", "data": {}, "parent_element_id": parent},
+        headers={**headers, "If-Match": str(ver)},
+    )
+
+
+class TestCreateAndRead:
+    async def test_create_with_parent_persists_and_round_trips(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        zone = await _elem(client, h, name="Zone", set_id=s)
+        child = await _elem(client, h, name="Cap", set_id=s, parent_element_id=zone["body"]["id"])
+        assert child["status"] == 201, child
+        assert child["body"]["parent_element_id"] == zone["body"]["id"]
+
+        resp = await client.get(f"/api/elements/{child['body']['id']}")
+        assert resp.status_code == 200
+        assert resp.json()["parent_element_id"] == zone["body"]["id"]
+        assert resp.json()["parent_element_name"] == "Zone"
+
+    async def test_create_with_missing_parent_returns_422(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        child = await _elem(
+            client, h, set_id=s,
+            parent_element_id="00000000-0000-0000-0000-000000000000",
+        )
+        assert child["status"] == 422, child
+
+    async def test_cross_set_parent_rejected(self, client):
+        h = await _auth(client)
+        a = await _set(client, h, name="A")
+        b = await _set(client, h, name="B")
+        zone_b = await _elem(client, h, name="ZB", set_id=b)
+        child = await _elem(client, h, set_id=a, parent_element_id=zone_b["body"]["id"])
+        assert child["status"] == 422, child
+
+
+class TestUpdate:
+    async def test_update_sets_and_clears_parent(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        zone = await _elem(client, h, name="Zone", set_id=s)
+        child = await _elem(client, h, name="Cap", set_id=s)
+        eid, ver = child["body"]["id"], child["body"]["current_version"]
+
+        r = await _update_parent(client, h, eid, ver, zone["body"]["id"])
+        assert r.status_code == 200, r.text
+        assert r.json()["parent_element_id"] == zone["body"]["id"]
+
+        r2 = await _update_parent(client, h, eid, r.json()["current_version"], None)
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["parent_element_id"] is None
+
+    async def test_update_omitting_leaves_untouched(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        zone = await _elem(client, h, name="Zone", set_id=s)
+        child = await _elem(client, h, name="Cap", set_id=s, parent_element_id=zone["body"]["id"])
+        eid, ver = child["body"]["id"], child["body"]["current_version"]
+        r = await client.put(
+            f"/api/elements/{eid}",
+            json={"name": "Renamed", "data": {}},  # parent omitted
+            headers={**h, "If-Match": str(ver)},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["parent_element_id"] == zone["body"]["id"]
+
+    async def test_self_parent_rejected(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        e = await _elem(client, h, name="E", set_id=s)
+        eid, ver = e["body"]["id"], e["body"]["current_version"]
+        r = await _update_parent(client, h, eid, ver, eid)
+        assert r.status_code == 422, r.text
+
+    async def test_cycle_rejected(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        a = await _elem(client, h, name="A", set_id=s)
+        b = await _elem(client, h, name="B", set_id=s, parent_element_id=a["body"]["id"])
+        # Now make A a child of B → cycle A→B→A.
+        r = await _update_parent(client, h, a["body"]["id"], a["body"]["current_version"], b["body"]["id"])
+        assert r.status_code == 422, r.text
+
+
+class TestChildrenAndAncestors:
+    async def test_children_and_ancestors(self, client):
+        h = await _auth(client)
+        s = await _set(client, h)
+        zone = await _elem(client, h, name="Zone", set_id=s)
+        cap = await _elem(client, h, name="Cap", set_id=s, parent_element_id=zone["body"]["id"])
+        sub = await _elem(client, h, name="Sub", set_id=s, parent_element_id=cap["body"]["id"])
+
+        kids = await client.get(f"/api/elements/{zone['body']['id']}/children")
+        assert kids.status_code == 200, kids.text
+        assert [k["name"] for k in kids.json()] == ["Cap"]
+
+        anc = await client.get(f"/api/elements/{sub['body']['id']}/ancestors")
+        assert anc.status_code == 200, anc.text
+        # root-first breadcrumb: Zone, Cap.
+        assert [a["name"] for a in anc.json()] == ["Zone", "Cap"]

--- a/backend/tests/test_import_sparx_xml/test_geanz_containment.py
+++ b/backend/tests/test_import_sparx_xml/test_geanz_containment.py
@@ -1,0 +1,138 @@
+"""ADR-231: importing the GEANZ Common Business Capabilities XMI preserves
+the nestedClassifier element-containment tree (capability zone → capability
+→ sub-capability) as ``elements.parent_element_id`` links.
+
+Uses the real committed GEANZ model at the repo root. Idempotent re-import
+back-fills links without duplicating elements.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from app.import_sparx_xml.service import import_sparx_xml_file
+
+from .conftest import admin_user_id, auth_headers
+
+if TYPE_CHECKING:
+    import httpx
+
+GEANZ_XML = (
+    Path(__file__).resolve().parents[3]
+    / "GEANZ Common Business Capabilities Sparx EA model.xml"
+)
+
+
+async def _count(db, sql: str) -> int:  # noqa: ANN001
+    cursor = await db.execute(sql)
+    return (await cursor.fetchone())[0]
+
+
+async def _count_p(db, sql: str, params: tuple) -> int:  # noqa: ANN001
+    cursor = await db.execute(sql, params)
+    return (await cursor.fetchone())[0]
+
+
+class TestGeanzContainment:
+    async def test_nested_classifier_tree_imported(self, client: httpx.AsyncClient) -> None:
+        await auth_headers(client)  # ensures the admin user exists
+        uid = await admin_user_id(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+
+        summary = await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid)
+        assert summary.elements_created > 100, summary
+
+        # Many elements are nested (capabilities under zones, sub-caps under caps).
+        nested = await _count(
+            db, "SELECT COUNT(*) FROM elements WHERE parent_element_id IS NOT NULL "
+            "AND is_deleted = 0",
+        )
+        assert nested > 100, f"expected a deep tree, only {nested} nested elements"
+
+        # Depth reaches 3 levels: a sub-capability → capability → zone (root).
+        three_deep = await _count(
+            db,
+            "SELECT COUNT(*) FROM elements e3 "
+            "JOIN elements e2 ON e3.parent_element_id = e2.id "
+            "JOIN elements e1 ON e2.parent_element_id = e1.id "
+            "WHERE e1.parent_element_id IS NULL AND e3.is_deleted = 0",
+        )
+        assert three_deep > 0, "no 3-level zone→capability→sub-capability chain found"
+
+        # A known zone owns children.
+        zone_kids = await _count(
+            db,
+            "SELECT COUNT(*) FROM elements c "
+            "JOIN elements z ON c.parent_element_id = z.id "
+            "JOIN element_versions zv ON z.id = zv.element_id AND z.current_version = zv.version "
+            "WHERE zv.name = 'Customer Service Delivery capability zone' "
+            "AND c.is_deleted = 0",
+        )
+        assert zone_kids > 0, "the CCS.00 zone has no child capabilities"
+
+    async def test_reimport_into_same_set_is_idempotent(self, client: httpx.AsyncClient) -> None:
+        """Re-importing into the SAME set dedups by ea_guid (no duplicate
+        elements) and the parent-link post-process is stable (same links)."""
+        headers = await auth_headers(client)
+        uid = await admin_user_id(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+
+        resp = await client.post("/api/sets", json={"name": "GEANZ"}, headers=headers)
+        set_id = resp.json()["id"]
+
+        await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid, set_id=set_id)
+        in_set = "WHERE set_id = ? AND is_deleted = 0"
+        elems_1 = await _count_p(db, f"SELECT COUNT(*) FROM elements {in_set}", (set_id,))
+        nested_1 = await _count_p(
+            db, f"SELECT COUNT(*) FROM elements {in_set} AND parent_element_id IS NOT NULL",
+            (set_id,),
+        )
+        assert nested_1 > 100, nested_1
+
+        await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid, set_id=set_id)
+        elems_2 = await _count_p(db, f"SELECT COUNT(*) FROM elements {in_set}", (set_id,))
+        nested_2 = await _count_p(
+            db, f"SELECT COUNT(*) FROM elements {in_set} AND parent_element_id IS NOT NULL",
+            (set_id,),
+        )
+
+        assert elems_2 == elems_1, f"re-import duplicated elements: {elems_1} -> {elems_2}"
+        assert nested_2 == nested_1
+
+    async def test_hierarchy_surfaces_nested_elements(self, client: httpx.AsyncClient) -> None:
+        """get_diagram_hierarchy nests element nodes under their parent element
+        / package, reaching the 3-level GEANZ depth (ADR-231 E5)."""
+        from app.diagrams.service import get_diagram_hierarchy
+
+        headers = await auth_headers(client)
+        uid = await admin_user_id(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+        resp = await client.post("/api/sets", json={"name": "GEANZ"}, headers=headers)
+        set_id = resp.json()["id"]
+        await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid, set_id=set_id)
+
+        tree = await get_diagram_hierarchy(db, set_id=set_id)
+
+        def max_element_depth(nodes: list, depth: int = 0) -> int:
+            best = depth
+            for n in nodes:
+                d = depth + (1 if n["node_type"] == "element" else 0)
+                best = max(best, d, max_element_depth(n["children"], d))
+            return best
+
+        # zone(1) → capability(2) → sub-capability(3).
+        assert max_element_depth(tree) >= 3, "element containment not nested 3 deep in tree"
+
+        # At least one element node has element children.
+        def has_nested_element(nodes: list) -> bool:
+            for n in nodes:
+                if n["node_type"] == "element" and any(
+                    c["node_type"] == "element" for c in n["children"]
+                ):
+                    return True
+                if has_nested_element(n["children"]):
+                    return True
+            return False
+
+        assert has_nested_element(tree)

--- a/backend/tests/test_migrations/test_element_parent_element_schema.py
+++ b/backend/tests/test_migrations/test_element_parent_element_schema.py
@@ -1,0 +1,57 @@
+"""ADR-231: assert the Supabase migration ``m087_element_parent_element.sql``
+mirrors the SQLite migration ``m081_element_parent_element.py`` — both add a
+nullable ``parent_element_id`` self-referencing column to ``elements`` with a
+matching index, idempotently.
+
+Mirrors ``test_element_detail_diagram_schema.py`` — a static-parser guard so a
+SQLite-only column-add can't slip through and 500 on Supabase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_supabase_migration() -> str:
+    path = ROOT / "app" / "migrations" / "supabase" / "m087_element_parent_element.sql"
+    return path.read_text(encoding="utf-8")
+
+
+def _read_sqlite_migration() -> str:
+    path = ROOT / "app" / "migrations" / "m081_element_parent_element.py"
+    return path.read_text(encoding="utf-8")
+
+
+def test_supabase_m087_adds_parent_element_column_idempotently() -> None:
+    sql = _read_supabase_migration()
+    assert "ADD COLUMN IF NOT EXISTS parent_element_id" in sql, sql
+    # Self-referencing FK to elements.
+    assert "REFERENCES public.elements(id)" in sql, sql
+
+
+def test_supabase_m087_creates_index() -> None:
+    sql = _read_supabase_migration()
+    assert "idx_elements_parent_element" in sql, sql
+    assert "ON public.elements(parent_element_id)" in sql, sql
+    assert "CREATE INDEX IF NOT EXISTS" in sql, sql
+
+
+def test_supabase_m087_declares_mirror_of_sqlite() -> None:
+    sql = _read_supabase_migration()
+    assert "Mirrors SQLite m081" in sql, sql
+
+
+def test_sqlite_m081_adds_parent_element_column_idempotently() -> None:
+    py = _read_sqlite_migration()
+    # PRAGMA-guarded ADD COLUMN.
+    assert "PRAGMA table_info(elements)" in py, py
+    assert "ADD COLUMN parent_element_id TEXT" in py, py
+    assert "REFERENCES elements(id)" in py, py
+
+
+def test_sqlite_m081_creates_index_if_not_exists() -> None:
+    py = _read_sqlite_migration()
+    assert "CREATE INDEX IF NOT EXISTS idx_elements_parent_element" in py, py
+    assert "ON elements(parent_element_id)" in py, py

--- a/cli/src/iris_cli/main.py
+++ b/cli/src/iris_cli/main.py
@@ -821,6 +821,14 @@ def create_element_cmd(
             "diagram in another set."
         ),
     ),
+    parent_element_id: str | None = typer.Option(
+        None, "--parent-element-id",
+        help=(
+            "Optional parent element — the containment hierarchy "
+            "(v6.43.0, ADR-231). The parent must be a live element in the "
+            "same set; cross-set or cyclic parents return 422."
+        ),
+    ),
     notation: str | None = typer.Option(None, "--notation"),
     description: str | None = typer.Option(None, "--description"),
     data_json: str | None = typer.Option(None, "--data-json"),
@@ -853,6 +861,8 @@ def create_element_cmd(
         body["package_id"] = package_id
     if detail_diagram_id is not None:
         body["detail_diagram_id"] = detail_diagram_id
+    if parent_element_id is not None:
+        body["parent_element_id"] = parent_element_id
     if notation is not None:
         body["notation"] = notation
     if description is not None:
@@ -1087,6 +1097,15 @@ def update_element_cmd(
             "unchanged."
         ),
     ),
+    parent_element_id: str | None = typer.Option(
+        None, "--parent-element-id",
+        help=(
+            "Set or clear the element's parent in the containment "
+            "hierarchy (v6.43.0, ADR-231). Pass an element UUID in the "
+            "same set to set, the literal 'null' to clear, or omit to "
+            "leave unchanged. Cross-set or cyclic parents return 422."
+        ),
+    ),
 ) -> None:
     """Update an Element. Note: elements cannot be moved between
     diagrams — they travel with their parent diagram (ADR-178 invariant)."""
@@ -1095,13 +1114,16 @@ def update_element_cmd(
         "data": _parse_json_opt(data_json, "--data-json"),
         "metadata": _parse_json_opt(metadata_json, "--metadata-json"),
     }
-    # package_id / detail_diagram_id are tri-state at the PUT body level:
-    # include the key to set (string) or clear (null), omit to leave
-    # untouched. The _put_merge_partial helper strips None so we wire them
-    # by hand.
+    # package_id / detail_diagram_id / parent_element_id are tri-state at the
+    # PUT body level: include the key to set (string) or clear (null), omit
+    # to leave untouched. The _put_merge_partial helper strips None so we
+    # wire them by hand.
     raw_package_id = _resolve_null(package_id) if package_id is not None else _UNSET
     raw_detail_diagram_id = (
         _resolve_null(detail_diagram_id) if detail_diagram_id is not None else _UNSET
+    )
+    raw_parent_element_id = (
+        _resolve_null(parent_element_id) if parent_element_id is not None else _UNSET
     )
 
     async def _do() -> Any:
@@ -1120,6 +1142,8 @@ def update_element_cmd(
                 body["package_id"] = raw_package_id
             if raw_detail_diagram_id is not _UNSET:
                 body["detail_diagram_id"] = raw_detail_diagram_id
+            if raw_parent_element_id is not _UNSET:
+                body["parent_element_id"] = raw_parent_element_id
             headers = {"If-Match": str(current.get("current_version", 1))}
             resp = await c._request(
                 "PUT", f"/api/elements/{element_id}", json=body, headers=headers,

--- a/docs/adrs/ADR-231-Element-Element-Containment.md
+++ b/docs/adrs/ADR-231-Element-Element-Containment.md
@@ -1,0 +1,138 @@
+# ADR-231: Element → element optional containment (nested elements)
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-231 |
+| **Initiative** | Import the GEANZ capability tree (and any Sparx EA nested-classifier model) with its full depth, as a navigable element hierarchy |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-01 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** importing Sparx EA models whose structure is an
+element-containment tree — the GEANZ Common Business Capabilities model
+(`set_id=7f2521de…`) nests *capability zone → capability → sub-capability*
+three levels deep, encoded in the XMI as `<nestedClassifier>` where each
+`<element>`'s `<model>` carries both `package="EAPK_…"` (its containing
+package) and `owner="EAID_…"` (its parent **element**),
+
+**facing** that Iris has no element→element containment. An element can
+belong to a **package** (ADR-184, the single nullable `elements.package_id`
+column — something EA lacks) and can drill to a **detail diagram** (ADR-221,
+`elements.detail_diagram_id`), but there is no way for an element to *own*
+child elements. The XMI importer (`backend/app/import_sparx_xml/reader.py`,
+Pass 2) reads each element's `<model package>` but **drops `<model owner>`**
+(the diagram path already reads `owner` for ADR-221 detail diagrams — the
+element path does not). So all ~394 GEANZ capability classes flatten under
+the top `CBC` package and the live set shows only `CBC → CBC Themes` — the
+3-level tree the EA Project Browser shows is lost. Re-importing reproduces
+this; it is a data-model gap, not a one-off,
+
+**we decided to** add a new **optional element-containment axis** —
+a nullable `elements.parent_element_id TEXT REFERENCES elements(id)` column,
+mirroring how `package_id` was added in ADR-184 — and wire it through the
+importer, the navigable hierarchy, and the element/MCP/CLI surfaces:
+
+  - **(E1) Schema.** `parent_element_id` + `idx_elements_parent_element`,
+    shipped as a paired SQLite (`m081`) + Supabase (`m087`) migration with a
+    schema-parity test (§15). Additive, nullable, no back-fill.
+
+  - **(E2) Two orthogonal axes, one placement rule.** An element row can
+    now carry both `package_id` (→package, ADR-184) and `parent_element_id`
+    (→element, this ADR). They are orthogonal. The **navigable tree
+    placement precedence** is defined **once**, in the hierarchy builder
+    (DRY §13): (1) if `parent_element_id` is set → the element is a child of
+    that element; (2) else if `package_id` is set → under that package
+    (today's behaviour); (3) else → loose under `set_id`. `package_id` is
+    **kept** (not cleared) on a nested element — it remains meaningful EA
+    data and ADR-184's set-consistency invariant still applies; the builder
+    simply prefers `parent_element_id` for placement.
+
+  - **(E3) Invariants** (service layer → HTTP 422, mirroring
+    `ElementPackageInvariantError`): the parent must exist and be
+    non-deleted; the child's effective `set_id` must equal the parent's
+    `set_id` (**single-set containment** — unlike the cross-set ADR-221
+    detail link, a structural tree must not span sets); no cycles (the
+    `validate_no_cycle` walk-up from `packages/service.py` ported to
+    elements); no self-parent.
+
+  - **(E4) Importer.** Read `<model owner>` in
+    `import_sparx_xml/reader.py` (mirroring the diagram `owner` logic),
+    carry it on `QeaElement.Parent_Object_ID`, and set `parent_element_id`
+    in an idempotent **post-process pass** in `import_sparx/service.py`
+    (parent elements may be created after their children — same reason the
+    ADR-221 detail-diagram link is post-processed). Re-import is the
+    canonical back-fill for the existing flat set.
+
+  - **(E5) Navigable hierarchy.** Extend `get_diagram_hierarchy` to emit
+    nested elements as `node_type:'element'` nodes (attaching via
+    `COALESCE(parent_element_id, package_id)`), reusing the existing
+    `DiagramHierarchyNode` model and `TreeNode.svelte` recursion. Add an
+    opt-in `include_elements` flag to `get_package_hierarchy` (ADR-158) so
+    the MCP `package_hierarchy` orient sheet can show depth — default off.
+
+  - **(E6) Write surface — an update, not a move.** `parent_element_id` is
+    set via the existing `create_element` / `update_element` verbs (exactly
+    the ADR-184 `package_id` precedent), exposed on backend + MCP + CLI. **No
+    `move_element` verb is added** — so ADR-178's forbidden-asymmetry
+    catalogue and `check_surface_parity.py` are untouched. Manual
+    drag-to-reparent is explicitly deferred to a later ADR.
+
+**because** the GEANZ depth is genuine element containment, not package
+nesting (the zones are rich elements — notes, maturity tagged values, their
+own CCS.00-style diagrams — so turning them into packages would be lossy),
+the `owner` linkage is already present in the XMI and merely discarded, and
+a nullable parent column reuses the proven `package_id`/`parent_package_id`
+patterns while keeping package membership and element containment as clean,
+independent axes.
+
+---
+
+## Consequences
+
+**Positive**
+- Sparx EA nested-classifier models (GEANZ and others) import with full
+  depth and render as a browsable tree in the existing nav sidebar.
+- Zones/capabilities remain first-class elements; nothing about ADR-184 or
+  ADR-221 changes — the new axis is additive and orthogonal.
+- No new write verb, no new parity entity, no ADR-178 amendment.
+
+**Negative / risks**
+- A third membership axis on the element row; the precedence rule must live
+  in exactly one place (the hierarchy builder) to avoid drift.
+- The existing flat GEANZ set stays flat until re-imported (the column has
+  no back-fill).
+- The hierarchy UNION must be scoped to containment-involved elements so it
+  does not pull the entire flat element pool into every package.
+
+## Alternatives considered
+1. **Map container elements to nested packages** (reuse `parent_package_id`).
+   Rejected: a capability zone would become a package, losing its element
+   identity/notes/maturity/own diagram, or be duplicated as both.
+2. **Reuse `package_id` for the tree.** Rejected: a different axis; would
+   conflate package membership with structural containment.
+3. **Detail-diagram drill-down only (ADR-221).** Rejected: navigation via
+   diagrams, not a browsable element tree; GEANZ uses nested classifiers,
+   not composite diagrams.
+4. **Many-to-many containment (join table).** Rejected: containment is a
+   tree; a single nullable column mirrors `package_id` and suffices.
+5. **Cross-set containment.** Rejected: keeps trees single-set and the
+   hierarchy query simple.
+
+## Surface parity (§14)
+`parent_element_id` enriches the existing `create_element` / `update_element`
+write verbs on all three surfaces — no new entity, no new exception, no
+`move_element`. `scripts/check_surface_parity.py` stays green unchanged.
+
+## SQLite ↔ Supabase parity (§15)
+Paired `m081` (SQLite) + `m087` (Supabase) migrations, both idempotent
+(`IF NOT EXISTS` / PRAGMA guard), with `test_element_parent_element_schema.py`.
+No boolean columns. Both run at startup (`startup.py`).
+
+## Dependencies
+Extends **ADR-184** (element-package membership) with a sibling axis;
+consistent with **ADR-178** (no element move) and **ADR-221** (detail
+diagram). Spec: `docs/adrs/specs/SPEC-231-A-Element-Element-Containment.md`.

--- a/docs/adrs/specs/SPEC-231-A-Element-Element-Containment.md
+++ b/docs/adrs/specs/SPEC-231-A-Element-Element-Containment.md
@@ -1,0 +1,72 @@
+# SPEC-231-A: Element → element containment
+
+Implements **[ADR-231](../ADR-231-Element-Element-Containment.md)**. Living
+document. v1 scope = **import + browse** (set parent on create/update; no
+drag-to-reparent).
+
+## Schema delta
+
+```sql
+-- SQLite m081 (PRAGMA-guarded) / Supabase m087 (IF NOT EXISTS)
+ALTER TABLE elements ADD COLUMN parent_element_id TEXT REFERENCES elements(id);
+CREATE INDEX idx_elements_parent_element ON elements(parent_element_id);
+```
+Nullable, additive, no back-fill. `parent_element_id` is unversioned (carried
+on the `elements` row, like `package_id` / `detail_diagram_id`).
+
+## Placement precedence (single source of truth — hierarchy builder)
+```
+if element.parent_element_id:  parent = that element        # node_type 'element'
+elif element.package_id:       parent = that package        # today's behaviour
+else:                          loose under set_id
+```
+
+## Invariants (service → 422, `ElementParentInvariantError`)
+- parent row exists and `is_deleted = 0`;
+- `parent.set_id == child.effective set_id` (single-set);
+- no cycle (walk `parent_element_id` up from the proposed parent; reject if
+  it reaches the child); reject `parent_element_id == id` (self-parent).
+
+## API surface
+| Verb | Backend | MCP | CLI | Note |
+|---|---|---|---|---|
+| create w/ parent | `POST /api/elements` (`parent_element_id`) | `create_element(parent_element_id?)` | `element create --parent-element-id` | enrichment |
+| update parent | `PUT /api/elements/{id}` (tri-state `parent_element_id`) | `update_element(parent_element_id?)` | `element update --parent-element-id` | enrichment |
+| children (read) | `GET /api/elements/{id}/children` | — | — | GET, not §14 |
+| ancestors (read) | `GET /api/elements/{id}/ancestors` | — | — | GET, breadcrumb |
+
+`ElementResponse` gains `parent_element_id` + `parent_element_name`. No
+`move_element` (ADR-178 untouched).
+
+## Importer mapping
+For each XMI `<element>` `<model owner="GUID">`:
+`parent_obj_id = guid_to_int[owner] if owner and owner != package_guid else None`
+(the `!= package` test discards the EAPK/root case; `element_map` discards a
+stray non-element owner). Carried on `QeaElement.Parent_Object_ID`; applied in
+an idempotent post-process `UPDATE elements SET parent_element_id=?` keyed off
+`element_map` (handles parent-after-child ordering). `package_id` wiring
+unchanged.
+
+## Hierarchy
+`get_diagram_hierarchy` gains a UNION arm: elements with `parent_element_id IS
+NOT NULL` OR that are themselves a parent → `node_type:'element'`, parent key
+`COALESCE(parent_element_id, package_id)`. `DiagramHierarchyNode.node_type` →
+`'package'|'diagram'|'element'`. `get_package_hierarchy(include_elements=False)`
+opt-in for the MCP orient path.
+
+## Acceptance criteria
+- **AC1** column + index present (SQLite + Supabase schema test).
+- **AC2** create with `parent_element_id` sets it; `get`/`list` return it + `parent_element_name`.
+- **AC3** invariants reject missing/soft-deleted/cross-set parent, cycle, self → 422.
+- **AC4** `update` tri-state: set / clear via `null` / omit = untouched.
+- **AC5** `GET /{id}/children` + `/{id}/ancestors`.
+- **AC6** importer: `<model owner=EAID>` → `parent_element_id` set; `owner=EAPK` (root) → NULL; idempotent re-import.
+- **AC7** `get_diagram_hierarchy` returns the GEANZ zone→capability→sub-capability subtree 3 deep; node count matches the XMI `owner=EAID` count.
+- **AC8** MCP + CLI round-trip `parent_element_id` on create + update; `check_surface_parity.py` green.
+- **AC9** Frontend: nested elements render in `TreeNode`; element page shows parent link + child list.
+
+## Files
+Backend: `migrations/m081_*.py` + `supabase/m087_*.sql` + `tests/test_migrations/test_element_parent_element_schema.py`; `elements/{service,models,router}.py`; `import_sparx/{reader,service}.py`; `import_sparx_xml/reader.py`; `diagrams/service.py`; `packages/service.py` (port cycle/ancestors); `startup.py`. MCP `iris_mcp/tools.py`; CLI `iris_cli/main.py`. Frontend `lib/types/api.ts`, `lib/components/TreeNode.svelte`, `routes/elements/[id]/+page.svelte`.
+
+## Out of scope (deferred)
+Drag-to-reparent UI + `move_element` / `PUT /api/elements/{id}/parent` (needs a new ADR amending ADR-178). Package-detail nested rendering.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.42.0",
+	"version": "6.43.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/TreeNode.svelte
+++ b/frontend/src/lib/components/TreeNode.svelte
@@ -72,6 +72,8 @@
 	}
 
 	const isPackage = $derived(node.node_type === 'package');
+	// ADR-231: nested element nodes in the containment hierarchy.
+	const isElement = $derived(node.node_type === 'element');
 	const indicatorType = $derived<'solid' | 'hollow' | 'none'>(
 		node.has_content
 			? 'solid'
@@ -79,7 +81,9 @@
 				? 'hollow'
 				: 'none'
 	);
-	const nodeHref = $derived(isPackage ? `/packages/${node.id}` : `/views/${node.id}`);
+	const nodeHref = $derived(
+		isPackage ? `/packages/${node.id}` : isElement ? `/elements/${node.id}` : `/views/${node.id}`,
+	);
 
 	const passesDiagramFilter = $derived(
 		!showDiagramsOnly || node.has_content || descendantHasContent(node)
@@ -87,7 +91,7 @@
 	/** Issue #27: hide leaf nodes whose kind is toggled off; packages are always shown. */
 	const isText = $derived(node.diagram_type === 'text');
 	const passesKindFilter = $derived(
-		isPackage || (isText ? showText : showDiagrams),
+		isPackage || isElement || (isText ? showText : showDiagrams),
 	);
 	const visible = $derived(
 		(matchesSearch || childMatchesSearch) && passesDiagramFilter && passesKindFilter,
@@ -210,7 +214,7 @@
 			<a
 				href={nodeHref}
 				class="tree-node__link"
-				title={node.diagram_type ? node.diagram_type : isPackage ? 'package' : undefined}
+				title={node.diagram_type ? node.diagram_type : isPackage ? 'package' : isElement ? 'element' : undefined}
 				onclick={() => { if (hasChildren && !expanded) { expanded = true; expandedIds.add(node.id); } }}
 				onkeydown={handleKeydown}
 			>

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -32,8 +32,14 @@ export interface Element {
 	set_name?: string;
 	metadata?: Record<string, unknown> | null;
 	notation?: string;
+	// ADR-184: the package this element belongs to.
+	package_id?: string | null;
+	package_name?: string | null;
 	// ADR-221: the diagram this element drills into (Sparx composite element).
 	detail_diagram_id?: string | null;
+	// ADR-231: the element that owns this element (containment hierarchy).
+	parent_element_id?: string | null;
+	parent_element_name?: string | null;
 }
 
 export interface Diagram {
@@ -78,9 +84,11 @@ export interface Package {
 export interface DiagramHierarchyNode {
 	id: string;
 	name: string;
-	node_type: 'package' | 'diagram';
+	// ADR-231: 'element' nodes are nested elements (containment hierarchy).
+	node_type: 'package' | 'diagram' | 'element';
 	diagram_type: string | null;
 	notation: string | null;
+	// For an 'element' node this is its parent element (or package) id.
 	parent_package_id: string | null;
 	has_content: boolean;
 	sequence_order: number;

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -48,6 +48,8 @@
 	let activeTab = $state<'details' | 'versions' | 'relationships'>('relationships');
 	let userSelectedTab = $state(false);
 	let packageMemberships = $state<{id: string; name: string}[]>([]);
+	// ADR-231: child elements owned by this element (containment hierarchy).
+	let childElements = $state<{id: string; name: string; element_type: string}[]>([]);
 	let showDeleteDialog = $state(false);
 	let showSaveTemplateDialog = $state(false);
 	let isBookmarked = $state(false);
@@ -184,6 +186,7 @@
 				loadRelationships(id),
 				loadDiagrams(id),
 				loadPackageMemberships(id),
+				loadChildElements(id),
 				loadDetailDiagramName(),
 				loadAllTags(),
 				loadBookmarkStatus(id),
@@ -219,6 +222,15 @@
 			packageMemberships = await apiFetch<{id: string; name: string}[]>(`/api/elements/${id}/package-memberships`);
 		} catch {
 			packageMemberships = [];
+		}
+	}
+
+	// ADR-231: direct child elements in the containment hierarchy.
+	async function loadChildElements(id: string) {
+		try {
+			childElements = await apiFetch<{id: string; name: string; element_type: string}[]>(`/api/elements/${id}/children`);
+		} catch {
+			childElements = [];
 		}
 	}
 
@@ -1181,6 +1193,39 @@
 			<!-- ADR-208 (v6.16.0): the Relationships tab now hosts three
 				 sections — Package membership, Used in Views, and the
 				 explicit Relationships table. Empty sections are hidden. -->
+
+			{#if entity?.parent_element_id}
+				<section class="mb-6">
+					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Parent element</h3>
+					<a
+						href="/elements/{entity.parent_element_id}"
+						class="flex items-center gap-3 rounded border block p-3"
+						style="border-color: var(--color-border); color: var(--color-primary)"
+					>
+						<span class="font-medium">{entity.parent_element_name ?? entity.parent_element_id}</span>
+					</a>
+				</section>
+			{/if}
+
+			{#if childElements.length > 0}
+				<section class="mb-6">
+					<h3 class="mb-2 text-sm font-semibold" style="color: var(--color-fg)">Child elements ({childElements.length})</h3>
+					<ul class="flex flex-col gap-2">
+						{#each childElements as child (child.id)}
+							<li>
+								<a
+									href="/elements/{child.id}"
+									class="flex items-center gap-3 rounded border block p-3"
+									style="border-color: var(--color-border); color: var(--color-primary)"
+								>
+									<span class="font-medium">{child.name}</span>
+									<span class="text-xs" style="color: var(--color-muted)">{child.element_type}</span>
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</section>
+			{/if}
 
 			{#if packageMemberships.length > 0}
 				<section class="mb-6">

--- a/frontend/tests/e2e/element-containment.spec.ts
+++ b/frontend/tests/e2e/element-containment.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * E2E for ADR-231 — element → element containment (nested elements).
+ *
+ * Seeds a 3-level capability tree (zone → capability → sub-capability) via
+ * the API using the new ``parent_element_id`` axis, then verifies the
+ * element detail page renders the "Parent element" link and the "Child
+ * elements" list — the browse half of the v1 feature.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import {
+	createElement,
+	createSet,
+	getAuthToken,
+	loginAsAdmin,
+	seedAdmin,
+} from './fixtures';
+
+test.describe('Element containment (ADR-231)', () => {
+	let zoneId: string;
+	let capId: string;
+	let subId: string;
+
+	test.beforeAll(async ({ baseURL }) => {
+		await seedAdmin(baseURL);
+		const token = await getAuthToken(baseURL);
+		const set = await createSet(baseURL, token, { name: `Containment ${Date.now()}` });
+		const setId = set.id as string;
+
+		zoneId = (await createElement(baseURL, token, {
+			name: 'Customer Service Delivery capability zone',
+			element_type: 'capability', set_id: setId,
+		})).id as string;
+		capId = (await createElement(baseURL, token, {
+			name: 'Case Management', element_type: 'capability', set_id: setId,
+			parent_element_id: zoneId,
+		})).id as string;
+		subId = (await createElement(baseURL, token, {
+			name: 'Triage', element_type: 'capability', set_id: setId,
+			parent_element_id: capId,
+		})).id as string;
+	});
+
+	test('element detail shows child elements and the parent link', async ({ page }) => {
+		await loginAsAdmin(page);
+
+		// Zone: has the capability as a child, no parent.
+		await page.goto(`/elements/${zoneId}`);
+		await expect(page.getByRole('heading', { name: 'Child elements (1)' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Case Management' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Parent element' })).toHaveCount(0);
+
+		// Capability: parent = zone, child = sub-capability.
+		await page.goto(`/elements/${capId}`);
+		await expect(page.getByRole('heading', { name: 'Parent element' })).toBeVisible();
+		await expect(
+			page.getByRole('link', { name: 'Customer Service Delivery capability zone' }),
+		).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Child elements (1)' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Triage' })).toBeVisible();
+
+		// Sub-capability: leaf — parent = capability, no children.
+		await page.goto(`/elements/${subId}`);
+		await expect(page.getByRole('heading', { name: 'Parent element' })).toBeVisible();
+		await expect(page.getByRole('link', { name: 'Case Management' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: /Child elements/ })).toHaveCount(0);
+	});
+});

--- a/frontend/tests/e2e/fixtures.ts
+++ b/frontend/tests/e2e/fixtures.ts
@@ -134,6 +134,7 @@ export async function createElement(
 		data?: Record<string, unknown>;
 		set_id?: string;
 		package_id?: string;
+		parent_element_id?: string;
 		notation?: string;
 		metadata?: Record<string, unknown>;
 	},
@@ -152,6 +153,7 @@ export async function createElement(
 			data: data.data ?? {},
 			set_id: data.set_id ?? null,
 			package_id: data.package_id ?? null,
+			parent_element_id: data.parent_element_id ?? null,
 			notation: data.notation ?? 'simple',
 			metadata: data.metadata ?? null,
 		}),

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.42.0"
+version = "6.43.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.42.0"
+version = "6.43.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/src/iris_mcp/tools.py
+++ b/mcp/src/iris_mcp/tools.py
@@ -425,7 +425,7 @@ async def _create_element(c: IrisClient, args: dict[str, Any]) -> str:
         body["name"] = args["name"]
     for key in (
         "description", "data", "set_id", "metadata", "notation",
-        "package_id", "detail_diagram_id", "template_id",
+        "package_id", "detail_diagram_id", "parent_element_id", "template_id",
     ):
         if args.get(key) is not None:
             body[key] = args[key]
@@ -938,7 +938,7 @@ async def _update_element(c: IrisClient, args: dict[str, Any]) -> str:
     try:
         # Special-case the tri-state fields: only forward to the body the
         # ones the caller actually supplied (including JSON null).
-        tristate = [k for k in ("package_id", "detail_diagram_id") if k in args]
+        tristate = [k for k in ("package_id", "detail_diagram_id", "parent_element_id") if k in args]
         if tristate:
             current_resp = await c._request(
                 "GET", f"/api/elements/{args['element_id']}",
@@ -1718,6 +1718,15 @@ TOOLS: list[Tool] = [
                 "point at a diagram in another set.",
                 required=False,
             ),
+            "parent_element_id": _str_arg(
+                "parent_element_id",
+                "Optional parent element — the containment hierarchy "
+                "(v6.43.0, ADR-231). The new element becomes a child of "
+                "this element in the navigable tree. The parent must be a "
+                "live element in the SAME set; cross-set or cyclic "
+                "parents return 422.",
+                required=False,
+            ),
             "notation": _str_arg(
                 "notation",
                 "Notation id (default 'simple'). Should match the "
@@ -2466,6 +2475,19 @@ TOOLS: list[Tool] = [
                         "link (v6.33.0, ADR-221 / issue #242). Pass a "
                         "diagram UUID to set (may be in another set), "
                         "JSON null to clear, or omit to leave unchanged."
+                    ),
+                },
+                False,
+            ),
+            "parent_element_id": (
+                {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Set or clear the element's parent in the "
+                        "containment hierarchy (v6.43.0, ADR-231). Pass an "
+                        "element UUID in the SAME set to set, JSON null to "
+                        "clear, or omit to leave unchanged. Cross-set or "
+                        "cyclic parents return 422."
                     ),
                 },
                 False,


### PR DESCRIPTION
## Problem

The GEANZ Common Business Capabilities import lost its depth: the EA model nests **capability zone → capability → sub-capability** 3 levels deep via `<nestedClassifier>` (each `<element>`'s `<model>` carries both `package="EAPK_…"` and `owner="EAID_…"`), but the importer read only `package` and dropped `owner` — so all ~394 capabilities flattened under one package. The live set showed just `CBC → CBC Themes`.

Iris had no element→element containment. It has element→**package** membership (ADR-184) and element→**diagram** drill (ADR-221), but no way for an element to own child elements.

## Approach (the design tension, resolved)

A new **optional `elements.parent_element_id` axis**, orthogonal to `package_id`. The two coexist; the navigable-tree **placement precedence** is defined once in the hierarchy builder: `parent_element_id` → else `package_id` → else loose under `set_id`. `package_id` is kept (not cleared) on nested elements; ADR-184's set-consistency still applies independently. Containment is **single-set**, cycle-guarded, no self-parent (→ 422).

## What's in v1 (import + browse)

- **Schema**: nullable `parent_element_id` + index — paired SQLite `m081` + Supabase `m087` migrations + schema-parity test (§15).
- **Service/API**: validation + tri-state create/update; `ElementResponse.parent_element_id`/`parent_element_name`; `GET /api/elements/{id}/children` + `/ancestors`.
- **Importer**: XMI reader reads `<model owner>` (mirroring the ADR-221 diagram path); orchestrator links child → parent in an **idempotent post-process pass** (handles parent-after-child ordering; re-import back-fills).
- **Hierarchy**: `get_diagram_hierarchy` nests `node_type:'element'` nodes via `COALESCE(parent_element_id, package_id)`, reusing `TreeNode.svelte`. **Only containment-involved elements** are included, so non-GEANZ hierarchies are unchanged.
- **Frontend**: element page shows a "Parent element" link + "Child elements" list; the nav tree nests elements.
- **Surface parity (§14)**: `parent_element_id` via the existing `create_element`/`update_element` verbs on backend + MCP + CLI (`--parent-element-id`). **No `move_element`** — ADR-178 untouched, parity stays green.

## Tests

- Backend integration: create/update with parent, invariants (missing / soft-deleted / cross-set / self / cycle → 422), tri-state, `/children` + `/ancestors`.
- **GEANZ end-to-end** (real committed XML): imports the 3-level tree (>100 nested, 3-deep chains, CCS.00 zone owns children); idempotent re-import into the same set; `get_diagram_hierarchy` nests 3 deep.
- Playwright `element-containment.spec.ts`: element-detail parent link + children list.
- Surface-parity clean; frontend typecheck adds no new errors.

## Docs / deploy

ADR-231 + SPEC-231-A. Version → **6.43.0** (all four). No back-fill — existing flat elements stay `NULL` until re-imported. After deploy, **re-import the GEANZ model to a new set** to get the full tree.

Deferred (later ADR): drag-to-reparent UI + a `move_element` op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)