### PR TITLE
fix(v6.44.3): element screen hierarchy toggle as inline icon (ADR-232 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.44.3] - 2026-06-01
+
+### Changed
+
+- **Element screen: the hierarchy toggle is now an icon inline with the tab
+  row (ADR-232 follow-up).** It was a text "Hierarchy" button up in the
+  page-action row; it's now the same sidebar icon used on the view screen,
+  sitting to the left of the Relationships / Details / Version History tabs —
+  so the two screens look and behave consistently. Same `aria-label` and
+  toggle behaviour; purely cosmetic.
+
 ## [6.44.2] - 2026-06-01
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.44.2"
+version = "6.44.3"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.44.2",
+	"version": "6.44.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -583,18 +583,6 @@
 			</p>
 		</div>
 		<div class="flex gap-2">
-			{#if entity.set_id}
-				<button
-					onclick={() => (sidebarOpen = !sidebarOpen)}
-					aria-label="Toggle hierarchy sidebar"
-					aria-pressed={sidebarOpen}
-					class="rounded px-2 py-1 text-sm"
-					style="border: 1px solid var(--color-border); background: {sidebarOpen ? 'var(--color-primary)' : 'transparent'}; color: {sidebarOpen ? 'white' : 'var(--color-muted)'}"
-					title="Show the set hierarchy"
-				>
-					Hierarchy
-				</button>
-			{/if}
 			{#if entity.element_type.startsWith('scenia_')}
 				<button
 					onclick={() => openScenia(entity.set_id, entity.id)}
@@ -639,7 +627,16 @@
 	<!-- Tab navigation. ADR-208 (v6.16.0): Relationships first; the
 		 old "Used In Diagrams" tab is folded into Relationships as a
 		 section, alongside the new Package membership section. -->
-	<div class="mt-6 flex gap-1 overflow-x-auto border-b" style="border-color: var(--color-border)" role="tablist" aria-label="Element sections">
+	<div class="mt-6 flex items-center gap-1 border-b" style="border-color: var(--color-border)">
+		{#if entity.set_id}
+			<button onclick={() => (sidebarOpen = !sidebarOpen)} aria-label="Toggle hierarchy sidebar" aria-pressed={sidebarOpen} class="rounded p-1" title="Show the set hierarchy">
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="currentColor" width="20" height="20"
+					style="color: {sidebarOpen ? 'var(--color-primary)' : 'var(--color-muted)'}">
+					<path d="M176,152h32a16,16,0,0,0,16-16V104a16,16,0,0,0-16-16H176a16,16,0,0,0-16,16v8H88V80h8a16,16,0,0,0,16-16V32A16,16,0,0,0,96,16H64A16,16,0,0,0,48,32V64A16,16,0,0,0,64,80h8V192a24,24,0,0,0,24,24h64v8a16,16,0,0,0,16,16h32a16,16,0,0,0,16-16V192a16,16,0,0,0-16-16H176a16,16,0,0,0-16,16v8H96a8,8,0,0,1-8-8V128h72v8A16,16,0,0,0,176,152ZM64,32H96V64H64ZM176,192h32v32H176Zm0-88h32v32H176Z"/>
+				</svg>
+			</button>
+		{/if}
+		<div class="flex gap-1 overflow-x-auto" role="tablist" aria-label="Element sections">
 		<button
 			role="tab"
 			aria-selected={activeTab === 'relationships'}
@@ -674,6 +671,7 @@
 		>
 			Version History
 		</button>
+		</div>
 	</div>
 
 	<!-- Tab panels -->

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.44.2"
+version = "6.44.3"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.44.2"
+version = "6.44.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Cosmetic consistency fix on the **element screen**: the hierarchy control was a text **"Hierarchy" button** in the page-action row (next to Bookmark/Clone/Delete). It's now the **same sidebar icon used on the view screen**, sitting inline to the left of the Relationships / Details / Version History tabs — so the element and view screens match.

## Change
`frontend/src/routes/elements/[id]/+page.svelte`:
- Removed the text "Hierarchy" button from the action row.
- Wrapped the tab nav in a `flex items-center` row with the 20×20 sidebar SVG icon first (same markup/icon/colour logic as `views/[id]/+page.svelte`), then the `role="tablist"`.

Behaviour unchanged: same `aria-label="Toggle hierarchy sidebar"`, same `sidebarOpen` toggle — so existing Playwright selectors keep working.

## Testing
- ✅ `svelte-check`: **165 errors / 0 new** (unchanged from baseline)
- ✅ div balance verified; `aria-label` preserved (e2e `getByRole('button', { name: 'Toggle hierarchy sidebar' })` still matches)
- Frontend-only; no backend/schema/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)