### PR TITLE
feat: Google Analytics for Iris UAT (frontend page views + MCP tool calls)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,12 @@ VITE_API_BASE_URL=
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 
+# Google Analytics 4 measurement ID (e.g. G-5B0T5HKVQ9). Baked into
+# src/app.html at build time; SvelteKit only exposes app.html env vars that
+# carry the PUBLIC_ prefix, so the name must be exactly PUBLIC_GA_MEASUREMENT_ID.
+# Leave unset locally — analytics only load when a real G-… ID is present.
+PUBLIC_GA_MEASUREMENT_ID=
+
 # ---------------------------------------------------------------------------
 # Optional backend tuning
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,16 @@ IRIS_RATE_LIMIT_REFRESH=30
 IRIS_RATE_LIMIT_GENERAL=1000
 IRIS_AI_MAX_CONTEXT_TOKENS=8000
 IRIS_AI_TIMEOUT_MS=30000
+
+# ---------------------------------------------------------------------------
+# iris-mcp — Google Analytics 4 tool-call tracking (optional)
+# ---------------------------------------------------------------------------
+# The MCP server sends a `mcp_tool_call` event to GA4 (Measurement Protocol)
+# on every tool dispatch, into the same GA4 property as the frontend.
+# Tracking is a no-op unless BOTH values are set, so local/stdio runs stay
+# silent. GA_MEASUREMENT_ID falls back to PUBLIC_GA_MEASUREMENT_ID (above),
+# so in production only the API secret is strictly MCP-specific.
+# GA_MEASUREMENT_ID=G-XXXXXXXXXX
+# Create under GA4 Admin → Data Streams → [stream] → Measurement Protocol
+# API secrets. Keep secret.
+# GA_API_SECRET=

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -5,6 +5,35 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
 		<!--
+			Google Analytics 4 (gtag.js). The measurement ID is baked in at
+			build time from PUBLIC_GA_MEASUREMENT_ID via
+			%sveltekit.env.PUBLIC_GA_MEASUREMENT_ID% — SvelteKit only exposes
+			env vars to app.html when they carry the PUBLIC_ prefix, so the
+			Render env var must be named PUBLIC_GA_MEASUREMENT_ID (value e.g.
+			`G-5B0T5HKVQ9`). Set it per environment in the Render dashboard.
+			The guard means analytics only load when a real `G-…` ID is
+			present, so local dev and PR previews (where the var is unset,
+			leaving an empty string) neither fire tracking nor make broken
+			requests. One measurement ID covers the whole SPA — a GA4 web
+			stream maps to the site/domain, not to each Render service.
+		-->
+		<script>
+			(function () {
+				var id = '%sveltekit.env.PUBLIC_GA_MEASUREMENT_ID%';
+				if (!id || id.indexOf('G-') !== 0) return;
+				window.dataLayer = window.dataLayer || [];
+				function gtag() { dataLayer.push(arguments); }
+				window.gtag = gtag;
+				gtag('js', new Date());
+				gtag('config', id);
+				var s = document.createElement('script');
+				s.async = true;
+				s.src = 'https://www.googletagmanager.com/gtag/js?id=' + id;
+				document.head.appendChild(s);
+			})();
+		</script>
+
+		<!--
 			Open Graph + Twitter Card metadata (ADR-126). These tags must live
 			in app.html (not in a <svelte:head> block) because Iris ships as
 			a static SPA (adapter-static / fallback: 'index.html'); social

--- a/mcp/src/iris_mcp/analytics.py
+++ b/mcp/src/iris_mcp/analytics.py
@@ -1,0 +1,141 @@
+"""GA4 Measurement Protocol event tracking for iris-mcp tool calls.
+
+Every MCP tool dispatch emits a fire-and-forget ``mcp_tool_call`` event to
+Google Analytics 4 via the Measurement Protocol, so backend tool usage
+lands in the *same* GA4 property as the frontend page-view stream — no
+separate stream, just the web stream's measurement ID plus a Measurement
+Protocol API secret.
+
+Tracking is a strict no-op unless BOTH of these are set, so local dev,
+stdio runs, and self-hosted deployments never phone home:
+
+* ``GA_MEASUREMENT_ID`` — the GA4 measurement ID, e.g. ``G-5B0T5HKVQ9``.
+  Falls back to ``PUBLIC_GA_MEASUREMENT_ID`` (the same value the frontend
+  build reads), so the shared Render env group covers both services.
+* ``GA_API_SECRET`` — a Measurement Protocol API secret created under
+  GA4 Admin → Data Streams → [stream] → Measurement Protocol API secrets.
+
+Server-side events carry no real browser, so a synthetic per-process
+``client_id`` / ``session_id`` is used: GA "users"/"sessions" for this
+traffic approximate running server instances, while the ``mcp_tool_call``
+event count and its ``tool`` parameter — the numbers that actually matter
+here — stay accurate. Register ``tool`` as a custom dimension in GA4 to
+slice usage by tool name.
+
+Reference:
+https://developers.google.com/analytics/devguides/collection/protocol/ga4
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# GA4 Measurement Protocol collection endpoint.
+GA_ENDPOINT = "https://www.google-analytics.com/mp/collect"
+
+# GA4 event name (<=40 chars, alnum + underscore, leading letter).
+EVENT_NAME = "mcp_tool_call"
+
+# Short send timeout — telemetry must never slow a tool response.
+_TIMEOUT_S = 2.0
+
+# One synthetic identity per process. All tool calls from a running
+# iris-mcp instance group under it, so "users" ≈ instances and event
+# counts stay true. Regenerated on restart, which is fine for telemetry.
+_CLIENT_ID = uuid.uuid4().hex
+_SESSION_ID = uuid.uuid4().hex
+
+# Strong references to in-flight fire-and-forget tasks so the event loop
+# does not garbage-collect them before the POST completes.
+_pending: set[asyncio.Task[None]] = set()
+
+
+def _measurement_id() -> str | None:
+    """GA4 measurement ID, reusing the frontend's value if only that is set."""
+    return os.environ.get("GA_MEASUREMENT_ID") or os.environ.get(
+        "PUBLIC_GA_MEASUREMENT_ID",
+    )
+
+
+def _api_secret() -> str | None:
+    return os.environ.get("GA_API_SECRET")
+
+
+def is_enabled() -> bool:
+    """True only when both the measurement ID and the API secret are set."""
+    return bool(_measurement_id() and _api_secret())
+
+
+def build_payload(
+    tool: str,
+    *,
+    success: bool,
+    duration_ms: float,
+    client_id: str = _CLIENT_ID,
+    session_id: str = _SESSION_ID,
+) -> dict[str, object]:
+    """Build the Measurement Protocol request body for one tool call.
+
+    ``session_id`` and ``engagement_time_msec`` are included so the event
+    registers in GA4's standard reports, not only Realtime / DebugView.
+    """
+    return {
+        "client_id": client_id,
+        "events": [
+            {
+                "name": EVENT_NAME,
+                "params": {
+                    # `tool` is the dimension worth slicing on — register it
+                    # as a custom dimension in GA4 to see per-tool usage.
+                    "tool": tool[:100],
+                    "success": "true" if success else "false",
+                    "duration_ms": int(duration_ms),
+                    "session_id": session_id,
+                    "engagement_time_msec": max(1, int(duration_ms)),
+                },
+            },
+        ],
+    }
+
+
+async def send_event(payload: dict[str, object], *, timeout: float = _TIMEOUT_S) -> None:
+    """POST an event payload to GA4. Swallows every error — telemetry is
+    best-effort and must never surface to the caller."""
+    measurement_id = _measurement_id()
+    api_secret = _api_secret()
+    if not (measurement_id and api_secret):
+        return
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as http:
+            await http.post(
+                GA_ENDPOINT,
+                params={"measurement_id": measurement_id, "api_secret": api_secret},
+                json=payload,
+            )
+    except Exception:
+        logger.debug("iris-mcp: GA event send failed", exc_info=True)
+
+
+def track_tool_call(tool: str, *, success: bool, duration_ms: float) -> None:
+    """Fire-and-forget: schedule a ``mcp_tool_call`` event for ``tool``.
+
+    Returns immediately. Does nothing when tracking is disabled or when no
+    event loop is running (e.g. synchronous unit tests).
+    """
+    if not is_enabled():
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    payload = build_payload(tool, success=success, duration_ms=duration_ms)
+    task = loop.create_task(send_event(payload))
+    _pending.add(task)
+    task.add_done_callback(_pending.discard)

--- a/mcp/src/iris_mcp/server.py
+++ b/mcp/src/iris_mcp/server.py
@@ -7,14 +7,15 @@ the server via `build_server(client)`; transport (stdio) is owned by
 
 from __future__ import annotations
 
-from typing import Any
-
+import time
 from importlib.metadata import PackageNotFoundError, version
+from typing import Any
 
 from iris_client import IrisClient
 from mcp import types
 from mcp.server import Server
 
+from iris_mcp import analytics as iris_analytics
 from iris_mcp import prompts as iris_prompts
 from iris_mcp import resources as iris_resources
 from iris_mcp import tools as iris_tools
@@ -57,7 +58,17 @@ def build_server(
     async def _call_tool(
         name: str, arguments: dict[str, Any] | None,
     ) -> list[types.TextContent]:
-        return await iris_tools.dispatch(name, client, arguments or {})
+        start = time.perf_counter()
+        result = await iris_tools.dispatch(name, client, arguments or {})
+        duration_ms = (time.perf_counter() - start) * 1000
+        # `dispatch` reports failures as a leading "ERROR:" TextContent
+        # rather than raising, so read success off the result. Tracking is
+        # fire-and-forget and a no-op unless GA env vars are set.
+        success = not (result and result[0].text.startswith("ERROR:"))
+        iris_analytics.track_tool_call(
+            name, success=success, duration_ms=duration_ms,
+        )
+        return result
 
     @server.list_resources()
     async def _list_resources() -> list[types.Resource]:

--- a/mcp/tests/test_analytics.py
+++ b/mcp/tests/test_analytics.py
@@ -1,0 +1,129 @@
+"""Tests for GA4 Measurement Protocol tool-call tracking (analytics.py)."""
+
+from __future__ import annotations
+
+import httpx
+
+from iris_mcp import analytics
+
+MEASUREMENT_ID = "G-TEST12345"
+API_SECRET = "test-secret"
+
+
+def _enable(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("GA_MEASUREMENT_ID", MEASUREMENT_ID)
+    monkeypatch.setenv("GA_API_SECRET", API_SECRET)
+
+
+class TestIsEnabled:
+    def test_disabled_when_nothing_set(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("PUBLIC_GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("GA_API_SECRET", raising=False)
+        assert analytics.is_enabled() is False
+
+    def test_disabled_without_api_secret(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.setenv("GA_MEASUREMENT_ID", MEASUREMENT_ID)
+        monkeypatch.delenv("GA_API_SECRET", raising=False)
+        assert analytics.is_enabled() is False
+
+    def test_enabled_with_both(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        _enable(monkeypatch)
+        assert analytics.is_enabled() is True
+
+    def test_falls_back_to_public_measurement_id(self, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+        # The frontend build var doubles as the id source when the shared
+        # env group only exposes PUBLIC_GA_MEASUREMENT_ID.
+        monkeypatch.delenv("GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.setenv("PUBLIC_GA_MEASUREMENT_ID", MEASUREMENT_ID)
+        monkeypatch.setenv("GA_API_SECRET", API_SECRET)
+        assert analytics.is_enabled() is True
+
+
+class TestBuildPayload:
+    def test_shape_and_params(self) -> None:
+        payload = analytics.build_payload(
+            "search", success=True, duration_ms=42.7,
+            client_id="cid", session_id="sid",
+        )
+        assert payload["client_id"] == "cid"
+        events = payload["events"]
+        assert isinstance(events, list) and len(events) == 1
+        event = events[0]
+        assert event["name"] == analytics.EVENT_NAME
+        params = event["params"]
+        assert params["tool"] == "search"
+        assert params["success"] == "true"
+        assert params["duration_ms"] == 42  # truncated to int
+        assert params["session_id"] == "sid"
+        assert params["engagement_time_msec"] >= 1
+
+    def test_failure_flag(self) -> None:
+        payload = analytics.build_payload("bad", success=False, duration_ms=0)
+        params = payload["events"][0]["params"]
+        assert params["success"] == "false"
+        # engagement_time_msec is clamped to a positive integer.
+        assert params["engagement_time_msec"] == 1
+
+    def test_tool_name_truncated(self) -> None:
+        payload = analytics.build_payload(
+            "x" * 200, success=True, duration_ms=1,
+        )
+        assert len(payload["events"][0]["params"]["tool"]) == 100
+
+
+class TestSendEvent:
+    async def test_noop_when_disabled(self, monkeypatch, respx_mock) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("PUBLIC_GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("GA_API_SECRET", raising=False)
+        route = respx_mock.post(analytics.GA_ENDPOINT).mock(
+            return_value=httpx.Response(204),
+        )
+        await analytics.send_event({"client_id": "x", "events": []})
+        assert not route.called
+
+    async def test_posts_with_credentials(self, monkeypatch, respx_mock) -> None:  # type: ignore[no-untyped-def]
+        _enable(monkeypatch)
+        route = respx_mock.post(analytics.GA_ENDPOINT).mock(
+            return_value=httpx.Response(204),
+        )
+        payload = analytics.build_payload("search", success=True, duration_ms=5)
+        await analytics.send_event(payload)
+        assert route.called
+        request = route.calls.last.request
+        assert request.url.params["measurement_id"] == MEASUREMENT_ID
+        assert request.url.params["api_secret"] == API_SECRET
+
+    async def test_swallows_transport_errors(self, monkeypatch, respx_mock) -> None:  # type: ignore[no-untyped-def]
+        _enable(monkeypatch)
+        respx_mock.post(analytics.GA_ENDPOINT).mock(
+            side_effect=httpx.ConnectError("boom"),
+        )
+        # Must not raise — telemetry failures are silent.
+        await analytics.send_event(
+            analytics.build_payload("search", success=True, duration_ms=5),
+        )
+
+
+class TestTrackToolCall:
+    async def test_disabled_schedules_nothing(self, monkeypatch, respx_mock) -> None:  # type: ignore[no-untyped-def]
+        monkeypatch.delenv("GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("PUBLIC_GA_MEASUREMENT_ID", raising=False)
+        monkeypatch.delenv("GA_API_SECRET", raising=False)
+        route = respx_mock.post(analytics.GA_ENDPOINT).mock(
+            return_value=httpx.Response(204),
+        )
+        analytics.track_tool_call("search", success=True, duration_ms=1)
+        assert not route.called
+
+    async def test_enabled_fires_event(self, monkeypatch, respx_mock) -> None:  # type: ignore[no-untyped-def]
+        _enable(monkeypatch)
+        route = respx_mock.post(analytics.GA_ENDPOINT).mock(
+            return_value=httpx.Response(204),
+        )
+        analytics.track_tool_call("search", success=True, duration_ms=1)
+        # Fire-and-forget: let the scheduled task run.
+        for task in list(analytics._pending):
+            await task
+        assert route.called

--- a/render.yaml
+++ b/render.yaml
@@ -28,6 +28,14 @@ services:
       # in the Render dashboard (sync: false).
       - key: PUBLIC_SITE_URL
         sync: false
+      # Google Analytics 4 measurement ID (e.g. `G-5B0T5HKVQ9`). Baked into
+      # src/app.html at build time via %sveltekit.env.PUBLIC_GA_MEASUREMENT_ID%
+      # (SvelteKit only exposes PUBLIC_-prefixed vars to app.html). Provided
+      # by the shared Render env group, or set here per environment. Only the
+      # frontend needs it — the API/MCP backends serve no browser pages, so
+      # gtag.js has nothing to run in. Leave unset to disable analytics.
+      - key: PUBLIC_GA_MEASUREMENT_ID
+        sync: false
     routes:
       - type: rewrite
         source: /*

--- a/render.yaml
+++ b/render.yaml
@@ -136,3 +136,15 @@ services:
         # OAuth dance. Without this env var, `resource` falls back to
         # IRIS_API_URL, which works but isn't the actual MCP endpoint.
         value: https://iris-mcp.onrender.com
+      # Google Analytics 4 (Measurement Protocol). iris-mcp emits a
+      # `mcp_tool_call` event per tool dispatch into the SAME GA4 property
+      # as the frontend — no separate stream. Tracking activates only when
+      # BOTH a measurement ID and an API secret are present, else it's a
+      # no-op. The measurement ID is inherited from the shared env group's
+      # PUBLIC_GA_MEASUREMENT_ID (analytics.py falls back to it), so the
+      # only value to set here is the secret below. Set GA_MEASUREMENT_ID
+      # explicitly only if you want a different ID than the frontend's.
+      - key: GA_API_SECRET
+        # GA4 Admin → Data Streams → [Iris UAT] → Measurement Protocol API
+        # secrets → Create. Sensitive — set per environment, never commit.
+        sync: false


### PR DESCRIPTION
## Summary

Wires Google Analytics 4 into the Iris UAT deployment. Two independent tracking paths into the **same** GA4 property (one web stream, `G-5B0T5HKVQ9`) — no separate stream per service.

- **Frontend page views** — the standard gtag.js browser tag, injected into the SvelteKit shell.
- **MCP tool usage** — server-side events sent from iris-mcp via the GA4 Measurement Protocol.

The API and scenia services are intentionally untouched: iris-api is a headless JSON backend (nothing renders a browser tag), and scenia is built from a separate repo.

## Frontend (`iris-frontend`)

- `frontend/src/app.html` — gtag.js loader in `<head>`. The measurement ID is baked in at build time from `PUBLIC_GA_MEASUREMENT_ID` via `%sveltekit.env.PUBLIC_GA_MEASUREMENT_ID%`, mirroring the existing `PUBLIC_SITE_URL` pattern. A guard means analytics only load when a real `G-…` ID is present, so local dev / PR previews (var unset) neither track nor make broken requests.
- SvelteKit only exposes `PUBLIC_`-prefixed vars to `app.html`, so the Render env var must be named `PUBLIC_GA_MEASUREMENT_ID` (a hyphenated name cannot work).

## MCP (`iris-mcp`)

- `mcp/src/iris_mcp/analytics.py` — fire-and-forget GA4 Measurement Protocol client. Emits an `mcp_tool_call` event (params: `tool`, `success`, `duration_ms`) per tool dispatch. Strict no-op unless both `GA_MEASUREMENT_ID` (falls back to the shared `PUBLIC_GA_MEASUREMENT_ID`) and `GA_API_SECRET` are set. Send failures are swallowed so telemetry never affects a tool response.
- `mcp/src/iris_mcp/server.py` — hooks the tracker into `build_server`'s `_call_tool`, so it covers both the stdio and HTTP transports from a single point.
- Server events use a synthetic per-process client/session id: GA "users"/"sessions" approximate running instances, while the event count and `tool` parameter (what matters here) stay accurate.

## Config & docs

- `render.yaml` — documents `PUBLIC_GA_MEASUREMENT_ID` on `iris-frontend` and `GA_API_SECRET` on `iris-mcp`.
- `.env.example` — documents both.

## Testing

- `mcp/tests/test_analytics.py` — 12 tests (respx): enablement gating, `PUBLIC_GA_MEASUREMENT_ID` fallback, payload shape, credentialed POST, error swallowing, and fire-and-forget dispatch. All pass.
- Full MCP suite: 255 pass; the 2 failures are pre-existing on `main` (unrelated tool-schema `required` assertions) and not touched by this change.

## Operator steps (in Render / GA4)

- Set `PUBLIC_GA_MEASUREMENT_ID` = `G-5B0T5HKVQ9` (shared env group).
- Create a Measurement Protocol API secret (GA4 Admin → Data Streams → Iris UAT → Measurement Protocol API secrets) and set `GA_API_SECRET` on iris-mcp.
- Optional: register `tool` as a custom dimension in GA4 to slice usage by tool name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157cP8QPHP8nZFxs3R4qNuB

---
_Generated by [Claude Code](https://claude.ai/code/session_0157cP8QPHP8nZFxs3R4qNuB)_