### PR TITLE
fix(v6.47.4): mobile overflow on bookmark filters + view toolbar (ADR-240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.47.4] - 2026-06-08
+
+### Fixed
+
+- **Mobile: Bookmarks filter dropdowns no longer spill off the right edge
+  (ADR-240).** The **Collection** and **Set** selectors are now full-width and
+  stack under the title on narrow screens, reverting to the title-left /
+  filters-right row at `sm` and up. `CollectionSelector` was brought to parity with
+  the already-responsive `SetSelector` (DRY).
+- **Mobile: Markdown/Smart Markdown view toolbar no longer overflows (ADR-240).**
+  Adding the **Checklist** button (ADR-239) pushed the Comments / Checklist /
+  Full-screen group past the viewport; the button group now wraps to a second line
+  instead of spilling right.
+
 ## [6.47.3] - 2026-06-06
 
 ### Fixed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-backend"
-version = "6.47.3"
+version = "6.47.4"
 description = "Iris — Integrated Repository for Information & Systems"
 requires-python = ">=3.11"
 dependencies = [

--- a/docs/adrs/ADR-240-Mobile-Responsive-Filter-And-Toolbar-Overflow.md
+++ b/docs/adrs/ADR-240-Mobile-Responsive-Filter-And-Toolbar-Overflow.md
@@ -1,0 +1,85 @@
+# ADR-240: Mobile-responsive fixes for bookmark filters and the view toolbar
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-240 |
+| **Initiative** | Stop the Bookmarks filter dropdowns and the Markdown/Smart Markdown view toolbar from spilling off the right edge on mobile |
+| **Proposed By** | Engineering |
+| **Date** | 2026-06-08 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the mobile-responsive rollout (ADR-229) whose invariant is
+"no page scrolls horizontally at the Pixel 5 viewport (393px)", two surfaces still
+leak a desktop layout through:
+
+1. The **Bookmarks** header (`routes/bookmarks/+page.svelte`) is a
+   `flex items-center justify-between` row holding the title plus the **Collection**
+   and **Set** filter dropdowns. `CollectionSelector` — unlike its sibling
+   `SetSelector` — carries **no responsive width constraints**, so its `<select>`
+   expands to its content and pushes the row past the viewport.
+2. The Markdown/Smart Markdown **view toolbar** (`routes/views/[id]/+page.svelte`)
+   gained a **Checklist** button in ADR-239. Its "View group"
+   (`ml-auto flex items-center gap-2`) has **no `flex-wrap`**, so with Comments +
+   Checklist + Full-screen all present the group overflows the right edge,
+
+**facing** the user report that both surfaces spill horizontally on a phone,
+
+**we decided to** fix both with **layout-only Tailwind changes, no new components or
+JS**: (a) bring `CollectionSelector` to byte-for-byte parity with the already-correct
+`SetSelector` responsive pattern (`min-w-0 flex-col … sm:flex-row` wrapper;
+`w-full min-w-0 max-w-full truncate … sm:w-auto sm:max-w-xs` select); (b) stack the
+Bookmarks header on mobile (`flex-col gap-3 sm:flex-row sm:items-center
+sm:justify-between`) with a full-width, column filter group that becomes a row at
+`sm`; and (c) add `flex-wrap justify-end` to **both** copies of the view-toolbar
+"View group" (the sequence and non-sequence toolbars) so the buttons reflow instead
+of overflowing,
+
+**and neglected** (1) capping the `<select>` width with a fixed `max-w` only —
+rejected because the real fix is letting the row stack/wrap, and `SetSelector`
+already encodes the agreed pattern (DRY §13 says reuse it, not invent a second one);
+(2) refactoring the two duplicated "View group" blocks into a shared snippet —
+deferred as out-of-scope for a layout bug fix; this ADR touches both copies
+identically and flags the duplication for a later cleanup; (3) a global CSS
+`overflow-x: hidden` guard — rejected because it hides the symptom while leaving the
+content clipped/unreachable, violating the WCAG 1.4.10 reflow intent ADR-229 is built
+around,
+
+**to achieve** the ADR-229 no-horizontal-overflow invariant on the Bookmarks and
+Markdown-view surfaces, with the filter dropdowns stacking under the title and the
+toolbar buttons wrapping, all at ≤393px,
+
+**accepting that** the two view-toolbar edits stay duplicated until the snippet
+extraction is done, and that the fix is verified by a viewport-overflow assertion
+(scrollWidth ≤ clientWidth) rather than pixel-perfect visual diffing.
+
+---
+
+## Consequences
+
+- **No schema, endpoint, MCP, or CLI change.** Pure frontend layout. Surface parity
+  (§14) and SQLite↔Supabase parity (§15) are N/A.
+- **No `{@html}` change (§7).** No new HTML rendering.
+- **DRY (§13).** `CollectionSelector` now shares the `SetSelector` responsive idiom;
+  the duplicated view-toolbar block is documented as a known follow-up, not widened.
+- **Regression guard.** Two new cases in `no-overflow.mobile.spec.ts` (the ADR-229
+  suite) cover `/bookmarks` and a checklist-eligible view, so a future desktop-only
+  layout edit re-failing either surface is caught in CI.
+
+## Alternatives considered
+
+See the **and neglected** clause: select-only max-width, snippet extraction, and a
+global `overflow-x` guard — each rejected/deferred with rationale.
+
+## Dependencies
+
+- ADR-229 (mobile-responsive rollout; the no-horizontal-overflow invariant and the
+  Pixel 5 `mobile` Playwright project).
+- ADR-239 (added the Checklist button that tipped the view-toolbar group over).
+
+## References
+
+- Implementation spec: [SPEC-240-A](./specs/SPEC-240-A-Mobile-Responsive-Filter-And-Toolbar-Overflow.md)

--- a/docs/adrs/specs/SPEC-240-A-Mobile-Responsive-Filter-And-Toolbar-Overflow.md
+++ b/docs/adrs/specs/SPEC-240-A-Mobile-Responsive-Filter-And-Toolbar-Overflow.md
@@ -1,0 +1,66 @@
+# SPEC-240-A: Mobile-responsive filter and toolbar overflow fixes
+
+Implements **[ADR-240](../ADR-240-Mobile-Responsive-Filter-And-Toolbar-Overflow.md)**.
+
+## 1. Canonical responsive selector pattern
+
+`SetSelector.svelte` is the source of truth. Both filter selectors use the same
+wrapper + `<select>` classes (DRY §13):
+
+| Element | Classes |
+|---------|---------|
+| wrapper `<div>` | `flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2` |
+| `<select>` | `w-full min-w-0 max-w-full truncate rounded border px-3 py-1.5 text-sm sm:w-auto sm:max-w-xs` |
+
+**Change:** `CollectionSelector.svelte` adopts both (previously
+`flex items-center gap-2` wrapper and an unconstrained `rounded border px-3 py-1.5
+text-sm` select). `min-w-0` lets the flex child shrink below its content width;
+`truncate` ellipsises a long collection name instead of widening the row.
+
+## 2. Bookmarks header (`routes/bookmarks/+page.svelte`)
+
+| Element | Before | After |
+|---------|--------|-------|
+| header row | `flex items-center justify-between` | `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between` |
+| filter group | `flex items-center gap-2` | `flex w-full min-w-0 flex-col gap-2 sm:w-auto sm:flex-row sm:items-center` |
+
+Mobile: title block stacks above a full-width filter column (each selector full
+width). At `sm` (≥640px) it reverts to the original title-left / filters-right row.
+
+## 3. View toolbar (`routes/views/[id]/+page.svelte`)
+
+Both "View group" containers — the sequence-diagram toolbar and the non-sequence
+toolbar — change from:
+
+```
+<div class="ml-auto flex items-center gap-2">
+```
+
+to:
+
+```
+<div class="ml-auto flex flex-wrap items-center justify-end gap-2">
+```
+
+`flex-wrap` lets the Comments / Checklist / TOC / Full-screen buttons wrap to a second
+line; `justify-end` keeps the wrapped rows right-aligned under `ml-auto`. Both copies
+must stay identical (known duplication, per ADR-240).
+
+## 4. Tests (TDD)
+
+Added to `frontend/tests/e2e/no-overflow.mobile.spec.ts` (ADR-229 `mobile` project,
+Pixel 5 393px), reusing the existing `expectNoHorizontalOverflow(page)` helper
+(asserts `documentElement.scrollWidth − clientWidth ≤ 1`):
+
+1. **`bookmarks page filters do not overflow`** — seed admin, log in, `goto('/bookmarks')`,
+   assert `#collection-selector` and `#set-selector` visible, then no overflow.
+2. **`markdown view toolbar with checklist button does not overflow`** — create a
+   `text`/`markdown` diagram with multi-item list content, log in, open the view,
+   wait for the `Toggle checklist mode` button, then no overflow.
+
+Run: `npm run test:mobile` (frontend).
+
+## 5. Out of scope
+
+- Extracting the duplicated "View group" block into a shared snippet (deferred,
+  flagged in ADR-240).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "frontend",
 	"private": true,
-	"version": "6.47.3",
+	"version": "6.47.4",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/frontend/src/lib/components/CollectionSelector.svelte
+++ b/frontend/src/lib/components/CollectionSelector.svelte
@@ -40,7 +40,7 @@
 	});
 </script>
 
-<div class="flex items-center gap-2">
+<div class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-center sm:gap-2">
 	<label for="collection-selector" class="text-sm font-medium" style="color: var(--color-fg)">
 		{label}
 	</label>
@@ -49,7 +49,7 @@
 		{value}
 		onchange={handleChange}
 		disabled={loading}
-		class="rounded border px-3 py-1.5 text-sm"
+		class="w-full min-w-0 max-w-full truncate rounded border px-3 py-1.5 text-sm sm:w-auto sm:max-w-xs"
 		style="border-color: var(--color-border); background: var(--color-bg); color: var(--color-fg)"
 	>
 		{#if showAll}

--- a/frontend/src/routes/bookmarks/+page.svelte
+++ b/frontend/src/routes/bookmarks/+page.svelte
@@ -135,12 +135,12 @@
 	<title>Bookmarks — Iris</title>
 </svelte:head>
 
-<div class="flex items-center justify-between">
+<div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 	<div>
 		<h1 class="text-2xl font-bold" style="color: var(--color-fg)">Bookmarks</h1>
 		<p class="mt-1 text-sm" style="color: var(--color-muted)">Your bookmarked diagrams and packages.</p>
 	</div>
-	<div class="flex items-center gap-2">
+	<div class="flex w-full min-w-0 flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
 		<CollectionSelector value={currentCollectionId} onchange={handleCollectionChange} />
 		<SetSelector value={currentSetId} onchange={handleSetChange} collectionId={currentCollectionId || null} />
 	</div>

--- a/frontend/src/routes/views/[id]/+page.svelte
+++ b/frontend/src/routes/views/[id]/+page.svelte
@@ -2776,7 +2776,7 @@
 						</button>
 					{/if}
 					<!-- View group (always visible) -->
-					<div class="ml-auto flex items-center gap-2">
+					<div class="ml-auto flex flex-wrap items-center justify-end gap-2">
 						{#if notation && editing && (notation as string) !== 'bpmn' && (notation as string) !== 'markdown' && (canvasType as string) !== 'text'}
 							<!-- v5.4.0 (#6): theme selector irrelevant on BPMN (theme fixed by m043
 								 bpmn-default seed) and on Text views (no canvas to theme). -->
@@ -3098,7 +3098,7 @@
 						</button>
 					{/if}
 					<!-- View group (always visible) -->
-					<div class="ml-auto flex items-center gap-2">
+					<div class="ml-auto flex flex-wrap items-center justify-end gap-2">
 						{#if notation && editing && (notation as string) !== 'bpmn' && (notation as string) !== 'markdown' && (canvasType as string) !== 'text'}
 							<!-- v5.4.0 (#6): theme selector irrelevant on BPMN (theme fixed by m043
 								 bpmn-default seed) and on Text views (no canvas to theme). -->

--- a/frontend/tests/e2e/no-overflow.mobile.spec.ts
+++ b/frontend/tests/e2e/no-overflow.mobile.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
-import { seedAdmin, getAuthToken, loginAsAdmin } from './fixtures';
+import { seedAdmin, getAuthToken, loginAsAdmin, createSet, createDiagram } from './fixtures';
 
 // Phase 2 of the mobile-responsive rollout (ADR-229 / SPEC-229-A).
 // No page should scroll horizontally at the Pixel 5 viewport (393px). A
@@ -54,6 +54,43 @@ test.describe('no horizontal overflow on mobile', () => {
 		await page.goto(`/elements/${elementId}`);
 		await page.getByRole('tab', { name: 'Details' }).click();
 		await expect(page.locator('.detail-grid').first()).toBeVisible();
+		await expectNoHorizontalOverflow(page);
+	});
+
+	// The Bookmarks header carries the Collection + Set filter dropdowns. On
+	// mobile they must stack under the title rather than spilling off the right
+	// edge (CollectionSelector previously had no responsive width constraints).
+	test('bookmarks page filters do not overflow', async ({ page }) => {
+		await seedAdmin();
+		await loginAsAdmin(page);
+		await page.goto('/bookmarks');
+		await expect(page.getByRole('heading', { name: 'Bookmarks' })).toBeVisible();
+		// Both filter selects are present in the header.
+		await expect(page.locator('#collection-selector')).toBeVisible();
+		await expect(page.locator('#set-selector')).toBeVisible();
+		await expectNoHorizontalOverflow(page);
+	});
+
+	// A text/smart_markdown view's toolbar gained a Checklist button (ADR-239).
+	// With Comments + Checklist + Full-screen all present, the view-group must
+	// wrap on mobile instead of pushing buttons off the right edge.
+	test('markdown view toolbar with checklist button does not overflow', async ({ page }) => {
+		const token = await getAuthToken();
+		const set = (await createSet(undefined, token, { name: `Overflow-Set-${Date.now()}` })) as {
+			id: string;
+		};
+		const diagram = (await createDiagram(undefined, token, {
+			diagram_type: 'text',
+			notation: 'markdown',
+			name: 'Toolbar-Overflow-View',
+			set_id: set.id,
+			data: { content: '- Buy milk\n- Clean kitchen\n- Walk dog' },
+		})) as { id: string };
+
+		await loginAsAdmin(page);
+		await page.goto(`/views/${diagram.id}`);
+		// The Checklist toggle is only rendered for text/smart_markdown views.
+		await expect(page.getByRole('button', { name: 'Toggle checklist mode' })).toBeVisible();
 		await expectNoHorizontalOverflow(page);
 	});
 });

--- a/iris-client/pyproject.toml
+++ b/iris-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-client"
-version = "6.47.3"
+version = "6.47.4"
 description = "Async Python client for the Iris HTTP API (ADR-132)"
 requires-python = ">=3.12"
 readme = "README.md"

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "iris-mcp"
-version = "6.47.3"
+version = "6.47.4"
 description = "Stdio MCP server for Iris (ADR-131)"
 requires-python = ">=3.12"
 readme = "README.md"


### PR DESCRIPTION
## What

Fixes two mobile horizontal-overflow regressions:

1. **Bookmarks page** — the **Collection** and **Set** filter dropdowns spilled off the right edge on mobile.
2. **Markdown / Smart Markdown view toolbar** — the **Checklist** button added in ADR-239 (#255) pushed the Comments / Checklist / Full-screen group past the viewport.

## Why

ADR-229 set the invariant *"no page scrolls horizontally at the Pixel 5 viewport (393px)"*. Both surfaces leaked a non-wrapping desktop layout through. `CollectionSelector` lacked the responsive width constraints its sibling `SetSelector` already had, and the view-toolbar "View group" had no `flex-wrap`.

## How

- `CollectionSelector.svelte` brought to byte-for-byte parity with `SetSelector`'s responsive pattern (DRY §13): full-width + `truncate` on mobile, `max-w-xs` at `sm+`.
- `bookmarks/+page.svelte` header stacks (`flex-col`) on mobile, reverts to title-left / filters-right row at `sm+`.
- `views/[id]/+page.svelte` — both "View group" containers (sequence + non-sequence toolbars) gain `flex-wrap justify-end` so buttons wrap instead of overflowing.

## Tests

Two cases added to `no-overflow.mobile.spec.ts` (ADR-229 Pixel 5 suite), reusing the existing `expectNoHorizontalOverflow` helper:
- `/bookmarks` filters do not overflow
- a checklist-eligible Markdown view's toolbar does not overflow

All 8 mobile no-overflow tests pass locally.

## Protocol compliance

- ADR-240 + SPEC-240-A added.
- CHANGELOG `Fixed` entry; version bumped to **6.47.4** across all four files (frontend/package.json + backend/mcp/iris-client pyproject.toml).
- Surface parity (§14) / DB parity (§15) / `{@html}` (§7): N/A — pure frontend layout.

## Follow-up

The two "View group" blocks remain duplicated (pre-existing); ADR-240 flags extracting them into a shared snippet as out-of-scope cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)