### PR TITLE
feat(v6.45.0): per-user collection write-scope (ADR-237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.45.0] - 2026-06-01
+
+### Added
+
+- **Per-user collection write-scope (ADR-237).** An admin can now keep a user's
+  global role (e.g. `architect`) but confine that role's WRITE/edit powers to a
+  whitelist of collections; everywhere else the user is read-only. Assignment is
+  a junction table (`user_collection_scope`) managed directly in Supabase — Iris
+  reads and enforces it. A user with no scope rows is unrestricted (unchanged
+  behaviour); admins always bypass. Scoped users cannot create or delete
+  collections, nor mutate global element templates, even inside their scope.
+  Every write endpoint (collections, sets, packages, diagrams, elements,
+  element-templates, comments, entity-images) is gated; reads are untouched.
+- **`GET /api/auth/me` now returns `write_scope`**, and element/diagram reads
+  carry `collection_id`, so the web UI hides Edit/Save/Delete affordances and
+  the comments panel in collections the user can't write to, and hides
+  New/Delete Collection for scoped users.
+
 ## [6.44.3] - 2026-06-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The default self-hosted mode requires no external services. The optional Render 
 - **Database:** SQLite with WAL mode (default) or PostgreSQL via Supabase (optional)
 - **Auth:** Argon2id password hashing + Iris JWT (SQLite) or Supabase Auth JWT (Supabase)
 - **RBAC:** 4 roles (Admin, Architect, Reviewer, Viewer) with 26 permission mappings
+- **Collection write-scope (ADR-237):** optionally confine a user's write/edit
+  permissions to a whitelist of collections (read-only elsewhere); assigned via
+  the `user_collection_scope` table in Supabase, enforced on every write endpoint
 - **Audit:** SHA-256 hash-chained immutable audit log (separate DB in SQLite; table in Supabase)
 - **Versioning:** Immutable append-only entity versions with revert-as-new-version rollback
 - **Search:** Full-text search with SQLite FTS5 (default) or PostgreSQL tsvector/GIN (Supabase)

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -10,6 +10,7 @@ from argon2.exceptions import VerifyMismatchError
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.auth.dependencies import get_current_user
+from app.authz import load_scope
 from app.auth.models import (
     ChangePasswordRequest,
     LoginRequest,
@@ -36,8 +37,19 @@ async def get_me(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, Any]:
-    """Return the authenticated user's profile (both deployment modes)."""
-    return {**current_user, "is_active": True}
+    """Return the authenticated user's profile (both deployment modes).
+
+    ADR-237: ``write_scope`` is the list of collection ids this user may write
+    in, or ``None`` when unrestricted (admins, or any user with no scope rows).
+    The frontend uses it to gate edit affordances and the comments panel.
+    """
+    if current_user.get("role") == "admin":
+        write_scope: list[str] | None = None
+    else:
+        db = request.app.state.db_manager.main_db
+        scope = await load_scope(db, current_user["id"])
+        write_scope = sorted(scope) if scope else None
+    return {**current_user, "is_active": True, "write_scope": write_scope}
 
 
 async def _get_session_timeout(db: object) -> int | None:

--- a/backend/app/authz/__init__.py
+++ b/backend/app/authz/__init__.py
@@ -1,0 +1,31 @@
+"""Authorization helpers (ADR-237): per-user collection write-scope.
+
+A user with no rows in ``user_collection_scope`` is *unscoped* — their role's
+write permissions apply everywhere (the pre-ADR-237 behaviour). A *scoped* user
+may write only inside their whitelisted collections, may never create or delete
+collections, and may not mutate global element templates. Admins always bypass.
+Reads are unaffected (ADR-123).
+"""
+
+from app.authz.collection_resolver import (
+    collection_of_diagram,
+    collection_of_element,
+    collection_of_entity,
+    collection_of_package,
+    collection_of_set,
+    collection_of_template,
+)
+from app.authz.collection_scope import load_scope
+from app.authz.enforce import assert_unscoped_or_admin, assert_write_allowed
+
+__all__ = [
+    "assert_unscoped_or_admin",
+    "assert_write_allowed",
+    "collection_of_diagram",
+    "collection_of_element",
+    "collection_of_entity",
+    "collection_of_package",
+    "collection_of_set",
+    "collection_of_template",
+    "load_scope",
+]

--- a/backend/app/authz/collection_resolver.py
+++ b/backend/app/authz/collection_resolver.py
@@ -1,0 +1,85 @@
+"""Resolve a write target's owning collection id (ADR-237).
+
+Every writable entity roots at a collection: a set carries ``collection_id``
+directly; a package / diagram / element / element_template carries ``set_id``,
+which resolves to the set's collection. Returns ``None`` when there is no owning
+collection — an un-grouped set (``collection_id IS NULL``, e.g. the seeded
+default set), a global element template (``set_id IS NULL``), or a missing row.
+The enforcement helper treats ``None`` as "outside any assigned collection".
+
+These are deliberately lightweight FK lookups rather than the full service
+getters: they stay off the write-path's critical latency and intentionally
+ignore ``is_deleted`` so authz resolves the true owning collection regardless
+of a row's soft-delete state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+async def _scalar(db: DatabasePort, sql: str, value: str) -> str | None:
+    cursor = await db.execute(sql, (value,))
+    row = await cursor.fetchone()
+    return row[0] if row else None
+
+
+async def collection_of_set(db: DatabasePort, set_id: str | None) -> str | None:
+    """The collection a set belongs to (or ``None`` if un-grouped/missing)."""
+    if not set_id:
+        return None
+    return await _scalar(db, "SELECT collection_id FROM sets WHERE id = ?", set_id)
+
+
+async def collection_of_package(db: DatabasePort, package_id: str | None) -> str | None:
+    if not package_id:
+        return None
+    set_id = await _scalar(db, "SELECT set_id FROM packages WHERE id = ?", package_id)
+    return await collection_of_set(db, set_id)
+
+
+async def collection_of_diagram(db: DatabasePort, diagram_id: str | None) -> str | None:
+    if not diagram_id:
+        return None
+    set_id = await _scalar(db, "SELECT set_id FROM diagrams WHERE id = ?", diagram_id)
+    return await collection_of_set(db, set_id)
+
+
+async def collection_of_element(db: DatabasePort, element_id: str | None) -> str | None:
+    if not element_id:
+        return None
+    set_id = await _scalar(db, "SELECT set_id FROM elements WHERE id = ?", element_id)
+    return await collection_of_set(db, set_id)
+
+
+async def collection_of_template(db: DatabasePort, template_id: str | None) -> str | None:
+    """The collection a template belongs to. Global templates resolve to
+    ``None`` (their ``set_id`` is NULL) — scoped users can't write them."""
+    if not template_id:
+        return None
+    set_id = await _scalar(
+        db, "SELECT set_id FROM element_templates WHERE id = ?", template_id
+    )
+    return await collection_of_set(db, set_id)
+
+
+async def collection_of_entity(
+    db: DatabasePort, entity_type: str, entity_id: str
+) -> str | None:
+    """Resolve the owning collection for any of the entity types used by the
+    entity-image attachment surface (ADR-209): a ``collection`` IS its own
+    collection; the rest delegate to the per-type resolvers above."""
+    if entity_type == "collection":
+        return entity_id
+    if entity_type == "set":
+        return await collection_of_set(db, entity_id)
+    if entity_type == "package":
+        return await collection_of_package(db, entity_id)
+    if entity_type == "diagram":
+        return await collection_of_diagram(db, entity_id)
+    if entity_type == "element":
+        return await collection_of_element(db, entity_id)
+    return None

--- a/backend/app/authz/collection_scope.py
+++ b/backend/app/authz/collection_scope.py
@@ -1,0 +1,27 @@
+"""Per-user collection write-scope loader (ADR-237).
+
+A user's *scope* is the set of collection ids they are permitted to **write**
+in. An empty set means *unscoped* — the user's role applies everywhere (the
+pre-ADR-237 behaviour). Assignment lives in the ``user_collection_scope`` table
+(managed directly in Supabase); this module only reads it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+
+async def load_scope(db: DatabasePort, user_id: str) -> set[str]:
+    """Return the set of collection ids this user may write in.
+
+    Empty set == unscoped (caller must treat as "write everywhere").
+    Positional row access (§15) — asyncpg returns plain tuples.
+    """
+    cursor = await db.execute(
+        "SELECT collection_id FROM user_collection_scope WHERE user_id = ?",
+        (user_id,),
+    )
+    return {row[0] for row in await cursor.fetchall()}

--- a/backend/app/authz/enforce.py
+++ b/backend/app/authz/enforce.py
@@ -1,0 +1,58 @@
+"""Write-scope enforcement helpers (ADR-237).
+
+A user with no scope rows is *unscoped* (writes everywhere). Admins always
+bypass. A *scoped* user may write only inside their whitelisted collections,
+may never create or delete collections, and may not mutate global element
+templates. Failures raise ``HTTPException(403)`` — consistent with
+``require_permission`` (401 stays reserved for missing/invalid credentials).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from fastapi import HTTPException
+
+from app.authz.collection_scope import load_scope
+
+if TYPE_CHECKING:
+    from app.db.adapter import DatabasePort
+
+_FORBIDDEN_DETAIL = "Outside your collection write-scope"
+
+
+def _is_exempt(user: dict[str, Any]) -> bool:
+    """Admins bypass scoping entirely (they assign scopes themselves)."""
+    return user.get("role") == "admin"
+
+
+async def assert_write_allowed(
+    db: DatabasePort, user: dict[str, Any], collection_id: str | None
+) -> None:
+    """Raise 403 if a scoped user is writing outside their scope.
+
+    Admins and unscoped users (no scope rows) are always allowed. For a scoped
+    user a ``collection_id`` of ``None`` — no owning collection, e.g. a global
+    template or an un-grouped set — is treated as outside scope.
+    """
+    if _is_exempt(user):
+        return
+    scope = await load_scope(db, user["id"])
+    if not scope:  # unscoped → write everywhere (pre-ADR-237 behaviour)
+        return
+    if collection_id is None or collection_id not in scope:
+        raise HTTPException(status_code=403, detail=_FORBIDDEN_DETAIL)
+
+
+async def assert_unscoped_or_admin(db: DatabasePort, user: dict[str, Any]) -> None:
+    """Raise 403 for any scoped (non-admin) user.
+
+    Guards operations a scoped user may never perform regardless of which
+    collection is involved: creating or deleting a collection, and writing a
+    server-wide (global) element template.
+    """
+    if _is_exempt(user):
+        return
+    scope = await load_scope(db, user["id"])
+    if scope:
+        raise HTTPException(status_code=403, detail=_FORBIDDEN_DETAIL)

--- a/backend/app/collections/router.py
+++ b/backend/app/collections/router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFil
 from fastapi.responses import Response as FastAPIResponse
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import assert_unscoped_or_admin, assert_write_allowed
 from app.collections.models import (
     CollectionCreate,
     CollectionListResponse,
@@ -40,6 +41,8 @@ async def create(
 ) -> CollectionResponse:
     """Create a new collection."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: a scoped user may not create new top-level collections.
+    await assert_unscoped_or_admin(db, current_user)
     try:
         result = await create_collection(
             db,
@@ -86,10 +89,12 @@ async def update(
     collection_id: str,
     body: CollectionUpdate,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> CollectionResponse:
     """Update a collection's name, description, and thumbnail settings."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: editing collection metadata is allowed only within write-scope.
+    await assert_write_allowed(db, current_user, collection_id)
     try:
         result = await update_collection(
             db, collection_id,
@@ -115,10 +120,12 @@ async def update(
 async def delete(
     collection_id: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> FastAPIResponse:
     """Soft-delete a collection and unlink its sets."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: a scoped user may not delete collections, even in-scope ones.
+    await assert_unscoped_or_admin(db, current_user)
 
     result = await soft_delete_collection(db, collection_id)
     if result is not None:
@@ -133,10 +140,12 @@ async def upload_thumbnail(
     collection_id: str,
     file: UploadFile,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> CollectionResponse:
     """Upload a thumbnail image for a collection."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: a thumbnail is collection content — gate by write-scope.
+    await assert_write_allowed(db, current_user, collection_id)
 
     if file.content_type not in _ALLOWED_CONTENT_TYPES:
         raise HTTPException(

--- a/backend/app/comments/router.py
+++ b/backend/app/comments/router.py
@@ -9,6 +9,11 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from app.auth.dependencies import get_current_user
+from app.authz import (
+    assert_write_allowed,
+    collection_of_diagram,
+    collection_of_element,
+)
 from app.comments.models import CommentCreate, CommentResponse, CommentUpdate
 
 router = APIRouter(tags=["comments"])
@@ -68,6 +73,8 @@ async def create_element_comment(
 ) -> CommentResponse:
     """Add a comment on an element."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: commenting is a write — gate by the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     comment_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
     await db.execute(
@@ -111,6 +118,8 @@ async def create_diagram_comment(
 ) -> CommentResponse:
     """Add a comment on a diagram."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: commenting is a write — gate by the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     comment_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
     await db.execute(
@@ -153,6 +162,13 @@ async def update_comment(
     if row[3] != current_user["id"] and current_user["role"] != "admin":
         raise HTTPException(status_code=403, detail="Not comment owner")
 
+    # ADR-237: editing a comment is a write — gate by the target's collection.
+    if row[1] == "element":
+        target_coll = await collection_of_element(db, row[2])
+    else:
+        target_coll = await collection_of_diagram(db, row[2])
+    await assert_write_allowed(db, current_user, target_coll)
+
     now = datetime.now(tz=UTC).isoformat()
     await db.execute(
         "UPDATE comments SET content = ?, updated_at = ? WHERE id = ?",
@@ -175,7 +191,8 @@ async def delete_comment(
     """Soft-delete a comment (owner or admin)."""
     db = request.app.state.db_manager.main_db
     cursor = await db.execute(
-        "SELECT user_id FROM comments WHERE id = ? AND is_deleted = 0",
+        "SELECT user_id, target_type, target_id FROM comments "
+        "WHERE id = ? AND is_deleted = 0",
         (comment_id,),
     )
     row = await cursor.fetchone()
@@ -183,6 +200,13 @@ async def delete_comment(
         raise HTTPException(status_code=404, detail="Comment not found")
     if row[0] != current_user["id"] and current_user["role"] != "admin":
         raise HTTPException(status_code=403, detail="Not comment owner")
+
+    # ADR-237: deleting a comment is a write — gate by the target's collection.
+    if row[1] == "element":
+        target_coll = await collection_of_element(db, row[2])
+    else:
+        target_coll = await collection_of_diagram(db, row[2])
+    await assert_write_allowed(db, current_user, target_coll)
 
     await db.execute(
         "UPDATE comments SET is_deleted = 1 WHERE id = ?", (comment_id,),

--- a/backend/app/diagrams/models.py
+++ b/backend/app/diagrams/models.py
@@ -52,6 +52,9 @@ class DiagramResponse(BaseModel):
     tags: list[str] = Field(default_factory=list)
     set_id: str | None = None
     set_name: str | None = None
+    # ADR-237: owning collection, so the client can gate edit affordances by
+    # write-scope without an extra fetch.
+    collection_id: str | None = None
     notation: str = "simple"
     detected_notations: list[str] = Field(default_factory=list)
     metadata: dict[str, object] | None = None

--- a/backend/app/diagrams/router.py
+++ b/backend/app/diagrams/router.py
@@ -9,6 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import Response as FastAPIResponse
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import (
+    assert_write_allowed,
+    collection_of_diagram,
+    collection_of_package,
+    collection_of_set,
+)
 from app.diagrams.models import (
     DiagramCreate,
     DiagramHierarchyNode,
@@ -65,6 +71,13 @@ async def create(
 ) -> DiagramResponse:
     """Create a new diagram."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the target set/package's collection.
+    _coll = (
+        await collection_of_set(db, body.set_id)
+        if body.set_id
+        else await collection_of_package(db, body.parent_package_id)
+    )
+    await assert_write_allowed(db, current_user, _coll)
     result = await create_diagram(
         db,
         diagram_type=body.diagram_type,
@@ -97,10 +110,19 @@ async def hierarchy(
 async def reorder(
     body: ReorderRequest,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, str]:
     """Reorder diagrams and packages within a parent group."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: reordering is a write within a parent group; gate by collection.
+    if body.parent_package_id:
+        _coll = await collection_of_package(db, body.parent_package_id)
+    elif body.ordered_ids:
+        _coll = await collection_of_diagram(db, body.ordered_ids[0]) or \
+            await collection_of_package(db, body.ordered_ids[0])
+    else:
+        _coll = None
+    await assert_write_allowed(db, current_user, _coll)
     await reorder_siblings(
         db,
         parent_package_id=body.parent_package_id,
@@ -174,6 +196,8 @@ async def update(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     result = await update_diagram(
         db, diagram_id,
         name=body.name,
@@ -211,6 +235,8 @@ async def delete(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     deleted = await soft_delete_diagram(
         db, diagram_id,
         deleted_by=current_user["id"],
@@ -247,13 +273,15 @@ async def set_parent(
     diagram_id: str,
     body: dict[str, Any],
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, Any]:
     """Set or unset the parent package for a diagram."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: re-parenting stays within the set; gate by its collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     parent_id = body.get("parent_package_id")
     result = await set_diagram_parent(
-        db, diagram_id, parent_id, updated_by=_current_user["id"],
+        db, diagram_id, parent_id, updated_by=current_user["id"],
     )
     if result is None:
         raise HTTPException(status_code=404, detail="Diagram or parent not found")
@@ -302,6 +330,8 @@ async def rollback(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     result = await rollback_diagram(
         db,
         diagram_id,
@@ -345,6 +375,8 @@ async def add_tag(
 ) -> dict[str, str]:
     """Add a tag to a diagram."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: tagging is a write — gate by the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     tag = body.get("tag", "").strip()
     if not tag or len(tag) > 50:
         raise HTTPException(status_code=400, detail="Tag must be 1-50 characters")
@@ -368,10 +400,12 @@ async def remove_tag(
     diagram_id: str,
     tag: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, str]:
     """Remove a tag from a diagram."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: untagging is a write — gate by the diagram's collection.
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, diagram_id))
     await db.execute(
         "DELETE FROM diagram_tags WHERE diagram_id = ? AND tag = ?",
         (diagram_id, tag),
@@ -501,10 +535,18 @@ diagram_rel_router = APIRouter(prefix="/api/diagram-relationships", tags=["diagr
 async def delete_diagram_relationship(
     relationship_id: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, str]:
     """Delete a diagram link."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by the source diagram's collection.
+    src = await db.execute(
+        "SELECT source_diagram_id FROM diagram_links WHERE id = ?", (relationship_id,)
+    )
+    link = await src.fetchone()
+    if link is None:
+        raise HTTPException(status_code=404, detail="Diagram link not found")
+    await assert_write_allowed(db, current_user, await collection_of_diagram(db, link[0]))
     cursor = await db.execute(
         "DELETE FROM diagram_links WHERE id = ?", (relationship_id,)
     )

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -150,7 +150,8 @@ async def get_diagram(
         "dv.name, dv.description, dv.data, "
         "d.created_at, d.created_by, d.updated_at, d.is_deleted, "
         "u.username, d.parent_package_id, d.set_id, s.name, dv.metadata, "
-        "d.notation, d.detected_notations "
+        "d.notation, d.detected_notations, "
+        "s.collection_id "  # ADR-237: owning collection for write-scope gating
         "FROM diagrams d "
         "JOIN diagram_versions dv ON d.id = dv.diagram_id "
         "AND d.current_version = dv.version "
@@ -207,6 +208,7 @@ async def get_diagram(
         "tags": tags,
         "set_id": row[12],
         "set_name": row[13],
+        "collection_id": row[17],  # ADR-237: owning collection for client gating
         "notation": row[15] or "simple",
         "detected_notations": detected,
         "metadata": json.loads(row[14]) if row[14] else None,

--- a/backend/app/element_templates/router.py
+++ b/backend/app/element_templates/router.py
@@ -7,6 +7,12 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import (
+    assert_unscoped_or_admin,
+    assert_write_allowed,
+    collection_of_set,
+    collection_of_template,
+)
 from app.element_templates.models import (
     ElementTemplateCreate,
     ElementTemplateListResponse,
@@ -42,6 +48,12 @@ async def create(
     yield non-empty content.
     """
     db = request.app.state.db_manager.main_db
+    # ADR-237: global templates are server-wide (scoped users denied);
+    # set-scoped templates require write-scope on the parent set's collection.
+    if body.is_global:
+        await assert_unscoped_or_admin(db, current_user)
+    else:
+        await assert_write_allowed(db, current_user, await collection_of_set(db, body.set_id))
     try:
         result = await create_element_template(
             db,
@@ -129,10 +141,13 @@ async def update(
     template_id: str,
     body: ElementTemplateUpdate,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> ElementTemplateResponse:
     """Edit a template. Templates are not versioned — no If-Match."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: editing a template requires write-scope on its collection
+    # (globals resolve to None → denied for scoped users).
+    await assert_write_allowed(db, current_user, await collection_of_template(db, template_id))
     # The model uses None to mean "leave untouched" for everything
     # except set_id; for set_id, we need a tri-state because None is
     # the legitimate value for globals. The Pydantic model's set_id
@@ -148,6 +163,9 @@ async def update(
         kwargs["included_fields"] = raw["included_fields"]
     if "is_global" in raw:
         kwargs["is_global"] = raw["is_global"]
+        if raw["is_global"]:
+            # ADR-237: promoting a template to global is admin/unscoped-only.
+            await assert_unscoped_or_admin(db, current_user)
     if "set_id" in raw:
         kwargs["set_id"] = raw["set_id"]  # may be None
     if "template_data" in raw:
@@ -167,10 +185,13 @@ async def update(
 async def delete(
     template_id: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> None:
     """Soft-delete a template."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: deleting a template requires write-scope on its collection
+    # (globals resolve to None → denied for scoped users).
+    await assert_write_allowed(db, current_user, await collection_of_template(db, template_id))
     ok = await delete_element_template(db, template_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Template not found")

--- a/backend/app/elements/models.py
+++ b/backend/app/elements/models.py
@@ -78,6 +78,9 @@ class ElementResponse(BaseModel):
     diagram_usage_count: int = 0
     set_id: str | None = None
     set_name: str | None = None
+    # ADR-237: owning collection, so the client can gate edit affordances by
+    # write-scope without an extra fetch.
+    collection_id: str | None = None
     package_id: str | None = None
     package_name: str | None = None
     detail_diagram_id: str | None = None

--- a/backend/app/elements/router.py
+++ b/backend/app/elements/router.py
@@ -9,6 +9,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import (
+    assert_write_allowed,
+    collection_of_element,
+    collection_of_package,
+    collection_of_set,
+)
 from app.elements.models import (
     ElementCreate,
     ElementListResponse,
@@ -53,6 +59,13 @@ async def create(
     request fields always win over template defaults.
     """
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the element's target collection.
+    _coll = (
+        await collection_of_set(db, body.set_id)
+        if body.set_id
+        else await collection_of_package(db, body.package_id)
+    )
+    await assert_write_allowed(db, current_user, _coll)
     fields = body.model_dump(exclude_unset=True)
     template_id = fields.pop("template_id", None)
     template_tags: list[str] = []
@@ -429,6 +442,8 @@ async def update(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     # ElementUpdate's ``package_id`` defaults to the _UNSET sentinel
     # (meaning "do not touch"); the service layer treats an explicit
     # ``None`` as "clear". Forward as-is via the same sentinel.
@@ -480,6 +495,8 @@ async def rollback(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     result = await rollback_element(
         db,
         element_id,
@@ -515,6 +532,8 @@ async def delete(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     if cascade:
         deleted = await cascade_delete_element(
             db, element_id, deleted_by=current_user["id"],
@@ -640,6 +659,8 @@ async def add_tag(
 ) -> dict[str, str]:
     """Add a tag to an element."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: tagging is a write — gate by the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     tag = body.get("tag", "").strip()
     if not tag or len(tag) > 50:
         raise HTTPException(status_code=400, detail="Tag must be 1-50 characters")
@@ -663,10 +684,12 @@ async def remove_tag(
     element_id: str,
     tag: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, str]:
     """Remove a tag from an element."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: untagging is a write — gate by the element's collection.
+    await assert_write_allowed(db, current_user, await collection_of_element(db, element_id))
     await db.execute(
         "DELETE FROM element_tags WHERE element_id = ? AND tag = ?",
         (element_id, tag),

--- a/backend/app/elements/service.py
+++ b/backend/app/elements/service.py
@@ -253,7 +253,8 @@ async def get_element(
         "(SELECT pev.name FROM elements pe "
         "  JOIN element_versions pev ON pe.id = pev.element_id "
         "    AND pe.current_version = pev.version "
-        "  WHERE pe.id = e.parent_element_id) AS parent_element_name "
+        "  WHERE pe.id = e.parent_element_id) AS parent_element_name, "
+        "s.collection_id "  # ADR-237: owning collection for write-scope gating
         "FROM elements e "
         "JOIN element_versions ev ON e.id = ev.element_id "
         "AND e.current_version = ev.version "
@@ -287,6 +288,7 @@ async def get_element(
         "parent_element_id": row[17],
         "package_name": row[18],
         "parent_element_name": row[19],
+        "collection_id": row[20],  # ADR-237: lets the client gate by write-scope
     }
     # ADR-233: read-through stereotype from metadata for display.
     element["stereotype"] = (element["metadata"] or {}).get("stereotype")  # type: ignore[union-attr]

--- a/backend/app/images/entity_attachment_router.py
+++ b/backend/app/images/entity_attachment_router.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from pydantic import BaseModel
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import assert_write_allowed, collection_of_entity
 from app.images import service as image_service
 from app.images.entity_attachment_service import (
     ALLOWED_ENTITY_TYPES,
@@ -86,6 +87,8 @@ async def upload_and_attach(
     """
     et = _check_entity_type(entity_type)
     db = request.app.state.db_manager.main_db
+    # ADR-237: attaching an image is a write — gate by the entity's collection.
+    await assert_write_allowed(db, current_user, await collection_of_entity(db, et, entity_id))
 
     data = await file.read()
     declared = file.content_type or "application/octet-stream"
@@ -147,6 +150,8 @@ async def attach_existing(
     MCP / CLI / cross-entity re-use flows."""
     et = _check_entity_type(entity_type)
     db = request.app.state.db_manager.main_db
+    # ADR-237: attaching an image is a write — gate by the entity's collection.
+    await assert_write_allowed(db, current_user, await collection_of_entity(db, et, entity_id))
     try:
         attachment = await attach_image(
             db, entity_type=et, entity_id=entity_id,
@@ -213,12 +218,14 @@ async def detach(
     entity_id: str,
     attachment_id: str,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> None:
     """Detach the image from the entity. Does NOT delete the underlying
     image — other entities may reference it."""
     et = _check_entity_type(entity_type)
     db = request.app.state.db_manager.main_db
+    # ADR-237: detaching an image is a write — gate by the entity's collection.
+    await assert_write_allowed(db, current_user, await collection_of_entity(db, et, entity_id))
     try:
         await detach_image(
             db, entity_type=et, entity_id=entity_id, attachment_id=attachment_id,

--- a/backend/app/migrations/m082_user_collection_scope.py
+++ b/backend/app/migrations/m082_user_collection_scope.py
@@ -1,0 +1,36 @@
+"""Migration 082: Per-user collection write-scope (ADR-237).
+
+Adds the ``user_collection_scope`` junction table. A row ``(user_id,
+collection_id)`` whitelists a collection the user may **write** in. A user with
+NO rows is *unscoped* — their role's write permissions apply everywhere (the
+pre-ADR-237 behaviour). Read access is unchanged (anonymous reads, ADR-123).
+
+Assignment is managed directly in Supabase (the admin inserts rows in the
+dashboard); Iris only reads + enforces. Mirrored by Supabase ``m088``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m082_user_collection_scope"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    await db.execute(
+        "CREATE TABLE IF NOT EXISTS user_collection_scope ("
+        "user_id TEXT NOT NULL REFERENCES users(id), "
+        "collection_id TEXT NOT NULL REFERENCES collections(id), "
+        "created_at TEXT NOT NULL DEFAULT (datetime('now')), "
+        "PRIMARY KEY (user_id, collection_id)"
+        ")"
+    )
+    await db.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ucs_user "
+        "ON user_collection_scope(user_id)"
+    )
+    await db.commit()

--- a/backend/app/migrations/supabase/m088_user_collection_scope.sql
+++ b/backend/app/migrations/supabase/m088_user_collection_scope.sql
@@ -1,0 +1,22 @@
+-- Migration 088: Per-user collection write-scope (ADR-237).
+--
+-- Mirrors SQLite m082. Junction table whitelisting the collections a user may
+-- WRITE in. No rows for a user = unscoped (writes everywhere, pre-ADR-237
+-- behaviour). Reads are unaffected (ADR-123).
+--
+-- ``user_id`` references ``profiles(id)`` (the Supabase user store), mirroring
+-- how the SQLite half references ``users(id)``.
+--
+-- Idempotent.
+
+CREATE TABLE IF NOT EXISTS user_collection_scope (
+    user_id       UUID        NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    collection_id TEXT        NOT NULL REFERENCES public.collections(id),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, collection_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ucs_user
+    ON public.user_collection_scope(user_id);
+
+ALTER TABLE public.user_collection_scope ENABLE ROW LEVEL SECURITY;

--- a/backend/app/packages/router.py
+++ b/backend/app/packages/router.py
@@ -7,6 +7,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import assert_write_allowed, collection_of_package, collection_of_set
 from app.elements.models import ElementListResponse, ElementResponse
 from app.packages.models import (
     PackageCreate,
@@ -42,6 +43,8 @@ async def create(
 ) -> PackageResponse:
     """Create a new package."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the parent set's collection.
+    await assert_write_allowed(db, current_user, await collection_of_set(db, body.set_id))
     result = await create_package(
         db,
         name=body.name,
@@ -138,6 +141,8 @@ async def update(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the package's collection.
+    await assert_write_allowed(db, current_user, await collection_of_package(db, package_id))
     result = await update_package(
         db, package_id,
         name=body.name,
@@ -174,6 +179,8 @@ async def delete(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-237: gate by write-scope on the package's collection.
+    await assert_write_allowed(db, current_user, await collection_of_package(db, package_id))
     deleted = await cascade_delete_package(
         db, package_id,
         deleted_by=current_user["id"],
@@ -234,13 +241,15 @@ async def set_parent(
     package_id: str,
     body: dict[str, Any],
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, Any]:
     """Set or unset the parent package."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: re-parenting stays within the set; gate by its collection.
+    await assert_write_allowed(db, current_user, await collection_of_package(db, package_id))
     parent_id = body.get("parent_package_id")
     result = await set_package_parent(
-        db, package_id, parent_id, updated_by=_current_user["id"],
+        db, package_id, parent_id, updated_by=current_user["id"],
     )
     if result is None:
         raise HTTPException(status_code=404, detail="Package or parent not found")

--- a/backend/app/sets/router.py
+++ b/backend/app/sets/router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, UploadFil
 from fastapi.responses import Response as FastAPIResponse
 
 from app.auth.dependencies import get_current_user, get_optional_user
+from app.authz import assert_write_allowed, collection_of_set
 from app.sets.models import (
     SetCreate,
     SetForceDeleteResponse,
@@ -41,6 +42,8 @@ async def create(
 ) -> SetResponse:
     """Create a new set."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: creating a set requires write-scope on its target collection.
+    await assert_write_allowed(db, current_user, body.collection_id)
     try:
         result = await create_set(
             db,
@@ -89,10 +92,15 @@ async def update(
     set_id: str,
     body: SetUpdate,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> SetResponse:
     """Update a set's name, description, and thumbnail settings."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: need write-scope on the set's current collection, plus the
+    # destination collection when this update moves the set.
+    await assert_write_allowed(db, current_user, await collection_of_set(db, set_id))
+    if body.collection_id:
+        await assert_write_allowed(db, current_user, body.collection_id)
     try:
         result = await update_set(
             db, set_id,
@@ -136,6 +144,8 @@ async def delete(
 ) -> FastAPIResponse | SetForceDeleteResponse:
     """Soft-delete a set. With force=true, also deletes all contents."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: deleting a set requires write-scope on its collection.
+    await assert_write_allowed(db, current_user, await collection_of_set(db, set_id))
 
     if force:
         result = await force_delete_set(db, set_id, deleted_by=current_user["id"])
@@ -169,10 +179,12 @@ async def upload_thumbnail(
     set_id: str,
     file: UploadFile,
     request: Request,
-    _current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
+    current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> SetResponse:
     """Upload a thumbnail image for a set."""
     db = request.app.state.db_manager.main_db
+    # ADR-237: a thumbnail is set content — gate by write-scope.
+    await assert_write_allowed(db, current_user, await collection_of_set(db, set_id))
 
     if file.content_type not in _ALLOWED_CONTENT_TYPES:
         raise HTTPException(

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -86,6 +86,7 @@ from app.migrations.m078_aggregation_list_diagram_type import up as m078_up
 from app.migrations.m079_rename_quantified_item_to_ingredient import up as m079_up
 from app.migrations.m080_element_detail_diagram import up as m080_up
 from app.migrations.m081_element_parent_element import up as m081_up
+from app.migrations.m082_user_collection_scope import up as m082_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -198,6 +199,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m079_up(main)  # issue #211, v6.29.0: rename seeded "Quantified item" → "Ingredient"
     await m080_up(main)  # issue #242, v6.33.0: elements.detail_diagram_id drill link (ADR-221)
     await m081_up(main)  # v6.43.0: elements.parent_element_id containment axis (ADR-231)
+    await m082_up(main)  # v6.45.0: user_collection_scope per-user write-scope (ADR-237)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.44.3"
+version = "6.45.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_authz/test_collection_scope.py
+++ b/backend/tests/test_authz/test_collection_scope.py
@@ -1,0 +1,343 @@
+"""ADR-237: per-user collection write-scope enforcement.
+
+A user with rows in ``user_collection_scope`` may WRITE only inside those
+collections; outside them they are read-only, and they may never create or
+delete collections nor mutate global element templates. Admins and users with
+no scope rows bypass. Reads are unaffected.
+
+The existing router suites all authenticate as ``admin`` (who bypasses), so
+these tests specifically drive a *scoped* ``architect`` user end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.main import create_app
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+_ARCH_PW = "ArchitectPass123!"
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+@pytest.fixture
+async def ctx(
+    app_config: AppConfig,
+) -> AsyncIterator[tuple[httpx.AsyncClient, DatabaseManager]]:
+    application = create_app(app_config)
+    db_manager = DatabaseManager(app_config)
+    await initialize_databases(db_manager)
+    application.state.db_manager = db_manager
+    transport = httpx.ASGITransport(app=application)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c, db_manager
+    await db_manager.close()
+
+
+async def _admin_headers(client: httpx.AsyncClient) -> dict[str, str]:
+    await client.post(
+        "/api/auth/setup", json={"username": "admin", "password": "AdminPass123!"}
+    )
+    r = await client.post(
+        "/api/auth/login", json={"username": "admin", "password": "AdminPass123!"}
+    )
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _create_architect(
+    client: httpx.AsyncClient, admin_headers: dict[str, str], username: str = "arch"
+) -> str:
+    r = await client.post(
+        "/api/users",
+        json={"username": username, "password": _ARCH_PW, "role": "architect"},
+        headers=admin_headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _login(client: httpx.AsyncClient, username: str) -> dict[str, str]:
+    r = await client.post(
+        "/api/auth/login", json={"username": username, "password": _ARCH_PW}
+    )
+    assert r.status_code == 200, r.text
+    return {"Authorization": f"Bearer {r.json()['access_token']}"}
+
+
+async def _add_scope(db_manager: DatabaseManager, user_id: str, *collection_ids: str) -> None:
+    db = db_manager.main_db
+    for cid in collection_ids:
+        await db.execute(
+            "INSERT INTO user_collection_scope (user_id, collection_id) VALUES (?, ?)",
+            (user_id, cid),
+        )
+    await db.commit()
+
+
+async def _mk_collection(client: httpx.AsyncClient, headers: dict[str, str], name: str) -> str:
+    r = await client.post("/api/collections", json={"name": name}, headers=headers)
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _mk_set(
+    client: httpx.AsyncClient, headers: dict[str, str], name: str, collection_id: str
+) -> httpx.Response:
+    return await client.post(
+        "/api/sets", json={"name": name, "collection_id": collection_id}, headers=headers
+    )
+
+
+async def _mk_element(
+    client: httpx.AsyncClient, headers: dict[str, str], set_id: str, name: str
+) -> dict:
+    r = await client.post(
+        "/api/elements",
+        json={"element_type": "component", "name": name, "data": {}, "set_id": set_id},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+class TestCollectionWriteScope:
+    async def test_scoped_user_writes_inside_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        # set + package + element all succeed inside collection A
+        s = await _mk_set(client, arch, "set-in-a", coll_a)
+        assert s.status_code == 201, s.text
+        set_id = s.json()["id"]
+        pkg = await client.post(
+            "/api/packages", json={"name": "p", "set_id": set_id}, headers=arch
+        )
+        assert pkg.status_code == 201, pkg.text
+        el = await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "e", "data": {}, "set_id": set_id},
+            headers=arch,
+        )
+        assert el.status_code == 201, el.text
+
+    async def test_scoped_user_403_outside_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        # admin seeds a set inside B
+        set_b = (await _mk_set(client, admin, "set-in-b", coll_b)).json()["id"]
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        # creating a set in B is denied
+        denied = await _mk_set(client, arch, "nope", coll_b)
+        assert denied.status_code == 403, denied.text
+        # creating an element in B's set is denied
+        el = await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "e", "data": {}, "set_id": set_b},
+            headers=arch,
+        )
+        assert el.status_code == 403, el.text
+
+    async def test_scoped_user_update_element_gated_by_collection(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        set_b = (await _mk_set(client, admin, "sb", coll_b)).json()["id"]
+        el_a = await _mk_element(client, admin, set_a, "ea")
+        el_b = await _mk_element(client, admin, set_b, "eb")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        # update inside scope (A) → 200
+        ok = await client.put(
+            f"/api/elements/{el_a['id']}",
+            json={"name": "ea2", "data": {}},
+            headers={**arch, "If-Match": str(el_a["current_version"])},
+        )
+        assert ok.status_code == 200, ok.text
+        # update outside scope (B) → 403
+        no = await client.put(
+            f"/api/elements/{el_b['id']}",
+            json={"name": "eb2", "data": {}},
+            headers={**arch, "If-Match": str(el_b["current_version"])},
+        )
+        assert no.status_code == 403, no.text
+
+    async def test_unscoped_user_unaffected(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_b = await _mk_collection(client, admin, "B")
+        await _create_architect(client, admin)  # NO scope rows
+        arch = await _login(client, "arch")
+        # writes everywhere, as before ADR-237
+        s = await _mk_set(client, arch, "free", coll_b)
+        assert s.status_code == 201, s.text
+
+    async def test_admin_bypasses_even_with_scope_rows(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        # find admin id and scope them to A only
+        cur = await dbm.main_db.execute("SELECT id FROM users WHERE username = 'admin'")
+        admin_id = (await cur.fetchone())[0]
+        await _add_scope(dbm, admin_id, coll_a)
+        # admin still writes in B
+        s = await _mk_set(client, admin, "admin-set-b", coll_b)
+        assert s.status_code == 201, s.text
+
+    async def test_scoped_user_cannot_create_collection(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        r = await client.post("/api/collections", json={"name": "new"}, headers=arch)
+        assert r.status_code == 403, r.text
+
+    async def test_scoped_user_cannot_delete_collection_even_in_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        r = await client.delete(f"/api/collections/{coll_a}", headers=arch)
+        assert r.status_code == 403, r.text
+
+    async def test_scoped_user_cannot_create_global_template(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        el = await _mk_element(client, admin, set_a, "e")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        r = await client.post(
+            "/api/element-templates",
+            json={
+                "name": "g",
+                "source_element_id": el["id"],
+                "is_global": True,
+            },
+            headers=arch,
+        )
+        assert r.status_code == 403, r.text
+
+    async def test_set_move_across_boundary_denied(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        # moving an in-scope set OUT to B (not in scope) is denied
+        r = await client.put(
+            f"/api/sets/{set_a}",
+            json={"name": "sa", "collection_id": coll_b},
+            headers=arch,
+        )
+        assert r.status_code == 403, r.text
+
+    async def test_comment_create_gated_by_collection(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        set_b = (await _mk_set(client, admin, "sb", coll_b)).json()["id"]
+        el_a = await _mk_element(client, admin, set_a, "ea")
+        el_b = await _mk_element(client, admin, set_b, "eb")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        ok = await client.post(
+            f"/api/elements/{el_a['id']}/comments",
+            json={"content": "hi"}, headers=arch,
+        )
+        assert ok.status_code == 201, ok.text
+        no = await client.post(
+            f"/api/elements/{el_b['id']}/comments",
+            json={"content": "hi"}, headers=arch,
+        )
+        assert no.status_code == 403, no.text
+
+    async def test_reads_unaffected_for_scoped_user(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        set_b = (await _mk_set(client, admin, "sb", coll_b)).json()["id"]
+        el_b = await _mk_element(client, admin, set_b, "eb")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        # reads outside scope still succeed
+        assert (await client.get(f"/api/sets/{set_b}", headers=arch)).status_code == 200
+        assert (await client.get(f"/api/elements/{el_b['id']}", headers=arch)).status_code == 200
+        assert (await client.get("/api/collections", headers=arch)).status_code == 200
+
+
+class TestAuthMeWriteScope:
+    async def test_scoped_user_me_lists_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        me = (await client.get("/api/auth/me", headers=arch)).json()
+        assert me["write_scope"] == [coll_a]
+
+    async def test_unscoped_user_me_null_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        await _create_architect(client, admin)
+        arch = await _login(client, "arch")
+        me = (await client.get("/api/auth/me", headers=arch)).json()
+        assert me["write_scope"] is None
+
+    async def test_admin_me_null_scope(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        me = (await client.get("/api/auth/me", headers=admin)).json()
+        assert me["write_scope"] is None

--- a/backend/tests/test_migrations/test_user_collection_scope_schema.py
+++ b/backend/tests/test_migrations/test_user_collection_scope_schema.py
@@ -1,0 +1,64 @@
+"""ADR-237: assert the Supabase migration ``m088_user_collection_scope.sql``
+mirrors the SQLite migration ``m082_user_collection_scope.py`` — both create
+the ``user_collection_scope`` junction (user_id, collection_id) with a matching
+index, idempotently.
+
+Mirrors ``test_element_parent_element_schema.py`` — a static-parser guard so a
+SQLite-only table-add can't slip through and 500 on Supabase.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read_supabase_migration() -> str:
+    path = ROOT / "app" / "migrations" / "supabase" / "m088_user_collection_scope.sql"
+    return path.read_text(encoding="utf-8")
+
+
+def _read_sqlite_migration() -> str:
+    path = ROOT / "app" / "migrations" / "m082_user_collection_scope.py"
+    return path.read_text(encoding="utf-8")
+
+
+def test_supabase_m088_creates_table_idempotently() -> None:
+    sql = _read_supabase_migration()
+    assert "CREATE TABLE IF NOT EXISTS user_collection_scope" in sql, sql
+    # user_id is the Supabase profiles UUID; collection_id is the TEXT id.
+    assert "user_id       UUID" in sql or "user_id UUID" in sql, sql
+    assert "REFERENCES public.profiles(id)" in sql, sql
+    assert "REFERENCES public.collections(id)" in sql, sql
+    assert "PRIMARY KEY (user_id, collection_id)" in sql, sql
+
+
+def test_supabase_m088_creates_index() -> None:
+    sql = _read_supabase_migration()
+    assert "CREATE INDEX IF NOT EXISTS idx_ucs_user" in sql, sql
+    assert "ON public.user_collection_scope(user_id)" in sql, sql
+
+
+def test_supabase_m088_enables_rls() -> None:
+    sql = _read_supabase_migration()
+    assert "ENABLE ROW LEVEL SECURITY" in sql, sql
+
+
+def test_supabase_m088_declares_mirror_of_sqlite() -> None:
+    sql = _read_supabase_migration()
+    assert "Mirrors SQLite m082" in sql, sql
+
+
+def test_sqlite_m082_creates_table_idempotently() -> None:
+    py = _read_sqlite_migration()
+    assert "CREATE TABLE IF NOT EXISTS user_collection_scope" in py, py
+    assert "REFERENCES users(id)" in py, py
+    assert "REFERENCES collections(id)" in py, py
+    assert "PRIMARY KEY (user_id, collection_id)" in py, py
+
+
+def test_sqlite_m082_creates_index_if_not_exists() -> None:
+    py = _read_sqlite_migration()
+    assert "CREATE INDEX IF NOT EXISTS idx_ucs_user" in py, py
+    assert "ON user_collection_scope(user_id)" in py, py

--- a/docs/adrs/ADR-237-Per-User-Collection-Write-Scope.md
+++ b/docs/adrs/ADR-237-Per-User-Collection-Write-Scope.md
@@ -1,0 +1,83 @@
+# ADR-237: Restrict a user's write permissions to a whitelist of collections
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-237 |
+| **Initiative** | Let an admin keep a user's global role (e.g. `architect`) but confine that role's WRITE powers to a specified list of collections; read-only everywhere else |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-01 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** wanting to hand someone an editing role but confine their
+edits to a subset of collections (e.g. give an external contributor `architect`
+on two collections only), where roles in Iris are global and there is no
+per-collection access control,
+
+**facing** that the only knobs today are the four global roles (admin /
+architect / reviewer / viewer) — a write-capable role can edit *every*
+collection — and that reads are already anonymous (ADR-123), so the meaningful
+lever is *write* authorization, not read,
+
+**we decided to** add a per-user **collection write-scope**: a junction table
+`user_collection_scope(user_id, collection_id)`. A user with rows may WRITE only
+inside those collections; a user with **no rows is unscoped** (writes everywhere
+— the prior behaviour); **admins always bypass**. Enforcement is a thin
+app-layer guard (`backend/app/authz/`): `assert_write_allowed(db, user,
+collection_id)` on every write endpoint (resolving the target entity's owning
+collection via `collection_of_set/package/diagram/element/template`), and
+`assert_unscoped_or_admin(db, user)` on the operations a scoped user may never
+perform — **creating or deleting a collection, and mutating a global element
+template**. Reads are untouched. Assignment is managed **directly in Supabase**
+(the admin inserts rows in the dashboard) — Iris only reads + enforces — so **no
+new write endpoint, MCP tool, or CLI command** is added. `/api/auth/me` returns
+`write_scope` and element/diagram reads now carry `collection_id` so the
+frontend can hide edit/comment affordances the user can't use.
+
+**because** scope is fundamentally a *write*-authorization concern: gating
+writes (a few dozen endpoints, all already authenticated) is tractable and
+leaves the anonymous-read model intact, whereas filtering reads would mean
+flipping the whole deployment to auth-required and touching ~10 read modules for
+no security gain. Keeping assignment in Supabase matches how users + roles are
+already administered and keeps the surface-parity contract untouched.
+
+## Consequences
+- A scoped user edits content (sets, packages, diagrams, elements, comments,
+  tags, images) only inside their assigned collections; elsewhere the API
+  returns `403` and the UI hides the affordances + the comments panel.
+- Scoped users cannot create or delete collections, nor write global templates,
+  even inside their scope — they work *within* assigned collections, not on the
+  containers.
+- PAT and OAuth callers are gated automatically (they resolve through the same
+  `get_current_user`).
+- No schema-dependent read path changes; existing deployments behave exactly as
+  before until scope rows are added for a user.
+
+## Alternatives considered
+- **Postgres Row-Level Security**: rejected — the backend connects via a
+  trusted service/direct connection that bypasses RLS, and RLS has no SQLite
+  analogue, so it wouldn't enforce through the app's data path.
+- **A new "access" role**: rejected — scope is orthogonal to the role; bolting it
+  onto a role would duplicate the permission matrix and still need the junction.
+- **Filtering reads too (auth-required deployment)**: rejected for now — large
+  blast radius (~10 read modules + closing anonymous browsing) for no benefit,
+  since the ask is to confine *edits*. Revisit if private read scoping is needed.
+- **A FastAPI dependency factory** instead of in-route helper calls: rejected —
+  the target collection is only known inside each route (resolved from a body
+  field or path id), so a factory would need the same async resolution plus more
+  glue.
+
+## Surface parity (§14) / §15
+No write endpoints, MCP tools, or CLI commands are added — `check_surface_parity`
+stays green (verified). The migration ships as a SQLite/Supabase pair
+(`m082_user_collection_scope.py` / `m088_user_collection_scope.sql`) with a
+schema-mirror test; `user_id` references `users(id)` on SQLite and `profiles(id)`
+on Supabase. Service/authz code uses positional row access.
+
+## Dependencies
+Builds on ADR-123 (anonymous reads), ADR-005 (RBAC roles), ADR-158
+(set→collection), ADR-191 (element templates), ADR-209 (entity images).
+Spec: `docs/adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md`.

--- a/docs/adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md
+++ b/docs/adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md
@@ -1,0 +1,68 @@
+# SPEC-237-A: Per-User Collection Write-Scope
+
+Implements **[ADR-237](../ADR-237-Per-User-Collection-Write-Scope.md)**.
+
+## 1. Data model
+
+Table `user_collection_scope` (SQLite `m082`, Supabase mirror `m088`):
+
+| column | SQLite | Supabase | notes |
+|--------|--------|----------|-------|
+| `user_id` | `TEXT REFERENCES users(id)` | `UUID REFERENCES profiles(id) ON DELETE CASCADE` | the scoped user |
+| `collection_id` | `TEXT REFERENCES collections(id)` | `TEXT REFERENCES public.collections(id)` | a writable collection |
+| `created_at` | `TEXT DEFAULT (datetime('now'))` | `TIMESTAMPTZ DEFAULT NOW()` | |
+
+`PRIMARY KEY (user_id, collection_id)`, index `idx_ucs_user`. Supabase enables
+RLS (per the post-m030 posture; the backend connects out-of-band). Both halves
+idempotent. **Assignment is performed directly in Supabase** — Iris exposes no
+write surface for it.
+
+**Semantics.** No rows for a user ⇒ *unscoped* ⇒ writes everywhere (pre-ADR-237
+behaviour). Rows present ⇒ writes only in those collections. Admins always
+bypass.
+
+## 2. Enforcement (`backend/app/authz/`)
+
+- `load_scope(db, user_id) -> set[str]` — the user's writable collection ids
+  (empty = unscoped). Positional row access.
+- `collection_resolver.collection_of_{set,package,diagram,element,template}` and
+  `collection_of_entity(entity_type, id)` — resolve a write target's owning
+  collection id (lightweight FK lookups, `is_deleted`-agnostic). `None` ⇒ no
+  owning collection (global template, un-grouped/default set).
+- `enforce.assert_write_allowed(db, user, collection_id)` — `403 "Outside your
+  collection write-scope"` unless admin, unscoped, or `collection_id ∈ scope`.
+  `collection_id is None` ⇒ denied for scoped users.
+- `enforce.assert_unscoped_or_admin(db, user)` — `403` for any scoped non-admin.
+
+## 3. Gated write endpoints
+
+`assert_write_allowed` (resolve owning collection) on:
+collections `PUT`/thumbnail; sets `POST`(body collection)/`PUT`(both source +
+destination on move)/`DELETE`/thumbnail; packages `POST`/`PUT`/`DELETE`/`PUT
+…/parent`; diagrams `POST`/`PUT`/`DELETE`/`PUT …/parent`/`rollback`/`reorder`/
+tags; elements `POST`/`PUT`/`DELETE`/`rollback`/tags; element_templates
+`PUT`/`DELETE`; comments create/update/delete (via target element/diagram);
+entity-image attach/detach (`collection_of_entity`); diagram-link delete (via
+source diagram).
+
+`assert_unscoped_or_admin` on: collection `POST`(create) and `DELETE`;
+element_template `POST` when `is_global` and `PUT` that sets `is_global`.
+
+## 4. Client surface
+
+- `GET /api/auth/me` → adds `write_scope: string[] | null` (null = unrestricted;
+  admins and unscoped users → null; scoped → sorted collection ids).
+- Element & diagram read responses add `collection_id`.
+- Frontend auth store: `isScoped()`, `canWrite(collectionId)`. Affordances gated:
+  New/Edit/Delete collection (hidden when `isScoped()`); collection/set Save +
+  image editors and element/set/diagram edit + delete (`canWrite(collection_id)`);
+  `CommentsPanel` hidden entirely when `!canWrite(collectionId)`.
+
+## 5. Acceptance tests (`backend/tests/test_authz/`)
+
+Scoped user writes inside scope (201/200) / 403 outside; element update gated by
+collection; unscoped user unaffected; admin bypasses even with scope rows;
+cannot create or delete a collection; cannot create a global template; set move
+across the boundary denied; comment create gated; reads unaffected;
+`/api/auth/me.write_scope` for scoped/unscoped/admin. Plus the migration
+schema-mirror test. `check_surface_parity` stays green.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.44.3",
+	"version": "6.45.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/CommentsPanel.svelte
+++ b/frontend/src/lib/components/CommentsPanel.svelte
@@ -5,16 +5,23 @@
 	 */
 	import DOMPurify from 'dompurify';
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { canWrite } from '$lib/stores/auth.svelte.js';
 	import type { Comment } from '$lib/types/api';
 
 	interface Props {
 		targetType: 'diagram' | 'element';
 		targetId: string;
+		/** ADR-237: owning collection. When provided and the user can't write to
+		 *  it, the whole panel is hidden — commenting is a write. */
+		collectionId?: string | null;
 		onclose?: () => void;
 		oncount?: (count: number) => void;
 	}
 
-	let { targetType, targetId, onclose, oncount }: Props = $props();
+	let { targetType, targetId, collectionId, onclose, oncount }: Props = $props();
+
+	// ADR-237: hide the comments section entirely in read-only collections.
+	const writable = $derived(canWrite(collectionId));
 
 	let comments = $state<Comment[]>([]);
 	let loading = $state(true);
@@ -122,6 +129,7 @@
 	}
 </script>
 
+{#if writable}
 <div class="comments-panel">
 	<div class="flex items-center justify-between">
 		<h3 class="text-base font-semibold" style="color: var(--color-fg)">Comments</h3>
@@ -228,3 +236,4 @@
 		</form>
 	{/if}
 </div>
+{/if}

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -120,6 +120,23 @@ export function isAnonymous(): boolean {
 	return accessToken === null;
 }
 
+/** ADR-237: the user is restricted to a whitelist of writable collections.
+ *  `write_scope` is a string[] when scoped, null when unrestricted (admins or
+ *  users with no scope rows), and may be undefined before the profile loads. */
+export function isScoped(): boolean {
+	return Array.isArray(currentUser?.write_scope);
+}
+
+/** ADR-237: may the current user WRITE in this collection? Unrestricted users
+ *  always can; scoped users only within their whitelist. A null/unknown
+ *  collection id is not writable for scoped users. The backend enforces this
+ *  regardless — this only gates UI affordances so they match permissions. */
+export function canWrite(collectionId: string | null | undefined): boolean {
+	const scope = currentUser?.write_scope;
+	if (!Array.isArray(scope)) return true; // unrestricted (or profile not yet loaded)
+	return collectionId != null && scope.includes(collectionId);
+}
+
 export function setAuth(tokens: AuthTokens, user: User): void {
 	accessToken = tokens.access_token;
 	refreshToken = tokens.refresh_token ?? null;

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -11,6 +11,9 @@ export interface User {
 	username: string;
 	role: string;
 	is_active: boolean;
+	/** ADR-237: collections this user may WRITE in, or null when unrestricted
+	 *  (admins, or any user with no scope rows). Drives canWrite()/isScoped(). */
+	write_scope?: string[] | null;
 }
 
 export interface Element {
@@ -30,6 +33,8 @@ export interface Element {
 	diagram_usage_count?: number;
 	set_id?: string;
 	set_name?: string;
+	// ADR-237: owning collection — used to gate edit affordances by write-scope.
+	collection_id?: string | null;
 	metadata?: Record<string, unknown> | null;
 	notation?: string;
 	// ADR-184: the package this element belongs to.
@@ -60,6 +65,8 @@ export interface Diagram {
 	tags?: string[];
 	set_id?: string;
 	set_name?: string;
+	// ADR-237: owning collection — used to gate edit affordances by write-scope.
+	collection_id?: string | null;
 	notation?: string;
 	detected_notations?: string[];
 	metadata?: Record<string, unknown> | null;

--- a/frontend/src/routes/collections/+page.svelte
+++ b/frontend/src/routes/collections/+page.svelte
@@ -7,6 +7,7 @@
 	import { recordVisit } from '$lib/stores/visitHistory.svelte.js';
 	import type { IrisCollection } from '$lib/types/api';
 	import CollectionDialog from '$lib/components/CollectionDialog.svelte';
+	import { isScoped } from '$lib/stores/auth.svelte.js';
 
 	let contextItems = $derived(getAiContextItems());
 	let contextItemIds = $derived(new Set(contextItems.map((i) => i.id)));
@@ -116,22 +117,27 @@
 				Reset filter
 			</button>
 		{/if}
-		<button
-			onclick={() => (editMode = !editMode)}
-			class="rounded border px-3 py-2 text-sm"
-			style="border-color: var(--color-border); {editMode
-				? 'background: var(--color-primary); color: white'
-				: 'color: var(--color-fg)'}"
-		>
-			Edit Collections
-		</button>
-		<button
-			onclick={() => (showCreateDialog = true)}
-			class="rounded px-4 py-2 text-sm text-white"
-			style="background-color: var(--color-primary)"
-		>
-			New Collection
-		</button>
+		<!-- ADR-237: collection-management affordances are hidden for write-scoped
+		     users — they edit content within assigned collections, not the
+		     collection containers (create/delete). -->
+		{#if !isScoped()}
+			<button
+				onclick={() => (editMode = !editMode)}
+				class="rounded border px-3 py-2 text-sm"
+				style="border-color: var(--color-border); {editMode
+					? 'background: var(--color-primary); color: white'
+					: 'color: var(--color-fg)'}"
+			>
+				Edit Collections
+			</button>
+			<button
+				onclick={() => (showCreateDialog = true)}
+				class="rounded px-4 py-2 text-sm text-white"
+				style="background-color: var(--color-primary)"
+			>
+				New Collection
+			</button>
+		{/if}
 	</div>
 </div>
 <div class="mt-3 flex flex-wrap items-center gap-2 sm:gap-4">

--- a/frontend/src/routes/collections/[id]/+page.svelte
+++ b/frontend/src/routes/collections/[id]/+page.svelte
@@ -7,6 +7,7 @@
 	import EntityImagesEditor from '$lib/components/EntityImagesEditor.svelte';
 	import NamedPromptsSection from '$lib/components/NamedPromptsSection.svelte';
 	import DOMPurify from 'dompurify';
+	import { canWrite, isScoped } from '$lib/stores/auth.svelte.js';
 
 	let collection = $state<IrisCollection | null>(null);
 	let sets = $state<IrisSet[]>([]);
@@ -199,7 +200,8 @@
 			<NamedPromptsSection scope_type="collection" scope_id={collection.id} />
 		{/if}
 
-		<!-- Save button -->
+		<!-- Save button (ADR-237: only when the user can write this collection) -->
+		{#if canWrite(collection?.id)}
 		<div class="mt-6">
 			<button
 				type="submit"
@@ -210,6 +212,7 @@
 				{saving ? 'Saving...' : 'Save Changes'}
 			</button>
 		</div>
+		{/if}
 	</form>
 
 	<!-- ADR-209 (v6.17.0): attached images for this collection. -->
@@ -218,7 +221,7 @@
 		<EntityImagesEditor
 			entityType="collection"
 			entityId={collection?.id ?? ''}
-			editing={true}
+			editing={canWrite(collection?.id)}
 			maxImages={1}
 		/>
 	</div>
@@ -255,7 +258,8 @@
 		<p>{collection.set_count} set{collection.set_count !== 1 ? 's' : ''} in this collection</p>
 	</div>
 
-	<!-- Danger zone -->
+	<!-- Danger zone (ADR-237: scoped users may not delete collections) -->
+	{#if !isScoped()}
 	<div
 		class="mt-8 rounded border p-4"
 		style="border-color: var(--color-danger); max-width: 600px"
@@ -272,6 +276,7 @@
 			Delete Collection
 		</button>
 	</div>
+	{/if}
 
 	<ConfirmDialog
 		open={showDeleteDialog}

--- a/frontend/src/routes/elements/[id]/+page.svelte
+++ b/frontend/src/routes/elements/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { canWrite } from '$lib/stores/auth.svelte.js';
 	import { goto } from '$app/navigation';
 	import { apiFetch, ApiError } from '$lib/utils/api';
 	import { joinTaggedValue, splitTaggedValue } from '$lib/utils/taggedValues';
@@ -614,6 +615,7 @@
 			>
 				Save as template
 			</button>
+			{#if canWrite(entity?.collection_id)}
 			<button
 				onclick={() => (showDeleteDialog = true)}
 				class="rounded px-4 py-2 text-sm text-white"
@@ -621,6 +623,7 @@
 			>
 				Delete
 			</button>
+			{/if}
 		</div>
 	</div>
 
@@ -699,7 +702,7 @@
 					{#if detailsDirty}
 						<span class="text-xs" style="color: var(--color-muted)">Unsaved changes</span>
 					{/if}
-				{:else}
+				{:else if canWrite(entity?.collection_id)}
 					<button
 						onclick={enterDetailsEdit}
 						class="rounded px-3 py-1.5 text-sm text-white"
@@ -1337,7 +1340,7 @@
 
 	<!-- Comments section -->
 	<section class="mt-8">
-		<CommentsPanel targetType="element" targetId={entity.id} />
+		<CommentsPanel targetType="element" targetId={entity.id} collectionId={entity.collection_id} />
 	</section>
 
 	<ConfirmDialog

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -157,14 +157,24 @@
 
 			const tokens: AuthTokens = await response.json();
 
-			// Decode user from JWT payload (base64url)
-			const payload = JSON.parse(atob(tokens.access_token.split('.')[1]));
-			const user: User = {
-				id: payload.sub,
-				username: payload.username,
-				role: payload.role,
-				is_active: true,
-			};
+			// ADR-237: fetch the full profile (role + write_scope) rather than
+			// decoding the JWT, so the UI can gate edit affordances by scope.
+			// Fall back to the JWT payload if /me is unavailable.
+			let user: User;
+			const meResponse = await fetch(`${API_BASE_URL}/api/auth/me`, {
+				headers: { Authorization: `Bearer ${tokens.access_token}` },
+			});
+			if (meResponse.ok) {
+				user = await meResponse.json();
+			} else {
+				const payload = JSON.parse(atob(tokens.access_token.split('.')[1]));
+				user = {
+					id: payload.sub,
+					username: payload.username,
+					role: payload.role,
+					is_active: true,
+				};
+			}
 
 			setAuth(tokens, user);
 			await goto(safeRedirectTarget());

--- a/frontend/src/routes/sets/[id]/+page.svelte
+++ b/frontend/src/routes/sets/[id]/+page.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { apiFetch } from '$lib/utils/api';
-	import { getAccessToken } from '$lib/stores/auth.svelte.js';
+	import { canWrite, getAccessToken } from '$lib/stores/auth.svelte.js';
 	import { API_BASE_URL } from '$lib/config.js';
 	import type {
 		IrisSet,
@@ -427,7 +427,8 @@
 			</div>
 		</fieldset>
 
-		<!-- Save button -->
+		<!-- Save button (ADR-237: only within the user's write-scope) -->
+		{#if canWrite(collectionId)}
 		<div class="mt-6">
 			<button
 				type="submit"
@@ -438,6 +439,7 @@
 				{saving ? 'Saving...' : 'Save Changes'}
 			</button>
 		</div>
+		{/if}
 	</form>
 
 	<!-- ADR-209 (v6.17.0): attached images for this set. -->
@@ -446,7 +448,7 @@
 		<EntityImagesEditor
 			entityType="set"
 			entityId={set?.id ?? ''}
-			editing={true}
+			editing={canWrite(collectionId)}
 			maxImages={1}
 		/>
 	</div>
@@ -477,6 +479,7 @@
 		<p class="mt-1 text-sm" style="color: var(--color-muted)">
 			This will permanently delete this set and all {set.diagram_count} diagram{set.diagram_count !== 1 ? 's' : ''} and {set.element_count} element{set.element_count !== 1 ? 's' : ''} within it.
 		</p>
+		{#if canWrite(collectionId)}
 		<button
 			onclick={() => (showDeleteDialog = true)}
 			class="mt-3 rounded px-4 py-2 text-sm text-white"
@@ -484,6 +487,7 @@
 		>
 			Delete Set and All Contents
 		</button>
+		{/if}
 	</div>
 
 	<ConfirmDialog

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { canWrite } from '$lib/stores/auth.svelte.js';
 	import { goto, beforeNavigate } from '$app/navigation';
 	import { onDestroy } from 'svelte';
 	import EntityImagesEditor from '$lib/components/EntityImagesEditor.svelte';
@@ -2086,6 +2087,7 @@
 			<CommentsPanel
 				targetType="diagram"
 				targetId={diagram.id}
+				collectionId={diagram.collection_id}
 				onclose={() => (showCommentsSidebar = false)}
 				oncount={(c) => (commentCount = c)}
 			/>
@@ -2161,6 +2163,7 @@
 			>
 				Clone
 			</button>
+			{#if canWrite(diagram?.collection_id)}
 			<button
 				onclick={() => (showDeleteDialog = true)}
 				class="whitespace-nowrap rounded px-4 py-2 text-sm text-white"
@@ -2168,6 +2171,7 @@
 			>
 				Delete
 			</button>
+			{/if}
 		</div>
 	</div>
 
@@ -2813,6 +2817,7 @@
 									<CommentsPanel
 										targetType="diagram"
 										targetId={diagram.id}
+				collectionId={diagram.collection_id}
 										onclose={() => (showCommentsSidebar = false)}
 										oncount={(c) => (commentCount = c)}
 									/>
@@ -3338,6 +3343,7 @@
 										<CommentsPanel
 											targetType="diagram"
 											targetId={diagram.id}
+				collectionId={diagram.collection_id}
 											onclose={() => (showCommentsSidebar = false)}
 											oncount={(c) => (commentCount = c)}
 										/>

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.44.3"
+version = "6.45.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.44.3"
+version = "6.45.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Keep a user's **global role** (e.g. `architect`) but confine that role's **write/edit** powers to a whitelist of collections; everywhere else they're read-only. **Reads are untouched** — this is purely a write-authorization layer, so the anonymous-read model (ADR-123) is unchanged.

Assignment is managed **directly in Supabase** (insert rows into `user_collection_scope`); Iris only reads + enforces. **No new write endpoint / MCP tool / CLI command**, so surface parity (§14) is unaffected (verified green).

## Model
- `user_collection_scope(user_id, collection_id)` junction — SQLite `m082` + Supabase `m088` mirror (+ schema-mirror test).
- **No rows = unscoped** (writes everywhere — prior behaviour). **Admins always bypass.**
- Scoped users **cannot create or delete collections**, nor write **global element templates**, even inside their scope.

## Enforcement (`backend/app/authz/`)
- `load_scope` + `collection_of_{set,package,diagram,element,template,entity}` resolver + `assert_write_allowed` / `assert_unscoped_or_admin`.
- Gated on **every** write endpoint: collections, sets, packages, diagrams, elements, element-templates, comments, entity-images, diagram-links. PAT/OAuth callers are gated automatically (same `get_current_user`).

## Client surface
- `GET /api/auth/me` → `write_scope: string[] | null`; element/diagram reads carry `collection_id`.
- Frontend `canWrite()`/`isScoped()`: hide Edit/Save/Delete affordances + the **comments panel** in read-only collections; hide **New/Delete Collection** for scoped users.

## Tests
- `backend/tests/test_authz/` — 14 scoped-user tests (writes in/out of scope, element-update gating, unscoped unaffected, admin bypass, no create/delete collection, no global template, set-move boundary, comment gating, reads unaffected, `/me.write_scope`). **14 passed.**
- Migration schema-mirror test; broad router suites still green (admins bypass); `check_surface_parity.py` clean.
- One pre-existing unrelated failure (`test_no_unregistered_iris_tool_refs::…parse_correctly`, anchor `'ask'`) fails identically on `main` — not touched here.

## Docs / release
ADR-237 + SPEC-237-A; README note; version ×4 → **6.45.0**; CHANGELOG.

### Supabase release ordering (§15)
Apply the migration before rolling the code: run `scripts/supabase-migrate.sh` (creates `user_collection_scope` via `m088`) **before** deploying, since `/api/auth/me` and the write guards read the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)