### PR TITLE
fix(v6.44.4): faster set list + mobile picker/input fixes (ADR-236)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.44.4] - 2026-06-01
+
+### Fixed
+
+- **Set dropdown populates fast again (ADR-236).** `GET /api/sets` computed its
+  diagram/element/package counts with four `COUNT(*)` queries *per set* — slow on
+  Supabase, where each query is a network round-trip. Counts are now computed with
+  four grouped `GROUP BY` queries total; identical output, far fewer round-trips.
+- **Mobile: AI-chat model picker no longer opens off-screen (ADR-236).** The
+  provider dropdown is clamped to the viewport and re-anchored on small screens.
+- **Mobile: import set picker fits the screen (ADR-236).** It now stacks and
+  width-caps instead of overflowing.
+- **Mobile: the view-type selector no longer runs off the right (ADR-236).** The
+  AI-chat creation controls wrap onto the next line.
+- **Mobile: tapping the chat input no longer zooms the page (ADR-236).** Form
+  controls are bumped to 16px on small screens, below iOS Safari's auto-zoom
+  threshold; pinch-zoom still works.
+
+### Changed
+
+- **AI chat: "Create Diagram" is now "Create View"; the view screen says
+  "Loading view…" (ADR-236).** Part of the ongoing diagram→view wording shift.
+
 ## [6.44.3] - 2026-06-01
 
 ### Changed

--- a/backend/app/sets/service.py
+++ b/backend/app/sets/service.py
@@ -51,6 +51,16 @@ def _row_to_dict(row: tuple, *, has_thumbnail_image: bool = False) -> dict[str, 
     }
 
 
+async def _grouped_counts(db: DatabasePort, sql: str) -> dict[object, int]:
+    """Run a ``SELECT key, COUNT(*) ... GROUP BY key`` and return ``{key: count}``.
+
+    Used by :func:`list_sets` (ADR-236) to fetch per-set counts in a single
+    query instead of one COUNT(*) per set. Positional row access (§15).
+    """
+    cursor = await db.execute(sql)
+    return {row[0]: row[1] for row in await cursor.fetchall()}
+
+
 _SET_COLUMNS = (
     "s.id, s.name, s.description, s.created_at, s.created_by, "
     "s.updated_at, s.is_deleted, s.thumbnail_source, s.thumbnail_diagram_id, "
@@ -185,36 +195,36 @@ async def list_sets(
         )
     rows = await cursor.fetchall()
 
+    # ADR-236: compute per-set counts with grouped aggregates (one query each)
+    # instead of four COUNT(*) queries per set. The old per-set loop was O(4N)
+    # round-trips — pathologically slow on Supabase, where each await is a
+    # network hop. One global GROUP BY per metric, mapped by set_id, is correct
+    # for both the filtered and unfiltered branches.
+    diagram_counts = await _grouped_counts(
+        db, "SELECT set_id, COUNT(*) FROM diagrams WHERE is_deleted = 0 GROUP BY set_id"
+    )
+    element_counts = await _grouped_counts(
+        db, "SELECT set_id, COUNT(*) FROM elements WHERE is_deleted = 0 GROUP BY set_id"
+    )
+    # Package counts (ADR-158, v5.13.0)
+    package_counts = await _grouped_counts(
+        db, "SELECT set_id, COUNT(*) FROM packages WHERE is_deleted = 0 GROUP BY set_id"
+    )
+    package_root_counts = await _grouped_counts(
+        db,
+        "SELECT set_id, COUNT(*) FROM packages "
+        "WHERE is_deleted = 0 AND parent_package_id IS NULL GROUP BY set_id",
+    )
+
     items = []
     for row in rows:
         item = _row_to_dict(row, has_thumbnail_image=bool(row[9]))
         set_id = row[0]
 
-        mc = await db.execute(
-            "SELECT COUNT(*) FROM diagrams WHERE set_id = ? AND is_deleted = 0",
-            (set_id,),
-        )
-        item["diagram_count"] = (await mc.fetchone())[0]
-
-        ec = await db.execute(
-            "SELECT COUNT(*) FROM elements WHERE set_id = ? AND is_deleted = 0",
-            (set_id,),
-        )
-        item["element_count"] = (await ec.fetchone())[0]
-
-        # Package counts (ADR-158, v5.13.0)
-        pc = await db.execute(
-            "SELECT COUNT(*) FROM packages WHERE set_id = ? AND is_deleted = 0",
-            (set_id,),
-        )
-        item["package_count"] = (await pc.fetchone())[0]
-
-        pcr = await db.execute(
-            "SELECT COUNT(*) FROM packages "
-            "WHERE set_id = ? AND is_deleted = 0 AND parent_package_id IS NULL",
-            (set_id,),
-        )
-        item["package_count_root"] = (await pcr.fetchone())[0]
+        item["diagram_count"] = diagram_counts.get(set_id, 0)
+        item["element_count"] = element_counts.get(set_id, 0)
+        item["package_count"] = package_counts.get(set_id, 0)
+        item["package_count_root"] = package_root_counts.get(set_id, 0)
 
         # Include thumbnail diagram data for client-side rendering (DRY)
         thumb_id = row[8]  # thumbnail_diagram_id

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.44.3"
+version = "6.44.4"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_sets/test_list_sets_counts.py
+++ b/backend/tests/test_sets/test_list_sets_counts.py
@@ -1,0 +1,155 @@
+"""ADR-236: `list_sets` computes diagram/element/package counts with grouped
+aggregate queries instead of per-set COUNT(*) loops. These tests pin the
+behaviour that matters for that refactor — counts must be mapped to the
+*correct* set (no cross-set leakage) and absent sets must read zero.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def client(app_config: AppConfig) -> AsyncIterator[httpx.AsyncClient]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as c:
+        yield c
+    await db_manager.close()
+
+
+async def _auth_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    resp = await client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "AdminPass123!"},
+    )
+    return {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+
+async def _make_set(client: httpx.AsyncClient, headers: dict[str, str], name: str) -> str:
+    return (await client.post("/api/sets", json={"name": name}, headers=headers)).json()["id"]
+
+
+async def _make_package(
+    client: httpx.AsyncClient,
+    headers: dict[str, str],
+    set_id: str,
+    name: str,
+    parent_package_id: str | None = None,
+) -> str:
+    body: dict = {"name": name, "set_id": set_id}
+    if parent_package_id is not None:
+        body["parent_package_id"] = parent_package_id
+    return (await client.post("/api/packages", json=body, headers=headers)).json()["id"]
+
+
+async def _make_element(
+    client: httpx.AsyncClient, headers: dict[str, str], set_id: str, name: str
+) -> None:
+    await client.post(
+        "/api/elements",
+        json={"element_type": "component", "name": name, "data": {}, "set_id": set_id},
+        headers=headers,
+    )
+
+
+async def _make_diagram(
+    client: httpx.AsyncClient, headers: dict[str, str], set_id: str, name: str
+) -> None:
+    await client.post(
+        "/api/diagrams",
+        json={"diagram_type": "simple-view", "name": name, "data": {}, "set_id": set_id},
+        headers=headers,
+    )
+
+
+class TestListSetsCountIsolation:
+    async def test_counts_mapped_to_correct_set(self, client: httpx.AsyncClient) -> None:
+        """Set A is populated; set B is empty. Each set must report ITS OWN
+        counts — a grouped query that mis-maps would leak A's counts onto B."""
+        headers = await _auth_headers(client)
+        set_a = await _make_set(client, headers, "Alpha")
+        set_b = await _make_set(client, headers, "Bravo")
+
+        # A: 2 packages (1 root + 1 child), 3 elements, 2 diagrams.
+        root = await _make_package(client, headers, set_a, "Root A")
+        await _make_package(client, headers, set_a, "Child A", parent_package_id=root)
+        for i in range(3):
+            await _make_element(client, headers, set_a, f"el-{i}")
+        for i in range(2):
+            await _make_diagram(client, headers, set_a, f"dg-{i}")
+
+        items = (await client.get("/api/sets", headers=headers)).json()["items"]
+        by_id = {i["id"]: i for i in items}
+
+        a = by_id[set_a]
+        assert a["package_count"] == 2
+        assert a["package_count_root"] == 1
+        assert a["element_count"] == 3
+        assert a["diagram_count"] == 2
+
+        b = by_id[set_b]
+        assert b["package_count"] == 0
+        assert b["package_count_root"] == 0
+        assert b["element_count"] == 0
+        assert b["diagram_count"] == 0
+
+    async def test_collection_filtered_list_keeps_correct_counts(
+        self, client: httpx.AsyncClient
+    ) -> None:
+        """The collection-filtered branch of list_sets must compute the same
+        per-set counts as the unfiltered branch."""
+        headers = await _auth_headers(client)
+        coll = (
+            await client.post("/api/collections", json={"name": "C"}, headers=headers)
+        ).json()["id"]
+        s = (
+            await client.post(
+                "/api/sets", json={"name": "InColl", "collection_id": coll}, headers=headers
+            )
+        ).json()["id"]
+        await _make_element(client, headers, s, "only-el")
+
+        items = (
+            await client.get(f"/api/sets?collection_id={coll}", headers=headers)
+        ).json()["items"]
+        ours = next(i for i in items if i["id"] == s)
+        assert ours["element_count"] == 1
+        assert ours["diagram_count"] == 0
+        assert ours["package_count"] == 0

--- a/docs/adrs/ADR-236-Sets-List-Count-Aggregation-And-Mobile-Picker-Sizing.md
+++ b/docs/adrs/ADR-236-Sets-List-Count-Aggregation-And-Mobile-Picker-Sizing.md
@@ -1,0 +1,72 @@
+# ADR-236: Grouped count aggregation for `list_sets`, and mobile-safe picker/control sizing
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-236 |
+| **Initiative** | Make the set dropdown populate fast and fix mobile picker/input sizing in the AI chat and import screens |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-01 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the import screen's set picker and the AI-chat selectors,
+which all read `GET /api/sets`, and of several mobile-layout reports (provider
+picker, set picker, view-type selector, and the chat input),
+
+**facing** that (a) `list_sets` took "ages" to populate because it issued **four
+`COUNT(*)` queries per set** in a Python loop — O(4N) round-trips, pathological
+on Supabase where every `await` is a network hop; and (b) several controls broke
+the mobile viewport — the provider dropdown opened off-screen left, the import
+set picker overflowed, the view-type selector ran off the right after a notation
+was picked, and tapping the chat input triggered iOS Safari's focus auto-zoom,
+
+**we decided to** (1) compute the diagram/element/package/root-package counts in
+**four grouped `GROUP BY set_id` queries run once**, mapped to each set by id in
+Python (`backend/app/sets/service.py::list_sets` via a `_grouped_counts` helper),
+giving byte-for-byte identical output with ~4N → 4 round-trips; and (2) apply
+CSS/copy fixes: clamp the provider dropdown to `calc(100vw - 32px)` and re-anchor
+it on small screens; make `SetSelector` stack and width-cap on mobile; add
+`flex-wrap` + `min-w-0/max-w-full` to the chat creation controls; and add a
+single global guard `@media (max-width: 640px){ input,select,textarea{ font-size:16px } }`
+in `app.css` so no focused control sits below iOS's 16px zoom threshold (the
+viewport meta is left untouched so pinch-zoom still works). The chat "Create
+Diagram" button and the view detail "Loading diagram…" text are renamed to
+"Create View" / "Loading view…" as part of the ongoing diagram→view wording shift.
+
+**because** the per-set loop was the dominant cost and grouped aggregates are the
+standard fix that benefits every `/api/sets` consumer; and a single shared
+font-size guard plus localized layout caps fix the mobile breakage at the source
+rather than per-component, keeping the change small and DRY.
+
+## Consequences
+- The set dropdown (and the sets list page) populate near-instantly on populated
+  databases, especially on Supabase. Output is unchanged; counts are mapped per
+  set with no cross-set leakage (regression-guarded by
+  `tests/test_sets/test_list_sets_counts.py`).
+- Mobile: the provider picker, import set picker, and view-type selector stay
+  on-screen; focusing the chat input no longer zooms the page.
+- The 16px guard slightly enlarges small controls' text on ≤640px screens — an
+  intended touch-usability improvement.
+
+## Alternatives considered
+- **Restrict the grouped queries with `WHERE set_id IN (…)`**: rejected — dynamic
+  placeholder lists complicate the SQLite↔asyncpg adapter; a single global
+  `GROUP BY` is simpler and still 4 queries total.
+- **Add a lightweight `?counts=false` mode** for the picker: rejected — the
+  dropdown shows counts, and the grouped fix removes the cost for everyone.
+- **`maximum-scale=1` in the viewport meta** to stop the zoom: rejected — it
+  disables pinch-zoom, an accessibility regression. Font-size ≥16px is the
+  recommended fix.
+
+## Surface parity (§14) / §15
+No endpoints added (parity unaffected). No schema change, so no migration pair;
+`GROUP BY` runs on both SQLite and asyncpg, and `list_sets` keeps positional row
+access (§15).
+
+## Dependencies
+Builds on ADR-158 (set package counts). Touches `backend/app/sets/service.py`,
+`frontend/src/lib/components/SetQA.svelte`, `SetSelector.svelte`,
+`frontend/src/routes/views/[id]/+page.svelte`, and `frontend/src/app.css`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.44.3",
+	"version": "6.44.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -765,3 +765,16 @@ body.scroll-locked {
 	pointer-events: none;
 }
 
+/* ── Mobile: stop iOS Safari auto-zooming on focus (ADR-236) ──
+   iOS zooms in whenever a focused form control has a font-size below 16px.
+   Many controls use Tailwind's text-sm (14px); bump them to 16px on small
+   screens so tapping the chat input / pickers no longer zooms the page.
+   The viewport meta is left untouched so pinch-zoom still works. */
+@media (max-width: 640px) {
+	input,
+	select,
+	textarea {
+		font-size: 16px;
+	}
+}
+

--- a/frontend/src/lib/components/SetQA.svelte
+++ b/frontend/src/lib/components/SetQA.svelte
@@ -627,7 +627,7 @@ function promptForLocation() {
 <div class="flex flex-col" style="height: 100%">
 	<!-- Header with mode toggle, clear, and history buttons -->
 	<div class="mb-3 flex items-center justify-between gap-2 flex-wrap">
-		<div class="flex items-center gap-2">
+		<div class="flex flex-wrap items-center gap-2">
 			<button
 				onclick={() => { creationMode = false; pendingDiagrams = null; creationHistory = []; locationChosen = false; selectedPackageId = null; }}
 				class="rounded px-3 py-1.5 text-sm"
@@ -653,15 +653,15 @@ function promptForLocation() {
 					? 'background: var(--color-primary); color: white; border: 1px solid var(--color-primary)'
 					: 'border: 1px solid var(--color-border); color: var(--color-fg)'}
 			>
-				Create Diagram
+				Create View
 			</button>
 			{#if creationMode}
 				<select
-					aria-label="Diagram notation"
+					aria-label="View notation"
 					bind:value={selectedNotation}
 					onchange={() => { selectedDiagramType = ''; }}
 					disabled={!catalogueLoaded || notationOptions.length === 0}
-					class="rounded border px-2 py-1.5 text-sm disabled:opacity-50"
+					class="min-w-0 max-w-full rounded border px-2 py-1.5 text-sm disabled:opacity-50"
 					style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 				>
 					<option value="" disabled>
@@ -673,12 +673,12 @@ function promptForLocation() {
 				</select>
 				{#if selectedNotation && requiresDiagramType}
 					<select
-						aria-label="Diagram type"
+						aria-label="View type"
 						bind:value={selectedDiagramType}
-						class="rounded border px-2 py-1.5 text-sm"
+						class="min-w-0 max-w-full rounded border px-2 py-1.5 text-sm"
 						style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 					>
-						<option value="" disabled>Select diagram type…</option>
+						<option value="" disabled>Select view type…</option>
 						{#each diagramTypeOptions as d (d.diagram_type)}
 							<option value={d.diagram_type}>{d.diagram_type_label}</option>
 						{/each}
@@ -1051,8 +1051,19 @@ function promptForLocation() {
 		margin: 0;
 		padding: 4px 0;
 		min-width: 100%;
+		max-width: calc(100vw - 32px);
 		white-space: nowrap;
 		box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+	}
+	/* ADR-236: on narrow screens anchor to the left of the (left-aligned)
+	   trigger and allow wrapping so the menu never runs off-screen. */
+	@media (max-width: 640px) {
+		.provider-dropdown-menu {
+			left: 0;
+			right: auto;
+			white-space: normal;
+			min-width: min(240px, calc(100vw - 32px));
+		}
 	}
 	.provider-dropdown-item {
 		display: flex;

--- a/frontend/src/lib/components/SetSelector.svelte
+++ b/frontend/src/lib/components/SetSelector.svelte
@@ -66,7 +66,7 @@
 	});
 </script>
 
-<div class="flex items-center gap-2">
+<div class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2">
 	<label for="set-selector" class="text-sm font-medium" style="color: var(--color-fg)">
 		{label}
 	</label>
@@ -75,7 +75,7 @@
 		{value}
 		onchange={handleChange}
 		disabled={loading}
-		class="rounded border px-3 py-1.5 text-sm"
+		class="w-full min-w-0 max-w-full truncate rounded border px-3 py-1.5 text-sm sm:w-auto sm:max-w-xs"
 		style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 	>
 		{#if showAll}

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2031,7 +2031,7 @@
 			 is in flight. -->
 		<FocusView onexit={() => (focusMode = false)}>
 			<div class="flex h-full w-full items-center justify-center">
-				<p style="color: var(--color-muted)">Loading diagram...</p>
+				<p style="color: var(--color-muted)">Loading view...</p>
 			</div>
 		</FocusView>
 	{:else}
@@ -2042,7 +2042,7 @@
 				<li aria-current="page">{page.params.id}</li>
 			</ol>
 		</nav>
-		<p style="color: var(--color-muted)">Loading diagram...</p>
+		<p style="color: var(--color-muted)">Loading view...</p>
 	{/if}
 {:else if error}
 	{#if focusMode}

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.44.3"
+version = "6.44.4"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.44.3"
+version = "6.44.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Bundled mobile/UX + performance fixes (patch **6.44.4**, ADR-236). No new endpoints — surface parity unaffected; no schema change.

### Fixes
1. **Set dropdown slow to populate** — `list_sets` issued 4 `COUNT(*)` queries *per set* (O(4N) round-trips, pathological on Supabase). Now 4 grouped `GROUP BY set_id` queries total, mapped by id — **byte-for-byte identical output**, far fewer round-trips. Benefits every `/api/sets` consumer.
2. **Mobile: AI-chat model (provider) picker opened off-screen left** — dropdown clamped to `calc(100vw - 32px)` and re-anchored on ≤640px.
3. **Mobile: import set picker overflowed** — `SetSelector` now stacks + width-caps.
4. **"Create Diagram" → "Create View"**, and the view-type selector no longer runs off the right on mobile (creation controls wrap).
5. **View screen: "Loading diagram…" → "Loading view…"**.
6. **Mobile: tapping the chat input zoomed the page** — iOS Safari auto-zooms focused controls under 16px; a global `@media (max-width:640px)` guard bumps `input/select/textarea` to 16px (viewport meta untouched, so pinch-zoom still works).

(4 & 5 are part of the ongoing diagram→view wording shift.)

## Tests
- New `backend/tests/test_sets/test_list_sets_counts.py` guards per-set count mapping (no cross-set leakage; zero-count sets; collection-filtered branch).
- `pytest backend/tests/test_sets` — **54 passed**.
- `svelte-check` — no new errors in the touched files (pre-existing baseline errors are unrelated).

## Verification notes
CSS/mobile fixes should be confirmed on a **populated** backend at a Pixel-5 viewport (empty backends hide data-driven overflow); the iOS auto-zoom is best confirmed on real iOS Safari. See ADR-236 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)