### PR TITLE
fix(v6.47.3): rapid checklist taps no longer uncheck items (ADR-239, #255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.47.3] - 2026-06-06
+
+### Fixed
+
+- **Checklist mode: ticking several items in quick succession no longer unchecks
+  them (ADR-239, #255).** When a tap arrived while a save was in flight, the
+  save's response (an older snapshot) overwrote the newer local ticks, so the
+  next coalesced save resent the stale state and cleared them. The background
+  save now adopts the server response only when no newer taps are pending,
+  preserving every in-flight tick. Guarded by a rapid-multi-tap E2E test.
+
 ## [6.47.2] - 2026-06-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.47.2"
+version = "6.47.3"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.47.2",
+	"version": "6.47.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -601,8 +601,14 @@
 					}),
 				});
 				diagram.current_version = res.current_version;
-				diagram.data = res.data;
-				diagram.metadata = res.metadata;
+				// Only adopt the server's authoritative state when NO newer taps
+				// arrived during this PUT. Otherwise res.data is an older snapshot
+				// and overwriting it would discard ticks made mid-flight (which the
+				// loop is about to resend) — the "rapid taps uncheck them" bug.
+				if (!checklistDirty) {
+					diagram.data = res.data;
+					diagram.metadata = res.metadata;
+				}
 			} catch (e) {
 				if (e instanceof ApiError && e.status === 409 && conflicts < 3) {
 					conflicts += 1;

--- a/frontend/tests/e2e/checklist-tap.spec.ts
+++ b/frontend/tests/e2e/checklist-tap.spec.ts
@@ -66,6 +66,55 @@ test.describe('Checklist mode (ADR-239)', () => {
 		await expect(page.locator('.md-view li').nth(1)).not.toHaveClass(/md-check-checked/);
 	});
 
+	test('rapid taps on multiple items all stick (no uncheck race)', async ({ page }) => {
+		const token = await getAuthToken();
+		const set = (await createSet(undefined, token, { name: `Set-${Date.now()}` })) as {
+			id: string;
+		};
+		const diagram = (await createDiagram(undefined, token, {
+			diagram_type: 'text',
+			notation: 'markdown',
+			name: 'Rapid-Checklist',
+			set_id: set.id,
+			data: { content: '- one\n- two\n- three\n- four\n- five' },
+			metadata: { checklist: true },
+		})) as { id: string };
+
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagram.id}`);
+
+		const boxes = page.locator('.md-check');
+		await expect(boxes).toHaveCount(5);
+
+		// Tap all five as fast as possible (no waiting between taps) — exercises
+		// the coalescing save while PUTs are in flight.
+		for (let i = 0; i < 5; i++) {
+			await boxes.nth(i).click({ noWaitAfter: true });
+		}
+
+		// Every item must end up checked and stay checked.
+		for (let i = 0; i < 5; i++) {
+			await expect(page.locator('.md-view li').nth(i)).toHaveClass(/md-check-checked/);
+		}
+
+		// And it must persist: poll the API until all five markers are saved.
+		await expect
+			.poll(async () => {
+				const res = await fetch(`${API_BASE}/api/diagrams/${diagram.id}`, {
+					headers: { Authorization: `Bearer ${token}` },
+				});
+				const body = (await res.json()) as { data: { content: string } };
+				return (body.data.content.match(/- \[x\] /g) ?? []).length;
+			})
+			.toBe(5);
+
+		// A fresh load reflects all five ticked.
+		await page.reload();
+		for (let i = 0; i < 5; i++) {
+			await expect(page.locator('.md-view li').nth(i)).toHaveClass(/md-check-checked/);
+		}
+	});
+
 	test('toggle button enables checklist mode from a plain text view', async ({ page }) => {
 		const token = await getAuthToken();
 		const set = (await createSet(undefined, token, { name: `Set-${Date.now()}` })) as {

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.47.2"
+version = "6.47.3"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.47.2"
+version = "6.47.3"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
Follow-up to #284 — ticking several items in quick succession would uncheck some of them (#255).

## Root cause
`flushChecklist` adopted the PUT response on every save (`diagram.data = res.data`). If a tap landed **while a PUT was in flight**, that response was an **older snapshot** (taken before the new tick). Adopting it overwrote the newer local ticks, and the next coalesced save then resent the stale content — so freshly-ticked items reverted.

## Fix
The background save now adopts the server's authoritative `data`/`metadata` **only when no newer taps are pending** (`checklistDirty === false` after the PUT). Otherwise it keeps the local state and the coalescing loop resends the latest — every in-flight tick is preserved. The version is still always adopted from the response (the read-replica-lag fix from v6.47.1), and the 409 path already preserves local ticks.

## Tests
- New E2E: taps five items as fast as possible, asserts all end checked, polls the API until all five `- [x]` markers are saved, and re-checks after reload.
- Full checklist e2e 4/4 green (prod build); svelte-check clean.

Versions bumped to **6.47.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)