### PR TITLE
fix(v6.44.1): anchor imported elements in their EA package (ADR-232 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.44.1] - 2026-06-01
+
+### Fixed
+
+- **GEANZ elements no longer render as a separate root tree from their
+  diagrams (ADR-232 follow-up).** Imported elements were created with no
+  `package_id`, so top-level capability zones floated at the hierarchy root
+  while the package held the diagrams — two side-by-side trees. The Sparx
+  importer now anchors each element in its EA package (`package_id`), so the
+  navigation tree shows a package's elements and diagrams together, with the
+  capability containment subtree nested under each zone. Import-side —
+  re-import the model to apply.
+
 ## [6.44.0] - 2026-06-01
 
 ### Added

--- a/backend/app/import_sparx/service.py
+++ b/backend/app/import_sparx/service.py
@@ -464,6 +464,11 @@ async def import_sparx_model(
             data=element_data,
             created_by=imported_by,
             set_id=set_id,
+            # ADR-184/ADR-232: anchor the element in its EA package so the
+            # navigation tree shows elements (and their containment subtree)
+            # UNDER their package, interleaved with that package's diagrams —
+            # not floating in a separate root tree.
+            package_id=package_map.get(elem.Package_ID),
             metadata=element_metadata,
             change_summary=f"Imported from {source_label} ({elem.Object_Type})",
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.44.0"
+version = "6.44.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_import_sparx_xml/test_geanz_containment.py
+++ b/backend/tests/test_import_sparx_xml/test_geanz_containment.py
@@ -137,6 +137,38 @@ class TestGeanzContainment:
 
         assert has_nested_element(tree)
 
+    async def test_elements_and_diagrams_share_one_package_tree(self, client: httpx.AsyncClient) -> None:
+        """ADR-232 (issue 1): top-level capability elements are anchored in their
+        package (package_id set on import), so the tree shows elements AND that
+        package's diagrams together under the package — not elements floating in
+        a separate root tree."""
+        from app.diagrams.service import get_diagram_hierarchy
+
+        headers = await auth_headers(client)
+        uid = await admin_user_id(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+        resp = await client.post("/api/sets", json={"name": "GEANZ"}, headers=headers)
+        set_id = resp.json()["id"]
+        await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid, set_id=set_id)
+        tree = await get_diagram_hierarchy(db, set_id=set_id)
+
+        # No capability ZONE element should be a root node (they belong under a package).
+        root_element_count = sum(1 for n in tree if n["node_type"] == "element")
+        assert root_element_count == 0, f"{root_element_count} elements floating at root"
+
+        # A package node holds BOTH element children and diagram children.
+        def pkg_has_both(nodes: list) -> bool:
+            for n in nodes:
+                if n["node_type"] == "package":
+                    kinds = {c["node_type"] for c in n["children"]}
+                    if "element" in kinds and "diagram" in kinds:
+                        return True
+                if pkg_has_both(n["children"]):
+                    return True
+            return False
+
+        assert pkg_has_both(tree), "no package mixes element + diagram children (still a split tree)"
+
     async def test_element_exposes_stereotype(self, client: httpx.AsyncClient) -> None:
         """ADR-233 (issue 2): imported GEANZ elements expose `stereotype`
         (derived from metadata.stereotype) on the element API. GEANZ

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.44.0",
+	"version": "6.44.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.44.0"
+version = "6.44.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.44.0"
+version = "6.44.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Problem
After v6.44.0, GEANZ diagrams still rendered in a **separate tree** from the capability elements (confirmed on a fresh import). Root cause: the Sparx importer created every element with **`package_id = NULL`**, so the 41 top-level capability zones floated at the hierarchy **root** while the package node held the 40 diagrams — two side-by-side trees. (My v6.44.0 nesting fix only handled element-*owned* diagrams via `detail_diagram_id`, which GEANZ doesn't use; and the interleave sort only helps within a shared parent.)

## Fix
The importer now passes `package_id=package_map.get(elem.Package_ID)` to `create_element`, anchoring each element in its EA package. The hierarchy's `COALESCE(parent_element_id, package_id)` then places top-level zones **under their package** (alongside that package's diagrams), with the capability→sub-capability containment nested under each zone — one unified tree. This also aligns with ADR-184 (elements belong to packages).

## Verification
`test_elements_and_diagrams_share_one_package_tree`: after the full GEANZ import, **no element floats at root** and a package node has **both** element and diagram children. Existing containment/stereotype/detail-diagram tests still green (24 passed).

Import-side fix → **re-import the model once more** to apply (this is the last re-import needed for the unified tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)