### PR TITLE
feat(v6.46.0): collection write-scope — consistency & completeness (ADR-238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.46.0] - 2026-06-02
+
+### Fixed
+
+- **Collection write-scope: "created but can't save" (ADR-238).** A scoped user
+  could create a view but got `403 "Outside your collection write-scope"` when
+  adding an element / saving. The create-gate, the persisted row, and the
+  update-gate now resolve the **same** collection via one shared
+  `resolve_effective_set` helper, and the canvas's add-element call carries the
+  diagram's `set_id`. Content created under a package now files in that package's
+  set instead of silently orphaning into the Default set (also fixed for
+  unscoped users).
+- **Write-scope UI gating now reliable & comprehensive (ADR-238).** `write_scope`
+  is refreshed from `/api/auth/me` on every app load (so a cached session can't
+  leave a scoped user ungated); out-of-scope views open read-only (canvas Edit
+  hidden, edit-mode entry blocked); the global New Set/View/Element buttons and
+  package edit controls are hidden outside scope.
+
+### Security
+
+- **All write surfaces are now scope-gated (ADR-238).** Element-relationships and
+  package-relationships create/edit/delete were previously ungated; they now
+  enforce write-scope via the source element/package's collection. Package read
+  responses carry `collection_id` for client gating.
+
 ## [6.45.1] - 2026-06-02
 
 ### Fixed

--- a/backend/app/authz/__init__.py
+++ b/backend/app/authz/__init__.py
@@ -12,8 +12,10 @@ from app.authz.collection_resolver import (
     collection_of_element,
     collection_of_entity,
     collection_of_package,
+    collection_of_relationship,
     collection_of_set,
     collection_of_template,
+    resolve_effective_set,
 )
 from app.authz.collection_scope import load_scope
 from app.authz.enforce import assert_unscoped_or_admin, assert_write_allowed
@@ -25,7 +27,9 @@ __all__ = [
     "collection_of_element",
     "collection_of_entity",
     "collection_of_package",
+    "collection_of_relationship",
     "collection_of_set",
     "collection_of_template",
     "load_scope",
+    "resolve_effective_set",
 ]

--- a/backend/app/authz/collection_resolver.py
+++ b/backend/app/authz/collection_resolver.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.migrations.m012_sets import DEFAULT_SET_ID
+
 if TYPE_CHECKING:
     from app.db.adapter import DatabasePort
 
@@ -66,6 +68,18 @@ async def collection_of_template(db: DatabasePort, template_id: str | None) -> s
     return await collection_of_set(db, set_id)
 
 
+async def collection_of_relationship(
+    db: DatabasePort, relationship_id: str | None
+) -> str | None:
+    """The collection an element-relationship belongs to, via its source element."""
+    if not relationship_id:
+        return None
+    src = await _scalar(
+        db, "SELECT source_element_id FROM relationships WHERE id = ?", relationship_id
+    )
+    return await collection_of_element(db, src)
+
+
 async def collection_of_entity(
     db: DatabasePort, entity_type: str, entity_id: str
 ) -> str | None:
@@ -83,3 +97,26 @@ async def collection_of_entity(
     if entity_type == "element":
         return await collection_of_element(db, entity_id)
     return None
+
+
+async def resolve_effective_set(
+    db: DatabasePort, set_id: str | None, parent_package_id: str | None
+) -> str:
+    """The set a new diagram / element / package will be persisted into:
+    an explicit ``set_id``; else the parent package's set; else the seeded
+    ``DEFAULT_SET_ID`` (ADR-238).
+
+    Used by BOTH the create-gate (router) and the create services so the create
+    check, the persisted row, and the later update/delete check all resolve the
+    SAME collection — otherwise a create can pass while the subsequent save
+    403s (the original ADR-237 defect).
+    """
+    if set_id:
+        return set_id
+    if parent_package_id:
+        pkg_set = await _scalar(
+            db, "SELECT set_id FROM packages WHERE id = ?", parent_package_id
+        )
+        if pkg_set:
+            return pkg_set
+    return DEFAULT_SET_ID

--- a/backend/app/diagrams/router.py
+++ b/backend/app/diagrams/router.py
@@ -14,6 +14,7 @@ from app.authz import (
     collection_of_diagram,
     collection_of_package,
     collection_of_set,
+    resolve_effective_set,
 )
 from app.diagrams.models import (
     DiagramCreate,
@@ -71,13 +72,11 @@ async def create(
 ) -> DiagramResponse:
     """Create a new diagram."""
     db = request.app.state.db_manager.main_db
-    # ADR-237: gate by write-scope on the target set/package's collection.
-    _coll = (
-        await collection_of_set(db, body.set_id)
-        if body.set_id
-        else await collection_of_package(db, body.parent_package_id)
-    )
-    await assert_write_allowed(db, current_user, _coll)
+    # ADR-237/238: gate on the EFFECTIVE set's collection — the same set the
+    # service persists into (set_id, else the parent package's set, else
+    # Default) — so create and the later save/update agree.
+    eff_set = await resolve_effective_set(db, body.set_id, body.parent_package_id)
+    await assert_write_allowed(db, current_user, await collection_of_set(db, eff_set))
     result = await create_diagram(
         db,
         diagram_type=body.diagram_type,

--- a/backend/app/diagrams/service.py
+++ b/backend/app/diagrams/service.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.migrations.m012_sets import DEFAULT_SET_ID
+from app.authz.collection_resolver import resolve_effective_set
 from app.diagrams.canvas_normalize import normalize_canvas_data
 from app.diagrams.thumbnail import VALID_THEMES, generate_and_store_thumbnail
 from app.package_relationships.service import create_package_relationship
@@ -46,7 +47,9 @@ async def create_diagram(
     data = normalize_canvas_data(data)
     data_json = json.dumps(data)
     metadata_json = json.dumps(metadata) if metadata else None
-    effective_set_id = set_id or DEFAULT_SET_ID
+    # ADR-238: resolve the same effective set the create-gate authorized
+    # (set_id, else the parent package's set, else Default).
+    effective_set_id = await resolve_effective_set(db, set_id, parent_package_id)
 
     # Validate set_id exists — fall back to default if not
     cursor = await db.execute(

--- a/backend/app/elements/router.py
+++ b/backend/app/elements/router.py
@@ -12,8 +12,8 @@ from app.auth.dependencies import get_current_user, get_optional_user
 from app.authz import (
     assert_write_allowed,
     collection_of_element,
-    collection_of_package,
     collection_of_set,
+    resolve_effective_set,
 )
 from app.elements.models import (
     ElementCreate,
@@ -59,13 +59,10 @@ async def create(
     request fields always win over template defaults.
     """
     db = request.app.state.db_manager.main_db
-    # ADR-237: gate by write-scope on the element's target collection.
-    _coll = (
-        await collection_of_set(db, body.set_id)
-        if body.set_id
-        else await collection_of_package(db, body.package_id)
-    )
-    await assert_write_allowed(db, current_user, _coll)
+    # ADR-237/238: gate on the EFFECTIVE set's collection — the same set the
+    # service persists into — so create and the later save/update agree.
+    eff_set = await resolve_effective_set(db, body.set_id, body.package_id)
+    await assert_write_allowed(db, current_user, await collection_of_set(db, eff_set))
     fields = body.model_dump(exclude_unset=True)
     template_id = fields.pop("template_id", None)
     template_tags: list[str] = []

--- a/backend/app/elements/service.py
+++ b/backend/app/elements/service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from app.common.nullable_filter import parse_nullable_id
-from app.migrations.m012_sets import DEFAULT_SET_ID
+from app.authz.collection_resolver import resolve_effective_set
 from app.search.service import index_element as _index_element
 from app.search.service import remove_element_index as _remove_element_index
 
@@ -183,7 +183,9 @@ async def create_element(
     now = datetime.now(tz=UTC).isoformat()
     data_json = json.dumps(data)
     metadata_json = json.dumps(metadata) if metadata else None
-    effective_set_id = set_id or DEFAULT_SET_ID
+    # ADR-238: persist into the same effective set the create-gate authorized
+    # (set_id, else the parent package's set, else Default).
+    effective_set_id = await resolve_effective_set(db, set_id, package_id)
 
     await _validate_element_package_set_consistency(
         db, set_id=effective_set_id, package_id=package_id,

--- a/backend/app/package_relationships/router.py
+++ b/backend/app/package_relationships/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from app.auth.dependencies import get_current_user
+from app.authz import assert_write_allowed, collection_of_package
 from app.package_relationships.service import (
     create_package_relationship,
     delete_package_relationship,
@@ -31,6 +32,8 @@ async def create(
 ) -> dict:
     """Create a relationship from this package to another."""
     db = request.app.state.db_manager.main_db
+    # ADR-238: gate by the source package's collection.
+    await assert_write_allowed(db, current_user, await collection_of_package(db, package_id))
 
     # Verify source package exists
     cursor = await db.execute(
@@ -89,6 +92,17 @@ async def delete(
 ) -> None:
     """Delete a package relationship."""
     db = request.app.state.db_manager.main_db
+    # ADR-238: gate by the relationship's source package's collection.
+    cur = await db.execute(
+        "SELECT source_package_id FROM package_relationships WHERE id = ?",
+        (relationship_id,),
+    )
+    src_row = await cur.fetchone()
+    if src_row is None:
+        raise HTTPException(status_code=404, detail="Relationship not found")
+    await assert_write_allowed(
+        db, current_user, await collection_of_package(db, src_row[0])
+    )
     deleted = await delete_package_relationship(db, relationship_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Relationship not found")

--- a/backend/app/packages/models.py
+++ b/backend/app/packages/models.py
@@ -39,6 +39,8 @@ class PackageResponse(BaseModel):
     parent_package_id: str | None = None
     set_id: str | None = None
     set_name: str | None = None
+    # ADR-238: owning collection, so the client can gate edit affordances.
+    collection_id: str | None = None
     metadata: dict[str, object] | None = None
 
 

--- a/backend/app/packages/service.py
+++ b/backend/app/packages/service.py
@@ -7,7 +7,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from app.migrations.m012_sets import DEFAULT_SET_ID
+from app.authz.collection_resolver import resolve_effective_set
 from app.search.service import (
     index_package as _index_package,
     remove_package_index as _remove_package_index,
@@ -33,7 +33,9 @@ async def create_package(
     package_id = str(uuid.uuid4())
     now = datetime.now(tz=UTC).isoformat()
     metadata_json = json.dumps(metadata) if metadata else None
-    effective_set_id = set_id or DEFAULT_SET_ID
+    # ADR-238: persist into the same effective set the create-gate authorized
+    # (set_id, else the parent package's set, else Default).
+    effective_set_id = await resolve_effective_set(db, set_id, parent_package_id)
 
     # Compute next sequence_order within the parent group
     if parent_package_id:
@@ -95,7 +97,8 @@ async def get_package(
         "SELECT p.id, p.current_version, "
         "pv.name, pv.description, "
         "p.created_at, p.created_by, p.updated_at, p.is_deleted, "
-        "u.username, p.parent_package_id, p.set_id, s.name, pv.metadata "
+        "u.username, p.parent_package_id, p.set_id, s.name, pv.metadata, "
+        "s.collection_id "  # ADR-238: owning collection for write-scope gating
         "FROM packages p "
         "JOIN package_versions pv ON p.id = pv.package_id "
         "AND p.current_version = pv.version "
@@ -122,6 +125,7 @@ async def get_package(
         "set_id": row[10],
         "set_name": row[11],
         "metadata": json.loads(row[12]) if row[12] else None,
+        "collection_id": row[13],  # ADR-238: for frontend write-scope gating
     }
 
 
@@ -222,7 +226,8 @@ async def list_packages(
         f"SELECT p.id, p.current_version, "  # noqa: S608
         "pv.name, pv.description, "
         "p.created_at, p.created_by, p.updated_at, p.is_deleted, "
-        "p.parent_package_id, p.set_id, s.name, pv.metadata "
+        "p.parent_package_id, p.set_id, s.name, pv.metadata, "
+        "s.collection_id "  # ADR-238: owning collection for write-scope gating
         "FROM packages p "
         "JOIN package_versions pv ON p.id = pv.package_id "
         "AND p.current_version = pv.version "
@@ -247,6 +252,7 @@ async def list_packages(
             "set_id": r[9],
             "set_name": r[10],
             "metadata": json.loads(r[11]) if r[11] else None,
+            "collection_id": r[12],  # ADR-238: for frontend write-scope gating
         }
         for r in rows
     ]

--- a/backend/app/relationships/router.py
+++ b/backend/app/relationships/router.py
@@ -7,6 +7,11 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from app.auth.dependencies import get_current_user
+from app.authz import (
+    assert_write_allowed,
+    collection_of_element,
+    collection_of_relationship,
+)
 from app.relationships.models import (
     RelationshipCreate,
     RelationshipListResponse,
@@ -32,6 +37,10 @@ async def create(
 ) -> RelationshipResponse:
     """Create a new relationship between elements."""
     db = request.app.state.db_manager.main_db
+    # ADR-238: a relationship is content in its source element's collection.
+    await assert_write_allowed(
+        db, current_user, await collection_of_element(db, body.source_element_id)
+    )
     result = await create_relationship(
         db,
         source_element_id=body.source_element_id,
@@ -101,6 +110,10 @@ async def update(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-238: gate by the relationship's collection (via its source element).
+    await assert_write_allowed(
+        db, current_user, await collection_of_relationship(db, rel_id)
+    )
     result = await update_relationship(
         db, rel_id,
         label=body.label,
@@ -137,6 +150,10 @@ async def delete(
         )
 
     db = request.app.state.db_manager.main_db
+    # ADR-238: gate by the relationship's collection (via its source element).
+    await assert_write_allowed(
+        db, current_user, await collection_of_relationship(db, rel_id)
+    )
     deleted = await soft_delete_relationship(
         db, rel_id,
         deleted_by=current_user["id"],

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.45.1"
+version = "6.46.0"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/backend/tests/test_authz/test_collection_scope.py
+++ b/backend/tests/test_authz/test_collection_scope.py
@@ -341,3 +341,131 @@ class TestAuthMeWriteScope:
         admin = await _admin_headers(client)
         me = (await client.get("/api/auth/me", headers=admin)).json()
         assert me["write_scope"] is None
+
+
+class TestScopeConsistencyADR238:
+    """ADR-238: create-gate, persisted row, and update-gate must resolve the
+    SAME collection — the original ADR-237 defect let a create pass while the
+    subsequent save 403'd."""
+
+    async def test_create_under_package_without_set_id_then_update(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        pkg = (
+            await client.post(
+                "/api/packages", json={"name": "p", "set_id": set_a}, headers=admin
+            )
+        ).json()
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        # Diagram created with ONLY parent_package_id (the canvas/hierarchy shape)
+        dg = await client.post(
+            "/api/diagrams",
+            json={
+                "diagram_type": "simple-view", "name": "d", "data": {},
+                "parent_package_id": pkg["id"],
+            },
+            headers=arch,
+        )
+        assert dg.status_code == 201, dg.text
+        dg_id = dg.json()["id"]
+        # It lands in the package's set (collection A), NOT the un-grouped Default.
+        got = (await client.get(f"/api/diagrams/{dg_id}", headers=arch)).json()
+        assert got["set_id"] == set_a
+        assert got["collection_id"] == coll_a
+        # And the subsequent save/update SUCCEEDS (the regression).
+        upd = await client.put(
+            f"/api/diagrams/{dg_id}",
+            json={"name": "d2", "data": {}},
+            headers={**arch, "If-Match": str(dg.json()["current_version"])},
+        )
+        assert upd.status_code == 200, upd.text
+
+        # Same for an element created with only package_id.
+        el = await client.post(
+            "/api/elements",
+            json={
+                "element_type": "component", "name": "e", "data": {},
+                "package_id": pkg["id"],
+            },
+            headers=arch,
+        )
+        assert el.status_code == 201, el.text
+        el_got = (await client.get(f"/api/elements/{el.json()['id']}", headers=arch)).json()
+        assert el_got["collection_id"] == coll_a
+
+    async def test_element_create_without_context_denied_for_scoped(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+        # No set_id and no package_id → resolves to the Default set (collection
+        # NULL) → 403 for a scoped user.
+        r = await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "e", "data": {}},
+            headers=arch,
+        )
+        assert r.status_code == 403, r.text
+        # An UNSCOPED architect can still do it (lands in Default) — unchanged.
+        await _create_architect(client, admin, username="free")
+        free = await _login(client, "free")
+        r2 = await client.post(
+            "/api/elements",
+            json={"element_type": "component", "name": "e", "data": {}},
+            headers=free,
+        )
+        assert r2.status_code == 201, r2.text
+
+    async def test_relationship_create_gated_by_collection(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        coll_b = await _mk_collection(client, admin, "B")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        set_b = (await _mk_set(client, admin, "sb", coll_b)).json()["id"]
+        a1 = await _mk_element(client, admin, set_a, "a1")
+        a2 = await _mk_element(client, admin, set_a, "a2")
+        b1 = await _mk_element(client, admin, set_b, "b1")
+        b2 = await _mk_element(client, admin, set_b, "b2")
+        uid = await _create_architect(client, admin)
+        await _add_scope(dbm, uid, coll_a)
+        arch = await _login(client, "arch")
+
+        ok = await client.post(
+            "/api/relationships",
+            json={
+                "source_element_id": a1["id"], "target_element_id": a2["id"],
+                "relationship_type": "uses",
+            },
+            headers=arch,
+        )
+        assert ok.status_code == 201, ok.text
+        no = await client.post(
+            "/api/relationships",
+            json={
+                "source_element_id": b1["id"], "target_element_id": b2["id"],
+                "relationship_type": "uses",
+            },
+            headers=arch,
+        )
+        assert no.status_code == 403, no.text
+
+    async def test_package_response_carries_collection_id(self, ctx) -> None:
+        client, dbm = ctx
+        admin = await _admin_headers(client)
+        coll_a = await _mk_collection(client, admin, "A")
+        set_a = (await _mk_set(client, admin, "sa", coll_a)).json()["id"]
+        pkg = (
+            await client.post(
+                "/api/packages", json={"name": "p", "set_id": set_a}, headers=admin
+            )
+        ).json()
+        got = (await client.get(f"/api/packages/{pkg['id']}", headers=admin)).json()
+        assert got["collection_id"] == coll_a

--- a/docs/adrs/ADR-238-Write-Scope-Consistency-And-Completeness.md
+++ b/docs/adrs/ADR-238-Write-Scope-Consistency-And-Completeness.md
@@ -1,0 +1,82 @@
+# ADR-238: Make collection write-scope consistent and comprehensive
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-238 |
+| **Initiative** | Fix the two defects found in live testing of ADR-237 write-scope: a create that passes but whose save 403s, and write affordances still shown in out-of-scope collections |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-02 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the per-user collection write-scope shipped in ADR-237
+(v6.45.0), where a scoped `architect` should be able to fully edit inside their
+collections and have no write access elsewhere,
+
+**facing** two defects found in live testing: (1) a scoped user could *create* a
+view but got `403 "Outside your collection write-scope"` when adding an element /
+saving — because the create-gate, the persisted row, and the update-gate each
+resolved "the collection" differently (request payload vs the service's
+`DEFAULT_SET_ID` fallback vs the persisted `set_id`), and the canvas's
+add-element call sent neither `set_id` nor `package_id`; and (2) write
+affordances (canvas **Edit**, global **New** buttons, package controls) still
+appeared in out-of-scope collections, partly because `write_scope` didn't
+reliably reach the client and partly because several surfaces (the canvas
+editor, global creates, and the **relationships** / **package-relationships**
+endpoints — ungated entirely) were never covered,
+
+**we decided to** (a) introduce a single shared resolver
+`resolve_effective_set(db, set_id, parent_package_id)` used by **both** the
+create-gate and the `create_diagram`/`create_element`/`create_package` services,
+so the create check, the persisted row, and the later update/delete check all
+resolve the **same** collection (an entity created under a package now lands in
+that package's set, not the un-grouped Default); (b) **gate every remaining
+write surface** — element-relationships and package-relationships create/edit/
+delete (via the source element/package's collection); (c) surface `collection_id`
+on **package** reads (it was missing) so the client can gate package screens;
+(d) make the frontend reliably load `write_scope` (refresh `/api/auth/me` on app
+load) and have the canvas/hierarchy creates send `set_id`; and (e) gate the
+remaining UI: force browse mode on out-of-scope views (hide the canvas Edit
+button + guard the edit-mode entry centrally), and hide the global New buttons +
+package edit controls when out of scope.
+
+**because** the root cause was *inconsistent collection resolution across
+operations* plus *incomplete coverage* — a single shared resolver removes the
+class of create/update divergence, and gating the last endpoints + threading
+collection context into the canvas closes the holes without changing the
+read model (reads remain open, unchanged from ADR-237).
+
+## Consequences
+- A scoped user can create AND edit content inside their collections; the
+  "created but can't save" failure is gone (regression-guarded in
+  `tests/test_authz/test_collection_scope.py::TestScopeConsistencyADR238`).
+- Canvas-created elements/diagrams land in their real set/collection instead of
+  silently orphaning into the Default set (this also fixed a latent bug that
+  affected *unscoped* users).
+- All write endpoints are now scope-gated (relationships and
+  package-relationships included). Reads are unaffected.
+- The web UI hides edit/create affordances in collections the user can't write
+  to, and reliably reflects scope after login and reload.
+
+## Alternatives considered
+- **Resolve the collection only at the gate (leave the service's Default
+  fallback)**: rejected — that's exactly the divergence that caused the bug; the
+  gate and the persisted row must agree.
+- **Deny-by-default in the frontend `canWrite` when `write_scope` is absent**:
+  rejected — would break unscoped/anonymous users; instead we ensure
+  `write_scope` is reliably loaded (refresh on app start).
+- **Restrict reads too**: out of scope (unchanged from ADR-237) — the ask is to
+  confine edits, not hide content.
+
+## Surface parity (§14) / §15
+No new endpoints, MCP tools, or CLI commands — only enforcement added to existing
+ones; `check_surface_parity` stays green. No schema change (package
+`collection_id` is a SELECT join, not a column) → no migration.
+
+## Dependencies
+Extends [ADR-237](ADR-237-Per-User-Collection-Write-Scope.md). Spec:
+`docs/adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md` (updated).
+Operator runbook: `docs/collection-write-scope.md`.

--- a/docs/collection-write-scope.md
+++ b/docs/collection-write-scope.md
@@ -1,7 +1,8 @@
 # Collection Write-Scope — Operator Runbook
 
 How to confine a user's **write/edit** permissions to a specific list of
-collections. Background and rationale: [ADR-237](adrs/ADR-237-Per-User-Collection-Write-Scope.md),
+collections. Background and rationale: [ADR-237](adrs/ADR-237-Per-User-Collection-Write-Scope.md)
+and [ADR-238](adrs/ADR-238-Write-Scope-Consistency-And-Completeness.md),
 spec: [SPEC-237-A](adrs/specs/SPEC-237-A-Per-User-Collection-Write-Scope.md).
 
 ## What it does
@@ -21,6 +22,11 @@ collections** — everywhere else they are read-only.
 - **Reads are never restricted** — a scoped user can still view everything; only
   writes are gated (API returns `403`, and the web UI hides Edit/Save/Delete and
   the comments box outside their scope).
+- **Edits happen inside a set/collection context** (ADR-238): a scoped user works
+  within their collections via the in-collection hierarchy/canvas. Root-level
+  "New Set/View/Element" buttons are hidden for scoped users, and an out-of-scope
+  view opens read-only (no canvas Edit). Creating content under a package files it
+  in that package's set — so it stays in the right collection.
 
 > A scope on a **viewer** has no effect — viewers can't write anywhere anyway.
 > To give someone "architect on these collections only", set their role to

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.45.1",
+	"version": "6.46.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/stores/auth.svelte.ts
+++ b/frontend/src/lib/stores/auth.svelte.ts
@@ -137,6 +137,14 @@ export function canWrite(collectionId: string | null | undefined): boolean {
 	return collectionId != null && scope.includes(collectionId);
 }
 
+/** ADR-238: re-fetch /api/auth/me to refresh the profile (notably
+ *  `write_scope`) for the current token. Called on app load so a cached or
+ *  stale session can't leave a scoped user without their scope. No-op when
+ *  unauthenticated. */
+export async function refreshProfile(): Promise<void> {
+	if (accessToken) await _fetchProfile(accessToken);
+}
+
 export function setAuth(tokens: AuthTokens, user: User): void {
 	accessToken = tokens.access_token;
 	refreshToken = tokens.refresh_token ?? null;

--- a/frontend/src/lib/types/api.ts
+++ b/frontend/src/lib/types/api.ts
@@ -87,6 +87,8 @@ export interface Package {
 	parent_package_id: string | null;
 	set_id?: string;
 	set_name?: string;
+	// ADR-238: owning collection, for write-scope gating.
+	collection_id?: string | null;
 	metadata?: Record<string, unknown> | null;
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import '../app.css';
+	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import favicon from '$lib/assets/favicon.svg';
 	import AppShell from '$lib/components/AppShell.svelte';
 	import SessionTimeoutWarning from '$lib/components/SessionTimeoutWarning.svelte';
-	import { isAuthenticated } from '$lib/stores/auth.svelte.js';
+	import { isAuthenticated, refreshProfile } from '$lib/stores/auth.svelte.js';
 	import { initViewport } from '$lib/stores/viewport.svelte';
 	import { ModeWatcher } from 'mode-watcher';
 
@@ -13,6 +14,13 @@
 	// Wire up the shared viewport breakpoint store once for the whole app
 	// (ADR-229). Runs browser-only; returns the matchMedia cleanup.
 	$effect(() => initViewport());
+
+	// ADR-238: on every app load, refresh the profile so `write_scope` is
+	// current even when the session was restored from cache (otherwise a
+	// scoped user could load with no scope and see write UI everywhere).
+	onMount(() => {
+		if (isAuthenticated()) refreshProfile();
+	});
 
 	// /login renders without the AppShell (clean full-page login form).
 	// Every other route renders inside the AppShell — anonymous visitors

--- a/frontend/src/routes/elements/+page.svelte
+++ b/frontend/src/routes/elements/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { apiFetch, ApiError } from '$lib/utils/api';
+	import { isScoped } from '$lib/stores/auth.svelte.js';
 	import { getActiveSetId, setActiveSet, clearActiveSet } from '$lib/stores/activeSet.svelte.js';
 	import { getActiveCollectionId } from '$lib/stores/activeCollection.svelte.js';
 	import type { Element, PaginatedResponse, BatchResult } from '$lib/types/api';
@@ -403,6 +404,7 @@
 		>
 			Templates
 		</button>
+		{#if !isScoped()}
 		<button
 			onclick={() => (showCreateDialog = true)}
 			class="rounded px-4 py-2 text-sm text-white"
@@ -410,6 +412,7 @@
 		>
 			New Element
 		</button>
+		{/if}
 	</div>
 </div>
 

--- a/frontend/src/routes/packages/[id]/+page.svelte
+++ b/frontend/src/routes/packages/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { canWrite } from '$lib/stores/auth.svelte.js';
 	import { apiFetch, ApiError } from '$lib/utils/api';
 	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import EntityImagesEditor from '$lib/components/EntityImagesEditor.svelte';
@@ -262,6 +263,7 @@
 
 	function enterDetailsEdit() {
 		if (!pkg) return;
+		if (!canWrite(pkg.collection_id)) return; // ADR-238: no editing outside write-scope
 		editName = pkg.name;
 		editDescription = pkg.description ?? '';
 		editingDetails = true;
@@ -724,7 +726,7 @@
 					{#if detailsDirty}
 						<span class="text-xs" style="color: var(--color-muted)">Unsaved changes</span>
 					{/if}
-				{:else}
+				{:else if canWrite(pkg?.collection_id)}
 					<button
 						onclick={enterDetailsEdit}
 						class="rounded px-3 py-1.5 text-sm text-white"

--- a/frontend/src/routes/sets/+page.svelte
+++ b/frontend/src/routes/sets/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { isScoped } from '$lib/stores/auth.svelte.js';
 	import { goto } from '$app/navigation';
 	import { apiFetch } from '$lib/utils/api';
 	import { API_BASE_URL } from '$lib/config.js';
@@ -152,6 +153,7 @@
 		>
 			Edit Sets
 		</button>
+		{#if !isScoped()}
 		<button
 			onclick={() => (showCreateDialog = true)}
 			class="rounded px-4 py-2 text-sm text-white"
@@ -159,6 +161,7 @@
 		>
 			New Set
 		</button>
+		{/if}
 	</div>
 </div>
 <div class="mt-3 flex flex-wrap items-center gap-2 sm:gap-4">

--- a/frontend/src/routes/views/+page.svelte
+++ b/frontend/src/routes/views/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
+	import { isScoped } from '$lib/stores/auth.svelte.js';
 	import { apiFetch, ApiError } from '$lib/utils/api';
 	import { API_BASE_URL } from '$lib/config.js';
 	import { getActiveSetId, setActiveSet, clearActiveSet } from '$lib/stores/activeSet.svelte.js';
@@ -423,6 +424,7 @@
 			 primary button matching the Elements-page button style + size.
 			 HierarchyControls is still used by the dashboard (/) and
 			 packages/[id]; only the views index page steps off it. -->
+		{#if !isScoped()}
 		<button
 			onclick={() => (showCreateDialog = true)}
 			class="rounded px-4 py-2 text-sm text-white"
@@ -430,6 +432,7 @@
 		>
 			New View
 		</button>
+		{/if}
 		<button
 			onclick={() => { selectMode = !selectMode; if (!selectMode) cancelSelection(); }}
 			class="rounded border px-3 py-2 text-sm"

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -148,6 +148,9 @@
 	let canvasNodes = $state.raw<CanvasNode[]>([]);
 	let canvasEdges = $state.raw<CanvasEdge[]>([]);
 	let editing = $state(false);
+	// ADR-238: read-only when the user can't write this view's collection —
+	// force browse mode and hide edit affordances (the backend also 403s).
+	const readOnly = $derived(!canWrite(diagram?.collection_id));
 	let showAddElement = $state(false);
 	let canvasDirty = $state(false);
 	let saving = $state(false);
@@ -1202,6 +1205,10 @@
 					description,
 					data: {},
 					notation: effectiveNotation,
+					// ADR-238: carry the diagram's set so the element lands in the
+					// right collection (not the Default set) and the create passes
+					// write-scope for a scoped user editing this view.
+					set_id: diagram?.set_id,
 				}),
 			});
 			if (canvasType === 'text') {
@@ -1908,6 +1915,7 @@
 	}
 
 	async function handleStartEditing() {
+		if (readOnly) return; // ADR-238: no editing outside write-scope
 		if (lockManager) {
 			const acquired = await lockManager.acquireLock();
 			if (acquired) {
@@ -2950,7 +2958,7 @@
 								<span class="text-xs" style="color: var(--color-muted)">Unsaved changes</span>
 							{/if}
 						</div>
-					{:else}
+					{:else if !readOnly}
 						<button
 							onclick={handleStartEditing}
 							class="rounded px-3 py-1.5 text-sm"

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.45.1"
+version = "6.46.0"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.45.1"
+version = "6.46.0"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Fixes the two defects found in live testing of ADR-237 (v6.45.0).

## Bug 1 — "created a view but can't save it" (403)
The canvas **Add Element** call POSTed `/api/elements` with no `set_id`/`package_id`, so the create-gate resolved to `None` → 403 for a scoped user. Underneath, the **create-gate, the persisted row, and the update-gate each resolved "the collection" differently** (request vs the service's `DEFAULT_SET_ID` fallback vs the persisted `set_id`), so they could disagree.

**Fix:** a single shared `resolve_effective_set(db, set_id, parent_package_id)` used by **both** the create-gate and `create_diagram`/`create_element`/`create_package` — create == persisted row == update. Content created under a package now files in that package's set (not the Default set), fixing the 403 **and** a latent orphaning bug that affected unscoped users too. The canvas add-element now also sends the diagram's `set_id`.

## Bug 2 — Edit/New still shown in out-of-scope collections
- `write_scope` is refreshed from `/api/auth/me` on every app load, so a cached/stale session can't leave a scoped user ungated (this alone re-activates the v6.45.0 gating).
- Out-of-scope views open **read-only** — canvas Edit hidden + edit-mode entry guarded centrally in `handleStartEditing`.
- Global **New Set/View/Element** buttons and **package** edit controls hidden outside scope; `Package` reads now carry `collection_id`.

## Also closed (were ungated entirely)
Element-**relationships** and **package-relationships** create/edit/delete are now scope-gated via the source element/package's collection.

## Tests
`TestScopeConsistencyADR238`: create-under-package-then-update **succeeds** (the regression); canvas-style create without context denied for scoped / allowed→Default for unscoped; relationships gated; package `collection_id` present. **495 backend tests pass**; `check_surface_parity` clean; `svelte-check` at baseline (no new errors).

No new endpoints (parity unaffected) and **no DB migration** (package `collection_id` is a join). Reads remain open (unchanged from ADR-237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)