### PR TITLE
fix(v6.47.2): instant checklist ticking + centred checkmark (ADR-239, #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.47.2] - 2026-06-06
+
+### Fixed
+
+- **Checklist mode: ticking now feels instant (ADR-239, #255).** A tap flips the
+  checkbox and strike-through immediately (optimistic UI) instead of waiting for
+  the server round-trip, which could take many seconds. The save runs in the
+  background and coalesces rapid taps into the latest state, so no tap is dropped
+  and only one write is in flight at a time.
+- **Checklist mode: checkmark is now centred in the box (ADR-239, #255).** The
+  tick was anchored to the top-left corner; it is now centred via a translate
+  transform, and the box is slightly larger with `box-sizing: border-box`.
+
 ## [6.47.1] - 2026-06-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.47.1"
+version = "6.47.2"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.47.1",
+	"version": "6.47.2",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/MarkdownView.svelte
+++ b/frontend/src/lib/components/MarkdownView.svelte
@@ -67,6 +67,13 @@
 			const idx = Number(check.getAttribute('data-checklist-index'));
 			if (!Number.isNaN(idx)) {
 				e.preventDefault();
+				// Optimistic, instant feedback — flip the checkbox + strike now,
+				// without waiting for the (possibly slow) server round-trip. The
+				// background persist re-renders to the authoritative state, which
+				// matches what we just set, so there is no flicker.
+				const next = check.getAttribute('aria-checked') !== 'true';
+				check.setAttribute('aria-checked', next ? 'true' : 'false');
+				check.closest('li')?.classList.toggle('md-check-checked', next);
 				ontoggle?.(idx);
 			}
 			return;
@@ -196,9 +203,10 @@
 	}
 	.md-view :global(.md-check) {
 		flex: 0 0 auto;
-		width: 1.05em;
-		height: 1.05em;
-		margin-top: 0.15em;
+		box-sizing: border-box;
+		width: 1.15em;
+		height: 1.15em;
+		margin-top: 0.12em;
 		padding: 0;
 		border: 1.5px solid var(--color-border, #9ca3af);
 		border-radius: 4px;
@@ -214,13 +222,13 @@
 	.md-view :global(.md-check[aria-checked='true'])::after {
 		content: '';
 		position: absolute;
-		left: 0.3em;
-		top: 0.08em;
-		width: 0.28em;
-		height: 0.55em;
+		left: 50%;
+		top: 47%;
+		width: 0.3em;
+		height: 0.56em;
 		border: solid #fff;
 		border-width: 0 2px 2px 0;
-		transform: rotate(45deg);
+		transform: translate(-50%, -50%) rotate(45deg);
 	}
 	.md-view :global(li.md-check-checked) {
 		text-decoration: line-through;

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -562,6 +562,7 @@
 	const checklistMode = $derived(checklistEligible && Boolean(diagram?.metadata?.checklist));
 
 	let checklistSaving = $state(false);
+	let checklistDirty = false;
 
 	/** The editable-source payload for a checklist persist. Text diagrams
 	 *  store markdown at data.content; smart_markdown at data.markdown_source
@@ -573,61 +574,71 @@
 	}
 
 	/**
-	 * Persist a checklist change (mode flag and/or a ticked item) without the
-	 * heavyweight saveCanvas() reload. `build` mutates `diagram` in place from
-	 * its CURRENT state, then we PUT and adopt the new `current_version` from
-	 * the PUT response itself — so we never depend on a read-after-write GET,
-	 * which on Render's Supabase read-replicas can lag and cause a 409. On a
-	 * genuine 409 (concurrent edit / stale version) we refetch the latest and
-	 * re-apply `build` once.
+	 * Drain pending checklist changes to the server. Coalescing loop: while the
+	 * state is dirty, PUT the CURRENT local state and adopt the new
+	 * `current_version` from the PUT response itself (so we never depend on a
+	 * read-after-write GET, which on Render's Supabase read-replicas can lag and
+	 * cause a 409). Rapid taps that arrive mid-flight just re-set the dirty flag
+	 * and are flushed in the next iteration — no tap is dropped and we don't
+	 * queue one PUT per tap. On a genuine 409 we refresh only the version
+	 * (preserving the user's local ticks) and retry.
 	 */
-	async function persistChecklist(build: (d: Diagram) => void): Promise<void> {
-		if (!diagram || checklistSaving) return;
+	async function flushChecklist(): Promise<void> {
+		if (!diagram) return;
+		let conflicts = 0;
+		while (checklistDirty) {
+			checklistDirty = false;
+			try {
+				const res = await apiFetch<Diagram>(`/api/diagrams/${diagram.id}`, {
+					method: 'PUT',
+					headers: { 'If-Match': String(diagram.current_version) },
+					body: JSON.stringify({
+						name: diagram.name,
+						description: diagram.description ?? '',
+						data: checklistDataPayload(diagram),
+						metadata: diagram.metadata,
+						change_summary: 'Checklist update',
+					}),
+				});
+				diagram.current_version = res.current_version;
+				diagram.data = res.data;
+				diagram.metadata = res.metadata;
+			} catch (e) {
+				if (e instanceof ApiError && e.status === 409 && conflicts < 3) {
+					conflicts += 1;
+					// Stale version — refresh ONLY the version (keep local ticks).
+					const fresh = await apiFetch<Diagram>(`/api/diagrams/${diagram.id}`);
+					diagram.current_version = fresh.current_version;
+					checklistDirty = true;
+					continue;
+				}
+				throw e;
+			}
+		}
+		loadVersions(diagram.id);
+	}
+
+	/**
+	 * Apply a checklist change locally (instant) and persist it in the
+	 * background. `build` mutates `diagram` in place from its CURRENT state, so
+	 * the view re-renders immediately; the server save is coalesced via
+	 * flushChecklist() and never blocks the tap.
+	 */
+	function persistChecklist(build: (d: Diagram) => void): void {
+		if (!diagram) return;
+		build(diagram);
+		checklistDirty = true;
+		if (checklistSaving) return; // an in-flight flush will pick this up
 		checklistSaving = true;
 		error = null;
-		try {
-			for (let attempt = 0; attempt < 2; attempt++) {
-				build(diagram);
-				try {
-					const res = await apiFetch<Diagram>(`/api/diagrams/${diagram.id}`, {
-						method: 'PUT',
-						headers: { 'If-Match': String(diagram.current_version) },
-						body: JSON.stringify({
-							name: diagram.name,
-							description: diagram.description ?? '',
-							data: checklistDataPayload(diagram),
-							metadata: diagram.metadata,
-							change_summary: 'Checklist update',
-						}),
-					});
-					// Adopt the authoritative post-write state from the response.
-					diagram.current_version = res.current_version;
-					diagram.data = res.data;
-					diagram.metadata = res.metadata;
-					loadVersions(diagram.id);
-					return;
-				} catch (e) {
-					if (e instanceof ApiError && e.status === 409 && attempt === 0) {
-						// Stale version — refetch the latest, then rebuild on top.
-						const fresh = await apiFetch<Diagram>(`/api/diagrams/${diagram.id}`);
-						diagram.current_version = fresh.current_version;
-						diagram.data = fresh.data;
-						diagram.metadata = fresh.metadata;
-						continue;
-					}
-					throw e;
-				}
-			}
-		} catch (e) {
-			error = e instanceof ApiError ? e.message : 'Failed to update checklist';
-		} finally {
-			checklistSaving = false;
-		}
+		flushChecklist()
+			.catch((e) => { error = e instanceof ApiError ? e.message : 'Failed to update checklist'; })
+			.finally(() => { checklistSaving = false; });
 	}
 
 	/** Toggle the per-diagram checklist-mode flag (metadata) and persist. */
-	async function toggleChecklistMode() {
-		await persistChecklist((d) => {
+	function toggleChecklistMode() {
+		persistChecklist((d) => {
 			d.metadata = { ...(d.metadata ?? {}), checklist: !d.metadata?.checklist };
 		});
 	}
@@ -635,8 +646,8 @@
 	/** A checklist item was tapped — flip its GFM marker in the editable
 	 *  source (smart_markdown → markdown_source; text → content) and save.
 	 *  The index maps 1:1 because token resolution preserves item order. */
-	async function handleChecklistToggle(index: number) {
-		await persistChecklist((d) => {
+	function handleChecklistToggle(index: number) {
+		persistChecklist((d) => {
 			if (d.diagram_type === 'smart_markdown') {
 				const src = (d.data?.markdown_source as string | undefined) ?? '';
 				d.data = { ...(d.data ?? {}), markdown_source: toggleChecklistItem(src, index) };

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.47.1"
+version = "6.47.2"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.47.1"
+version = "6.47.2"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Follow-up to #283 — two UX defects in checklist mode (#255).

## 1. Ticking took many seconds
The tick waited on the full PUT round-trip (which on Render can take 10s+) before the UI updated.

**Fix:** the tap now flips the checkbox + strike-through **optimistically and instantly** (`MarkdownView` updates the DOM before calling `ontoggle`), and the local diagram state mutates synchronously so the re-render is immediate. The server save runs in the **background** and **coalesces** rapid taps: `persistChecklist` marks state dirty and a single `flushChecklist` loop drains it, sending the latest full state — no tap is dropped and only one write is ever in flight. The 409 path now refreshes **only the version** (preserving the user's local ticks) and retries, bounded to 3.

## 2. Checkmark sat in the top-left of the box
Anchored with fixed `left/top` offsets.

**Fix:** centred via `left/top: 50%/47%` + `translate(-50%, -50%) rotate(45deg)`; box enlarged slightly with `box-sizing: border-box`.

## Tests
- Unit 26/26, e2e 3/3 (prod build), svelte-check clean for touched symbols.

Versions bumped to **6.47.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)