### PR TITLE
fix(v6.44.2): nest GEANZ composite diagrams under their element (ADR-235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.44.2] - 2026-06-01
+
+### Fixed
+
+- **GEANZ capability diagrams now nest under their capability element instead
+  of sitting flat at the package root (ADR-235).** Each diagram in the Sparx
+  model is the composite child-diagram of an element, recorded on the
+  `<diagram><model parent="…">` attribute — but the importer only read
+  `owner`, which for every GEANZ diagram is the *root package* it is filed
+  under, so the composite link never fired and all 40 diagrams landed flat in
+  the tree. The XMI reader now derives a diagram's owning element from
+  `parent` (falling back to a non-package `owner`), so the existing ADR-221
+  post-process sets that element's `detail_diagram_id` and the navigation tree
+  nests the diagram under its capability — the structure Sparx EA's Project
+  Browser shows (e.g. "CCO.08 Payroll capability area" under the "Payroll"
+  element). 39/40 diagrams nest; the top-level capability-zones map correctly
+  stays at the package root. Import-side — **re-import** existing sets to pick
+  up the links (back-filled idempotently). No schema change.
+
 ## [6.44.1] - 2026-06-01
 
 ### Fixed

--- a/backend/app/import_sparx_xml/reader.py
+++ b/backend/app/import_sparx_xml/reader.py
@@ -324,19 +324,22 @@ def parse_sparx_xmi(path: str) -> SparxXmiModel:
         m = _child(dg, "model")
         props = _child(dg, "properties")
         pkg_guid = m.get("package") if m is not None else None
-        # ADR-221: a composite (element-owned) diagram carries an `owner`
-        # GUID that differs from its containing package. Map it to the
-        # owning element's int id so the orchestrator can set that
-        # element's detail_diagram_id. A package-owned diagram (owner ==
-        # package) is not composite → leave ParentID unset. The
-        # orchestrator further filters to element ids, so a stray
-        # non-element owner is harmless.
+        # ADR-221 / ADR-235: a composite diagram is the child-diagram of an
+        # element. EA records this with the `parent` attribute, which names
+        # the owning element directly — this is the nesting Sparx shows in
+        # its Project Browser. The `owner` attribute, by contrast, only names
+        # the package the diagram is *filed* under (the GEANZ capability
+        # diagrams are all filed flat in the root package, yet each `parent`
+        # points at its capability element). Prefer `parent`; fall back to a
+        # non-package `owner` for exports that only set the latter. The
+        # orchestrator filters ParentID to real element ids, so a stray
+        # package/diagram reference here is harmless.
         owner_guid = m.get("owner") if m is not None else None
-        parent_id = (
-            guid_to_int.get(owner_guid)
-            if owner_guid and owner_guid != pkg_guid
-            else None
+        parent_guid = m.get("parent") if m is not None else None
+        parent_ref = parent_guid or (
+            owner_guid if owner_guid and owner_guid != pkg_guid else None
         )
+        parent_id = guid_to_int.get(parent_ref) if parent_ref else None
 
         cx = cy = None
         style1 = _child(dg, "style1")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.44.1"
+version = "6.44.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_import_sparx_xml/test_geanz_containment.py
+++ b/backend/tests/test_import_sparx_xml/test_geanz_containment.py
@@ -169,6 +169,87 @@ class TestGeanzContainment:
 
         assert pkg_has_both(tree), "no package mixes element + diagram children (still a split tree)"
 
+    async def test_capability_diagrams_nest_under_their_element(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """ADR-235 (issue 1, root cause): a GEANZ capability diagram is the
+        composite child-diagram of its capability element. EA files all 40
+        diagrams flat in the root package (``owner``) but records the real
+        nesting on the diagram's ``parent`` attribute, which names the owning
+        element. The importer reads ``parent`` → sets the element's
+        ``detail_diagram_id`` → ``get_diagram_hierarchy`` nests the diagram
+        under that element node (NOT flat under the package)."""
+        from app.diagrams.service import get_diagram_hierarchy
+
+        headers = await auth_headers(client)
+        uid = await admin_user_id(client)
+        db = client._transport.app.state.db_manager.main_db  # type: ignore[union-attr]
+        resp = await client.post("/api/sets", json={"name": "GEANZ"}, headers=headers)
+        set_id = resp.json()["id"]
+        await import_sparx_xml_file(db, str(GEANZ_XML), imported_by=uid, set_id=set_id)
+
+        # The composite link is populated for the vast majority of diagrams
+        # (39/40 in the GEANZ model; only the top-level capability-zones map
+        # has no parent element).
+        linked = await _count_p(
+            db,
+            "SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0 "
+            "AND detail_diagram_id IS NOT NULL",
+            (set_id,),
+        )
+        assert linked >= 30, f"only {linked} elements got a composite child-diagram"
+
+        tree = await get_diagram_hierarchy(db, set_id=set_id)
+
+        # A diagram appears as a child of an ELEMENT node somewhere in the tree.
+        def diagram_under_element(nodes: list, parent_is_element: bool = False) -> bool:
+            for n in nodes:
+                if parent_is_element and n["node_type"] == "diagram":
+                    return True
+                if diagram_under_element(
+                    n["children"], n["node_type"] == "element"
+                ):
+                    return True
+            return False
+
+        assert diagram_under_element(tree), "no diagram nests under an element node"
+
+        # Concretely: the 'Payroll' element owns the 'CCO.08 Payroll capability
+        # area' diagram as a child.
+        def find_element(nodes: list, name: str) -> dict | None:
+            for n in nodes:
+                if n["node_type"] == "element" and n["name"] == name:
+                    return n
+                hit = find_element(n["children"], name)
+                if hit:
+                    return hit
+            return None
+
+        payroll = find_element(tree, "Payroll")
+        assert payroll is not None, "Payroll element missing from tree"
+        child_diagram_names = [
+            c["name"] for c in payroll["children"] if c["node_type"] == "diagram"
+        ]
+        assert any("Payroll" in nm for nm in child_diagram_names), (
+            f"Payroll's diagram not nested under it; children={child_diagram_names}"
+        )
+
+        # And the capability diagrams are NOT all dumped flat under the root
+        # package: at most a handful of diagrams sit directly under a package.
+        def diagrams_directly_under_packages(nodes: list) -> int:
+            total = 0
+            for n in nodes:
+                if n["node_type"] == "package":
+                    total += sum(
+                        1 for c in n["children"] if c["node_type"] == "diagram"
+                    )
+                total += diagrams_directly_under_packages(n["children"])
+            return total
+
+        assert diagrams_directly_under_packages(tree) <= 5, (
+            "capability diagrams are still filed flat under their package"
+        )
+
     async def test_element_exposes_stereotype(self, client: httpx.AsyncClient) -> None:
         """ADR-233 (issue 2): imported GEANZ elements expose `stereotype`
         (derived from metadata.stereotype) on the element API. GEANZ

--- a/docs/adrs/ADR-235-Composite-Diagram-Element-Nesting.md
+++ b/docs/adrs/ADR-235-Composite-Diagram-Element-Nesting.md
@@ -1,0 +1,71 @@
+# ADR-235: Nest a composite diagram under its element via the EA `parent` attribute
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-235 |
+| **Initiative** | Make imported GEANZ capability diagrams nest under their capability element, as Sparx shows them |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-01 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the GEANZ Common Business Capabilities model imported
+into Iris, where the nav tree should show each capability diagram nested under
+its capability element (the "CCO.08 Payroll capability area" diagram beneath
+the "Payroll" element) exactly as Sparx EA's Project Browser does,
+
+**facing** that all 40 diagrams instead appeared **flat under the root
+package**, because the XMI importer derived a diagram's owning element only
+from the `<model owner="...">` attribute — and in this model every diagram's
+`owner` is the **root package** (the EA "filed-under" location), so the
+ADR-221 composite-link logic (`owner != package`) never fired and
+`detail_diagram_id` was never set,
+
+**we decided to** read the diagram's `<model parent="...">` attribute as the
+authoritative composite child-diagram link: EA records the Project-Browser
+nesting there (it names the owning **element**), while `owner` only names the
+package the diagram is filed under. The XMI reader now derives the diagram's
+`ParentID` from `parent` first, falling back to a non-package `owner` for
+exports that only set the latter. The existing orchestrator post-process
+(ADR-221, service.py step 7) then sets the owning element's
+`detail_diagram_id`, and `get_diagram_hierarchy`'s existing COALESCE nests the
+diagram under that element node — no new schema, no name-matching heuristic.
+
+**because** the link is structural and unambiguous: 39 of the 40 GEANZ
+diagrams carry `parent="EAID_…"` pointing at a real element (the 1 without is
+the top-level capability-zones map, a genuine root diagram), and that element
+is already imported and nested by ADR-231. Matching diagram→element by name
+was considered and rejected — only 13/40 names match cleanly (the EA code
+prefix and the inconsistent "capability area"/"capability zone" suffixes make
+it fragile), whereas `parent` resolves 39/40 deterministically.
+
+## Consequences
+- Imported GEANZ capability diagrams nest under their capability element in the
+  hierarchy tree and become that element's drill-down (detail) diagram — the
+  Sparx Project-Browser structure is reproduced.
+- Applies to any Sparx XMI export that records composite diagrams via `parent`,
+  not just GEANZ.
+- Import-side only → existing sets must be **re-imported** to pick up the link
+  (`detail_diagram_id` is back-filled idempotently on re-import of the same set).
+- The top-level capability-zones map correctly stays at the package root (it has
+  no parent element).
+
+## Alternatives considered
+- **Name-matching** diagram → element (strip code prefix / suffix): rejected —
+  26/40 misses; fragile and locale-sensitive (e.g. "Māori-Crown Relations").
+- **Leave diagrams flat** (faithful to `owner`): rejected — `owner` is only the
+  filing package; `parent` is the nesting the user sees in Sparx and expects.
+- **New explicit diagram→element column**: rejected — `detail_diagram_id`
+  (ADR-221) already models exactly this composite child-diagram relationship.
+
+## Surface parity (§14) / §15
+Pure import-reader logic; reuses the ADR-221 `detail_diagram_id` post-process.
+No schema, no new endpoints, no MCP/CLI surface, no migration.
+
+## Dependencies
+Builds on ADR-221 (composite `detail_diagram_id` drill-down), ADR-231
+(element containment), and ADR-232 (hierarchy COALESCE nesting).
+Spec: `docs/adrs/specs/SPEC-235-A-Composite-Diagram-Element-Nesting.md`.

--- a/docs/adrs/specs/SPEC-235-A-Composite-Diagram-Element-Nesting.md
+++ b/docs/adrs/specs/SPEC-235-A-Composite-Diagram-Element-Nesting.md
@@ -1,0 +1,54 @@
+# SPEC-235-A: Composite diagram → element nesting via the EA `parent` attribute
+
+Implements **[ADR-235](../ADR-235-Composite-Diagram-Element-Nesting.md)**
+(builds on ADR-221, ADR-231, ADR-232).
+
+## Root cause
+In the GEANZ XMI every `<diagram><model>` has:
+- `owner` = the **root package** GUID (where the diagram is *filed*), and
+- `parent` = the **element** GUID it is the composite child-diagram of.
+
+The reader only consulted `owner`, and because `owner == package` for all 40
+diagrams the ADR-221 composite link (`owner != package`) never fired, so
+`detail_diagram_id` stayed NULL and the hierarchy filed every diagram flat
+under the root package. 39/40 diagrams carry `parent="EAID_…"`; the 1 without
+is the top-level "Common Business Capabilities - capability zones" map.
+
+## Change — `backend/app/import_sparx_xml/reader.py` (pass 4: diagrams)
+Derive the diagram's `ParentID` from `parent` first, then fall back to a
+non-package `owner`:
+
+```python
+owner_guid = m.get("owner") if m is not None else None
+parent_guid = m.get("parent") if m is not None else None
+parent_ref = parent_guid or (
+    owner_guid if owner_guid and owner_guid != pkg_guid else None
+)
+parent_id = guid_to_int.get(parent_ref) if parent_ref else None
+```
+
+`guid_to_int` already interns every EA-extension `<element idref>` (pass 1),
+so the `parent` element GUID resolves to its synthetic int id.
+
+## Downstream (unchanged — reused)
+- `backend/app/import_sparx/service.py` **step 7** maps `diag.ParentID` →
+  `element_map` → sets `elements.detail_diagram_id` (idempotent; back-fills on
+  re-import of the same set).
+- `backend/app/diagrams/service.py` `get_diagram_hierarchy` diagram UNION arm
+  already nests a diagram under the element whose `detail_diagram_id` matches
+  (`COALESCE(<owning element id>, d.parent_package_id)`).
+
+## Tests — `backend/tests/test_import_sparx_xml/test_geanz_containment.py`
+`test_capability_diagrams_nest_under_their_element`:
+- ≥30 elements get a non-null `detail_diagram_id` after import;
+- a diagram node appears as a **child of an element node** in
+  `get_diagram_hierarchy`;
+- concretely the **Payroll** element owns the "CCO.08 Payroll capability area"
+  diagram as a child;
+- ≤5 diagrams remain directly under any package (only genuine root maps).
+
+## Verification
+Backend: `pytest tests/test_import_sparx_xml/test_geanz_containment.py` (6/6).
+No schema, no endpoint, no MCP/CLI surface change → `check_surface_parity.py`
+unaffected, no migration. Existing sets need a **re-import** to pick up the
+links.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.44.1",
+	"version": "6.44.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.44.1"
+version = "6.44.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.44.1"
+version = "6.44.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
GEANZ capability diagrams were appearing **flat at the package root** instead of nested under their capability element (as Sparx EA's Project Browser shows them).

**Root cause:** each diagram in the Sparx model is the composite child-diagram of an element, recorded on `<diagram><model parent="EAID_…">`. The importer only read `<model owner>`, which for *every* GEANZ diagram is the **root package** the diagram is filed under — so the ADR-221 `owner != package` composite link never fired and `detail_diagram_id` was never set. All 40 diagrams landed flat.

**Fix:** the XMI reader now derives a diagram's `ParentID` from `parent` first (falling back to a non-package `owner`). The existing ADR-221 step-7 post-process then sets the owning element's `detail_diagram_id`, and `get_diagram_hierarchy`'s existing COALESCE nests the diagram under its capability element. **No new schema, no name-matching heuristic.**

- 39/40 diagrams nest under their element; the 1 without (`Common Business Capabilities - capability zones` top-level map) correctly stays at the package root.
- Rejected alternative: diagram→element **name-matching** — only 13/40 names match cleanly (EA code prefix + inconsistent "capability area/zone" suffixes). `parent` resolves 39/40 deterministically.

## Why diagrams looked flat before
`owner` = where the diagram is *filed* (root package). `parent` = the element it *belongs to* (the nesting Sparx shows). We were reading the wrong one.

## Changes
- `backend/app/import_sparx_xml/reader.py` — prefer `<model parent>` for the composite link.
- `backend/tests/test_import_sparx_xml/test_geanz_containment.py` — new `test_capability_diagrams_nest_under_their_element` (Payroll element owns its diagram; ≤5 diagrams remain flat).
- ADR-235 + SPEC-235-A; CHANGELOG; all four version numbers → 6.44.2.

## Testing
- ✅ `test_geanz_containment.py` 6/6 (incl. new nesting test)
- ✅ full XMI + qea import suites (199 passed; 2 pre-existing `.eap`-converter env failures, reproduced on `main`, unrelated)
- ✅ diagrams hierarchy/composite tests 29/29
- ✅ `check_surface_parity.py` clean (no surface change)

## Deploy note
Import-side only — **re-import** existing GEANZ sets to pick up the links (back-filled idempotently). No Supabase migration (no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)