### PR TITLE
fix(deploy): link shared env group so iris-mcp GA4 tracking fires (ADR-241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP analytics: `mcp_tool_call` events now actually reach GA4 (ADR-241).** The
+  server-side Measurement Protocol tracking added in PR #288 was a silent no-op in
+  production: `iris-mcp` had `GA_API_SECRET` but was never given a measurement ID
+  (`PUBLIC_GA_MEASUREMENT_ID` was frontend-only and no env group was linked in the
+  Blueprint), so `is_enabled()` failed closed with no log or error. Both GA vars now
+  live in the `iris shared environment vars` env group, declared at the Blueprint
+  top level and linked to `iris-frontend` and `iris-mcp` via `fromGroup`; the
+  redundant per-service `GA_API_SECRET` is removed. Verified live — a single tool
+  dispatch produces exactly one `mcp_tool_call` event in GA Realtime. Deploy config
+  only; no schema/endpoint/tool/CLI change.
+
 ## [6.47.4] - 2026-06-08
 
 ### Fixed

--- a/docs/adrs/ADR-241-MCP-Analytics-Env-Group-Linkage.md
+++ b/docs/adrs/ADR-241-MCP-Analytics-Env-Group-Linkage.md
@@ -1,0 +1,104 @@
+# ADR-241: iris-mcp GA4 tracking needs the shared env group linked in the Blueprint
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-241 |
+| **Initiative** | Make the `mcp_tool_call` Measurement Protocol tracking (from the GA4-for-UAT work, PR #288) actually fire in production, and capture the env-group linkage in `render.yaml` so it can't silently regress |
+| **Proposed By** | Engineering |
+| **Date** | 2026-07-07 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the Google-Analytics-for-UAT work (PR #288: frontend
+`gtag.js` page views + `mcp/src/iris_mcp/analytics.py` server-side
+`mcp_tool_call` events via the Measurement Protocol), the MCP-side tracking was a
+**strict no-op in production despite the deploy being live and serving tool
+traffic**. `analytics.py:is_enabled()` requires **both** a measurement ID and an
+API secret; the ID is resolved as `GA_MEASUREMENT_ID` or, as a fallback,
+`PUBLIC_GA_MEASUREMENT_ID`. The `iris-mcp` service was given `GA_API_SECRET`
+(declared `sync: false`) but **was never supplied a measurement ID** —
+`PUBLIC_GA_MEASUREMENT_ID` was declared only on the `iris-frontend` service, and
+`render.yaml` contained **no env-group linkage** despite a code comment claiming
+the ID "is inherited from the shared env group". Diagnosis confirmed this: GA
+reported zero `mcp_tool_call` events over 365 days while Render request logs
+showed active `POST /` MCP traffic to the deployed service,
+
+**facing** the fact that GA env vars (`sync: false`) are entered in the Render
+dashboard and are trivially, silently divergent from the committed Blueprint —
+`is_enabled()` fails closed and swallows all send errors by design, so a missing
+ID produces **no log, no error, no event**, only absent data,
+
+**we decided to** (a) put **both** GA vars — `PUBLIC_GA_MEASUREMENT_ID` and
+`GA_API_SECRET` — into the existing **`iris shared environment vars`** Render env
+group, and (b) declare that group at the Blueprint top level (`envVarGroups`) and
+reference it from **both** `iris-frontend` and `iris-mcp` via `fromGroup`, so the
+MCP's measurement-ID fallback is actually satisfied and the linkage lives in
+code, not just the dashboard; the redundant per-service `GA_API_SECRET` key on
+`iris-mcp` is removed since the group now provides it,
+
+**and neglected** (1) hard-coding a second per-service `GA_MEASUREMENT_ID` on
+`iris-mcp` — rejected because it duplicates the frontend's value and re-creates
+the same dashboard-vs-code drift this ADR exists to kill; (2) keeping
+`GA_API_SECRET` per-service on `iris-mcp` only (strict least-privilege, so the
+frontend build never sees the secret) — considered and **not** taken because the
+static frontend bakes in only `PUBLIC_`-prefixed vars referenced in `app.html`,
+so a non-`PUBLIC_` secret present in its build env is never emitted to the client;
+the simpler single-group model was preferred, and this trade-off is recorded here
+so it can be revisited; (3) making `analytics.py` fail *loud* (log a warning when
+only one of the two vars is set) — deferred as a follow-up, out of scope for the
+config fix,
+
+**to achieve** a live `mcp_tool_call` event stream in the same GA4 property as
+the frontend page-view stream (verified: one `list_collections` dispatch produced
+exactly one `mcp_tool_call` event in GA Realtime immediately after the group was
+linked and redeployed), captured durably in the Blueprint,
+
+**accepting that** a `render blueprint sync` reconciles a group's membership to
+what the `envVarGroups` block lists — so the block must enumerate **every** member
+of `iris shared environment vars`, or a sync will prune the omitted ones; this ADR
+lists the two GA vars known to be in the group and flags the constraint inline in
+`render.yaml`. Values remain `sync: false` (dashboard-only, never committed).
+
+---
+
+## Consequences
+
+- **No schema, endpoint, MCP tool, or CLI change.** Deploy configuration only.
+  Surface parity (§14) and SQLite↔Supabase parity (§15) are N/A — no write
+  surface is added or altered.
+- **No `{@html}` change (§7).** No HTML rendering.
+- **DRY (§13).** The GA measurement ID now has a single source of truth (the env
+  group) instead of being declared per-service; the duplicated per-service
+  `GA_API_SECRET` on `iris-mcp` is removed.
+- **Prune hazard documented.** Because Blueprint sync is authoritative over group
+  membership, `render.yaml` now carries a `⚠️` note that every group member must
+  be listed before a sync. If the group later gains shared vars, they must be
+  added to the `envVarGroups` block.
+- **Least-privilege note.** `iris-frontend` now also receives `GA_API_SECRET` via
+  the shared group. It is not exposed to browsers (static build emits only
+  referenced `PUBLIC_` vars), but the blast radius is slightly wider; revisiting
+  is captured in the **and neglected** clause.
+- **Follow-up flagged.** `analytics.py` could log a one-time warning when exactly
+  one of the two GA vars is set, converting this class of silent-no-op back into a
+  visible signal. Tracked as a follow-up, not done here.
+
+## Alternatives considered
+
+See the **and neglected** clause: per-service `GA_MEASUREMENT_ID`, keeping the
+secret per-service for least-privilege, and making `analytics.py` fail loud — each
+rejected or deferred with rationale.
+
+## Dependencies
+
+- PR #288 (feat: Google Analytics for Iris UAT — frontend page views + MCP tool
+  calls; commits `3959afb`, `c0e585c`) — introduced `analytics.py` and the
+  `GA_API_SECRET` / `PUBLIC_GA_MEASUREMENT_ID` env contract this ADR wires up.
+
+## References
+
+- Implementation spec: [SPEC-241-A](./specs/SPEC-241-A-MCP-Analytics-Env-Group-Linkage.md)
+- `mcp/src/iris_mcp/analytics.py` — `is_enabled()`, `_measurement_id()` fallback.
+- `render.yaml` — `envVarGroups: iris shared environment vars` + `fromGroup` refs.

--- a/docs/adrs/specs/SPEC-241-A-MCP-Analytics-Env-Group-Linkage.md
+++ b/docs/adrs/specs/SPEC-241-A-MCP-Analytics-Env-Group-Linkage.md
@@ -1,0 +1,67 @@
+# SPEC-241-A: iris-mcp GA4 tracking via the shared env group
+
+Implements **[ADR-241](../ADR-241-MCP-Analytics-Env-Group-Linkage.md)**.
+
+## 1. The enablement contract (unchanged code, `mcp/src/iris_mcp/analytics.py`)
+
+`mcp_tool_call` events fire only when **both** resolve to a truthy value:
+
+| Function | Reads | Notes |
+|----------|-------|-------|
+| `_measurement_id()` | `GA_MEASUREMENT_ID` → else `PUBLIC_GA_MEASUREMENT_ID` | fallback to the frontend's var |
+| `_api_secret()` | `GA_API_SECRET` | Measurement Protocol secret |
+
+`is_enabled()` is `bool(measurement_id and api_secret)`. When false, `track_tool_call`
+returns before any POST — **no log, no error, no event**. This spec supplies the
+missing measurement ID to `iris-mcp` so the AND is satisfied; no code changes.
+
+## 2. Env group membership (`iris shared environment vars`)
+
+The group is authoritative for both GA vars. Both `sync: false` (values live in
+the Render dashboard, never committed):
+
+| Key | Consumed by | Purpose |
+|-----|-------------|---------|
+| `PUBLIC_GA_MEASUREMENT_ID` | iris-frontend (build-time `gtag.js`), iris-mcp (MP fallback ID) | GA4 measurement ID, e.g. `G-5B0T5HKVQ9` |
+| `GA_API_SECRET` | iris-mcp | GA4 Measurement Protocol API secret |
+
+## 3. Blueprint changes (`render.yaml`)
+
+| Location | Before | After |
+|----------|--------|-------|
+| top level | *(no `envVarGroups`)* | `envVarGroups:` declaring `iris shared environment vars` with both keys (`sync: false`) |
+| `iris-frontend` `envVars` | `- key: PUBLIC_GA_MEASUREMENT_ID` (`sync: false`) | `- fromGroup: iris shared environment vars` |
+| `iris-mcp` `envVars` | `- key: GA_API_SECRET` (`sync: false`), no ID | `- fromGroup: iris shared environment vars` (provides both; per-service `GA_API_SECRET` removed) |
+
+`iris-api` is **not** linked — it renders no browser pages and has no Measurement
+Protocol code (verified: the only "analytics" references in `backend/` are demo
+seed content in `scenia_seed.py`).
+
+## 4. Blueprint-sync invariant (prune hazard)
+
+A `render blueprint sync` reconciles a group's membership to exactly what the
+`envVarGroups` block lists. Therefore the block **must enumerate every member** of
+`iris shared environment vars`; any dashboard var omitted here is pruned on sync.
+Currently the group holds exactly the two GA vars above. `render.yaml` carries a
+`⚠️` comment stating this constraint.
+
+## 5. Verification
+
+1. Link the group to `iris-mcp` in the dashboard and redeploy (done manually
+   2026-07-07, deploy `dep-d96oak3tqb8s73eb879g`, status `live`).
+2. Invoke any MCP tool against the deployed server.
+3. GA4 Realtime → filter `eventName` contains `mcp` → expect `mcp_tool_call ≥ 1`.
+   **Observed:** one `list_collections` dispatch produced exactly one
+   `mcp_tool_call` event in property `chrisbarlow.nz` (`532831327`).
+
+Failed dispatches still emit an event with `success=false` (by design), so a 401
+from an expired backend token during the check still validates the path.
+
+## 6. Out of scope / follow-ups
+
+- **Loud enablement warning.** `analytics.py` could log once when exactly one of
+  the two GA vars is set (silent-no-op → visible signal). Deferred (ADR-241
+  **and neglected** #3).
+- **Custom dimensions.** Register `tool` (and optionally `success`, `duration_ms`)
+  as GA4 event-scoped custom definitions to slice `mcp_tool_call` by tool name.
+  Dashboard action, no code/Blueprint change; does not backfill.

--- a/render.yaml
+++ b/render.yaml
@@ -28,14 +28,13 @@ services:
       # in the Render dashboard (sync: false).
       - key: PUBLIC_SITE_URL
         sync: false
-      # Google Analytics 4 measurement ID (e.g. `G-5B0T5HKVQ9`). Baked into
-      # src/app.html at build time via %sveltekit.env.PUBLIC_GA_MEASUREMENT_ID%
-      # (SvelteKit only exposes PUBLIC_-prefixed vars to app.html). Provided
-      # by the shared Render env group, or set here per environment. Only the
-      # frontend needs it — the API/MCP backends serve no browser pages, so
-      # gtag.js has nothing to run in. Leave unset to disable analytics.
-      - key: PUBLIC_GA_MEASUREMENT_ID
-        sync: false
+      # Google Analytics 4 measurement ID (e.g. `G-5B0T5HKVQ9`) plus other
+      # shared secrets come from the `iris shared environment vars` group.
+      # PUBLIC_GA_MEASUREMENT_ID is baked into src/app.html at build time via
+      # %sveltekit.env.PUBLIC_GA_MEASUREMENT_ID% (SvelteKit only exposes
+      # PUBLIC_-prefixed vars to app.html); env-group vars are present at
+      # build. Leave the group's value unset to disable analytics.
+      - fromGroup: iris shared environment vars
     routes:
       - type: rewrite
         source: /*
@@ -139,12 +138,32 @@ services:
       # Google Analytics 4 (Measurement Protocol). iris-mcp emits a
       # `mcp_tool_call` event per tool dispatch into the SAME GA4 property
       # as the frontend — no separate stream. Tracking activates only when
-      # BOTH a measurement ID and an API secret are present, else it's a
-      # no-op. The measurement ID is inherited from the shared env group's
-      # PUBLIC_GA_MEASUREMENT_ID (analytics.py falls back to it), so the
-      # only value to set here is the secret below. Set GA_MEASUREMENT_ID
-      # explicitly only if you want a different ID than the frontend's.
+      # BOTH the measurement ID and the API secret are present, else it's a
+      # no-op. Both come from the shared env group linked below:
+      # PUBLIC_GA_MEASUREMENT_ID (analytics.py falls back to it) and
+      # GA_API_SECRET. The group MUST be linked or tracking stays off. Set
+      # GA_MEASUREMENT_ID explicitly only to use a different ID than the
+      # frontend's.
+      - fromGroup: iris shared environment vars
+
+# Shared env group referenced by iris-frontend and iris-mcp above via
+# `fromGroup`. The group already exists in the Render dashboard; it is
+# declared here only so the Blueprint can link it. Values stay in the
+# dashboard (sync: false) and are never committed.
+#
+# ⚠️  A Blueprint sync reconciles a group's membership to what is listed
+#     here. If the group holds any shared vars in the dashboard beyond the
+#     two below, add every one of them here BEFORE running
+#     `render blueprint sync`, or the sync will prune the ones not listed.
+envVarGroups:
+  - name: iris shared environment vars
+    envVars:
+      # GA4 measurement ID (e.g. `G-5B0T5HKVQ9`), shared by the frontend
+      # (gtag.js page views) and iris-mcp (Measurement Protocol tool calls).
+      - key: PUBLIC_GA_MEASUREMENT_ID
+        sync: false
+      # GA4 Measurement Protocol API secret used by iris-mcp to POST
+      # `mcp_tool_call` events. GA4 Admin → Data Streams → [Iris UAT] →
+      # Measurement Protocol API secrets → Create. Sensitive.
       - key: GA_API_SECRET
-        # GA4 Admin → Data Streams → [Iris UAT] → Measurement Protocol API
-        # secrets → Create. Sensitive — set per environment, never commit.
         sync: false


### PR DESCRIPTION
## Problem

The server-side `mcp_tool_call` Measurement Protocol tracking added in **PR #288** was a **silent no-op in production**, despite the `iris-mcp` deploy being live and actively serving tool traffic.

`analytics.is_enabled()` requires **both** a measurement ID and an API secret. `iris-mcp` had `GA_API_SECRET` but was **never supplied a measurement ID**:
- `PUBLIC_GA_MEASUREMENT_ID` was declared only on `iris-frontend`
- No env group was linked in the Blueprint, so the `_measurement_id()` fallback resolved to `None`

The gate fails closed and swallows send errors by design → **no log, no error, no event**. Diagnosis: GA showed **0** `mcp_tool_call` events over 365 days while Render request logs showed active `POST /` MCP traffic.

## Fix

- Both GA vars (`PUBLIC_GA_MEASUREMENT_ID`, `GA_API_SECRET`) now live in the **`iris shared environment vars`** env group.
- Group declared at the Blueprint top level (`envVarGroups`) and referenced from **`iris-frontend`** and **`iris-mcp`** via `fromGroup`.
- Redundant per-service `GA_API_SECRET` on `iris-mcp` removed.
- `iris-api` intentionally **not** linked — no browser pages, no Measurement Protocol code (verified: only "analytics" refs in `backend/` are demo seed content).

## Verification

Group linked + redeployed manually (`dep-d96oak3tqb8s73eb879g`, live). A single `list_collections` dispatch against the deployed MCP produced **exactly one** `mcp_tool_call` event in GA Realtime, in the same property as the frontend page-view stream (`chrisbarlow.nz` / `532831327`). This PR captures that linkage in code so it can't silently regress.

## Notes

- ⚠️ A `render blueprint sync` reconciles group membership to what `envVarGroups` lists — the block must enumerate **every** member or a sync prunes the rest. Flagged inline in `render.yaml`.
- Deploy config only: **no schema / endpoint / MCP tool / CLI change** (Surface Parity §14 and SQLite↔Supabase parity §15 N/A).

## Follow-ups (not in this PR)

- Register `tool` (and optionally `success`, `duration_ms`) as GA4 custom dimensions to slice `mcp_tool_call` by tool name.
- Make `analytics.py` log a warning when exactly one of the two GA vars is set, so this class of silent no-op becomes visible.

## Files

- `render.yaml` — env group + `fromGroup` refs
- `docs/adrs/ADR-241-MCP-Analytics-Env-Group-Linkage.md`
- `docs/adrs/specs/SPEC-241-A-MCP-Analytics-Env-Group-Linkage.md`
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)