### PR TITLE
fix(thumbnails): surface regen sweep counts via print, not logging (ADR-242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `force=True`; bump `_THUMBNAIL_RENDERER_VERSION` to force a global rebuild.
   Adds a nullable `content_hash` column to `diagram_thumbnails` (SQLite migration
   `m083`; Supabase `ADD COLUMN IF NOT EXISTS`). Legacy rows regenerate once, then
-  settle. No schema-write endpoint / MCP tool / CLI change (Protocol §14 parity
-  unaffected).
+  settle. Each sweep prints `[Thumbnails] regen sweep: N written, M skipped` to
+  stdout so the effect is visible in Render logs (the back-fill boot writes all;
+  every boot after shows `0 written`). No schema-write endpoint / MCP tool / CLI
+  change (Protocol §14 parity unaffected).
 - **MCP analytics: `mcp_tool_call` events now actually reach GA4 (ADR-241).** The
   server-side Measurement Protocol tracking added in PR #288 was a silent no-op in
   production: `iris-mcp` had `GA_API_SECRET` but was never given a measurement ID

--- a/backend/app/diagrams/thumbnail.py
+++ b/backend/app/diagrams/thumbnail.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import logging
 import re
 from datetime import UTC, datetime
 from html import escape as html_escape
@@ -12,8 +11,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import aiosqlite
     from app.db.adapter import DatabasePort
-
-log = logging.getLogger(__name__)
 
 # ADR-242: bump when the rasteriser changes in a way that does NOT alter the
 # generated SVG string (e.g. cairosvg output dimensions), to force a global
@@ -450,9 +447,14 @@ async def regenerate_all_thumbnails(db: DatabasePort, *, force: bool = False) ->
                 written += 1
 
     total = len(rows) * len(VALID_THEMES)
-    log.info(
-        "[Thumbnails] regen sweep: %d written, %d skipped "
-        "(%d diagrams x %d themes, force=%s)",
-        written, total - written, len(rows), len(VALID_THEMES), force,
+    # ADR-242: emit via print (not logging) so the written-vs-skipped counter
+    # actually surfaces in Render stdout, matching the rest of the startup path.
+    # This is the line that shows the bandwidth fix working: after the one-time
+    # back-fill boot, subsequent boots report "0 written".
+    print(  # noqa: T201 — intentional startup stdout, matches startup.py logging
+        f"[Thumbnails] regen sweep: {written} written, "
+        f"{total - written} skipped "
+        f"({len(rows)} diagrams x {len(VALID_THEMES)} themes, force={force})",
+        flush=True,
     )
     return len(rows)

--- a/docs/adrs/ADR-242-Idempotent-Thumbnail-Regeneration.md
+++ b/docs/adrs/ADR-242-Idempotent-Thumbnail-Regeneration.md
@@ -84,8 +84,11 @@ rasterisation in a way that does **not** change `svg_str` requires a manual
 - **Surface parity (Protocol §14 / ADR-182):** no new write endpoint, MCP tool,
   or CLI subcommand — this is an internal idempotency optimisation of an existing
   code path. Parity unaffected.
-- **Observability:** `regenerate_all_thumbnails()` logs written-vs-skipped counts
-  so the effect is visible in Render logs after deploy.
+- **Observability:** `regenerate_all_thumbnails()` **prints** (not `logging`, which
+  this app does not propagate to stdout) a `[Thumbnails] regen sweep: N written,
+  M skipped` line so the effect is visible in Render logs after deploy — the
+  one-time back-fill boot shows all rows written, every subsequent boot shows
+  `0 written`.
 
 ## Related
 


### PR DESCRIPTION
Follow-up to #290 (ADR-242).

The written/skipped counter that proves the bandwidth fix used `logging.getLogger().info()`, which this app does not propagate to Render stdout — so it was invisible. Verified against the live deploy: boot #1's `[STARTUP] regenerated 1221 diagram thumbnails` print showed, but the `[Thumbnails] regen sweep: …` logging line did not.

Switch to `print(flush=True)` (matching the rest of the startup path). The one-time back-fill boot prints all rows written; every subsequent boot prints `0 written` — which is what makes the ~56 MB/restart egress fix observable.

No behaviour change beyond logging; removes the now-unused module logger. Tests unchanged (25 pass); no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)