### PR TITLE
fix(thumbnails): idempotent startup regeneration — stop ~56 MB/restart Supabase egress (ADR-242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Thumbnail regeneration is now idempotent — stops ~56 MB of Supabase egress per
+  restart (ADR-242).** `iris-api` re-rendered and re-wrote a PNG for **all 1221
+  diagrams × 3 themes** back to Supabase on **every** boot, and the free-tier
+  service restarts ~12–24×/day — a Render metrics/logs investigation traced the
+  service's runaway bandwidth (6 GB and climbing) to this: hours with no restart
+  transferred ~0 MB, hours with a restart ~56 MB. Each stored thumbnail now
+  carries a `content_hash` (`sha256(renderer_version ‖ svg)`); the startup sweep
+  prefetches all hashes in one query and **skips the render and the DB write for
+  any unchanged `(diagram, theme)`**, so a steady boot writes **zero** thumbnails
+  (verified: a repeat sweep over an unchanged database performs no writes). New
+  and edited diagrams still render on demand and on change; the admin
+  `POST /api/admin/thumbnails/regenerate` endpoint force-refreshes via
+  `force=True`; bump `_THUMBNAIL_RENDERER_VERSION` to force a global rebuild.
+  Adds a nullable `content_hash` column to `diagram_thumbnails` (SQLite migration
+  `m083`; Supabase `ADD COLUMN IF NOT EXISTS`). Legacy rows regenerate once, then
+  settle. No schema-write endpoint / MCP tool / CLI change (Protocol §14 parity
+  unaffected).
 - **MCP analytics: `mcp_tool_call` events now actually reach GA4 (ADR-241).** The
   server-side Measurement Protocol tracking added in PR #288 was a silent no-op in
   production: `iris-mcp` had `GA_API_SECRET` but was never given a measurement ID

--- a/backend/app/diagrams/router.py
+++ b/backend/app/diagrams/router.py
@@ -57,10 +57,15 @@ async def regenerate_thumbnails(
     request: Request,
     current_user: dict[str, Any] = Depends(get_current_user),  # noqa: B008
 ) -> dict[str, int]:
-    """Regenerate PNG thumbnails for all diagrams. Requires admin role."""
+    """Regenerate PNG thumbnails for all diagrams. Requires admin role.
+
+    ADR-242: an explicit admin action always force-refreshes (``force=True``),
+    bypassing the content-hash skip that keeps the automatic startup sweep
+    bandwidth-free.
+    """
     _require_admin(current_user)
     db = request.app.state.db_manager.main_db
-    count = await regenerate_all_thumbnails(db)
+    count = await regenerate_all_thumbnails(db, force=True)
     return {"count": count}
 
 

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -1,7 +1,9 @@
 """Thumbnail generation for diagram gallery cards."""
 from __future__ import annotations
 
+import hashlib
 import json
+import logging
 import re
 from datetime import UTC, datetime
 from html import escape as html_escape
@@ -10,6 +12,28 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
     from app.db.adapter import DatabasePort
+
+log = logging.getLogger(__name__)
+
+# ADR-242: bump when the rasteriser changes in a way that does NOT alter the
+# generated SVG string (e.g. cairosvg output dimensions), to force a global
+# thumbnail regeneration. Changes to ``generate_svg_from_diagram_data`` are
+# captured automatically because the content hash is taken over the SVG itself.
+_THUMBNAIL_RENDERER_VERSION = "1"
+
+# Sentinel distinguishing "caller did not supply a known hash" (do the lookup)
+# from "caller prefetched the hash and it is None" (no existing row).
+_UNSET = object()
+
+
+def _compute_thumbnail_hash(svg_str: str) -> str:
+    """Content hash identifying a rendered thumbnail (ADR-242).
+
+    Taken over the exact SVG that would be rasterised, prefixed with the
+    renderer version, so it changes iff the resulting PNG would change.
+    """
+    payload = f"{_THUMBNAIL_RENDERER_VERSION}\x00{svg_str}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 THEME_COLORS: dict[str, dict[str, str]] = {
     "light": {
@@ -252,10 +276,22 @@ async def generate_and_store_thumbnail(
     data: dict,
     diagram_type: str,
     theme: str = "dark",
-) -> None:
+    *,
+    force: bool = False,
+    known_hash: object = _UNSET,
+) -> bool:
     """Generate PNG thumbnail and store in database.
 
     Falls back to storing SVG as bytes if cairosvg is not available.
+
+    ADR-242: content-addressed / idempotent. Unless ``force`` is set, the
+    cairosvg render and the DB write are **skipped** when the stored
+    ``content_hash`` already matches the SVG that would be produced — this is
+    what stops the startup sweep from re-writing every thumbnail to Supabase on
+    each restart. ``known_hash`` lets a batch caller
+    (:func:`regenerate_all_thumbnails`) pass a prefetched hash so no per-row
+    ``SELECT`` is needed. Returns ``True`` if the thumbnail was (re)written,
+    ``False`` if an up-to-date thumbnail already existed and was left untouched.
     """
     # v6.17.9 (issue #208): for smart_markdown, resolve `{{...}}` tokens
     # to their rendered values so the thumbnail shows the actual content
@@ -277,6 +313,24 @@ async def generate_and_store_thumbnail(
             )
 
     svg_str = generate_svg_from_diagram_data(data, diagram_type, theme=theme)
+
+    # ADR-242: skip the render + write when the stored thumbnail is already
+    # up to date. The hash is over the rendered SVG, so it captures diagram
+    # edits, smart_markdown token resolution, theme, and renderer changes.
+    content_hash = _compute_thumbnail_hash(svg_str)
+    if not force:
+        if known_hash is _UNSET:
+            cursor = await db.execute(
+                "SELECT content_hash FROM diagram_thumbnails "
+                "WHERE diagram_id = ? AND theme = ?",
+                (diagram_id, theme),
+            )
+            row = await cursor.fetchone()
+            existing_hash = row[0] if row is not None else None
+        else:
+            existing_hash = known_hash
+        if existing_hash is not None and existing_hash == content_hash:
+            return False
 
     png_bytes: bytes
     try:
@@ -305,10 +359,12 @@ async def generate_and_store_thumbnail(
     now = datetime.now(tz=UTC).isoformat()
     await db.execute(
         "INSERT OR REPLACE INTO diagram_thumbnails "
-        "(diagram_id, theme, thumbnail, updated_at) VALUES (?, ?, ?, ?)",
-        (diagram_id, theme, png_bytes, now),
+        "(diagram_id, theme, thumbnail, content_hash, updated_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (diagram_id, theme, png_bytes, content_hash, now),
     )
     await db.commit()
+    return True
 
 
 async def get_thumbnail(
@@ -347,15 +403,29 @@ async def get_thumbnail(
     return None
 
 
-async def regenerate_all_thumbnails(db: DatabasePort) -> int:
+async def regenerate_all_thumbnails(db: DatabasePort, *, force: bool = False) -> int:
     """Regenerate PNG thumbnails for all non-deleted diagrams in all themes.
 
     Called during startup to ensure all diagrams have up-to-date PNG thumbnails,
     including diagrams created before the thumbnail migration and diagrams with
     stale SVG-byte thumbnails from when cairosvg was not installed.
 
+    ADR-242: idempotent. Existing ``content_hash`` values are prefetched in a
+    single query and passed through, so a boot with no diagram or renderer
+    changes performs one read and **zero** writes instead of re-writing every
+    thumbnail to Supabase (~56 MB egress per restart on the free tier). Pass
+    ``force=True`` (e.g. the admin regenerate endpoint) to rewrite regardless.
+
     Returns the number of diagrams processed.
     """
+    existing_hashes: dict[tuple[str, str], object] = {}
+    if not force:
+        cursor = await db.execute(
+            "SELECT diagram_id, theme, content_hash FROM diagram_thumbnails"
+        )
+        for hrow in await cursor.fetchall():
+            existing_hashes[(hrow[0], hrow[1])] = hrow[2]
+
     cursor = await db.execute(
         "SELECT d.id, d.diagram_type, dv.data "
         "FROM diagrams d "
@@ -365,13 +435,24 @@ async def regenerate_all_thumbnails(db: DatabasePort) -> int:
     )
     rows = await cursor.fetchall()
 
+    written = 0
     for row in rows:
         diagram_id = row[0]
         diagram_type = row[1]
         data = json.loads(row[2]) if row[2] else {}
         for theme in VALID_THEMES:
-            await generate_and_store_thumbnail(
+            known = _UNSET if force else existing_hashes.get((diagram_id, theme))
+            wrote = await generate_and_store_thumbnail(
                 db, diagram_id, data, diagram_type, theme=theme,
+                force=force, known_hash=known,
             )
+            if wrote:
+                written += 1
 
+    total = len(rows) * len(VALID_THEMES)
+    log.info(
+        "[Thumbnails] regen sweep: %d written, %d skipped "
+        "(%d diagrams x %d themes, force=%s)",
+        written, total - written, len(rows), len(VALID_THEMES), force,
+    )
     return len(rows)

--- a/backend/app/migrations/m083_thumbnail_content_hash.py
+++ b/backend/app/migrations/m083_thumbnail_content_hash.py
@@ -1,0 +1,29 @@
+"""Migration 083: content-hash guard for thumbnail regeneration (ADR-242).
+
+Adds a nullable ``content_hash`` column to ``diagram_thumbnails`` so startup
+regeneration can skip the cairosvg render and the DB write for any
+``(diagram_id, theme)`` whose rendered SVG is unchanged. Eliminates the
+~56 MB-per-boot Supabase egress the free-tier ``iris-api`` was paying on every
+restart. No back-fill — pre-existing rows keep ``content_hash = NULL`` and
+regenerate exactly once (hash mismatch), which populates the column.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+MIGRATION_ID = "m083_thumbnail_content_hash"
+
+
+async def up(db: aiosqlite.Connection) -> None:
+    """Run migration up. Idempotent."""
+    cursor = await db.execute("PRAGMA table_info(diagram_thumbnails)")
+    cols = {row[1] for row in await cursor.fetchall()}
+    if "content_hash" not in cols:
+        await db.execute(
+            "ALTER TABLE diagram_thumbnails ADD COLUMN content_hash TEXT"
+        )
+    await db.commit()

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -87,6 +87,7 @@ from app.migrations.m079_rename_quantified_item_to_ingredient import up as m079_
 from app.migrations.m080_element_detail_diagram import up as m080_up
 from app.migrations.m081_element_parent_element import up as m081_up
 from app.migrations.m082_user_collection_scope import up as m082_up
+from app.migrations.m083_thumbnail_content_hash import up as m083_up
 from app.migrations.seed import seed_roles_and_permissions
 from app.search.service import rebuild_search_index
 from app.seed.creation_prompts import seed_creation_prompts
@@ -200,6 +201,7 @@ async def _initialize_sqlite(db_manager: DatabaseManager) -> None:
     await m080_up(main)  # issue #242, v6.33.0: elements.detail_diagram_id drill link (ADR-221)
     await m081_up(main)  # v6.43.0: elements.parent_element_id containment axis (ADR-231)
     await m082_up(main)  # v6.45.0: user_collection_scope per-user write-scope (ADR-237)
+    await m083_up(main)  # content_hash guard for idempotent thumbnail regen (ADR-242)
 
     # Service-layer seeds — receive DatabasePort (SqliteAdapter wrapping main)
     port = db_manager.main_db
@@ -312,6 +314,14 @@ async def _initialize_supabase(db_manager: DatabaseManager) -> None:
     )
     await port.execute(
         "ALTER TABLE packages ADD COLUMN IF NOT EXISTS sequence_order INTEGER NOT NULL DEFAULT 0"
+    )
+    await port.commit()
+
+    # m083 (ADR-242): content_hash guard so startup thumbnail regeneration
+    # skips the render + write for unchanged (diagram, theme) pairs, instead of
+    # re-writing every thumbnail to Supabase (~56 MB egress) on each restart.
+    await port.execute(
+        "ALTER TABLE diagram_thumbnails ADD COLUMN IF NOT EXISTS content_hash TEXT"
     )
     await port.commit()
 

--- a/backend/tests/test_diagrams/test_thumbnail_idempotent.py
+++ b/backend/tests/test_diagrams/test_thumbnail_idempotent.py
@@ -1,0 +1,254 @@
+"""Tests for content-hashed, idempotent thumbnail regeneration (ADR-242).
+
+Startup regeneration must skip the cairosvg render *and* the DB write for any
+``(diagram, theme)`` whose rendered SVG is unchanged, so the free-tier
+``iris-api`` stops re-writing ~56 MB of thumbnails to Supabase on every restart.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from app.config import AppConfig, AuthConfig, DatabaseConfig
+from app.database import DatabaseManager
+from app.diagrams.thumbnail import (
+    VALID_THEMES,
+    _compute_thumbnail_hash,
+    generate_and_store_thumbnail,
+    get_thumbnail,
+    regenerate_all_thumbnails,
+)
+from app.startup import initialize_databases
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import aiosqlite
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+SENTINEL_TS = "1999-01-01T00:00:00+00:00"
+
+_DIAGRAMS_INSERT = (
+    "INSERT INTO diagrams "
+    "(id, diagram_type, current_version, created_at, created_by, updated_at) "
+    "VALUES (?, 'simple-view', 1, ?, ?, ?)"
+)
+_VERSIONS_INSERT = (
+    "INSERT INTO diagram_versions "
+    "(diagram_id, version, name, description, data, "
+    "change_type, created_at, created_by) "
+    "VALUES (?, 1, ?, NULL, ?, 'create', ?, ?)"
+)
+
+
+@pytest.fixture
+def app_config(tmp_path: Path) -> AppConfig:
+    return AppConfig(
+        debug=True,
+        cors_origins=["http://localhost:5173"],
+        database=DatabaseConfig(data_dir=str(tmp_path / "data")),
+        auth=AuthConfig(
+            jwt_secret="test-secret-key-that-is-at-least-32-bytes-long-for-hs256",
+            argon2_time_cost=1,
+            argon2_memory_cost=8192,
+            argon2_parallelism=1,
+        ),
+    )
+
+
+def _node_data(label: str = "T") -> dict:
+    return {"nodes": [{"id": "n1", "position": {"x": 0, "y": 0},
+                       "data": {"label": label}}]}
+
+
+async def _insert_diagram(
+    db: aiosqlite.Connection, diagram_id: str, data: dict,
+) -> None:
+    now = datetime.now(tz=UTC).isoformat()
+    user_id = "test-user-id"
+    cursor = await db.execute("SELECT id FROM users WHERE id = ?", (user_id,))
+    if not await cursor.fetchone():
+        cursor = await db.execute("SELECT id FROM roles WHERE name = 'Viewer'")
+        role_row = await cursor.fetchone()
+        await db.execute(
+            "INSERT INTO users (id, username, password_hash, role) "
+            "VALUES (?, ?, ?, ?)",
+            (user_id, "testuser", "not-a-real-hash",
+             role_row[0] if role_row else "viewer"),
+        )
+    await db.execute(_DIAGRAMS_INSERT, (diagram_id, now, user_id, now))
+    await db.execute(
+        _VERSIONS_INSERT, (diagram_id, "T", json.dumps(data), now, user_id),
+    )
+    await db.commit()
+
+
+async def _updated_at(
+    db: aiosqlite.Connection, diagram_id: str, theme: str,
+) -> str | None:
+    cursor = await db.execute(
+        "SELECT updated_at FROM diagram_thumbnails "
+        "WHERE diagram_id = ? AND theme = ?",
+        (diagram_id, theme),
+    )
+    row = await cursor.fetchone()
+    return row[0] if row else None
+
+
+async def _set_sentinel_ts(
+    db: aiosqlite.Connection, diagram_id: str, theme: str,
+) -> None:
+    await db.execute(
+        "UPDATE diagram_thumbnails SET updated_at = ? "
+        "WHERE diagram_id = ? AND theme = ?",
+        (SENTINEL_TS, diagram_id, theme),
+    )
+    await db.commit()
+
+
+class TestContentHash:
+    def test_hash_is_stable_and_input_sensitive(self) -> None:
+        a = _compute_thumbnail_hash("<svg>one</svg>")
+        assert a == _compute_thumbnail_hash("<svg>one</svg>")
+        assert a != _compute_thumbnail_hash("<svg>two</svg>")
+        assert len(a) == 64  # sha256 hex
+
+
+class TestIdempotentGenerate:
+    async def test_second_identical_call_skips_write(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC1: identical data → True then False, no second write."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        await _insert_diagram(db, "d-idem", _node_data("A"))
+
+        wrote_first = await generate_and_store_thumbnail(
+            db, "d-idem", _node_data("A"), "simple-view", theme="dark",
+        )
+        assert wrote_first is True
+        await _set_sentinel_ts(db, "d-idem", "dark")
+
+        wrote_second = await generate_and_store_thumbnail(
+            db, "d-idem", _node_data("A"), "simple-view", theme="dark",
+        )
+        assert wrote_second is False
+        assert await _updated_at(db, "d-idem", "dark") == SENTINEL_TS
+        await db_manager.close()
+
+    async def test_changed_data_regenerates(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC2: different data → hash differs → regenerates."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        await _insert_diagram(db, "d-chg", _node_data("A"))
+
+        await generate_and_store_thumbnail(
+            db, "d-chg", _node_data("A"), "simple-view", theme="dark",
+        )
+        await _set_sentinel_ts(db, "d-chg", "dark")
+
+        wrote = await generate_and_store_thumbnail(
+            db, "d-chg", _node_data("DIFFERENT"), "simple-view", theme="dark",
+        )
+        assert wrote is True
+        assert await _updated_at(db, "d-chg", "dark") != SENTINEL_TS
+        await db_manager.close()
+
+    async def test_force_always_rewrites(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC3: force=True rewrites even when unchanged."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        await _insert_diagram(db, "d-force", _node_data("A"))
+
+        await generate_and_store_thumbnail(
+            db, "d-force", _node_data("A"), "simple-view", theme="dark",
+        )
+        await _set_sentinel_ts(db, "d-force", "dark")
+
+        wrote = await generate_and_store_thumbnail(
+            db, "d-force", _node_data("A"), "simple-view",
+            theme="dark", force=True,
+        )
+        assert wrote is True
+        assert await _updated_at(db, "d-force", "dark") != SENTINEL_TS
+        await db_manager.close()
+
+    async def test_legacy_null_hash_regenerates_once(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC4: a row with NULL content_hash regenerates once, then skips."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        await _insert_diagram(db, "d-legacy", _node_data("A"))
+
+        # Simulate a pre-ADR-242 row: PNG present, content_hash NULL.
+        await db.execute(
+            "INSERT OR REPLACE INTO diagram_thumbnails "
+            "(diagram_id, theme, thumbnail, updated_at) VALUES (?, ?, ?, ?)",
+            ("d-legacy", "dark", b"<svg>legacy</svg>", SENTINEL_TS),
+        )
+        await db.commit()
+
+        first = await generate_and_store_thumbnail(
+            db, "d-legacy", _node_data("A"), "simple-view", theme="dark",
+        )
+        assert first is True
+        thumb = await get_thumbnail(db, "d-legacy", theme="dark")
+        assert thumb is not None
+        assert thumb != b"<svg>legacy</svg>"  # the legacy bytes were replaced
+
+        await _set_sentinel_ts(db, "d-legacy", "dark")
+        second = await generate_and_store_thumbnail(
+            db, "d-legacy", _node_data("A"), "simple-view", theme="dark",
+        )
+        assert second is False
+        assert await _updated_at(db, "d-legacy", "dark") == SENTINEL_TS
+        await db_manager.close()
+
+
+class TestIdempotentSweep:
+    async def test_second_sweep_writes_nothing(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC5: a repeat sweep over an unchanged DB performs zero writes."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        await _insert_diagram(db, "d-sweep", _node_data("A"))
+
+        # First sweep establishes hashes for every theme.
+        await regenerate_all_thumbnails(db)
+        for theme in VALID_THEMES:
+            await _set_sentinel_ts(db, "d-sweep", theme)
+
+        # Second sweep must skip everything → all sentinels intact.
+        await regenerate_all_thumbnails(db)
+        for theme in VALID_THEMES:
+            assert await _updated_at(db, "d-sweep", theme) == SENTINEL_TS, (
+                f"theme {theme} was rewritten by an unchanged sweep"
+            )
+        await db_manager.close()
+
+    async def test_column_exists_on_fresh_db(
+        self, app_config: AppConfig,
+    ) -> None:
+        """AC7: content_hash column exists after initialisation."""
+        db_manager = DatabaseManager(app_config)
+        await initialize_databases(db_manager)
+        db = db_manager.main_db
+        cursor = await db.execute("PRAGMA table_info(diagram_thumbnails)")
+        cols = {row[1] for row in await cursor.fetchall()}
+        assert "content_hash" in cols
+        await db_manager.close()

--- a/docs/adrs/ADR-242-Idempotent-Thumbnail-Regeneration.md
+++ b/docs/adrs/ADR-242-Idempotent-Thumbnail-Regeneration.md
@@ -1,0 +1,95 @@
+# ADR-242: Content-hash guard makes startup thumbnail regeneration idempotent
+
+| Field | Value |
+|-------|-------|
+| **Decision ID** | ADR-242 |
+| **Initiative** | Stop `iris-api` from re-writing every diagram thumbnail to Supabase on every boot, which was burning ~56 MB of Render egress per restart (~30–40 GB/month) |
+| **Proposed By** | Engineering |
+| **Date** | 2026-07-07 |
+| **Status** | Approved |
+
+---
+
+## ADR (WH(Y) Statement format)
+
+**In the context of** the `iris-api` Render service (free plan, Singapore)
+reading persistently high bandwidth — flagged at 6 GB and climbing — where a
+Render metrics + logs investigation established that: (a) the bandwidth arrives
+in discrete ~56 MB units, one per hour of *service uptime*; (b) hours containing
+**no** restart show ~0 MB (e.g. 2026-07-07 15:00 = 0.0002 MB, 19:00 = 0.0005 MB)
+while every hour containing a restart shows ~56 MB; (c) the free service restarts
+~12–24×/day (spin-down/cycle/deploy), each boot logging
+`[STARTUP] regenerated 1221 diagram thumbnails`; and (d) the database is
+**Supabase** (external over the public internet), so the startup sweep's writes
+are billed as Render egress,
+
+**facing** `regenerate_all_thumbnails()` in `backend/app/diagrams/thumbnail.py`,
+which on **every** startup unconditionally re-rendered and re-wrote a PNG for
+**all 1221 non-deleted diagrams × 3 themes** (~3,663 `INSERT OR REPLACE` blobs,
+~48 MB egress) back to Supabase — even though the diagrams and the renderer had
+not changed since the previous boot, and even though the module already renders
+any genuinely new/changed diagram fresh on its first `GET /thumbnail`, making the
+blanket sweep almost entirely redundant work,
+
+**we decided to** make thumbnail generation **content-addressed / idempotent**:
+store a `content_hash` per `(diagram_id, theme)` row equal to
+`sha256(renderer_version ‖ svg_str)` — the SHA-256 of the exact SVG that would be
+rasterised, prefixed with a bumpable `_THUMBNAIL_RENDERER_VERSION` constant.
+`generate_and_store_thumbnail()` now computes that hash and, unless `force=True`,
+**skips both the cairosvg render and the DB write** when the stored hash already
+matches. `regenerate_all_thumbnails()` prefetches all existing hashes in a single
+`SELECT` and only writes the rows whose content actually changed, so a steady
+boot costs **one small read and zero writes** instead of ~48 MB of writes,
+
+**and neglected** (1) hashing the diagram *input* (`data` + `diagram_type` +
+`theme`) rather than the rendered `svg_str` — rejected because a `smart_markdown`
+thumbnail depends on **resolved** `{{…}}` tokens (other elements), so input-only
+hashing would wrongly skip regeneration when a referenced element changed;
+hashing the final `svg_str` captures every determinant of the output and also
+auto-invalidates whenever `generate_svg_from_diagram_data` changes; (2) gating the
+sweep behind an env flag so it runs only after a renderer change — considered, but
+the hash guard subsumes it (an SVG change changes the hash) and needs no operator
+action, with the `_THUMBNAIL_RENDERER_VERSION` bump left as the explicit
+global-invalidation knob for rasteriser changes that don't alter the SVG string;
+(3) simply reducing restart frequency (paid plan) — orthogonal; it would mask, not
+fix, the redundant-write waste and every deploy would still pay it; (4) skipping
+the SVG generation too on unchanged rows — not taken because SVG generation is
+pure in-memory string building with no I/O, so it contributes no bandwidth and
+gates the hash,
+
+**to achieve** steady-state boots that re-write **~0** thumbnails and transfer
+~0 MB (down from ~56 MB), collapsing the restart-driven ~30–40 GB/month egress to
+a one-time sweep after each genuine renderer or diagram change, while preserving
+the existing guarantees (new/changed diagrams still render on demand; the admin
+`POST /api/admin/thumbnails/regenerate` endpoint still force-refreshes via
+`force=True`),
+
+**accepting that** (i) the **first** boot after this deploy still performs one
+full sweep, because pre-existing rows have `content_hash = NULL` and hash-mismatch
+forces a single regeneration that back-fills the hashes; (ii) changing the
+rasterisation in a way that does **not** change `svg_str` requires a manual
+`_THUMBNAIL_RENDERER_VERSION` bump to propagate; and (iii) a new nullable
+`content_hash` column is added to `diagram_thumbnails` on both the SQLite
+(migration `m083`) and Supabase (`ALTER TABLE … ADD COLUMN IF NOT EXISTS`) paths.
+
+---
+
+## Consequences
+
+- **Bandwidth:** restart-driven thumbnail egress drops from ~56 MB/boot to ~0 in
+  steady state. Verified in tests: a second `regenerate_all_thumbnails()` over an
+  unchanged database performs zero thumbnail writes.
+- **Schema:** `diagram_thumbnails` gains `content_hash TEXT` (nullable). Legacy
+  rows (`NULL`) regenerate exactly once, then settle.
+- **Surface parity (Protocol §14 / ADR-182):** no new write endpoint, MCP tool,
+  or CLI subcommand — this is an internal idempotency optimisation of an existing
+  code path. Parity unaffected.
+- **Observability:** `regenerate_all_thumbnails()` logs written-vs-skipped counts
+  so the effect is visible in Render logs after deploy.
+
+## Related
+
+- Supersedes the unconditional-sweep behaviour introduced for issue #208
+  (v6.17.8) and kept when the sweep was backgrounded (v6.30.2). The sweep still
+  exists and still propagates renderer changes — it is now idempotent.
+- Implemented by [SPEC-242-A](./specs/SPEC-242-A-Idempotent-Thumbnail-Regeneration.md).

--- a/docs/adrs/specs/SPEC-242-A-Idempotent-Thumbnail-Regeneration.md
+++ b/docs/adrs/specs/SPEC-242-A-Idempotent-Thumbnail-Regeneration.md
@@ -1,0 +1,74 @@
+# SPEC-242-A: Idempotent (content-hashed) thumbnail regeneration
+
+**Implements:** [ADR-242](../ADR-242-Idempotent-Thumbnail-Regeneration.md)
+**Status:** Implemented
+**Date:** 2026-07-07
+
+## Summary
+
+Add a `content_hash` to each stored diagram thumbnail so startup regeneration
+skips the cairosvg render **and** the Supabase write for any `(diagram, theme)`
+whose rendered SVG is unchanged. Eliminates the ~56 MB-per-boot egress that the
+free-tier `iris-api` was paying on every one of its ~12–24 daily restarts.
+
+## Schema
+
+`diagram_thumbnails` gains one nullable column:
+
+```
+content_hash TEXT   -- sha256(_THUMBNAIL_RENDERER_VERSION ‖ "\0" ‖ svg_str), hex
+```
+
+- **SQLite:** migration `m083_thumbnail_content_hash` — idempotent
+  `PRAGMA table_info` guard + `ALTER TABLE diagram_thumbnails ADD COLUMN content_hash TEXT`.
+- **Supabase:** `_initialize_supabase()` runs
+  `ALTER TABLE diagram_thumbnails ADD COLUMN IF NOT EXISTS content_hash TEXT`.
+
+PK is unchanged (`diagram_id, theme`); the `INSERT OR REPLACE` upsert now writes
+`(diagram_id, theme, thumbnail, content_hash, updated_at)`.
+
+## Behaviour
+
+`backend/app/diagrams/thumbnail.py`:
+
+- `_THUMBNAIL_RENDERER_VERSION = "1"` — bump to force a global regeneration when
+  the rasteriser changes in a way that does not alter the SVG string.
+- `_compute_thumbnail_hash(svg_str) -> str` — `sha256(version + "\0" + svg_str)`.
+- `generate_and_store_thumbnail(..., *, force=False, known_hash=_UNSET) -> bool`:
+  1. build `svg_str` (unchanged; includes the `smart_markdown` token resolve so
+     the hash reflects resolved content),
+  2. `content_hash = _compute_thumbnail_hash(svg_str)`,
+  3. if not `force`: resolve the existing hash (`known_hash` if the caller
+     prefetched it, else a one-row `SELECT`); if it equals `content_hash`,
+     **return `False` without rendering or writing**,
+  4. otherwise render the PNG and upsert the row with the new hash; **return `True`**.
+- `regenerate_all_thumbnails(db, *, force=False) -> int`:
+  - prefetches all `(diagram_id, theme) → content_hash` in a single `SELECT`,
+  - passes each as `known_hash` so a steady sweep does **one** read and **zero**
+    writes,
+  - logs `written` vs `skipped`,
+  - returns the number of diagrams processed (`len(rows)`), unchanged, so the
+    admin endpoint's `{"count": …}` contract holds.
+
+`backend/app/diagrams/router.py`: `POST /api/admin/thumbnails/regenerate` calls
+`regenerate_all_thumbnails(db, force=True)` — an explicit admin action always
+force-refreshes.
+
+Startup (`backend/app/startup.py`) calls the sweep with the default
+`force=False` on both the SQLite (awaited) and Supabase (backgrounded) paths.
+
+## Acceptance criteria
+
+1. Calling `generate_and_store_thumbnail` twice with identical data returns
+   `True` then `False`; the second call performs no DB write (the row's
+   `updated_at` is unchanged).
+2. Changing the diagram `data` between calls returns `True` again (hash differs).
+3. `force=True` always returns `True` and rewrites, even when unchanged.
+4. A legacy row with `content_hash = NULL` regenerates once (`True`), then a
+   subsequent call skips (`False`).
+5. `regenerate_all_thumbnails` over an unchanged database writes **zero**
+   thumbnails (all skipped) on the second run.
+6. Existing thumbnail guarantees still hold: new diagrams get PNGs, deleted
+   diagrams are skipped, all three themes are produced, and the admin regenerate
+   endpoint returns a count ≥ 1.
+7. The `content_hash` column exists on a freshly initialised database.


### PR DESCRIPTION
## Problem

`iris-api`'s Render bandwidth was climbing past 6 GB with no obvious cause. A Render metrics + logs investigation found:

- Bandwidth arrives in discrete **~56 MB units, one per hour of *uptime*** — hours with **no restart** transfer ~0 MB (e.g. 07-07 15:00 = 0.0002 MB, 19:00 = 0.0005 MB); every hour **with** a restart = ~56 MB.
- The free service restarts **~12–24×/day**, each boot logging `[STARTUP] regenerated 1221 diagram thumbnails`.
- The DB is **Supabase** (external), so the startup sweep's writes are billed as Render egress.

Root cause: `regenerate_all_thumbnails()` re-rendered and re-wrote a PNG for **all 1221 diagrams × 3 themes** back to Supabase on **every** boot (~48 MB egress), even when nothing changed — while new/changed diagrams already render on demand, making the blanket sweep almost entirely redundant. ~56 MB × ~18 restarts/day ≈ **~30–40 GB/month** of waste.

## Fix (ADR-242)

Content-address the thumbnails: each row stores `content_hash = sha256(renderer_version ‖ svg)`.

- `generate_and_store_thumbnail(..., *, force=False, known_hash=…)` — **skips the cairosvg render and the DB write** when the stored hash matches; returns whether it wrote.
- `regenerate_all_thumbnails(db, *, force=False)` — prefetches all hashes in **one** `SELECT`, writes only changed rows, logs `written`/`skipped`. Steady boot = one read, **zero** writes.
- Hash is taken over the rendered **SVG** (not raw input), so it correctly captures `smart_markdown` token resolution and auto-invalidates on any renderer change; `_THUMBNAIL_RENDERER_VERSION` is the explicit global-rebuild knob.
- Admin `POST /api/admin/thumbnails/regenerate` passes `force=True` — explicit refresh still works.

Adds nullable `content_hash` to `diagram_thumbnails` (SQLite migration `m083`; Supabase `ADD COLUMN IF NOT EXISTS`). Legacy `NULL`-hash rows regenerate **once**, then settle.

## Verification

- **36/36** thumbnail tests + **572** `test_diagrams`/`test_startup`/`test_migrations` pass; **surface parity clean** (Protocol §14 unaffected — no new write endpoint/MCP tool/CLI).
- New files lint clean; edited files add zero new ruff errors.
- End-to-end double-sweep: `15 written` → **`0 written, 15 skipped`** → `force=True` `15 written`.

## Migrations

Applied **automatically on deploy** — no manual step. SQLite runs `m083` on init; Supabase runs the idempotent `ADD COLUMN IF NOT EXISTS`. First boot after deploy does one full sweep (back-filling hashes), then settles.

## Docs

ADR-242, SPEC-242-A, CHANGELOG (`[Unreleased] → Fixed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)