### PR TITLE
fix(v6.45.1): tool-refs test anchor + write-scope operator runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.45.1] - 2026-06-02
+
+### Fixed
+
+- **`test_no_unregistered_iris_tool_refs` anchor list (ADR-237 follow-up).** The
+  parser smoke-test listed `ask` as an expected MCP tool, but `ask` is CLI-only
+  (ADR-168 — MCP clients bring their own LLM) and is intentionally not a
+  registered MCP tool, so the test failed. Anchored on `create_collection`
+  instead and documented why `ask` is excluded.
+
+### Documentation
+
+- **Collection write-scope operator runbook** at
+  [docs/collection-write-scope.md](docs/collection-write-scope.md): step-by-step
+  Supabase SQL to assign/verify/remove a user's write-scope (find user by email
+  via `auth.users`, set role, insert `user_collection_scope` rows), plus the
+  SQLite variant. Linked from the README.
+
 ## [6.45.0] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The default self-hosted mode requires no external services. The optional Render 
 - **Collection write-scope (ADR-237):** optionally confine a user's write/edit
   permissions to a whitelist of collections (read-only elsewhere); assigned via
   the `user_collection_scope` table in Supabase, enforced on every write endpoint
+  — operator runbook: [docs/collection-write-scope.md](docs/collection-write-scope.md)
 - **Audit:** SHA-256 hash-chained immutable audit log (separate DB in SQLite; table in Supabase)
 - **Versioning:** Immutable append-only entity versions with revert-as-new-version rollback
 - **Search:** Full-text search with SQLite FTS5 (default) or PostgreSQL tsvector/GIN (Supabase)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.45.0"
+version = "6.45.1"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_migrations/test_no_unregistered_iris_tool_refs.py
+++ b/backend/tests/test_migrations/test_no_unregistered_iris_tool_refs.py
@@ -221,7 +221,10 @@ def test_registered_tool_names_parse_correctly() -> None:
     # Known anchor tools that have been registered since v5.x — if
     # this set ever drops one, the parser is broken or a tool was
     # genuinely removed (in which case update the anchor list).
-    anchors = {"search", "package_hierarchy", "create_diagram", "ask"}
+    # NB: `ask` is deliberately NOT here — it is a CLI-only command
+    # (ADR-168: MCP clients bring their own LLM), so it is never a
+    # registered MCP tool. Anchor only on real MCP tools.
+    anchors = {"search", "package_hierarchy", "create_diagram", "create_collection"}
     missing = anchors - registered
     assert not missing, (
         f"Tool name parser couldn't find expected anchor tools: "

--- a/docs/collection-write-scope.md
+++ b/docs/collection-write-scope.md
@@ -1,0 +1,137 @@
+# Collection Write-Scope — Operator Runbook
+
+How to confine a user's **write/edit** permissions to a specific list of
+collections. Background and rationale: [ADR-237](adrs/ADR-237-Per-User-Collection-Write-Scope.md),
+spec: [SPEC-237-A](adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md).
+
+## What it does
+
+A user keeps their **global role** (e.g. `architect`) but, once they have any
+rows in the `user_collection_scope` table, their **writes are confined to those
+collections** — everywhere else they are read-only.
+
+- **Role decides *what*** they can do (architect = create/edit/delete; viewer =
+  read only). **Scope decides *where*** that applies.
+- **No scope rows ⇒ unrestricted** — the role applies everywhere (the default,
+  pre-ADR-237 behaviour).
+- **Admins always bypass** scope.
+- A scoped user **cannot create or delete collections**, nor edit global element
+  templates, *even inside their scope* — they work within assigned collections,
+  not on the containers.
+- **Reads are never restricted** — a scoped user can still view everything; only
+  writes are gated (API returns `403`, and the web UI hides Edit/Save/Delete and
+  the comments box outside their scope).
+
+> A scope on a **viewer** has no effect — viewers can't write anywhere anyway.
+> To give someone "architect on these collections only", set their role to
+> `architect` **and** add the scope rows.
+
+## Where scope is managed
+
+Assignment is **data**, managed **directly in Supabase** (SQL editor or
+dashboard) — there is no Iris API/MCP/CLI for it by design. Iris only reads and
+enforces the rows.
+
+## Assigning scope (Supabase / PostgreSQL)
+
+All queries key the user by **email via `auth.users`** — Supabase stores email
+there, while `profiles.username` may be a display name rather than the email.
+
+### 1. Find the user and confirm their role
+
+```sql
+select p.id, p.username, p.role, u.email
+from profiles p
+join auth.users u on u.id = p.id
+where u.email = 'person@example.com';
+```
+
+You want exactly one row. If `role` is not the write-capable role you intend
+(e.g. it's `viewer`), set it — scope on a viewer does nothing:
+
+```sql
+update profiles set role = 'architect'
+where id = (select id from auth.users where email = 'person@example.com');
+```
+
+### 2. Confirm the target collection names
+
+```sql
+select id, name, is_deleted from collections
+where name in ('Collection A', 'Collection B');
+```
+
+Expect one row per collection, `is_deleted = false`. If you get fewer, the names
+differ (check spacing/casing) — adjust the strings to what this returns.
+
+### 3. Add the scope rows
+
+```sql
+insert into user_collection_scope (user_id, collection_id)
+select p.id, c.id
+from profiles p
+join auth.users u on u.id = p.id
+cross join collections c
+where u.email = 'person@example.com'
+  and c.name in ('Collection A', 'Collection B')
+  and c.is_deleted = false
+on conflict (user_id, collection_id) do nothing;
+```
+
+Idempotent — safe to re-run. (Don't add a `p.role = '…'` filter here: if the
+role doesn't match it silently inserts nothing.)
+
+### 4. Verify
+
+```sql
+select c.name
+from user_collection_scope ucs
+join profiles p   on p.id = ucs.user_id
+join auth.users u on u.id = p.id
+join collections c on c.id = ucs.collection_id
+where u.email = 'person@example.com'
+order by c.name;
+```
+
+Should list exactly the collections you assigned.
+
+## Changing or removing scope
+
+- **Add another collection:** re-run step 3 with the new name.
+- **Remove one collection** (keep the rest scoped):
+
+  ```sql
+  delete from user_collection_scope
+  where user_id = (select id from auth.users where email = 'person@example.com')
+    and collection_id = (select id from collections where name = 'Collection B');
+  ```
+
+- **Make them a full (unrestricted) member again** — delete *all* their rows:
+
+  ```sql
+  delete from user_collection_scope
+  where user_id = (select id from auth.users where email = 'person@example.com');
+  ```
+
+## Release note (§15)
+
+The `user_collection_scope` table ships in Supabase migration
+`m088_user_collection_scope.sql` (mirrors SQLite `m082`). Apply it with
+`scripts/supabase-migrate.sh` **before** rolling out the code that reads it
+(`/api/auth/me` and the write guards), so there's no missing-table window.
+
+## SQLite / self-hosted mode
+
+Same table and semantics, but the user store is the `users` table (not Supabase
+`auth.users`/`profiles`). Resolve the user directly:
+
+```sql
+insert into user_collection_scope (user_id, collection_id)
+select u.id, c.id
+from users u
+cross join collections c
+where u.username = 'person'
+  and c.name in ('Collection A', 'Collection B')
+  and c.is_deleted = 0
+on conflict (user_id, collection_id) do nothing;
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.45.0",
+	"version": "6.45.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.45.0"
+version = "6.45.1"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.45.0"
+version = "6.45.1"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## Summary
Two small follow-ups (patch **6.45.1**):

1. **Fix the failing `test_no_unregistered_iris_tool_refs::test_registered_tool_names_parse_correctly`.** Its anchor set expected `ask` to be a registered MCP tool, but `ask` is **CLI-only** (ADR-168 — MCP clients bring their own LLM) and is intentionally never registered as an MCP tool, so the test failed on `main`. Swapped the anchor to `create_collection` (a genuinely-registered tool) and documented why `ask` is excluded. Verified `ask` ∉ the 56 registered tools while `search`/`package_hierarchy`/`create_diagram`/`create_collection` ∈.
2. **Operator runbook for collection write-scope** — `docs/collection-write-scope.md`: step-by-step Supabase SQL to find a user by email (via `auth.users`), set their role, insert/verify/remove `user_collection_scope` rows, plus the SQLite variant and the §15 release-ordering note. Linked from the README. (Based on the exact queries validated against prod.)

## Tests
`pytest backend/tests/test_migrations` → **270 passed** (was 1 failing).

No application code changes — test + docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)